### PR TITLE
Sweep assemblies fix

### DIFF
--- a/linker/Mono.Linker.Steps/SweepStep.cs
+++ b/linker/Mono.Linker.Steps/SweepStep.cs
@@ -29,6 +29,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using Mono.Cecil;
 using Mono.Collections.Generic;
 using Mono.Cecil.Cil;
@@ -48,7 +49,7 @@ namespace Mono.Linker.Steps {
 
 		protected override void Process ()
 		{
-			assemblies = Context.GetAssemblies ();
+			assemblies = Context.Annotations.GetAssemblies ().ToArray ();
 			foreach (var assembly in assemblies) {
 				SweepAssembly (assembly);
 				if ((Annotations.GetAction (assembly) == AssemblyAction.Copy) &&

--- a/linker/Mono.Linker/Annotations.cs
+++ b/linker/Mono.Linker/Annotations.cs
@@ -78,6 +78,11 @@ namespace Mono.Linker {
 			writer.WriteEndAttribute ();
 		}
 
+		public ICollection<AssemblyDefinition> GetAssemblies()
+		{
+			return assembly_actions.Keys;
+		}
+
 		public AssemblyAction GetAction (AssemblyDefinition assembly)
 		{
 			AssemblyAction action;

--- a/linker/Mono.Linker/Annotations.cs
+++ b/linker/Mono.Linker/Annotations.cs
@@ -78,7 +78,7 @@ namespace Mono.Linker {
 			writer.WriteEndAttribute ();
 		}
 
-		public ICollection<AssemblyDefinition> GetAssemblies()
+		public ICollection<AssemblyDefinition> GetAssemblies ()
 		{
 			return assembly_actions.Keys;
 		}

--- a/linker/Mono.Linker/LinkContext.cs
+++ b/linker/Mono.Linker/LinkContext.cs
@@ -243,9 +243,9 @@ namespace Mono.Linker {
 
 		public AssemblyDefinition [] GetAssemblies ()
 		{
-			IDictionary cache = _resolver.AssemblyCache;
-			AssemblyDefinition [] asms = new AssemblyDefinition [cache.Count];
-			cache.Values.CopyTo (asms, 0);
+			var assemblies = Annotations.GetAssemblies();
+			AssemblyDefinition [] asms = new AssemblyDefinition [assemblies.Count];
+			assemblies.CopyTo (asms, 0);
 			return asms;
 		}
 

--- a/linker/Mono.Linker/LinkContext.cs
+++ b/linker/Mono.Linker/LinkContext.cs
@@ -243,9 +243,9 @@ namespace Mono.Linker {
 
 		public AssemblyDefinition [] GetAssemblies ()
 		{
-			var assemblies = Annotations.GetAssemblies ();
-			AssemblyDefinition [] asms = new AssemblyDefinition [assemblies.Count];
-			assemblies.CopyTo (asms, 0);
+			IDictionary cache = _resolver.AssemblyCache;
+			AssemblyDefinition [] asms = new AssemblyDefinition [cache.Count];
+			cache.Values.CopyTo (asms, 0);
 			return asms;
 		}
 

--- a/linker/Mono.Linker/LinkContext.cs
+++ b/linker/Mono.Linker/LinkContext.cs
@@ -243,7 +243,7 @@ namespace Mono.Linker {
 
 		public AssemblyDefinition [] GetAssemblies ()
 		{
-			var assemblies = Annotations.GetAssemblies();
+			var assemblies = Annotations.GetAssemblies ();
 			AssemblyDefinition [] asms = new AssemblyDefinition [assemblies.Count];
 			assemblies.CopyTo (asms, 0);
 			return asms;


### PR DESCRIPTION
Sweep all of the assemblies that were linked, not all of the assemblies that were resolved.  There may be some assemblies that are resolved, but are not linked.  We ran into this problem with the WinRT support in the UnityLinker.