### PR TITLE
Fix marking of exported nested types.

### DIFF
--- a/linker/Mono.Linker.Steps/MarkStep.cs
+++ b/linker/Mono.Linker.Steps/MarkStep.cs
@@ -122,7 +122,14 @@ namespace Mono.Linker.Steps {
 					continue;
 
 				foreach (var exported in assembly.MainModule.ExportedTypes) {
-					if (!exported.IsForwarder)
+					bool isForwarder = exported.IsForwarder;
+					var declaringType = exported.DeclaringType;
+					while (!isForwarder && (declaringType != null)) {
+						isForwarder = declaringType.IsForwarder;
+						declaringType = declaringType.DeclaringType;
+					}
+
+					if (!isForwarder)
 						continue;
 					var type = exported.Resolve ();
 					if (!Annotations.IsMarked (type))


### PR DESCRIPTION
The linker should mark exported nested types if they resolve to
marked types. IsForwarder property is only set on the outermost
enclosing type so nested types weren't marked.