### PR TITLE
Add an option to use only entry points visible outside of an assembly as roots.

### DIFF
--- a/linker/Mono.Linker.Steps/LoadI18nAssemblies.cs
+++ b/linker/Mono.Linker.Steps/LoadI18nAssemblies.cs
@@ -77,7 +77,7 @@ namespace Mono.Linker.Steps {
 		void LoadAssembly (AssemblyNameReference name)
 		{
 			AssemblyDefinition assembly = Context.Resolve (name);
-			ResolveFromAssemblyStep.ProcessLibrary (Context, assembly);
+			ResolveFromAssemblyStep.ProcessLibrary (Context, assembly, ResolveFromAssemblyStep.RootVisibility.Any);
 		}
 
 		AssemblyNameReference GetAssemblyName (I18nAssemblies assembly)

--- a/linker/Mono.Linker/Driver.cs
+++ b/linker/Mono.Linker/Driver.cs
@@ -136,9 +136,13 @@ namespace Mono.Linker {
 						p.PrependStep (new ResolveFromXmlStep (new XPathDocument (file)));
 					resolver = true;
 					break;
+				case 'r':
 				case 'a':
+					var rootVisibility = (token[1] == 'r')
+							? ResolveFromAssemblyStep.RootVisibility.PublicAndFamily
+							: ResolveFromAssemblyStep.RootVisibility.Any;
 					foreach (string file in GetFiles (GetParam ()))
-						p.PrependStep (new ResolveFromAssemblyStep (file));
+						p.PrependStep (new ResolveFromAssemblyStep (file, rootVisibility));
 					resolver = true;
 					break;
 				case 'i':
@@ -294,6 +298,7 @@ namespace Mono.Linker {
 			Console.WriteLine ("                 default is all");
 			Console.WriteLine ("   -x          Link from an XML descriptor");
 			Console.WriteLine ("   -a          Link from a list of assemblies");
+			Console.WriteLine ("   -r          Link from a list of assemblies using roots visible outside of the assembly");
 			Console.WriteLine ("   -i          Link from an mono-api-info descriptor");
 			Console.WriteLine ("");
 


### PR DESCRIPTION
This change adds an option -r that is similar to -a except only types, methods, and
fields visible from outside of an assembly are initially marked. This is useful for running the linker to
remove dead privates.