### PR TITLE
Fix unused interface method not being removed

### DIFF
--- a/linker/Mono.Linker.Steps/TypeMapStep.cs
+++ b/linker/Mono.Linker.Steps/TypeMapStep.cs
@@ -70,7 +70,7 @@ namespace Mono.Linker.Steps {
 					if (@base == null)
 						continue;
 
-					Annotations.AddPreservedMethod (type, @base);
+					AnnotateMethods (method, @base);
 				}
 			}
 		}


### PR DESCRIPTION
Fix a case where a class interface member is not removed when it is not used.

Our unit test for this case has already been ported to the new test framework.  You can find it here
https://github.com/Unity-Technologies/linker/blob/unity-master-new-test-framework-upstream-compat/linker/Tests2/Mono.Linker.Tests.Cases/Basic/InterfaceMethodImplementedOnBaseClassDoesNotGetStripped.cs

Here is the output from our failed test.

Expected Base::Unused() to not exist, but it did
*******************
Available method were: 
*******************
	System.Void I1::Used()
	System.Void Base::Unused()
	System.Void Base::Used()
	System.Void Base::.ctor()
	System.Void Derived::.ctor()
	System.Void Entry::Main()
*******************

