### PR TITLE
Ignore unresolved type forwarders and assembly references.

### DIFF
--- a/linker/Mono.Linker.Steps/LoadReferencesStep.cs
+++ b/linker/Mono.Linker.Steps/LoadReferencesStep.cs
@@ -48,8 +48,16 @@ namespace Mono.Linker.Steps {
 
 			_references.Add (assembly.Name, assembly);
 
-			foreach (AssemblyNameReference reference in assembly.MainModule.AssemblyReferences)
-				ProcessReferences (Context.Resolve (reference));
+			foreach (AssemblyNameReference reference in assembly.MainModule.AssemblyReferences) {
+				AssemblyDefinition definition = null;
+				try {
+					definition = Context.Resolve (reference);
+				}
+				catch (AssemblyResolutionException) {
+					continue;
+				}
+				ProcessReferences (definition);
+			}
 		}
 	}
 }

--- a/linker/Mono.Linker.Steps/MarkStep.cs
+++ b/linker/Mono.Linker.Steps/MarkStep.cs
@@ -131,7 +131,13 @@ namespace Mono.Linker.Steps {
 
 					if (!isForwarder)
 						continue;
-					var type = exported.Resolve ();
+					TypeDefinition type = null;
+					try {
+						type = exported.Resolve ();
+					}
+					catch (AssemblyResolutionException) {
+						continue;
+					}
 					if (!Annotations.IsMarked (type))
 						continue;
 					Annotations.Mark (exported);

--- a/linker/Mono.Linker.Steps/ResolveFromAssemblyStep.cs
+++ b/linker/Mono.Linker.Steps/ResolveFromAssemblyStep.cs
@@ -95,7 +95,13 @@ namespace Mono.Linker.Steps {
 
 					if (!isForwarder)
 						continue;
-					var resolvedExportedType = exported.Resolve ();
+					TypeDefinition resolvedExportedType = null;
+					try {
+						resolvedExportedType = exported.Resolve ();
+					}
+					catch (AssemblyResolutionException) {
+						continue;
+					}
 					var resolvedTypeAssembly = context.Resolve (resolvedExportedType.Scope);
 					MarkType (context, resolvedExportedType);
 					context.Annotations.Mark (exported);

--- a/linker/Mono.Linker.Steps/ResolveFromXmlStep.cs
+++ b/linker/Mono.Linker.Steps/ResolveFromXmlStep.cs
@@ -176,7 +176,12 @@ namespace Mono.Linker.Steps {
 			if (regex.Match (exportedType.FullName).Success) {
 				Annotations.Mark (exportedType);
 				Annotations.Mark (module);
-				var type = exportedType.Resolve ();
+				TypeDefinition type = null;
+				try {
+					type = exportedType.Resolve ();
+				}
+				catch (AssemblyResolutionException) {
+				}
 				if (type != null) {
 					ProcessType (type, nav);
 				}
@@ -399,8 +404,14 @@ namespace Mono.Linker.Steps {
 
 		static void ProcessReferences (AssemblyDefinition assembly, LinkContext context)
 		{
-			foreach (AssemblyNameReference name in assembly.MainModule.AssemblyReferences)
-				context.Resolve (name);
+			foreach (AssemblyNameReference name in assembly.MainModule.AssemblyReferences) {
+				try {
+					context.Resolve (name);
+				}
+				catch (AssemblyResolutionException) {
+					continue;
+				}
+			}
 		}
 
 		static bool IsRequired (XPathNavigator nav)

--- a/linker/Mono.Linker.Steps/SweepStep.cs
+++ b/linker/Mono.Linker.Steps/SweepStep.cs
@@ -127,7 +127,13 @@ namespace Mono.Linker.Steps {
 			var references = assembly.MainModule.AssemblyReferences;
 			for (int i = 0; i < references.Count; i++) {
 				var reference = references [i];
-				var r = Context.Resolver.Resolve (reference);
+				AssemblyDefinition r = null;
+				try {
+					r = Context.Resolver.Resolve (reference);
+				}
+				catch (AssemblyResolutionException) {
+					continue;
+				}
 				if (!AreSameReference (r.Name, target.Name))
 					continue;
 


### PR DESCRIPTION
This change modifies the linker to ignore unresolved type forwarders and assembly references.
This is needed to support .NET Core 2.0 scenarios where mscorlib.dll (and possibly other assemblies) will
contain type forwarders that point to assemblies that may not always be resolved.