### PR TITLE
Fix AssemblyDefinition caching in AssemblyResolver.

### DIFF
--- a/linker/Mono.Linker/AssemblyResolver.cs
+++ b/linker/Mono.Linker/AssemblyResolver.cs
@@ -28,6 +28,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using Mono.Cecil;
 
@@ -42,7 +43,7 @@ namespace Mono.Linker {
 		}
 
 		public AssemblyResolver ()
-			: this (new Hashtable ())
+			: this (new Dictionary<string, AssemblyDefinition> (StringComparer.OrdinalIgnoreCase))
 		{
 		}
 


### PR DESCRIPTION
AssemblyDefinition caching should use string-insensitive string comparisons
so that only a single AssemblyDefinition is created when assembly name is specified
with a different case (e.g., in -a, in -x file, reference in metadata, etc.).