### PR TITLE
Add an option to use reflection heuristics during marking step.

### DIFF
--- a/linker/Mono.Linker.Steps/MarkStep.cs
+++ b/linker/Mono.Linker.Steps/MarkStep.cs
@@ -115,6 +115,7 @@ namespace Mono.Linker.Steps {
 			while (!QueueIsEmpty ()) {
 				ProcessQueue ();
 				ProcessVirtualMethods ();
+				DoAdditionalProcessing ();
 			}
 
 			// deal with [TypeForwardedTo] pseudo-attributes
@@ -599,6 +600,11 @@ namespace Mono.Linker.Steps {
 			return type;
 		}
 
+		// Allow subclassers to mark additional things in the main processing loop
+		protected virtual void DoAdditionalProcessing()
+		{
+		}
+
 		// Allow subclassers to mark additional things when marking a method
 		protected virtual void DoAdditionalTypeProcessing (TypeDefinition method)
 		{
@@ -841,9 +847,9 @@ namespace Mono.Linker.Steps {
 				parameters [1].ParameterType.Name == "StreamingContext";
 		}
 
-		delegate bool MethodPredicate (MethodDefinition method);
+		protected delegate bool MethodPredicate (MethodDefinition method);
 
-		void MarkMethodsIf (ICollection methods, MethodPredicate predicate)
+		protected void MarkMethodsIf (ICollection methods, MethodPredicate predicate)
 		{
 			foreach (MethodDefinition method in methods)
 				if (predicate (method)) {
@@ -860,7 +866,9 @@ namespace Mono.Linker.Steps {
 			return IsConstructor (method) && !method.HasParameters;
 		}
 
-		static bool IsConstructor (MethodDefinition method)
+		protected static MethodPredicate IsConstructorPredicate = new MethodPredicate (IsConstructor);
+
+		protected static bool IsConstructor (MethodDefinition method)
 		{
 			return method.IsConstructor && !method.IsStatic;
 		}

--- a/linker/Mono.Linker.Steps/MarkStepWithReflectionHeuristics.cs
+++ b/linker/Mono.Linker.Steps/MarkStepWithReflectionHeuristics.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+namespace Mono.Linker.Steps {
+
+	public class MarkStepWithReflectionHeuristics : MarkStep {
+
+		protected ICollection<string> _reflectionHeuristics;
+
+		public MarkStepWithReflectionHeuristics (ICollection<string> reflectionHeuristics)
+		{
+			_reflectionHeuristics = reflectionHeuristics;
+		}
+
+		protected override void MarkInstruction (Instruction instruction)
+		{
+			base.MarkInstruction (instruction);
+
+			if (instruction.OpCode == OpCodes.Ldtoken) {
+				object token = instruction.Operand;
+				if (token is TypeReference) {
+					TypeDefinition type = ResolveTypeDefinition (GetOriginalType (((TypeReference) token)));
+					if (type != null) {
+						if (_reflectionHeuristics.Contains ("LdtokenTypeMethods")) {
+							MarkMethods (type);
+						}
+						if (_reflectionHeuristics.Contains  ("LdtokenTypeFields")) {
+							MarkFields (type, includeStatic: true);
+						}
+					}
+				}
+			}
+		}
+
+		protected override void DoAdditionalProcessing()
+		{
+			if (_reflectionHeuristics.Contains ("InstanceConstructors")) {
+				ProcessConstructors ();
+			}
+		}
+
+		void ProcessConstructors()
+		{
+			foreach (AssemblyDefinition assembly in _context.GetAssemblies ()) {
+				foreach (TypeDefinition type in assembly.MainModule.Types) {
+					ProcessConstructors (type);
+				}
+			}
+		}
+
+		void ProcessConstructors(TypeDefinition type)
+		{
+			if (Annotations.IsMarked (type)) {
+
+				bool hasMarkedConstructors = false;
+				bool hasMarkedInstanceMember = false;
+				foreach (var method in type.Methods) {
+					if (Annotations.IsMarked (method)) {
+						if (!method.IsStatic) {
+							hasMarkedInstanceMember = true;
+						}
+
+						if (IsConstructor (method)) {
+							hasMarkedConstructors = true;
+						}
+
+						if (hasMarkedInstanceMember && hasMarkedConstructors) {
+							break;
+						}
+					}
+				}
+
+				if (!hasMarkedConstructors) {
+					if (!hasMarkedInstanceMember) {
+						foreach (var field in type.Fields) {
+							if (!field.IsStatic && Annotations.IsMarked (field)) {
+								hasMarkedInstanceMember = true;
+								break;
+							}
+						}
+					}
+
+					if (hasMarkedInstanceMember) {
+						MarkMethodsIf (type.Methods, IsConstructorPredicate);
+					}
+				}
+
+				foreach (var nestedType in type.NestedTypes) {
+					ProcessConstructors (nestedType);
+				}
+			}
+		}
+	}
+}

--- a/linker/Mono.Linker.csproj
+++ b/linker/Mono.Linker.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Mono.Linker.Steps\IStep.cs" />
     <Compile Include="Mono.Linker.Steps\LoadReferencesStep.cs" />
     <Compile Include="Mono.Linker.Steps\MarkStep.cs" />
+    <Compile Include="Mono.Linker.Steps\MarkStepWithReflectionHeuristics.cs" />
     <Compile Include="Mono.Linker.Steps\OutputStep.cs" />
     <Compile Include="Mono.Linker.Steps\ResolveFromXApiStep.cs" />
     <Compile Include="Mono.Linker.Steps\ResolveFromAssemblyStep.cs" />

--- a/linker/Mono.Linker/Driver.cs
+++ b/linker/Mono.Linker/Driver.cs
@@ -28,6 +28,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using SR = System.Reflection;
 using System.Xml.XPath;
@@ -165,6 +166,10 @@ namespace Mono.Linker {
 					break;
 				case 'v':
 					context.KeepMembersForDebuggerAttributes = bool.Parse (GetParam ());
+						break;
+				case 'h':
+					ICollection<string> reflectionHeuristics = ParseReflectionHeuristics (GetParam ());
+					p.ReplaceStep (typeof (MarkStep), new MarkStepWithReflectionHeuristics (reflectionHeuristics));
 					break;
 				default:
 					Usage ("Unknown option: `" + token [1] + "'");
@@ -254,6 +259,16 @@ namespace Mono.Linker {
 			return assemblies;
 		}
 
+		protected static ICollection<string> ParseReflectionHeuristics(string str)
+		{
+			HashSet<string> heuristics = new HashSet<string> (StringComparer.OrdinalIgnoreCase);
+			string[] parts = str.Split (',');
+			foreach (string part in parts)
+				heuristics.Add (part);
+
+			return heuristics;
+		}
+
 		static AssemblyAction ParseAssemblyAction (string s)
 		{
 			return (AssemblyAction) Enum.Parse (typeof (AssemblyAction), s, true);
@@ -297,6 +312,15 @@ namespace Mono.Linker {
 			Console.WriteLine ("   -b          Generate debug symbols for each linked module (true or false)");
 			Console.WriteLine ("   -g          Generate a new unique guid for each linked module (true or false)");
 			Console.WriteLine ("   -v          Keep memebers needed by debugger attributes (true or false)");
+			Console.WriteLine ("   -h          List of reflection heuristics separated with a comma.");
+			Console.WriteLine ("               Supported heuristics:");
+			Console.WriteLine ("                 LdtokenTypeMethods:   mark all methods of types whose token is used");
+			Console.WriteLine ("                                       in an ldtoken instruction");
+			Console.WriteLine ("                 LdtokenTypeFields:    mark all fields of types whose token is used");
+			Console.WriteLine ("                                       in an ldtoken instruction");
+			Console.WriteLine ("                 InstanceConstructors: mark all instance constructors in types");
+			Console.WriteLine ("                                       where an instance member has been marked but");
+			Console.WriteLine ("                                       none of the instance constructors have been marked");
 			Console.WriteLine ("   -l          List of i18n assemblies to copy to the output directory");
 			Console.WriteLine ("                 separated with a comma: none,all,cjk,mideast,other,rare,west");
 			Console.WriteLine ("                 default is all");


### PR DESCRIPTION
This change adds a -h option that can specify heuristics for keeping
types/methods/fields that may be needed for reflection. Three simple
and coarse-grained heuristic options are added initially (all are off by default):

1. "LdtokenTypeMethods": mark all methods of types whose token is used
in an ldtoken instruction.
2. "LdtokenTypeFields": mark all fields of types whose token is used
in an ldtoken instruction.
3. "InstanceConstructors": mark all instance constructors in types
where an instance member has been marked but none of the instance
constructors have been marked. (The type is likely to be instantiated via CreateInstance).

When -h is specified MarkStep is replaced with MarkStepWithReflectionHeuristics that
derives from MarkStep. The names of heuristics are specified in a comma-separated list.
More heuristics will be added over time and any subset of them can be used for a particular
linker invocation.