### PR TITLE
Rename .NET core build of linker to illink

### DIFF
--- a/linker/Mono.Linker.csproj
+++ b/linker/Mono.Linker.csproj
@@ -10,7 +10,8 @@
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Mono.Linker</RootNamespace>
-    <AssemblyName>monolinker</AssemblyName>
+    <AssemblyName Condition=" ! $(Configuration.StartsWith('netcore')) ">monolinker</AssemblyName>
+    <AssemblyName Condition=" $(Configuration.StartsWith('netcore')) ">illink</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/linker/Mono.Linker/Driver.cs
+++ b/linker/Mono.Linker/Driver.cs
@@ -38,7 +38,11 @@ namespace Mono.Linker {
 
 	public class Driver {
 
+#if NET_CORE
+		static readonly string _linker = "IL Linker";
+#else
 		static readonly string _linker = "Mono CIL Linker";
+#endif
 
 		public static int Main (string [] args)
 		{
@@ -269,7 +273,11 @@ namespace Mono.Linker {
 			Console.WriteLine (_linker);
 			if (msg != null)
 				Console.WriteLine ("Error: " + msg);
+#if NET_CORE
+			Console.WriteLine ("illink [options] -x|-a|-i file");
+#else
 			Console.WriteLine ("monolinker [options] -x|-a|-i file");
+#endif
 
 			Console.WriteLine ("   --about     About the {0}", _linker);
 			Console.WriteLine ("   --version   Print the version number of the {0}", _linker);

--- a/linker/NetCore.props
+++ b/linker/NetCore.props
@@ -6,7 +6,7 @@
     <DefineConstants>$(DefineConstants);NET_CORE</DefineConstants>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <AssemblyName>monolinker</AssemblyName>
+    <AssemblyName>illink</AssemblyName>
     <OutputType>exe</OutputType>
   </PropertyGroup>
 


### PR DESCRIPTION
The .NET core linker is being renamed to "illink". The usage info is changed correspondingly:

```
IL Linker
Error: No parameters specified
illink [options] -x|-a|-i file
   --about     About the IL Linker
   --version   Print the version number of the IL Linker
   -out        Specify the output directory, default to `output'
   -c          Action on the core assemblies, skip, copy or link, default to skip
   -p          Action per assembly
   -s          Add a new step to the pipeline.
   -t          Keep assemblies in which only type forwarders are referenced.
   -d          Add a directory where the linker will look for assemblies
   -b          Generate debug symbols for each linked module (true or false)
   -g          Generate a new unique guid for each linked module (true or false)
   -l          List of i18n assemblies to copy to the output directory
                 separated with a comma: none,all,cjk,mideast,other,rare,west
                 default is all
   -x          Link from an XML descriptor
   -a          Link from a list of assemblies
   -i          Link from an mono-api-info descriptor
```

Note that we still allow -i, which appear to take inputs specific to the mono tooling. Is this what we want? @swaroop-sridhar @erozenfeld @russellhadley