### PR TITLE
Build Mono.Cecil.Pdb.dll in netcore illink builds.

### DIFF
--- a/corebuild/restore.cmd
+++ b/corebuild/restore.cmd
@@ -14,4 +14,5 @@ REM need to explicitly restore Mono.Cecil as well as Mono.Linker.
 
 @call run.cmd restore "'-Project=..\linker\Mono.Linker.csproj'" "'-Configuration=netcore_Debug'" %*
 @call run.cmd restore "'-Project=..\cecil\Mono.Cecil.csproj'" "'-Configuration=netstandard_Debug'" %*
+@call run.cmd restore "'-Project=..\cecil\symbols\pdb\Mono.Cecil.Pdb.csproj'" "'-Configuration=netstandard_Debug'" %*
 @exit /b %ERRORLEVEL%

--- a/corebuild/restore.sh
+++ b/corebuild/restore.sh
@@ -15,3 +15,4 @@
 working_tree_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 $working_tree_root/run.sh restore -Project=../linker/Mono.Linker.csproj -Configuration=netcore_Debug $@
 $working_tree_root/run.sh restore -Project=../cecil/Mono.Cecil.csproj -Configuration=netstandard_Debug $@
+$working_tree_root/run.sh restore -Project=../cecil/symbols/pdb/Mono.Cecil.Pdb.csproj -Configuration=netstandard_Debug $@

--- a/linker/Mono.Linker.csproj
+++ b/linker/Mono.Linker.csproj
@@ -110,4 +110,12 @@
       <Name>Mono.Cecil</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup Condition=" $(Configuration.StartsWith('netcore'))">
+    <ProjectReference Include="..\cecil\symbols\pdb\Mono.Cecil.Pdb.csproj">
+      <SetConfiguration Condition=" '$(Configuration)' == 'netcore_Debug' ">Configuration=netstandard_Debug</SetConfiguration>
+      <SetConfiguration Condition=" '$(Configuration)' == 'netcore_Release' ">Configuration=netstandard_Release</SetConfiguration>
+      <Project>{63E6915C-7EA4-4D76-AB28-0D7191EEA626}</Project>
+      <Name>Mono.Cecil.Pdb</Name>
+    </ProjectReference>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Build Mono.Cecil.Pdb.dll in netcore illink builds to be able to handle native pdbs.