### PR TITLE
Fix generated jobs by removing \b from job steps, and update submodules in netci.groovy

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -3,6 +3,20 @@ import jobs.generation.Utilities;
 def project = GithubProject
 def branch = GithubBranchName
 
+def static setRecursiveSubmoduleOption(def job) {
+    job.with {
+        scm {
+            git {
+                configure { gitscm ->
+                    gitscm / 'extensions' << 'hudson.plugins.git.extensions.impl.SubmoduleOption' {
+                        recursiveSubmodules(true)
+                    }
+                }
+            }
+        }
+    }
+}
+
 [true, false].each { isPR ->
     ['Windows_NT'].each { os ->
 
@@ -25,6 +39,7 @@ def branch = GithubBranchName
         Utilities.setMachineAffinity(newJob, os, 'latest-or-auto')
 
         Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
+        setRecursiveSubmoduleOption(job)
 
         if (isPR) {
             Utilities.addGithubPRTriggerForBranch(newJob, branch, "${os} Build")

--- a/netci.groovy
+++ b/netci.groovy
@@ -11,13 +11,13 @@ def branch = GithubBranchName
         if (os == 'Windows_NT') {
             newJob.with {
                 steps {
-                    batchFile(".\build.cmd")
+                    batchFile("build.cmd")
                 }
             }
         } else if (os == 'Ubuntu') {
             newJob.with {
                 steps {
-                    shell("\build.sh")
+                    shell("build.sh")
                 }
             }
         }


### PR DESCRIPTION
The \ wasn't escaped, causing strange behavior with jobs not showing up.
This also fixes build failures due to the submodule for Mono.Cecil not being initialized.