### PR TITLE
Fix ProcessInteropMethod.

### DIFF
--- a/linker/Mono.Linker.Steps/MarkStep.cs
+++ b/linker/Mono.Linker.Steps/MarkStep.cs
@@ -1100,7 +1100,7 @@ namespace Mono.Linker.Steps {
 				TypeDefinition paramTypeDefinition = ResolveTypeDefinition (paramTypeReference);
 				if (paramTypeDefinition != null) {
 					MarkFields (paramTypeDefinition, includeStaticFields);
-					if (paramTypeReference.IsByReference) {
+					if (pd.ParameterType.IsByReference) {
 						MarkDefaultConstructor (paramTypeDefinition);
 					}
 				}


### PR DESCRIPTION
My PR  https://github.com/mono/linker/pull/27 yesterday
had a bug that resulted in default constructors of by-ref interop method
parameter types not getting marked. This change fixes the bug.