### PR TITLE
Fix assembly resolution exception that would happen during every test

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Core/Mono.Linker.Tests.Core.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Core/Mono.Linker.Tests.Core.csproj
@@ -68,6 +68,10 @@
       <Project>{d68133bd-1e63-496e-9ede-4fbdbf77b486}</Project>
       <Name>Mono.Cecil</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\Mono.Linker.csproj">
+      <Project>{dd28e2b1-057b-4b4d-a04d-b2ebd9e76e46}</Project>
+      <Name>Mono.Linker</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Mono.Linker.Tests.Cases.Expectations\Mono.Linker.Tests.Cases.Expectations.csproj">
       <Project>{2c26601f-3e2f-45b9-a02f-58ee9296e19e}</Project>
       <Name>Mono.Linker.Tests.Cases.Expectations</Name>


### PR DESCRIPTION
Fix assembly resolution exception that would happen during every test

The reason this issue started when the tests were moved upstream was due to a behavior change in the newer nunit.  nunit/nunit#1072

This PR implements more explicit resolution for the input & output which is more correct anyways