### PR TITLE
Support a custom annotation store

### DIFF
--- a/linker/Mono.Linker/LinkContext.cs
+++ b/linker/Mono.Linker/LinkContext.cs
@@ -121,17 +121,18 @@ namespace Mono.Linker {
 			: this(pipeline, resolver, new ReaderParameters
 			{
 				AssemblyResolver = resolver
-			})
+			},
+			new AnnotationStore ())
 		{
 		}
 
-		public LinkContext (Pipeline pipeline, AssemblyResolver resolver, ReaderParameters readerParameters)
+		public LinkContext (Pipeline pipeline, AssemblyResolver resolver, ReaderParameters readerParameters, AnnotationStore annotations)
 		{
 			_pipeline = pipeline;
 			_resolver = resolver;
 			_actions = new Dictionary<string, AssemblyAction> ();
 			_parameters = new Dictionary<string, string> ();
-			_annotations = new AnnotationStore ();
+			_annotations = annotations;
 			_readerParameters = readerParameters;
 		}
 


### PR DESCRIPTION
We have our own AnnotationsStore that we want to pass in to the LinkContext, this change exposes the ability to create our own instance and pass it in when we construct the LinkContext