### PR TITLE
AssemblyCache: Index by Assemblyname, instead of file name

### DIFF
--- a/linker/Mono.Linker/AssemblyResolver.cs
+++ b/linker/Mono.Linker/AssemblyResolver.cs
@@ -61,7 +61,7 @@ namespace Mono.Linker {
 			AssemblyDefinition asm = (AssemblyDefinition) _assemblies [name.Name];
 			if (asm == null) {
 				asm = base.Resolve (name, parameters);
-				_assemblies [name.Name] = asm;
+				_assemblies [asm.Name.Name] = asm;
 			}
 
 			return asm;


### PR DESCRIPTION
Currently, if we have a file containing a module with a different name, the linker crashes in the mark step.

If A.exe contains a module B, when A.exe is processed by the linker, the assembly is entered AssemblyCache as _assemblies["A"]. However, when the linker is marking the methods, it looks for methods in assembly scope `B`. It cannot find it in the assembly-cache or a file named B.exe/B.dll and therefore fails.

This change fixes the problem by inserting assemblies to the cache by assembly-name, and not file name.

Fixes #61