### PR TITLE
FIX - GenericParam count on method not taken into consideration

### DIFF
--- a/linker/Mono.Linker.Steps/TypeMapStep.cs
+++ b/linker/Mono.Linker.Steps/TypeMapStep.cs
@@ -215,6 +215,9 @@ namespace Mono.Linker.Steps {
 			if (cp.Count != mp.Count)
 				return false;
 
+			if (candidate.GenericParameters.Count != method.GenericParameters.Count)
+				return false;
+
 			for (int i = 0; i < cp.Count; i++) {
 				if (!TypeMatch (cp [i].ParameterType, mp [i].ParameterType, ref genericParameters))
 					return false;


### PR DESCRIPTION
Could result in a base class method with the same name as a derived method, but a different number of generic parameters , not being stripped when it should have been.

I brought the test we wrote for this fix over to the new test framework branch.  The link to the change set is https://github.com/Unity-Technologies/linker/commit/1f3e74972be7aed20b65ffa4ffe0214d0d0d0fa3.

