### PR TITLE
Test framework - No test framework attributes in linker input assembly

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/BaseExpectedLinkedBehaviorAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/BaseExpectedLinkedBehaviorAttribute.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Diagnostics;
 
 namespace Mono.Linker.Tests.Cases.Expectations.Assertions {
 	/// <summary>
 	/// Base attribute for attributes that mark up the expected behavior of the linker on a member
 	/// </summary>
+	[Conditional("INCLUDE_EXPECTATIONS")]
 	public abstract class BaseExpectedLinkedBehaviorAttribute : Attribute {
 	}
 }

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptInterfaceAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptInterfaceAttribute.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Diagnostics;
+
 namespace Mono.Linker.Tests.Cases.Expectations.Assertions
 {
 	[AttributeUsage (AttributeTargets.Class, AllowMultiple = true, Inherited = false)]

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/BaseMetadataAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/BaseMetadataAttribute.cs
@@ -1,0 +1,9 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Metadata
+{
+	[Conditional("INCLUDE_EXPECTATIONS")]
+	public abstract class BaseMetadataAttribute : Attribute {
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/CoreLinkAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/CoreLinkAttribute.cs
@@ -2,7 +2,7 @@
 
 namespace Mono.Linker.Tests.Cases.Expectations.Metadata {
 	[AttributeUsage (AttributeTargets.Class)]
-	public class CoreLinkAttribute : Attribute {
+	public class CoreLinkAttribute : BaseMetadataAttribute {
 		public readonly string Value;
 
 		public CoreLinkAttribute (string value)

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/NotATestCaseAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/NotATestCaseAttribute.cs
@@ -2,6 +2,6 @@
 
 namespace Mono.Linker.Tests.Cases.Expectations.Metadata {
 	[AttributeUsage (AttributeTargets.Class)]
-	public class NotATestCaseAttribute : Attribute {
+	public class NotATestCaseAttribute : BaseMetadataAttribute {
 	}
 }

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/ReferenceAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/ReferenceAttribute.cs
@@ -2,7 +2,7 @@
 
 namespace Mono.Linker.Tests.Cases.Expectations.Metadata {
 	[AttributeUsage (AttributeTargets.Class)]
-	public class ReferenceAttribute : Attribute {
+	public class ReferenceAttribute : BaseMetadataAttribute {
 		public readonly string Value;
 
 		public ReferenceAttribute (string value)

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/SandboxDependencyAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/SandboxDependencyAttribute.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Mono.Linker.Tests.Cases.Expectations.Metadata {
 	[AttributeUsage (AttributeTargets.Class)]
-	public class SandboxDependencyAttribute : Attribute {
+	public class SandboxDependencyAttribute : BaseMetadataAttribute {
 		public readonly string RelativePathToFile;
 
 		public SandboxDependencyAttribute (string relativePathToFile)

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
@@ -44,6 +44,7 @@
     <Compile Include="Assertions\KeptBackingFieldAttribute.cs" />
     <Compile Include="Assertions\KeptMemberAttribute.cs" />
     <Compile Include="Assertions\RemovedAssemblyAttribute.cs" />
+    <Compile Include="Metadata\BaseMetadataAttribute.cs" />
     <Compile Include="Metadata\CoreLinkAttribute.cs" />
     <Compile Include="Metadata\NotATestCaseAttribute.cs" />
     <Compile Include="Metadata\ReferenceAttribute.cs" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -17,7 +17,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;INCLUDE_EXPECTATIONS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -25,7 +25,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;INCLUDE_EXPECTATIONS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/linker/Tests/TestCasesRunner/LinkedTestCaseResult.cs
+++ b/linker/Tests/TestCasesRunner/LinkedTestCaseResult.cs
@@ -6,12 +6,14 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 		public readonly TestCase TestCase;
 		public readonly NPath InputAssemblyPath;
 		public readonly NPath OutputAssemblyPath;
+		public readonly NPath ExpectationsAssemblyPath;
 
-		public LinkedTestCaseResult (TestCase testCase, NPath inputAssemblyPath, NPath outputAssemblyPath)
+		public LinkedTestCaseResult (TestCase testCase, NPath inputAssemblyPath, NPath outputAssemblyPath, NPath expectationsAssemblyPath)
 		{
 			TestCase = testCase;
 			InputAssemblyPath = inputAssemblyPath;
 			OutputAssemblyPath = outputAssemblyPath;
+			ExpectationsAssemblyPath = expectationsAssemblyPath;
 		}
 	}
 }

--- a/linker/Tests/TestCasesRunner/ManagedCompilationResult.cs
+++ b/linker/Tests/TestCasesRunner/ManagedCompilationResult.cs
@@ -2,11 +2,14 @@
 
 namespace Mono.Linker.Tests.TestCasesRunner {
 	public class ManagedCompilationResult {
-		public ManagedCompilationResult (NPath assemblyPath)
+		public ManagedCompilationResult (NPath inputAssemblyPath, NPath expectationsAssemblyPath)
 		{
-			AssemblyPath = assemblyPath;
+			InputAssemblyPath = inputAssemblyPath;
+			ExpectationsAssemblyPath = expectationsAssemblyPath;
 		}
 
-		public NPath AssemblyPath { get; }
+		public NPath InputAssemblyPath { get; }
+
+		public NPath ExpectationsAssemblyPath { get; }
 	}
 }

--- a/linker/Tests/TestCasesRunner/ResultChecker.cs
+++ b/linker/Tests/TestCasesRunner/ResultChecker.cs
@@ -11,7 +11,7 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 		{
 			Assert.IsTrue (linkResult.OutputAssemblyPath.FileExists (), $"The linked output assembly was not found.  Expected at {linkResult.OutputAssemblyPath}");
 
-			using (var original = ReadAssembly (linkResult.InputAssemblyPath)) {
+			using (var original = ReadAssembly (linkResult.ExpectationsAssemblyPath)) {
 				PerformOutputAssemblyChecks (original.Definition, linkResult.OutputAssemblyPath.Parent);
 
 				using (var linked = ReadAssembly (linkResult.OutputAssemblyPath)) {

--- a/linker/Tests/TestCasesRunner/TestCaseSandbox.cs
+++ b/linker/Tests/TestCasesRunner/TestCaseSandbox.cs
@@ -34,18 +34,25 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 
 			InputDirectory = _directory.Combine ("input").EnsureDirectoryExists ();
 			OutputDirectory = _directory.Combine ("output").EnsureDirectoryExists ();
+			ExpectationsDirectory = _directory.Combine ("expectations").EnsureDirectoryExists ();
 		}
 
 		public NPath InputDirectory { get; }
 
 		public NPath OutputDirectory { get; }
 
+		public NPath ExpectationsDirectory { get; }
+
 		public IEnumerable<NPath> SourceFiles {
 			get { return _directory.Files ("*.cs"); }
 		}
 
-		public IEnumerable<NPath> References {
+		public IEnumerable<NPath> InputDirectoryReferences {
 			get { return InputDirectory.Files ("*.dll"); }
+		}
+
+		public IEnumerable<NPath> ExpectationsDirectoryReferences {
+			get { return ExpectationsDirectory.Files ("*.dll"); }
 		}
 
 		public IEnumerable<NPath> LinkXmlFiles {
@@ -64,6 +71,8 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			foreach (var dep in metadataProvider.AdditionalFilesToSandbox ()) {
 				dep.FileMustExist ().Copy (_directory);
 			}
+
+			InputDirectoryReferences.Copy (ExpectationsDirectory);
 		}
 
 		private static NPath GetExpectationsAssemblyPath ()


### PR DESCRIPTION
Compile the input test assembly with all expectation attributes removed so that they could not cause any unintended consequences during linking.

In order to make the assertions we now compile the test case assembly twice.  Once in a new "expectations"
directory with all attributes compiled in.  And then a second time in the "input" directory without the expecation attributes compiled in

The "expectations" assembly is used by the ResultChecker to determine what the expected results are

And the "input" assembly is the one passed to the linker for processing