### PR TITLE
Remove unused variable to fix warn as error

### DIFF
--- a/linker/Mono.Linker.Steps/ResolveFromAssemblyStep.cs
+++ b/linker/Mono.Linker.Steps/ResolveFromAssemblyStep.cs
@@ -102,7 +102,7 @@ namespace Mono.Linker.Steps {
 					catch (AssemblyResolutionException) {
 						continue;
 					}
-					var resolvedTypeAssembly = context.Resolve (resolvedExportedType.Scope);
+					context.Resolve (resolvedExportedType.Scope);
 					MarkType (context, resolvedExportedType);
 					context.Annotations.Mark (exported);
 					if (context.KeepTypeForwarderOnlyAssemblies) {


### PR DESCRIPTION
We compile the linker with warnings as errors which led us to this unused variable