### PR TITLE
Fix DirectoryAssemblyResolver.

### DIFF
--- a/linker/Mono.Linker/DirectoryAssemblyResolver.cs
+++ b/linker/Mono.Linker/DirectoryAssemblyResolver.cs
@@ -56,12 +56,6 @@ namespace Mono.Linker {
 			if (assembly != null)
 				return assembly;
 
-			var framework_dir = Path.GetDirectoryName (typeof (object).Module.FullyQualifiedName);
-
-			assembly = SearchDirectory (name, new [] { framework_dir }, parameters);
-			if (assembly != null)
-				return assembly;
-
 			throw new AssemblyResolutionException (name);
 		}
 


### PR DESCRIPTION
DirectoryAssemblyResolver shouldn't add the directory containing the core assembly
for the linker itself to the list of search directories. That core assembly is not necessarily
used by the app being linked so a wrong assembly may be found.