### PR TITLE
Linker resolver interface

### DIFF
--- a/linker/Mono.Linker/AssemblyResolver.cs
+++ b/linker/Mono.Linker/AssemblyResolver.cs
@@ -67,10 +67,11 @@ namespace Mono.Linker {
 			return asm;
 		}
 
-		public void CacheAssembly (AssemblyDefinition assembly)
+		public AssemblyDefinition CacheAssembly (AssemblyDefinition assembly)
 		{
 			_assemblies [assembly.Name.Name] = assembly;
 			base.AddSearchDirectory (Path.GetDirectoryName (assembly.MainModule.FileName));
+			return assembly;
 		}
 	}
 }

--- a/linker/Mono.Linker/AssemblyResolver.cs
+++ b/linker/Mono.Linker/AssemblyResolver.cs
@@ -67,7 +67,7 @@ namespace Mono.Linker {
 			return asm;
 		}
 
-		public AssemblyDefinition CacheAssembly (AssemblyDefinition assembly)
+		public virtual AssemblyDefinition CacheAssembly (AssemblyDefinition assembly)
 		{
 			_assemblies [assembly.Name.Name] = assembly;
 			base.AddSearchDirectory (Path.GetDirectoryName (assembly.MainModule.FileName));

--- a/linker/Mono.Linker/LinkContext.cs
+++ b/linker/Mono.Linker/LinkContext.cs
@@ -153,8 +153,7 @@ namespace Mono.Linker {
 		{
 			if (File.Exists (name)) {
 				AssemblyDefinition assembly = AssemblyDefinition.ReadAssembly (name, _readerParameters);
-				_resolver.CacheAssembly (assembly);
-				return assembly;
+				return _resolver.CacheAssembly (assembly);
 			}
 
 			return Resolve (new AssemblyNameReference (name, new Version ()));


### PR DESCRIPTION
We need to use our own resolver.  This PR introduces an interface for the resolver that the linker uses.  It adds a few extra things to cecil's IAssemblyResolver

There's also a change here to change the return value of CacheAssembly from void to AssemblyDefinition.  I have another PR I will post after this one lands that will make use of the return value.  There is a minor issue today where CacheAssembly is called and then the caller returns the newly loaded assembly rather than the assembly that was already in the cache.