### PR TITLE
Mark methods and fields needed for types with debugger attributes.

### DIFF
--- a/linker/Mono.Linker/Driver.cs
+++ b/linker/Mono.Linker/Driver.cs
@@ -163,6 +163,9 @@ namespace Mono.Linker {
 					if (!bool.Parse (GetParam ()))
 						p.RemoveStep (typeof (RegenerateGuidStep));
 					break;
+				case 'v':
+					context.KeepMembersForDebuggerAttributes = bool.Parse (GetParam ());
+					break;
 				default:
 					Usage ("Unknown option: `" + token [1] + "'");
 					break;
@@ -293,6 +296,7 @@ namespace Mono.Linker {
 			Console.WriteLine ("   -d          Add a directory where the linker will look for assemblies");
 			Console.WriteLine ("   -b          Generate debug symbols for each linked module (true or false)");
 			Console.WriteLine ("   -g          Generate a new unique guid for each linked module (true or false)");
+			Console.WriteLine ("   -v          Keep memebers needed by debugger attributes (true or false)");
 			Console.WriteLine ("   -l          List of i18n assemblies to copy to the output directory");
 			Console.WriteLine ("                 separated with a comma: none,all,cjk,mideast,other,rare,west");
 			Console.WriteLine ("                 default is all");

--- a/linker/Mono.Linker/LinkContext.cs
+++ b/linker/Mono.Linker/LinkContext.cs
@@ -44,6 +44,7 @@ namespace Mono.Linker {
 		Hashtable _parameters;
 		bool _linkSymbols;
 		bool _keepTypeForwarderOnlyAssemblies;
+		bool _keepMembersForDebuggerAttributes;
 
 		AssemblyResolver _resolver;
 
@@ -80,6 +81,12 @@ namespace Mono.Linker {
 		{
 			get { return _keepTypeForwarderOnlyAssemblies; }
 			set { _keepTypeForwarderOnlyAssemblies = value; }
+		}
+
+		public bool KeepMembersForDebuggerAttributes
+		{
+			get { return _keepMembersForDebuggerAttributes; }
+			set { _keepMembersForDebuggerAttributes = value; }
 		}
 
 		public IDictionary Actions {


### PR DESCRIPTION
1. Keep all fields and methods in types with DebuggerDisplayAttribute.
2. Keep all fields and methods in proxy types from DebuggerTypeProxyAttribute.