### PR TITLE
Make ResolveStep  ctr protected so that we can derive

### DIFF
--- a/linker/Mono.Linker.Steps/ResolveStep.cs
+++ b/linker/Mono.Linker.Steps/ResolveStep.cs
@@ -34,7 +34,7 @@ namespace Mono.Linker.Steps {
 
 		ArrayList _unResolved;
 
-		internal ResolveStep ()
+		protected ResolveStep ()
 		{
 			_unResolved = new ArrayList ();
 		}


### PR DESCRIPTION
We've made a number of changes to ResolveFromXmlStep.  It will take some
time to upstream them,
until then we are going to maintain our copy and in order to do that we
need to be able to derive from ResolveStep in our linker project.