### PR TITLE
Don't preserve default constructor and fields when IsImport is true

### DIFF
--- a/linker/Mono.Linker.Steps/MarkStep.cs
+++ b/linker/Mono.Linker.Steps/MarkStep.cs
@@ -1328,7 +1328,7 @@ namespace Mono.Linker.Steps {
 		{
 			TypeDefinition returnTypeDefinition = ResolveTypeDefinition (method.ReturnType);
 			const bool includeStaticFields = false;
-			if (returnTypeDefinition != null) {
+			if (returnTypeDefinition != null && !returnTypeDefinition.IsImport) {
 				MarkDefaultConstructor (returnTypeDefinition);
 				MarkFields (returnTypeDefinition, includeStaticFields);
 			}
@@ -1343,7 +1343,7 @@ namespace Mono.Linker.Steps {
 					paramTypeReference = (paramTypeReference as TypeSpecification).ElementType;
 				}
 				TypeDefinition paramTypeDefinition = ResolveTypeDefinition (paramTypeReference);
-				if (paramTypeDefinition != null) {
+				if (paramTypeDefinition != null && !paramTypeDefinition.IsImport) {
 					MarkFields (paramTypeDefinition, includeStaticFields);
 					if (pd.ParameterType.IsByReference) {
 						MarkDefaultConstructor (paramTypeDefinition);

--- a/linker/Mono.Linker.Steps/MarkStep.cs
+++ b/linker/Mono.Linker.Steps/MarkStep.cs
@@ -1333,7 +1333,7 @@ namespace Mono.Linker.Steps {
 				MarkFields (returnTypeDefinition, includeStaticFields);
 			}
 
-			if (method.HasThis) {
+			if (method.HasThis && !method.DeclaringType.IsImport) {
 				MarkFields (method.DeclaringType, includeStaticFields);
 			}
 


### PR DESCRIPTION
I updated our fork with the latest upstream changes and one of our Window Runtime related tests started failing.  The behavior change that lead to the failure was the introduction of processing methods with IsInternalCall in https://github.com/mono/linker/pull/27

For ComImport types, we don't need to preserve the default constructor and fields.  I don't fully understand this one, so I'm going to let others who know more about it provide additional commentary :smile:

If this PR ends up landing, I will add new unit tests