### PR TITLE
Test framework check and collect tweaking

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Core/Customizable/ObjectFactory.cs
+++ b/linker/Tests/Mono.Linker.Tests.Core/Customizable/ObjectFactory.cs
@@ -16,12 +16,7 @@ namespace Mono.Linker.Tests.Core.Customizable {
 		{
 			return new LinkerDriver ();
 		}
-
-		public virtual ResultChecker CreateChecker (ExpectationsProvider expectations)
-		{
-			return new ResultChecker (expectations);
-		}
-
+		
 		public virtual TestCaseMetadaProvider CreateMetadatProvider (TestCase testCase, AssemblyDefinition fullTestCaseAssemblyDefinition)
 		{
 			return new TestCaseMetadaProvider (testCase, fullTestCaseAssemblyDefinition);

--- a/linker/Tests/Mono.Linker.Tests.Core/TestRunner.cs
+++ b/linker/Tests/Mono.Linker.Tests.Core/TestRunner.cs
@@ -12,7 +12,7 @@ namespace Mono.Linker.Tests.Core {
 			_factory = factory;
 		}
 
-		public void Run (TestCase testCase)
+		public LinkedTestCaseResult Run (TestCase testCase)
 		{
 			using (var fullTestCaseAssemblyDefinition = AssemblyDefinition.ReadAssembly (testCase.OriginalTestCaseAssemblyPath.ToString ())) {
 				var metadataProvider = _factory.CreateMetadatProvider (testCase, fullTestCaseAssemblyDefinition);
@@ -24,8 +24,7 @@ namespace Mono.Linker.Tests.Core {
 				var sandbox = Sandbox (testCase, metadataProvider);
 				var compilationResult = Compile (sandbox, metadataProvider);
 				PrepForLink (sandbox, compilationResult);
-				var linkResult = Link (testCase, sandbox, compilationResult, metadataProvider);
-				Check (linkResult);
+				return Link (testCase, sandbox, compilationResult, metadataProvider);
 			}
 		}
 
@@ -67,13 +66,6 @@ namespace Mono.Linker.Tests.Core {
 			linker.Link (builder.ToArgs ());
 
 			return new LinkedTestCaseResult (testCase, compilationResult.AssemblyPath, sandbox.OutputDirectory.Combine (compilationResult.AssemblyPath.FileName));
-		}
-
-		private void Check (LinkedTestCaseResult linkResult)
-		{
-			var checker = _factory.CreateChecker (_factory.CreateExpectationsProvider ());
-
-			checker.Check (linkResult);
 		}
 	}
 }

--- a/linker/Tests/TestsCases/TestSuites.cs
+++ b/linker/Tests/TestsCases/TestSuites.cs
@@ -70,7 +70,8 @@ namespace Mono.Linker.Tests.TestsCases
 		protected virtual void Run (TestCase testCase)
 		{
 			var runner = new TestRunner (new ObjectFactory ());
-			runner.Run (testCase);
+			var linkedResult = runner.Run (testCase);
+			new ResultChecker ().Check (linkedResult);
 		}
 	}
 }


### PR DESCRIPTION
I'm converting some of our tests to the new scheme that have non-linking related Assertion requirements.

For example, the tests that verify our Sweep Report I made a reference to last week need to Assert a SweepReport.log file is written and do a little light weight processing of the file to verify that it is correct

For tests like this, I want to leverage the TestCaseCollector & TestRunner, but the [Test] itself is going to end up doing all of the Assert's rather than relying on ResultChecker

This PR moves some things around to make writing [Test]'s like this easier.

* Shuffle around collector public API's to make it more reusable

* Pull result checking out of TestRunner.