### PR TITLE
Changes to allow tracking of all removals during sweep step

### DIFF
--- a/linker/Mono.Linker.Steps/SweepStep.cs
+++ b/linker/Mono.Linker.Steps/SweepStep.cs
@@ -94,6 +94,8 @@ namespace Mono.Linker.Steps {
 
 				if (type.Name == "<Module>")
 					types.Add (type);
+				else
+					ElementRemoved (type);
 			}
 
 			assembly.MainModule.Types.Clear ();
@@ -137,6 +139,7 @@ namespace Mono.Linker.Steps {
 				if (!AreSameReference (r.Name, target.Name))
 					continue;
 
+				ReferenceRemoved (assembly, references [i]);
 				references.RemoveAt (i);
 				// Removing the reference does not mean it will be saved back to disk!
 				// That depends on the AssemblyAction set for the `assembly`
@@ -230,6 +233,7 @@ namespace Mono.Linker.Steps {
 				if (Annotations.IsMarked (nested)) {
 					SweepType (nested);
 				} else {
+					ElementRemoved (type.NestedTypes [i]);
 					type.NestedTypes.RemoveAt (i--);
 				}
 			}
@@ -290,8 +294,10 @@ namespace Mono.Linker.Steps {
 		protected void SweepCollection<T> (IList<T> list) where T : IMetadataTokenProvider
 		{
 			for (int i = 0; i < list.Count; i++)
-				if (!Annotations.IsMarked (list [i]))
+				if (!Annotations.IsMarked (list [i])) {
+					ElementRemoved (list [i]);
 					list.RemoveAt (i--);
+				}
 		}
 
 		static bool AreSameReference (AssemblyNameReference a, AssemblyNameReference b)
@@ -306,6 +312,14 @@ namespace Mono.Linker.Steps {
 				return false;
 
 			return true;
+		}
+
+		protected virtual void ElementRemoved (IMetadataTokenProvider element)
+		{
+		}
+
+		protected virtual void ReferenceRemoved (AssemblyDefinition assembly, AssemblyNameReference reference)
+		{
 		}
 	}
 }


### PR DESCRIPTION
Our sweep step does some information gathering and outputs a report at the end.  We need to add some callbacks so that our sweep step can track all removals.