### PR TITLE
Bring over more test cases

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases/Generics/CorrectOverloadedMethodGetsStrippedInGenericClass.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Generics/CorrectOverloadedMethodGetsStrippedInGenericClass.cs
@@ -1,0 +1,36 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Generics {
+	class CorrectOverloadedMethodGetsStrippedInGenericClass {
+		public static void Main ()
+		{
+			// Call overloaded method through the abstract base class
+			GenericClassWithTwoOverloadedAbstractMethods<float> item = new SpecializedClassWithTwoOverloadedVirtualMethods ();
+			item.OverloadedMethod (5);
+		}
+
+		public abstract class GenericClassWithTwoOverloadedAbstractMethods<T> {
+			[Removed]
+			public abstract string OverloadedMethod (T thing); // Don't call this one, it should be stripped
+
+			[Kept]
+			public abstract string OverloadedMethod (int thing); // Call to this should preserve the overriden one
+		}
+
+		public class SpecializedClassWithTwoOverloadedVirtualMethods : GenericClassWithTwoOverloadedAbstractMethods<float> {
+			// Don't call this one, it should be stripped
+			[Removed]
+			public override string OverloadedMethod (float thing)
+			{
+				return "first";
+			}
+
+			// Don't call this one, but it shouldn't be stripped because the method it overrides is invoked
+			[Kept]
+			public override string OverloadedMethod (int thing)
+			{
+				return "second";
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -59,6 +59,7 @@
     <Compile Include="CoreLink\LinkingOfCoreLibrariesRemovesUnusedTypes.cs" />
     <Compile Include="Future\DeadCodeElimination1.cs" />
     <Compile Include="Future\FieldThatOnlyGetsSetIsRemoved.cs" />
+    <Compile Include="Generics\CorrectOverloadedMethodGetsStrippedInGenericClass.cs" />
     <Compile Include="Generics\DerivedClassWithMethodOfSameNameAsBaseButDifferentNumberOfGenericParametersUnusedBaseWillGetStripped.cs" />
     <Compile Include="Generics\GenericInstanceInterfaceMethodImplementedWithDifferentGenericArgumentNameDoesNotGetStripped.cs" />
     <Compile Include="Generics\MethodWithParameterWhichHasGenericParametersAndOverrideUsesADifferentNameForGenericParameter.cs" />
@@ -80,6 +81,11 @@
     <Compile Include="Interop\UnusedTypeWithSequentialLayoutIsRemoved.cs" />
     <Compile Include="LinkXml\UnusedTypePreservedByLinkXmlIsKept.cs" />
     <Compile Include="References\ReferencesAreRemovedWhenAllUsagesAreRemoved.cs" />
+    <Compile Include="VirtualMethods\ClassImplemtingInterfaceMethodsThroughBaseClass2.cs" />
+    <Compile Include="VirtualMethods\ClassImplemtingInterfaceMethodsThroughBaseClass3.cs" />
+    <Compile Include="VirtualMethods\ClassImplemtingInterfaceMethodsThroughBaseClass4.cs" />
+    <Compile Include="VirtualMethods\ClassImplemtingInterfaceMethodsThroughBaseClass5.cs" />
+    <Compile Include="VirtualMethods\ClassImplemtingInterfaceMethodsThroughBaseClass6.cs" />
     <Compile Include="VirtualMethods\HarderToDetectUnusedVirtualMethodGetsRemoved.cs" />
     <Compile Include="Basic\UnusedClassGetsRemoved.cs" />
     <Compile Include="Basic\UnusedNestedClassGetsRemoved.cs" />
@@ -91,6 +97,8 @@
     <Compile Include="Generics\UsedOverloadedGenericMethodWithNoParametersIsNotStripped.cs" />
     <Compile Include="Statics\UnusedStaticConstructorGetsRemoved.cs" />
     <Compile Include="VirtualMethods\TypeGetsMarkedThatImplementsAlreadyMarkedInterfaceMethod.cs" />
+    <Compile Include="VirtualMethods\VirtualMethodGetsPerservedIfBaseMethodGetsInvoked.cs" />
+    <Compile Include="VirtualMethods\VirtualMethodGetsStrippedIfImplementingMethodGetsInvokedDirectly.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="LinkXml\UnusedTypePreservedByLinkXmlIsKept.xml" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/VirtualMethods/ClassImplemtingInterfaceMethodsThroughBaseClass2.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/VirtualMethods/ClassImplemtingInterfaceMethodsThroughBaseClass2.cs
@@ -1,0 +1,29 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.VirtualMethods {
+	[IgnoreTestCase ("This test fails and is ignored for an unknown reason. We should investigate this more.")]
+	class ClassImplemtingInterfaceMethodsThroughBaseClass2 {
+		public static void Main ()
+		{
+			new B ();
+			IFoo i = null;
+			i.Foo ();
+		}
+
+		interface IFoo {
+			[Kept]
+			void Foo ();
+		}
+
+		class B {
+			[Removed]
+			public void Foo ()
+			{
+			}
+		}
+
+		class A : B, IFoo {
+			//my IFoo.Foo() is actually implemented by B which doesn't know about it.
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/VirtualMethods/ClassImplemtingInterfaceMethodsThroughBaseClass3.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/VirtualMethods/ClassImplemtingInterfaceMethodsThroughBaseClass3.cs
@@ -1,0 +1,26 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.VirtualMethods {
+	class ClassImplemtingInterfaceMethodsThroughBaseClass3 {
+		public static void Main ()
+		{
+			new B ().Foo ();
+		}
+
+		interface IFoo {
+			[Removed]
+			void Foo ();
+		}
+
+		class B {
+			[Kept]
+			public void Foo ()
+			{
+			}
+		}
+
+		class A : B, IFoo {
+			//my IFoo.Foo() is actually implemented by B which doesn't know about it.
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/VirtualMethods/ClassImplemtingInterfaceMethodsThroughBaseClass4.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/VirtualMethods/ClassImplemtingInterfaceMethodsThroughBaseClass4.cs
@@ -1,0 +1,26 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.VirtualMethods {
+	class ClassImplemtingInterfaceMethodsThroughBaseClass4 {
+		public static void Main ()
+		{
+			new A ().Foo ();
+		}
+
+		interface IFoo {
+			[Removed]
+			void Foo ();
+		}
+
+		class B {
+			[Kept]
+			public void Foo ()
+			{
+			}
+		}
+
+		class A : B, IFoo {
+			//my IFoo.Foo() is actually implemented by B which doesn't know about it.
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/VirtualMethods/ClassImplemtingInterfaceMethodsThroughBaseClass5.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/VirtualMethods/ClassImplemtingInterfaceMethodsThroughBaseClass5.cs
@@ -1,0 +1,26 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.VirtualMethods {
+	class ClassImplemtingInterfaceMethodsThroughBaseClass5 {
+		public static void Main ()
+		{
+			new A ();
+		}
+
+		interface IFoo {
+			[Removed]
+			void Foo ();
+		}
+
+		class B {
+			[Removed]
+			public void Foo ()
+			{
+			}
+		}
+
+		class A : B, IFoo {
+			//my IFoo.Foo() is actually implemented by B which doesn't know about it.
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/VirtualMethods/ClassImplemtingInterfaceMethodsThroughBaseClass6.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/VirtualMethods/ClassImplemtingInterfaceMethodsThroughBaseClass6.cs
@@ -1,0 +1,36 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.VirtualMethods {
+	[IgnoreTestCase ("This test fails and is ignored for an unknown reason. We should investigate this more.")]
+	class ClassImplemtingInterfaceMethodsThroughBaseClass6 {
+		public static void Main ()
+		{
+			B tmp = new B ();
+			IFoo i = new C ();
+			i.Foo ();
+		}
+
+		interface IFoo {
+			[Kept]
+			void Foo ();
+		}
+
+		class B {
+			[Removed]
+			public void Foo ()
+			{
+			}
+		}
+
+		class A : B, IFoo {
+			//my IFoo.Foo() is actually implemented by B which doesn't know about it.
+		}
+
+		class C : IFoo {
+			[Kept]
+			public void Foo ()
+			{
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/VirtualMethods/VirtualMethodGetsPerservedIfBaseMethodGetsInvoked.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/VirtualMethods/VirtualMethodGetsPerservedIfBaseMethodGetsInvoked.cs
@@ -1,0 +1,25 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.VirtualMethods {
+	class VirtualMethodGetsPerservedIfBaseMethodGetsInvoked {
+		public static void Main ()
+		{
+			new A ();
+			new B ().Foo ();
+		}
+
+		class B {
+			[Kept]
+			public virtual void Foo ()
+			{
+			}
+		}
+
+		class A : B {
+			[Kept]
+			public override void Foo ()
+			{
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/VirtualMethods/VirtualMethodGetsStrippedIfImplementingMethodGetsInvokedDirectly.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/VirtualMethods/VirtualMethodGetsStrippedIfImplementingMethodGetsInvokedDirectly.cs
@@ -1,0 +1,25 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.VirtualMethods {
+	[IgnoreTestCase ("We would like this to be true, but it is not yet today")]
+	class VirtualMethodGetsStrippedIfImplementingMethodGetsInvokedDirectly {
+		public static void Main ()
+		{
+			new A ().Foo ();
+		}
+
+		class B {
+			[Removed]
+			public virtual void Foo ()
+			{
+			}
+		}
+
+		class A : B {
+			[Kept]
+			public override void Foo ()
+			{
+			}
+		}
+	}
+}


### PR DESCRIPTION
Bring over more of the Unity virtual method unit tests.

Note : CorrectOverloadedMethodGetsStrippedInGenericClass is currently failing.  It is fixed by https://github.com/mono/linker/pull/29