### PR TITLE
Fix ResolveFromAssemblyStep.MarkType processing of nested types.

### DIFF
--- a/linker/Mono.Linker.Steps/ResolveFromAssemblyStep.cs
+++ b/linker/Mono.Linker.Steps/ResolveFromAssemblyStep.cs
@@ -138,8 +138,12 @@ namespace Mono.Linker.Steps {
 					markType = true;
 					break;
 
+				case RootVisibility.PublicAndFamilyAndAssembly:
+					markType = !type.IsNestedPrivate;
+					break;
+
 				case RootVisibility.PublicAndFamily:
-					markType = type.IsPublic || type.IsNestedFamily || type.IsNestedFamilyOrAssembly;
+					markType = type.IsPublic || type.IsNestedPublic || type.IsNestedFamily || type.IsNestedFamilyOrAssembly;
 					break;
 			}
 


### PR DESCRIPTION
Pulbic nested types have IsNestedPublic set to true but IsPublic set to false.
This change fixes ResolveFromAssemblyStep.MarkType to take that into account.

Also, NestedPrivate types shouldn't be marked when root visibility is set to
PublicAndFamilyAndAssembly.