### PR TITLE
Option to keep assemblies that have only type forwarders referenced.

### DIFF
--- a/linker/Mono.Linker.Steps/MarkStep.cs
+++ b/linker/Mono.Linker.Steps/MarkStep.cs
@@ -135,7 +135,9 @@ namespace Mono.Linker.Steps {
 					if (!Annotations.IsMarked (type))
 						continue;
 					Annotations.Mark (exported);
-					Annotations.Mark (assembly.MainModule);
+					if (_context.KeepTypeForwarderOnlyAssemblies) {
+						Annotations.Mark (assembly.MainModule);
+					}
 				}
 			}
 		}

--- a/linker/Mono.Linker.Steps/SweepStep.cs
+++ b/linker/Mono.Linker.Steps/SweepStep.cs
@@ -44,13 +44,14 @@ namespace Mono.Linker.Steps {
 			assemblies = Context.GetAssemblies ();
 			foreach (var assembly in assemblies) {
 				SweepAssembly (assembly);
-				if (Annotations.GetAction (assembly) == AssemblyAction.Copy) {
-					// Copy assemblies can still contain Type references with
-					// type forwarders from Delete assemblies
-					// thus try to resolve all the type references and see
-					// if some changed the scope. if yes change the action to Save
-					if (ResolveAllTypeReferences (assembly))
-						Annotations.SetAction (assembly, AssemblyAction.Save);
+				if ((Annotations.GetAction (assembly) == AssemblyAction.Copy) &&
+					!Context.KeepTypeForwarderOnlyAssemblies) {
+						// Copy assemblies can still contain Type references with
+						// type forwarders from Delete assemblies
+						// thus try to resolve all the type references and see
+						// if some changed the scope. if yes change the action to Save
+						if (ResolveAllTypeReferences (assembly))
+							Annotations.SetAction (assembly, AssemblyAction.Save);
 				}
 
 				AssemblyAction currentAction = Annotations.GetAction(assembly);
@@ -131,12 +132,16 @@ namespace Mono.Linker.Steps {
 					// Copy means even if "unlinked" we still want that assembly to be saved back 
 					// to disk (OutputStep) without the (removed) reference
 					Annotations.SetAction (assembly, AssemblyAction.Save);
-					ResolveAllTypeReferences (assembly);
+					if (!Context.KeepTypeForwarderOnlyAssemblies) {
+						ResolveAllTypeReferences (assembly);
+					}
 					break;
 
 				case AssemblyAction.Save:
 				case AssemblyAction.Link:
-					ResolveAllTypeReferences (assembly);
+					if (!Context.KeepTypeForwarderOnlyAssemblies) {
+						ResolveAllTypeReferences (assembly);
+					}
 					break;
 				}
 				return;

--- a/linker/Mono.Linker/Driver.cs
+++ b/linker/Mono.Linker/Driver.cs
@@ -124,6 +124,9 @@ namespace Mono.Linker {
 				case 's':
 					custom_steps.Add (GetParam ());
 					break;
+				case 't':
+					context.KeepTypeForwarderOnlyAssemblies = true;
+					break;
 				case 'x':
 					foreach (string file in GetFiles (GetParam ()))
 						p.PrependStep (new ResolveFromXmlStep (new XPathDocument (file)));
@@ -274,6 +277,7 @@ namespace Mono.Linker {
 			Console.WriteLine ("   -c          Action on the core assemblies, skip, copy or link, default to skip");
 			Console.WriteLine ("   -p          Action per assembly");
 			Console.WriteLine ("   -s          Add a new step to the pipeline.");
+			Console.WriteLine ("   -t          Keep assemblies in which only type forwarders are referenced.");
 			Console.WriteLine ("   -d          Add a directory where the linker will look for assemblies");
 			Console.WriteLine ("   -b          Generate debug symbols for each linked module (true or false)");
 			Console.WriteLine ("   -g          Generate a new unique guid for each linked module (true or false)");

--- a/linker/Mono.Linker/LinkContext.cs
+++ b/linker/Mono.Linker/LinkContext.cs
@@ -43,6 +43,7 @@ namespace Mono.Linker {
 		string _outputDirectory;
 		Hashtable _parameters;
 		bool _linkSymbols;
+		bool _keepTypeForwarderOnlyAssemblies;
 
 		AssemblyResolver _resolver;
 
@@ -73,6 +74,12 @@ namespace Mono.Linker {
 		public bool LinkSymbols {
 			get { return _linkSymbols; }
 			set { _linkSymbols = value; }
+		}
+
+		public bool KeepTypeForwarderOnlyAssemblies
+		{
+			get { return _keepTypeForwarderOnlyAssemblies; }
+			set { _keepTypeForwarderOnlyAssemblies = value; }
 		}
 
 		public IDictionary Actions {


### PR DESCRIPTION
The linker had an optimization that removed assemblies that had only type forwarders referenced.
https://github.com/mono/linker/pull/2 broke that optimization by adding a line that
marked assembly.MainModule whenever a type forwarder was marked.

This change introduces a new switch -t that controls this optimization. The optimization is on
by default; if -t is specified, the optimization is disabled and assemblies with referenced type
forwarders are kept.

Additionally, this includes a change that marks all type forwarders in assemblies specified with -a.