### PR TITLE
Fix complex generic param bug

### DIFF
--- a/linker/Mono.Linker.Steps/TypeMapStep.cs
+++ b/linker/Mono.Linker.Steps/TypeMapStep.cs
@@ -138,13 +138,13 @@ namespace Mono.Linker.Steps {
 
 		static MethodDefinition GetBaseMethodInTypeHierarchy (TypeDefinition type, MethodDefinition method)
 		{
-			TypeDefinition @base = GetBaseType (type);
+			TypeReference @base = type.GetInflatedBaseType ();
 			while (@base != null) {
 				MethodDefinition base_method = TryMatchMethod (@base, method);
 				if (base_method != null)
 					return base_method;
 
-				@base = GetBaseType (@base);
+				@base = @base.GetInflatedBaseType ();
 			}
 
 			return null;
@@ -155,16 +155,9 @@ namespace Mono.Linker.Steps {
 			return GetBaseMethodsInInterfaceHierarchy (method.DeclaringType, method);
 		}
 
-		static IEnumerable<MethodDefinition> GetBaseMethodsInInterfaceHierarchy (TypeDefinition type, MethodDefinition method)
+		static IEnumerable<MethodDefinition> GetBaseMethodsInInterfaceHierarchy (TypeReference type, MethodDefinition method)
 		{
-			if (!type.HasInterfaces)
-				yield break;
-
-			foreach (var interface_ref in type.Interfaces) {
-				TypeDefinition @interface = interface_ref.InterfaceType.Resolve ();
-				if (@interface == null)
-					continue;
-
+			foreach (TypeReference @interface in type.GetInflatedInterfaces ()) {
 				MethodDefinition base_method = TryMatchMethod (@interface, method);
 				if (base_method != null)
 					yield return base_method;
@@ -174,25 +167,21 @@ namespace Mono.Linker.Steps {
 			}
 		}
 
-		static MethodDefinition TryMatchMethod (TypeDefinition type, MethodDefinition method)
+		static MethodDefinition TryMatchMethod (TypeReference type, MethodDefinition method)
 		{
-			if (!type.HasMethods)
-				return null;
-
-			Dictionary<string,string> gp = null;
-			foreach (MethodDefinition candidate in type.Methods) {
-				if (MethodMatch (candidate, method, ref gp))
-					return candidate;
-				if (gp != null)
-					gp.Clear ();
+			foreach (var candidate in type.GetMethods ()) {
+				if (MethodMatch (candidate, method))
+					return candidate.Resolve ();
 			}
 
 			return null;
 		}
 
-		static bool MethodMatch (MethodDefinition candidate, MethodDefinition method, ref Dictionary<string,string> genericParameters)
+		static bool MethodMatch (MethodReference candidate, MethodDefinition method)
 		{
-			if (!candidate.IsVirtual)
+			var candidateDef = candidate.Resolve ();
+
+			if (!candidateDef.IsVirtual)
 				return false;
 
 			if (candidate.HasParameters != method.HasParameters)
@@ -206,7 +195,7 @@ namespace Mono.Linker.Steps {
 
 			// we need to track what the generic parameter represent - as we cannot allow it to
 			// differ between the return type or any parameter
-			if (!TypeMatch (candidate.ReturnType, method.ReturnType, ref genericParameters))
+			if (!TypeMatch (candidate.GetReturnType (), method.GetReturnType ()))
 				return false;
 
 			if (!candidate.HasParameters)
@@ -218,37 +207,37 @@ namespace Mono.Linker.Steps {
 				return false;
 
 			for (int i = 0; i < cp.Count; i++) {
-				if (!TypeMatch (cp [i].ParameterType, mp [i].ParameterType, ref genericParameters))
+				if (!TypeMatch (candidate.GetParameterType (i), method.GetParameterType (i)))
 					return false;
 			}
 
 			return true;
 		}
 
-		static bool TypeMatch (IModifierType a, IModifierType b, ref Dictionary<string,string> gp)
+		static bool TypeMatch (IModifierType a, IModifierType b)
 		{
-			if (!TypeMatch (a.ModifierType, b.ModifierType, ref gp))
+			if (!TypeMatch (a.ModifierType, b.ModifierType))
 				return false;
 
-			return TypeMatch (a.ElementType, b.ElementType, ref gp);
+			return TypeMatch (a.ElementType, b.ElementType);
 		}
 
-		static bool TypeMatch (TypeSpecification a, TypeSpecification b, ref Dictionary<string,string> gp)
+		static bool TypeMatch (TypeSpecification a, TypeSpecification b)
 		{
 			var gita = a as GenericInstanceType;
 			if (gita != null)
-				return TypeMatch (gita, (GenericInstanceType) b, ref gp);
+				return TypeMatch (gita, (GenericInstanceType) b);
 
 			var mta = a as IModifierType;
 			if (mta != null)
-				return TypeMatch (mta, (IModifierType) b, ref gp);
+				return TypeMatch (mta, (IModifierType) b);
 
-			return TypeMatch (a.ElementType, b.ElementType, ref gp);
+			return TypeMatch (a.ElementType, b.ElementType);
 		}
 
-		static bool TypeMatch (GenericInstanceType a, GenericInstanceType b, ref Dictionary<string,string> gp)
+		static bool TypeMatch (GenericInstanceType a, GenericInstanceType b)
 		{
-			if (!TypeMatch (a.ElementType, b.ElementType, ref gp))
+			if (!TypeMatch (a.ElementType, b.ElementType))
 				return false;
 
 			if (a.HasGenericArguments != b.HasGenericArguments)
@@ -263,45 +252,37 @@ namespace Mono.Linker.Steps {
 				return false;
 
 			for (int i = 0; i < gaa.Count; i++) {
-				if (!TypeMatch (gaa [i], gab [i], ref gp))
+				if (!TypeMatch (gaa [i], gab [i]))
 					return false;
 			}
 
 			return true;
 		}
 
-		static bool TypeMatch (TypeReference a, TypeReference b, ref Dictionary<string,string> gp)
+		static bool TypeMatch (GenericParameter a, GenericParameter b)
 		{
-			var gpa = a as GenericParameter;
-			if (gpa != null) {
-				if (gp == null)
-					gp = new Dictionary<string, string> ();
-				string match;
-				if (!gp.TryGetValue (gpa.FullName, out match)) {
-					// first use, we assume it will always be used this way
-					gp.Add (gpa.FullName, b.ToString ());
-					return true;
-				}
-				// re-use, it should match the previous usage
-				return match == b.ToString ();
-			}
+			if (a.Position != b.Position)
+				return false;
 
+			if (a.Type != b.Type)
+				return false;
+
+			return true;
+		}
+
+		static bool TypeMatch (TypeReference a, TypeReference b)
+		{
 			if (a is TypeSpecification || b is TypeSpecification) {
 				if (a.GetType () != b.GetType ())
 					return false;
 
-				return TypeMatch ((TypeSpecification) a, (TypeSpecification) b, ref gp);
+				return TypeMatch ((TypeSpecification) a, (TypeSpecification) b);
 			}
 
+			if (a is GenericParameter && b is GenericParameter)
+				return TypeMatch ((GenericParameter)a, (GenericParameter)b);
+
 			return a.FullName == b.FullName;
-		}
-
-		static TypeDefinition GetBaseType (TypeDefinition type)
-		{
-			if (type == null || type.BaseType == null)
-				return null;
-
-			return type.BaseType.Resolve ();
 		}
 	}
 }

--- a/linker/Mono.Linker.csproj
+++ b/linker/Mono.Linker.csproj
@@ -70,8 +70,10 @@
     <Compile Include="Mono.Linker\LinkContext.cs" />
     <Compile Include="Mono.Linker\MarkException.cs" />
     <Compile Include="Mono.Linker\MethodAction.cs" />
+    <Compile Include="Mono.Linker\MethodReferenceExtensions.cs" />
     <Compile Include="Mono.Linker\Pipeline.cs" />
     <Compile Include="Mono.Linker\TypePreserve.cs" />
+    <Compile Include="Mono.Linker\TypeReferenceExtensions.cs" />
     <Compile Include="Mono.Linker\XApiReader.cs" />
     <Compile Include="Mono.Linker.Steps\TypeMapStep.cs" />
   </ItemGroup>

--- a/linker/Mono.Linker/MethodReferenceExtensions.cs
+++ b/linker/Mono.Linker/MethodReferenceExtensions.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Mono.Cecil;
+
+namespace Mono.Linker
+{
+	static class MethodReferenceExtensions
+	{
+		public static TypeReference GetReturnType (this MethodReference method)
+		{
+			var genericInstance = method.DeclaringType as GenericInstanceType;
+
+			if (genericInstance != null)
+				return TypeReferenceExtensions.InflateGenericType (genericInstance, method.ReturnType);
+
+			return method.ReturnType;
+		}
+
+		public static TypeReference GetParameterType (this MethodReference method, int parameterIndex)
+		{
+			var genericInstance = method.DeclaringType as GenericInstanceType;
+
+			if (genericInstance != null)
+				return TypeReferenceExtensions.InflateGenericType (genericInstance, method.Parameters [parameterIndex].ParameterType);
+
+			return method.Parameters [parameterIndex].ParameterType;
+		}
+	}
+}

--- a/linker/Mono.Linker/TypeReferenceExtensions.cs
+++ b/linker/Mono.Linker/TypeReferenceExtensions.cs
@@ -1,0 +1,199 @@
+﻿using Mono.Cecil;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Mono.Linker
+{
+	static class TypeReferenceExtensions
+	{
+		public static TypeReference GetInflatedBaseType (this TypeReference type)
+		{
+			if (type == null)
+				return null;
+
+			if (type.IsGenericParameter || type.IsByReference || type.IsPointer)
+				return null;
+
+			var sentinelType = type as SentinelType;
+			if (sentinelType != null)
+				return sentinelType.ElementType.GetInflatedBaseType ();
+
+			var pinnedType = type as PinnedType;
+			if (pinnedType != null)
+				return pinnedType.ElementType.GetInflatedBaseType ();
+
+			var requiredModifierType = type as RequiredModifierType;
+			if (requiredModifierType != null)
+				return requiredModifierType.ElementType.GetInflatedBaseType ();
+
+			var genericInstance = type as GenericInstanceType;
+			if (genericInstance != null) {
+				var baseType = type.Resolve ().BaseType;
+				var baseTypeGenericInstance = baseType as GenericInstanceType;
+
+				if (baseTypeGenericInstance != null)
+					return InflateGenericType (genericInstance, baseType);
+
+				return baseType;
+			}
+
+			return type.Resolve ().BaseType;
+		}
+
+		public static IEnumerable<TypeReference> GetInflatedInterfaces (this TypeReference typeRef)
+		{
+			var typeDef = typeRef.Resolve ();
+
+			if (!typeDef.HasInterfaces)
+				yield break;
+
+			var genericInstance = typeRef as GenericInstanceType;
+			if (genericInstance != null) {
+				foreach (var interfaceImpl in typeDef.Interfaces)
+					yield return InflateGenericType (genericInstance, interfaceImpl.InterfaceType);
+			} else {
+				foreach (var interfaceImpl in typeDef.Interfaces)
+					yield return interfaceImpl.InterfaceType;
+			}
+		}
+
+		public static TypeReference InflateGenericType (GenericInstanceType genericInstanceProvider, TypeReference typeToInflate)
+		{
+			var arrayType = typeToInflate as ArrayType;
+			if (arrayType != null) {
+				var inflatedElementType = InflateGenericType (genericInstanceProvider, arrayType.ElementType);
+
+				if (inflatedElementType != arrayType.ElementType)
+					return new ArrayType (inflatedElementType, arrayType.Rank);
+
+				return arrayType;
+			}
+
+			var genericInst = typeToInflate as GenericInstanceType;
+			if (genericInst != null)
+				return MakeGenericType (genericInstanceProvider, genericInst);
+
+			var genericParameter = typeToInflate as GenericParameter;
+			if (genericParameter != null) {
+				if (genericParameter.Owner is MethodReference)
+					return genericParameter;
+
+				var elementType = genericInstanceProvider.ElementType.Resolve ();
+				var parameter = elementType.GenericParameters.Single (p => p == genericParameter);
+				return genericInstanceProvider.GenericArguments [parameter.Position];
+			}
+
+			var functionPointerType = typeToInflate as FunctionPointerType;
+			if (functionPointerType != null) {
+				var result = new FunctionPointerType ();
+				result.ReturnType = InflateGenericType (genericInstanceProvider, functionPointerType.ReturnType);
+
+				for (int i = 0; i < functionPointerType.Parameters.Count; i++) {
+					var inflatedParameterType = InflateGenericType(genericInstanceProvider, functionPointerType.Parameters [i].ParameterType);
+					result.Parameters.Add (new ParameterDefinition (inflatedParameterType));
+				}
+
+				return result;
+			}
+
+			var modifierType = typeToInflate as IModifierType;
+			if (modifierType != null) {
+				var modifier = InflateGenericType (genericInstanceProvider, modifierType.ModifierType);
+				var elementType = InflateGenericType (genericInstanceProvider, modifierType.ElementType);
+
+				if (modifierType is OptionalModifierType) {
+					return new OptionalModifierType (modifier, elementType);
+				}
+
+				return new RequiredModifierType (modifier, elementType);
+			}
+
+			var pinnedType = typeToInflate as PinnedType;
+			if (pinnedType != null) {
+				var elementType = InflateGenericType (genericInstanceProvider, pinnedType.ElementType);
+
+				if (elementType != pinnedType.ElementType)
+					return new PinnedType (elementType);
+
+				return pinnedType;
+			}
+
+			var pointerType = typeToInflate as PointerType;
+			if (pointerType != null) {
+				var elementType = InflateGenericType (genericInstanceProvider, pointerType.ElementType);
+
+				if (elementType != pointerType.ElementType)
+					return new PointerType (elementType);
+
+				return pointerType;
+			}
+
+			var byReferenceType = typeToInflate as ByReferenceType;
+			if (byReferenceType != null) {
+				var elementType = InflateGenericType (genericInstanceProvider, byReferenceType.ElementType);
+
+				if (elementType != byReferenceType.ElementType)
+					return new ByReferenceType (elementType);
+
+				return byReferenceType;
+			}
+
+			var sentinelType = typeToInflate as SentinelType;
+			if (sentinelType != null) {
+				var elementType = InflateGenericType (genericInstanceProvider, sentinelType.ElementType);
+
+				if (elementType != sentinelType.ElementType)
+					return new SentinelType (elementType);
+
+				return sentinelType;
+			}
+
+			return typeToInflate;
+		}
+
+		private static GenericInstanceType MakeGenericType (GenericInstanceType genericInstanceProvider, GenericInstanceType type)
+		{
+			var result = new GenericInstanceType (type.ElementType);
+
+			for (var i = 0; i < type.GenericArguments.Count; ++i) {
+				result.GenericArguments.Add (InflateGenericType (genericInstanceProvider, type.GenericArguments [i]));
+			}
+
+			return result;
+		}
+
+		public static IEnumerable<MethodReference> GetMethods (this TypeReference type)
+		{
+			var typeDef = type.Resolve ();
+
+			if (!typeDef.HasMethods)
+				yield break;
+
+			var genericInstanceType = type as GenericInstanceType;
+			if (genericInstanceType != null) {
+				foreach (var methodDef in typeDef.Methods)
+					yield return MakeMethodReferenceForGenericInstanceType (genericInstanceType, methodDef);
+			} else {
+				foreach (var method in typeDef.Methods)
+					yield return method;
+			}
+		}
+
+		private static MethodReference MakeMethodReferenceForGenericInstanceType (GenericInstanceType genericInstanceType, MethodDefinition methodDef)
+		{
+			var method = new MethodReference (methodDef.Name, methodDef.ReturnType, genericInstanceType) {
+				HasThis = methodDef.HasThis,
+				ExplicitThis = methodDef.ExplicitThis,
+				CallingConvention = methodDef.CallingConvention
+			};
+
+			foreach (var parameter in methodDef.Parameters)
+				method.Parameters.Add (new ParameterDefinition(parameter.Name, parameter.Attributes, parameter.ParameterType));
+
+			foreach (var gp in methodDef.GenericParameters)
+				method.GenericParameters.Add (new GenericParameter (gp.Name, method));
+
+			return method;
+		}
+	}
+}


### PR DESCRIPTION
This PR fixes a bug that leads to mishandling of overloads with parameters that have types with generic parameters and use a different generic param name than the base method.

* Undo the upstream change made at https://github.com/mono/linker/commit/6f0742cdc4cdbd7627b765992e2e5baeb5edbe58 this fix was not a complete fix

* Unity hit this bug a couple years ago and we've had a fix in our linker since.  Bring over this fix which does a more exhaustive comparison of generic parameters

I have ported the unit tests that we wrote for this case into the new linker test framework (still a work in progress).  See the following change set if you would like to see examples of the cases this PR fixes.
https://github.com/Unity-Technologies/linker/commit/f7b455831f3a82b1426a5e13bcebbcc5abdc3971

