### PR TITLE
Fix the names of output assembly files

### DIFF
--- a/linker/Mono.Linker.Steps/OutputStep.cs
+++ b/linker/Mono.Linker.Steps/OutputStep.cs
@@ -152,7 +152,7 @@ namespace Mono.Linker.Steps {
 
 		static string GetAssemblyFileName (AssemblyDefinition assembly, string directory)
 		{
-			string file = assembly.Name.Name + (assembly.MainModule.Kind == ModuleKind.Dll ? ".dll" : ".exe");
+			string file = GetOriginalAssemblyFileInfo (assembly).Name;
 			return Path.Combine (directory, file);
 		}
 	}


### PR DESCRIPTION
The file name of an output assembly of the linker should match the file name of the corresponding input assembly.

Before this fix, OutputStep.GetAssemblyFileName inferred the name of the output file from assembly name and the main module kind.
The name of the input assembly doesn't have to be the same as the name of the corresponding file;
moreover, a Windows or Console main module can live in a dll file instead of an exe file.
