### PR TITLE
Fixes for type forwarders.

### DIFF
--- a/linker/Mono.Linker.Steps/MarkStep.cs
+++ b/linker/Mono.Linker.Steps/MarkStep.cs
@@ -115,6 +115,22 @@ namespace Mono.Linker.Steps {
 				ProcessQueue ();
 				ProcessVirtualMethods ();
 			}
+
+			// deal with [TypeForwardedTo] pseudo-attributes
+			foreach (AssemblyDefinition assembly in _context.GetAssemblies ()) {
+				if (!assembly.MainModule.HasExportedTypes)
+					continue;
+
+				foreach (var exported in assembly.MainModule.ExportedTypes) {
+					if (!exported.IsForwarder)
+						continue;
+					var type = exported.Resolve ();
+					if (!Annotations.IsMarked (type))
+						continue;
+					Annotations.Mark (exported);
+					Annotations.Mark (assembly.MainModule);
+				}
+			}
 		}
 
 		void ProcessQueue ()

--- a/linker/Mono.Linker.Steps/SweepStep.cs
+++ b/linker/Mono.Linker.Steps/SweepStep.cs
@@ -52,6 +52,16 @@ namespace Mono.Linker.Steps {
 					if (ResolveAllTypeReferences (assembly))
 						Annotations.SetAction (assembly, AssemblyAction.Save);
 				}
+
+				AssemblyAction currentAction = Annotations.GetAction(assembly);
+
+				if ((currentAction == AssemblyAction.Link) || (currentAction == AssemblyAction.Save)) {
+					// if we save (only or by linking) then unmarked exports (e.g. forwarders) must be cleaned
+					// or they can point to nothing which will break later (e.g. when re-loading for stripping IL)
+					// reference: https://bugzilla.xamarin.com/show_bug.cgi?id=36577
+					if (assembly.MainModule.HasExportedTypes)
+						SweepCollection(assembly.MainModule.ExportedTypes);
+				}
 			}
 		}
 

--- a/linker/Mono.Linker.csproj
+++ b/linker/Mono.Linker.csproj
@@ -71,7 +71,7 @@
     <Compile Include="Mono.Linker\XApiReader.cs" />
     <Compile Include="Mono.Linker.Steps\TypeMapStep.cs" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" '$(DoNotEmbedDescriptors)' == '' ">
     <EmbeddedResource Include="Descriptors\mscorlib.xml">
       <LogicalName>mscorlib.xml</LogicalName>
     </EmbeddedResource>


### PR DESCRIPTION
The changes in MarkStep.cs and SweepStep.cs are mostly from https://github.com/xamarin/xamarin-macios/blob/master/tools/linker/MobileMarkStep.cs#L33 and https://github.com/xamarin/xamarin-macios/blob/master/tools/linker/MobileSweepStep.cs#L45 . One additional line
Annotations.Mark (assembly.MainModule);
was added to MarkStep.Process().

The changes in ResolveFromXmlStep.cs are new and allow type forwarders to be specified in xml descriptors.

The change in Mono.Linker.csproj allows opt-out from embedding the default xml descriptors.