### PR TITLE
Mark step continue with

### DIFF
--- a/linker/Mono.Linker.Steps/MarkStep.cs
+++ b/linker/Mono.Linker.Steps/MarkStep.cs
@@ -1200,7 +1200,7 @@ namespace Mono.Linker.Steps {
 			}
 		}
 
-		protected virtual bool ContinueWith(TypeDefinition type, TypeReference reference)
+		protected virtual bool ContinueWith (TypeDefinition type, TypeReference reference)
 		{
 			if (type == null) {
 				throw new ResolutionException (reference);
@@ -1209,7 +1209,7 @@ namespace Mono.Linker.Steps {
 			return true;
 		}
 
-		protected virtual bool ContinueWith(MethodDefinition method, MethodReference reference)
+		protected virtual bool ContinueWith (MethodDefinition method, MethodReference reference)
 		{
 			if (method == null) {
 				throw new ResolutionException (reference);

--- a/linker/Mono.Linker.Steps/MarkStep.cs
+++ b/linker/Mono.Linker.Steps/MarkStep.cs
@@ -235,9 +235,8 @@ namespace Mono.Linker.Steps {
 				TypeDefinition type = constructor_type.Resolve ();
 
 				if (type == null) {
-					if (!HandleUnresolvedType (constructor_type)) {
-						return;
-					}
+					HandleUnresolvedType (constructor_type);
+					return;
 				}
 
 				MarkCustomAttributeProperties (ca, type);
@@ -525,8 +524,8 @@ namespace Mono.Linker.Steps {
 			TypeDefinition type = ResolveTypeDefinition (reference);
 
 			if (type == null) {
-				if (!HandleUnresolvedType (reference))
-					return null;
+				HandleUnresolvedType (reference);
+				return null;
 			}
 
 			if (CheckProcessed (type))
@@ -967,9 +966,8 @@ namespace Mono.Linker.Steps {
 
 			try {
 				if (method == null) {
-					if (!HandleUnresolvedMethod (reference)) {
-						return null;
-					}
+					HandleUnresolvedMethod (reference);
+					return null;
 				}
 
 				if (Annotations.GetAction (method) == MethodAction.Nothing)
@@ -1209,12 +1207,12 @@ namespace Mono.Linker.Steps {
 			}
 		}
 
-		protected virtual bool HandleUnresolvedType (TypeReference reference)
+		protected virtual void HandleUnresolvedType (TypeReference reference)
 		{
 			throw new ResolutionException (reference);
 		}
 
-		protected virtual bool HandleUnresolvedMethod (MethodReference reference)
+		protected virtual void HandleUnresolvedMethod (MethodReference reference)
 		{
 			throw new ResolutionException (reference);
 		}

--- a/linker/Mono.Linker.Steps/MarkStep.cs
+++ b/linker/Mono.Linker.Steps/MarkStep.cs
@@ -234,8 +234,10 @@ namespace Mono.Linker.Steps {
 				TypeReference constructor_type = ca.Constructor.DeclaringType;
 				TypeDefinition type = constructor_type.Resolve ();
 
-				if (!ContinueWith (type, constructor_type)) {
-					return;
+				if (type == null) {
+					if (!HandleUnresolvedType (constructor_type)) {
+						return;
+					}
 				}
 
 				MarkCustomAttributeProperties (ca, type);
@@ -522,8 +524,10 @@ namespace Mono.Linker.Steps {
 
 			TypeDefinition type = ResolveTypeDefinition (reference);
 
-			if (!ContinueWith (type, reference))
-				return null;
+			if (type == null) {
+				if (!HandleUnresolvedType (reference))
+					return null;
+			}
 
 			if (CheckProcessed (type))
 				return null;
@@ -962,8 +966,10 @@ namespace Mono.Linker.Steps {
 			MethodDefinition method = ResolveMethodDefinition (reference);
 
 			try {
-				if (!ContinueWith (method, reference)) {
-					return null;
+				if (method == null) {
+					if (!HandleUnresolvedMethod (reference)) {
+						return null;
+					}
 				}
 
 				if (Annotations.GetAction (method) == MethodAction.Nothing)
@@ -1203,22 +1209,14 @@ namespace Mono.Linker.Steps {
 			}
 		}
 
-		protected virtual bool ContinueWith (TypeDefinition type, TypeReference reference)
+		protected virtual bool HandleUnresolvedType (TypeReference reference)
 		{
-			if (type == null) {
-				throw new ResolutionException (reference);
-			}
-
-			return true;
+			throw new ResolutionException (reference);
 		}
 
-		protected virtual bool ContinueWith (MethodDefinition method, MethodReference reference)
+		protected virtual bool HandleUnresolvedMethod (MethodReference reference)
 		{
-			if (method == null) {
-				throw new ResolutionException (reference);
-			}
-
-			return true;
+			throw new ResolutionException (reference);
 		}
 	}
 }

--- a/linker/Mono.Linker.Steps/MarkStep.cs
+++ b/linker/Mono.Linker.Steps/MarkStep.cs
@@ -232,9 +232,10 @@ namespace Mono.Linker.Steps {
 
 			TypeReference constructor_type = ca.Constructor.DeclaringType;
 			TypeDefinition type = constructor_type.Resolve ();
-			if (type == null) {
+
+			if (!ContinueWith (type, constructor_type)) {
 				Annotations.Pop ();
-				throw new ResolutionException (constructor_type);
+				return;
 			}
 
 			MarkCustomAttributeProperties (ca, type);
@@ -519,8 +520,8 @@ namespace Mono.Linker.Steps {
 
 			TypeDefinition type = ResolveTypeDefinition (reference);
 
-			if (type == null)
-				throw new ResolutionException (reference);
+			if (!ContinueWith (type, reference))
+				return null;
 
 			if (CheckProcessed (type))
 				return null;
@@ -958,9 +959,9 @@ namespace Mono.Linker.Steps {
 
 			MethodDefinition method = ResolveMethodDefinition (reference);
 
-			if (method == null) {
+			if (!ContinueWith (method, reference)) {
 				Annotations.Pop ();
-				throw new ResolutionException (reference);
+				return null;
 			}
 
 			if (Annotations.GetAction (method) == MethodAction.Nothing)
@@ -1197,6 +1198,24 @@ namespace Mono.Linker.Steps {
 			default:
 				break;
 			}
+		}
+
+		protected virtual bool ContinueWith(TypeDefinition type, TypeReference reference)
+		{
+			if (type == null) {
+				throw new ResolutionException (reference);
+			}
+
+			return true;
+		}
+
+		protected virtual bool ContinueWith(MethodDefinition method, MethodReference reference)
+		{
+			if (method == null) {
+				throw new ResolutionException (reference);
+			}
+
+			return true;
 		}
 	}
 }


### PR DESCRIPTION
In the UnityLinker, we don't error on unresolved types/method.  Instead we have a custom step that stubs in these missing types/methods.  Introducing ContinueWith gives us the extension point that we need to customize the behavior of the MarkStep.

There's no behavior change here.