### PR TITLE
Dispose of loaded assembly definitions

### DIFF
--- a/linker/Mono.Linker/AssemblyResolver.cs
+++ b/linker/Mono.Linker/AssemblyResolver.cs
@@ -71,5 +71,14 @@ namespace Mono.Linker {
 			_assemblies [assembly.Name.Name] = assembly;
 			base.AddSearchDirectory (Path.GetDirectoryName (assembly.MainModule.FileName));
 		}
+
+		protected override void Dispose (bool disposing)
+		{
+			foreach (var asm in _assemblies.Values) {
+				asm.Dispose ();
+			}
+
+			_assemblies.Clear ();
+		}
 	}
 }

--- a/linker/Mono.Linker/Driver.cs
+++ b/linker/Mono.Linker/Driver.cs
@@ -77,109 +77,110 @@ namespace Mono.Linker {
 		void Run ()
 		{
 			Pipeline p = GetStandardPipeline ();
-			LinkContext context = GetDefaultContext (p);
-			I18nAssemblies assemblies = I18nAssemblies.All;
-			var custom_steps = new List<string> ();
+			using (LinkContext context = GetDefaultContext (p)) {
+				I18nAssemblies assemblies = I18nAssemblies.All;
+				var custom_steps = new List<string> ();
 
-			bool resolver = false;
-			while (HaveMoreTokens ()) {
-				string token = GetParam ();
-				if (token.Length < 2)
-					Usage ("Option is too short");
-
-				if (! (token [0] == '-' || token [1] == '/'))
-					Usage ("Expecting an option, got instead: " + token);
-
-				if (token [0] == '-' && token [1] == '-') {
-
-					if (token.Length < 3)
+				bool resolver = false;
+				while (HaveMoreTokens ()) {
+					string token = GetParam ();
+					if (token.Length < 2)
 						Usage ("Option is too short");
 
-					switch (token [2]) {
-					case 'v':
-						Version ();
+					if (!(token [0] == '-' || token [1] == '/'))
+						Usage ("Expecting an option, got instead: " + token);
+
+					if (token [0] == '-' && token [1] == '-') {
+
+						if (token.Length < 3)
+							Usage ("Option is too short");
+
+						switch (token [2]) {
+						case 'v':
+							Version ();
+							break;
+						case 'a':
+							About ();
+							break;
+						default:
+							Usage (null);
+							break;
+						}
+					}
+
+					switch (token [1]) {
+					case 'd': {
+						DirectoryInfo info = new DirectoryInfo (GetParam ());
+						context.Resolver.AddSearchDirectory (info.FullName);
 						break;
+					}
+					case 'o':
+						context.OutputDirectory = GetParam ();
+						break;
+					case 'c':
+						context.CoreAction = ParseAssemblyAction (GetParam ());
+						break;
+					case 'p':
+						AssemblyAction action = ParseAssemblyAction (GetParam ());
+						context.Actions [GetParam ()] = action;
+						break;
+					case 's':
+						custom_steps.Add (GetParam ());
+						break;
+					case 't':
+						context.KeepTypeForwarderOnlyAssemblies = true;
+						break;
+					case 'x':
+						foreach (string file in GetFiles (GetParam ()))
+							p.PrependStep (new ResolveFromXmlStep (new XPathDocument (file)));
+						resolver = true;
+						break;
+					case 'r':
 					case 'a':
-						About ();
+						var rootVisibility = (token [1] == 'r')
+							? ResolveFromAssemblyStep.RootVisibility.PublicAndFamily
+							: ResolveFromAssemblyStep.RootVisibility.Any;
+						foreach (string file in GetFiles (GetParam ()))
+							p.PrependStep (new ResolveFromAssemblyStep (file, rootVisibility));
+						resolver = true;
+						break;
+					case 'i':
+						foreach (string file in GetFiles (GetParam ()))
+							p.PrependStep (new ResolveFromXApiStep (new XPathDocument (file)));
+						resolver = true;
+						break;
+					case 'l':
+						assemblies = ParseI18n (GetParam ());
+						break;
+					case 'm':
+						context.SetParameter (GetParam (), GetParam ());
+						break;
+					case 'b':
+						context.LinkSymbols = bool.Parse (GetParam ());
+						break;
+					case 'g':
+						if (!bool.Parse (GetParam ()))
+							p.RemoveStep (typeof (RegenerateGuidStep));
+						break;
+					case 'v':
+						context.KeepMembersForDebuggerAttributes = bool.Parse (GetParam ());
 						break;
 					default:
-						Usage (null);
+						Usage ("Unknown option: `" + token [1] + "'");
 						break;
 					}
 				}
 
-				switch (token [1]) {
-				case 'd': {
-					DirectoryInfo info = new DirectoryInfo (GetParam ());
-					context.Resolver.AddSearchDirectory (info.FullName);
-					break;
-				}
-				case 'o':
-					context.OutputDirectory = GetParam ();
-					break;
-				case 'c':
-					context.CoreAction = ParseAssemblyAction (GetParam ());
-					break;
-				case 'p':
-					AssemblyAction action = ParseAssemblyAction (GetParam ());
-					context.Actions [GetParam ()] = action;
-					break;
-				case 's':
-					custom_steps.Add (GetParam ());
-					break;
-				case 't':
-					context.KeepTypeForwarderOnlyAssemblies = true;
-					break;
-				case 'x':
-					foreach (string file in GetFiles (GetParam ()))
-						p.PrependStep (new ResolveFromXmlStep (new XPathDocument (file)));
-					resolver = true;
-					break;
-				case 'r':
-				case 'a':
-					var rootVisibility = (token[1] == 'r')
-							? ResolveFromAssemblyStep.RootVisibility.PublicAndFamily
-							: ResolveFromAssemblyStep.RootVisibility.Any;
-					foreach (string file in GetFiles (GetParam ()))
-						p.PrependStep (new ResolveFromAssemblyStep (file, rootVisibility));
-					resolver = true;
-					break;
-				case 'i':
-					foreach (string file in GetFiles (GetParam ()))
-						p.PrependStep (new ResolveFromXApiStep (new XPathDocument (file)));
-					resolver = true;
-					break;
-				case 'l':
-					assemblies = ParseI18n (GetParam ());
-					break;
-				case 'm':
-					context.SetParameter (GetParam (), GetParam ());
-					break;
-				case 'b':
-					context.LinkSymbols = bool.Parse (GetParam ());
-					break;
-				case 'g':
-					if (!bool.Parse (GetParam ()))
-						p.RemoveStep (typeof (RegenerateGuidStep));
-					break;
-				case 'v':
-					context.KeepMembersForDebuggerAttributes = bool.Parse (GetParam ());
-					break;
-				default:
-					Usage ("Unknown option: `" + token [1] + "'");
-					break;
-				}
+				if (!resolver)
+					Usage ("No resolver was created (use -x, -a or -i)");
+
+				foreach (string custom_step in custom_steps)
+					AddCustomStep (p, custom_step);
+
+				p.AddStepAfter (typeof (LoadReferencesStep), new LoadI18nAssemblies (assemblies));
+
+				p.Process (context);
 			}
-
-			if (!resolver)
-				Usage ("No resolver was created (use -x, -a or -i)");
-
-			foreach (string custom_step in custom_steps)
-				AddCustomStep (p, custom_step);
-
-			p.AddStepAfter (typeof (LoadReferencesStep), new LoadI18nAssemblies (assemblies));
-
-			p.Process (context);
 		}
 
 		protected static void AddCustomStep (Pipeline pipeline, string arg)

--- a/linker/Mono.Linker/LinkContext.cs
+++ b/linker/Mono.Linker/LinkContext.cs
@@ -34,7 +34,7 @@ using Mono.Cecil.Cil;
 
 namespace Mono.Linker {
 
-	public class LinkContext {
+	public class LinkContext : IDisposable {
 
 		Pipeline _pipeline;
 		AssemblyAction _coreAction;
@@ -295,6 +295,11 @@ namespace Mono.Linker {
 			string val = null;
 			_parameters.TryGetValue (key, out val);
 			return val;
+		}
+
+		public void Dispose ()
+		{
+			_resolver.Dispose ();
 		}
 	}
 }


### PR DESCRIPTION
Not disposing of the assembly definitions leads to file access
exceptions.

This is not causing any issues today since there is nothing that runs
the linker multiple times within the same process.

However, the new test framework does, and the lack of assembly def
disposal leads to file access exceptions during all tests after the
first.