### PR TITLE
Allow pass in of reader params

### DIFF
--- a/linker/Mono.Linker/LinkContext.cs
+++ b/linker/Mono.Linker/LinkContext.cs
@@ -90,6 +90,10 @@ namespace Mono.Linker {
 			get { return _resolver; }
 		}
 
+		public ReaderParameters ReaderParameters {
+			get { return _readerParameters; }
+		}
+
 		public ISymbolReaderProvider SymbolReaderProvider {
 			get { return _symbolReaderProvider; }
 			set { _symbolReaderProvider = value; }
@@ -107,16 +111,22 @@ namespace Mono.Linker {
 		{
 		}
 
-		public LinkContext (Pipeline pipeline, AssemblyResolver resolver)
+		public LinkContext(Pipeline pipeline, AssemblyResolver resolver)
+			: this(pipeline, resolver, new ReaderParameters
+			{
+				AssemblyResolver = resolver,
+			})
+		{
+		}
+
+		public LinkContext (Pipeline pipeline, AssemblyResolver resolver, ReaderParameters readerParameters)
 		{
 			_pipeline = pipeline;
 			_resolver = resolver;
 			_actions = new Hashtable ();
 			_parameters = new Hashtable ();
 			_annotations = new AnnotationStore ();
-			_readerParameters = new ReaderParameters {
-				AssemblyResolver = _resolver,
-			};
+			_readerParameters = readerParameters;
 		}
 
 		public TypeDefinition GetType (string fullName)

--- a/linker/Mono.Linker/LinkContext.cs
+++ b/linker/Mono.Linker/LinkContext.cs
@@ -111,10 +111,10 @@ namespace Mono.Linker {
 		{
 		}
 
-		public LinkContext(Pipeline pipeline, AssemblyResolver resolver)
+		public LinkContext (Pipeline pipeline, AssemblyResolver resolver)
 			: this(pipeline, resolver, new ReaderParameters
 			{
-				AssemblyResolver = resolver,
+				AssemblyResolver = resolver
 			})
 		{
 		}


### PR DESCRIPTION
Unity linker has it's own reader parameters that we want to pass in & need access to later on during some of our steps.