### PR TITLE
Eliminate need for full type names as strings in KeptBase and KeptInterface attributes

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptBaseTypeAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptBaseTypeAttribute.cs
@@ -5,11 +5,25 @@ namespace Mono.Linker.Tests.Cases.Expectations.Assertions
 	[AttributeUsage (AttributeTargets.Class | AttributeTargets.Delegate, AllowMultiple = false, Inherited = false)]
 	public sealed class KeptBaseTypeAttribute : KeptAttribute
 	{
-		public readonly string TypeName;
+		public readonly Type BaseType;
+		public readonly object [] GenericParameterNames;
 
-		public KeptBaseTypeAttribute (string typeName)
+		public KeptBaseTypeAttribute (Type baseType)
 		{
-			TypeName = typeName;
+			BaseType = baseType;
+			GenericParameterNames = null;
+		}
+
+		public KeptBaseTypeAttribute (Type baseType, string arg1Name)
+		{
+			BaseType = baseType;
+			GenericParameterNames = new [] { arg1Name };
+		}
+
+		public KeptBaseTypeAttribute (Type baseType, string arg1Name, Type arg2Name, Type arg3Name, Type arg4Name)
+		{
+			BaseType = baseType;
+			GenericParameterNames = new object [] { arg1Name, arg2Name, arg3Name, arg4Name };
 		}
 	}
 }

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptInterfaceAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptInterfaceAttribute.cs
@@ -4,11 +4,11 @@ namespace Mono.Linker.Tests.Cases.Expectations.Assertions
 	[AttributeUsage (AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
 	public class KeptInterfaceAttribute : KeptAttribute
 	{
-		public readonly string TypeName;
+		public readonly Type InterfaceType;
 
-		public KeptInterfaceAttribute (string typeName)
+		public KeptInterfaceAttribute (Type interfaceType)
 		{
-			TypeName = typeName;
+			InterfaceType = interfaceType;
 		}
 	}
 }

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/AttributeOnPreservedTypeIsKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/AttributeOnPreservedTypeIsKept.cs
@@ -8,7 +8,7 @@ namespace Mono.Linker.Tests.Cases.Attributes {
 		{
 		}
 
-		[KeptBaseType ("System.Attribute")]
+		[KeptBaseType (typeof (System.Attribute))]
 		class FooAttribute : Attribute {
 			[Kept]
 			public FooAttribute ()

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/AttributeOnPreservedTypeWithTypeUsedInConstructorIsKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/AttributeOnPreservedTypeWithTypeUsedInConstructorIsKept.cs
@@ -8,7 +8,7 @@ namespace Mono.Linker.Tests.Cases.Attributes {
 		{
 		}
 
-		[KeptBaseType ("System.Attribute")]
+		[KeptBaseType (typeof (System.Attribute))]
 		class FooAttribute : Attribute {
 			[Kept]
 			public FooAttribute (Type val)

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/AttributeOnPreservedTypeWithTypeUsedInDifferentNamespaceIsKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/AttributeOnPreservedTypeWithTypeUsedInDifferentNamespaceIsKept.cs
@@ -17,7 +17,7 @@ namespace Mono.Linker.Tests.Cases.Attributes {
 		{
 		}
 
-		[KeptBaseType ("System.Attribute")]
+		[KeptBaseType (typeof (System.Attribute))]
 		class FooAttribute : Attribute {
 			[Kept]
 			public FooAttribute (Type val)

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/AttributeOnPreservedTypeWithTypeUsedInFieldIsKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/AttributeOnPreservedTypeWithTypeUsedInFieldIsKept.cs
@@ -9,7 +9,7 @@ namespace Mono.Linker.Tests.Cases.Attributes {
 		}
 
 		[KeptMember(".ctor()")]
-		[KeptBaseType ("System.Attribute")]
+		[KeptBaseType (typeof (System.Attribute))]
 		class FooAttribute : Attribute {
 			[Kept]
 			public Type Val;

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/AttributeOnPreservedTypeWithTypeUsedInPropertySetterIsKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/AttributeOnPreservedTypeWithTypeUsedInPropertySetterIsKept.cs
@@ -9,7 +9,7 @@ namespace Mono.Linker.Tests.Cases.Attributes {
 		}
 
 		[KeptMember (".ctor()")]
-		[KeptBaseType ("System.Attribute")]
+		[KeptBaseType (typeof (System.Attribute))]
 		class FooAttribute : Attribute {
 			[Kept]
 			[KeptBackingField]

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/AttributeOnPreservedTypeWithUsedSetter.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/AttributeOnPreservedTypeWithUsedSetter.cs
@@ -9,7 +9,7 @@ namespace Mono.Linker.Tests.Cases.Attributes {
 		}
 
 		[KeptMember (".ctor()")]
-		[KeptBaseType ("System.Attribute")]
+		[KeptBaseType (typeof (System.Attribute))]
 		class FooAttribute : Attribute {
 			[Kept]
 			[KeptBackingField]

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/AttributeOnUsedFieldIsKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/AttributeOnUsedFieldIsKept.cs
@@ -16,7 +16,7 @@ namespace Mono.Linker.Tests.Cases.Attributes {
 
 		[Kept]
 		[KeptMember(".ctor()")]
-		[KeptBaseType ("System.Attribute")]
+		[KeptBaseType (typeof (System.Attribute))]
 		class FooAttribute : Attribute {
 		}
 	}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/AttributeOnUsedMethodIsKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/AttributeOnUsedMethodIsKept.cs
@@ -19,7 +19,7 @@ namespace Mono.Linker.Tests.Cases.Attributes {
 
 		[Kept]
 		[KeptMember (".ctor()")]
-		[KeptBaseType ("System.Attribute")]
+		[KeptBaseType (typeof (System.Attribute))]
 		class FooAttribute : Attribute {
 		}
 	}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/AttributeOnUsedPropertyIsKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/AttributeOnUsedPropertyIsKept.cs
@@ -19,7 +19,7 @@ namespace Mono.Linker.Tests.Cases.Attributes {
 
 		[Kept]
 		[KeptMember (".ctor()")]
-		[KeptBaseType ("System.Attribute")]
+		[KeptBaseType (typeof (System.Attribute))]
 		class FooAttribute : Attribute {
 		}
 	}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Basic/InterfaceMethodImplementedOnBaseClassDoesNotGetStripped.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Basic/InterfaceMethodImplementedOnBaseClassDoesNotGetStripped.cs
@@ -29,8 +29,8 @@ namespace Mono.Linker.Tests.Cases.Basic {
 
 		[Kept]
 		[KeptMember (".ctor()")]
-		[KeptBaseType ("Mono.Linker.Tests.Cases.Basic.InterfaceMethodImplementedOnBaseClassDoesNotGetStripped/Base")]
-		[KeptInterface ("Mono.Linker.Tests.Cases.Basic.InterfaceMethodImplementedOnBaseClassDoesNotGetStripped/I1")]
+		[KeptBaseType (typeof (Base))]
+		[KeptInterface (typeof (I1))]
 		public class Derived : Base, I1 {
 		}
 	}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Basic/NestedDelegateInvokeMethodsPreserved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Basic/NestedDelegateInvokeMethodsPreserved.cs
@@ -17,7 +17,7 @@ namespace Mono.Linker.Tests.Cases.Basic {
 			[KeptMember ("BeginInvoke(System.AsyncCallback,System.Object)")]
 			[KeptMember ("EndInvoke(System.IAsyncResult)")]
 			[KeptMember (".ctor(System.Object,System.IntPtr)")]
-			[KeptBaseType ("System.MulticastDelegate")]
+			[KeptBaseType (typeof (System.MulticastDelegate))]
 			public delegate void Delegate ();
 		}
 	}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Basic/UninvokedInterfaceMemberGetsRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Basic/UninvokedInterfaceMemberGetsRemoved.cs
@@ -14,7 +14,7 @@ namespace Mono.Linker.Tests.Cases.Basic {
 
 		[Kept]
 		[KeptMember (".ctor()")]
-		[KeptInterface ("Mono.Linker.Tests.Cases.Basic.UninvokedInterfaceMemberGetsRemoved/I")]
+		[KeptInterface (typeof (I))]
 		class B : I {
 			public void Method ()
 			{

--- a/linker/Tests/Mono.Linker.Tests.Cases/Generics/CorrectOverloadedMethodGetsStrippedInGenericClass.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Generics/CorrectOverloadedMethodGetsStrippedInGenericClass.cs
@@ -18,7 +18,7 @@ namespace Mono.Linker.Tests.Cases.Generics {
 		}
 
 		[KeptMember (".ctor()")]
-		[KeptBaseType ("Mono.Linker.Tests.Cases.Generics.CorrectOverloadedMethodGetsStrippedInGenericClass/GenericClassWithTwoOverloadedAbstractMethods`1<System.Single>")]
+		[KeptBaseType (typeof (GenericClassWithTwoOverloadedAbstractMethods<System.Single>))]
 		public class SpecializedClassWithTwoOverloadedVirtualMethods : GenericClassWithTwoOverloadedAbstractMethods<float> {
 			// Don't call this one, it should be stripped
 			public override string OverloadedMethod (float thing)

--- a/linker/Tests/Mono.Linker.Tests.Cases/Generics/DerivedClassWithMethodOfSameNameAsBaseButDifferentNumberOfGenericParametersUnusedBaseWillGetStripped.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Generics/DerivedClassWithMethodOfSameNameAsBaseButDifferentNumberOfGenericParametersUnusedBaseWillGetStripped.cs
@@ -18,7 +18,7 @@ namespace Mono.Linker.Tests.Cases.Generics {
 		}
 
 		[KeptMember (".ctor()")]
-		[KeptBaseType ("Mono.Linker.Tests.Cases.Generics.DerivedClassWithMethodOfSameNameAsBaseButDifferentNumberOfGenericParametersUnusedBaseWillGetStripped/MyBase")]
+		[KeptBaseType (typeof (MyBase))]
 		class MyDerived : MyBase {
 			[Kept]
 			public virtual T Method<T, K> (T arg1)

--- a/linker/Tests/Mono.Linker.Tests.Cases/Generics/GenericInstanceInterfaceMethodImplementedWithDifferentGenericArgumentNameDoesNotGetStripped.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Generics/GenericInstanceInterfaceMethodImplementedWithDifferentGenericArgumentNameDoesNotGetStripped.cs
@@ -18,7 +18,7 @@ namespace Mono.Linker.Tests.Cases.Generics {
 		}
 
 		[KeptMember (".ctor()")]
-		[KeptInterface ("Mono.Linker.Tests.Cases.Generics.GenericInstanceInterfaceMethodImplementedWithDifferentGenericArgumentNameDoesNotGetStripped/ISomething")]
+		[KeptInterface (typeof (ISomething))]
 		public class Concrete : ISomething {
 			[Kept]
 			public GenericType<TInConcrete> ShouldNotGetStripped<TInConcrete> ()

--- a/linker/Tests/Mono.Linker.Tests.Cases/Generics/MethodWithParameterWhichHasGenericParametersAndOverrideUsesADifferentNameForGenericParameter.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Generics/MethodWithParameterWhichHasGenericParametersAndOverrideUsesADifferentNameForGenericParameter.cs
@@ -15,7 +15,7 @@ namespace Mono.Linker.Tests.Cases.Generics {
 		}
 
 		[KeptMember (".ctor()")]
-		[KeptBaseType ("Mono.Linker.Tests.Cases.Generics.MethodWithParameterWhichHasGenericParametersAndOverrideUsesADifferentNameForGenericParameter/Base`1<TResult1>")]
+		[KeptBaseType (typeof (Base<>), "TResult1")]
 		public class Derived<TSource, TResult1> : Base<TResult1> {
 			[Kept]
 			public override TResult2 Method<TResult2> (System.Func<TResult1, TResult2> arg)

--- a/linker/Tests/Mono.Linker.Tests.Cases/Generics/MethodWithParameterWhichHasGenericParametersAndOverrideUsesADifferentNameForGenericParameterNestedCase.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Generics/MethodWithParameterWhichHasGenericParametersAndOverrideUsesADifferentNameForGenericParameterNestedCase.cs
@@ -19,7 +19,7 @@ namespace Mono.Linker.Tests.Cases.Generics {
 		}
 
 		[KeptMember (".ctor()")]
-		[KeptBaseType ("Mono.Linker.Tests.Cases.Generics.MethodWithParameterWhichHasGenericParametersAndOverrideUsesADifferentNameForGenericParameterNestedCase/Base`1/Nested<TResult1>")]
+		[KeptBaseType (typeof (Base<>.Nested), "TResult1")]
 		public class Derived<TSource, TResult1> : Base<TResult1>.Nested {
 			[Kept]
 			public override TResult2 Method<TResult2> (System.Func<TResult1, TResult2> arg)

--- a/linker/Tests/Mono.Linker.Tests.Cases/Generics/MethodWithParameterWhichHasGenericParametersAndOverrideUsesADifferentNameForGenericParameterNestedCase2.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Generics/MethodWithParameterWhichHasGenericParametersAndOverrideUsesADifferentNameForGenericParameterNestedCase2.cs
@@ -19,7 +19,7 @@ namespace Mono.Linker.Tests.Cases.Generics {
 		}
 
 		[KeptMember (".ctor()")]
-		[KeptBaseType ("Mono.Linker.Tests.Cases.Generics.MethodWithParameterWhichHasGenericParametersAndOverrideUsesADifferentNameForGenericParameterNestedCase2/Base`1/Nested`3<TResult1,System.Int32,System.Int32,System.String>")]
+		[KeptBaseType (typeof (Base<>.Nested<,,>), "TResult1", typeof (int), typeof (int), typeof (string))]
 		public class Derived<TSource, TResult1> : Base<TResult1>.Nested<int, int, string> {
 			[Kept]
 			public override TResult2 Method<TResult2> (System.Func<TResult1, TResult2> arg)

--- a/linker/Tests/Mono.Linker.Tests.Cases/Generics/OverrideWithAnotherVirtualMethodOfSameNameWithDifferentParameterType.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Generics/OverrideWithAnotherVirtualMethodOfSameNameWithDifferentParameterType.cs
@@ -17,7 +17,7 @@ namespace Mono.Linker.Tests.Cases.Generics {
 		}
 
 		[KeptMember (".ctor()")]
-		[KeptBaseType ("Mono.Linker.Tests.Cases.Generics.OverrideWithAnotherVirtualMethodOfSameNameWithDifferentParameterType/Base`1<K>")]
+		[KeptBaseType (typeof (Base<>), "K")]
 		public class Derived<K, S> : Base<K> {
 			[Kept]
 			public override K Method (K arg)

--- a/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/TypeWithPreserveFieldsHasBackingFieldsOfPropertiesRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/TypeWithPreserveFieldsHasBackingFieldsOfPropertiesRemoved.cs
@@ -9,13 +9,13 @@ namespace Mono.Linker.Tests.Cases.LinkXml
 		}
 
 		[Kept]
-		[KeptInterface("Mono.Linker.Tests.Cases.LinkXml.TypeWithPreserveFieldsHasBackingFieldsOfPropertiesRemoved/IFoo`1<System.Int32>")]
-		[KeptInterface("Mono.Linker.Tests.Cases.LinkXml.TypeWithPreserveFieldsHasBackingFieldsOfPropertiesRemoved/IFoo`1<System.String>")]
-		[KeptInterface("Mono.Linker.Tests.Cases.LinkXml.TypeWithPreserveFieldsHasBackingFieldsOfPropertiesRemoved/IFoo`1<Mono.Linker.Tests.Cases.LinkXml.TypeWithPreserveFieldsHasBackingFieldsOfPropertiesRemoved/Cat>")]
-		[KeptInterface("Mono.Linker.Tests.Cases.LinkXml.TypeWithPreserveFieldsHasBackingFieldsOfPropertiesRemoved/IFoo2`1<System.Int32>")]
-		[KeptInterface("Mono.Linker.Tests.Cases.LinkXml.TypeWithPreserveFieldsHasBackingFieldsOfPropertiesRemoved/IFoo3`3<System.Int32,System.String,System.Char>")]
-		[KeptInterface("Mono.Linker.Tests.Cases.LinkXml.TypeWithPreserveFieldsHasBackingFieldsOfPropertiesRemoved/IDog")]
-		[KeptInterface("Mono.Linker.Tests.Cases.LinkXml.TypeWithPreserveFieldsHasBackingFieldsOfPropertiesRemoved/IFoo`1<Mono.Linker.Tests.Cases.LinkXml.TypeWithPreserveFieldsHasBackingFieldsOfPropertiesRemoved/IFoo`1<System.Int32>>")]
+		[KeptInterface(typeof (IFoo<System.Int32>))]
+		[KeptInterface(typeof (IFoo<System.String>))]
+		[KeptInterface(typeof (IFoo<Cat>))]
+		[KeptInterface(typeof (IFoo2<System.Int32>))]
+		[KeptInterface(typeof (IFoo3<System.Int32,System.String,System.Char>))]
+		[KeptInterface(typeof (IDog))]
+		[KeptInterface(typeof (IFoo<IFoo<System.Int32>>))]
 		class Unused : IFoo<int>, IFoo<string>, IFoo<Cat>, IFoo2<int>, IFoo3<int, string, char>, IDog, IFoo<IFoo<int>> {
 			[Kept]
 			public int Field1;

--- a/linker/Tests/Mono.Linker.Tests.Cases/VirtualMethods/ClassImplemtingInterfaceMethodsThroughBaseClass4.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/VirtualMethods/ClassImplemtingInterfaceMethodsThroughBaseClass4.cs
@@ -21,8 +21,8 @@ namespace Mono.Linker.Tests.Cases.VirtualMethods {
 		}
 
 		[KeptMember (".ctor()")]
-		[KeptBaseType ("Mono.Linker.Tests.Cases.VirtualMethods.ClassImplemtingInterfaceMethodsThroughBaseClass4/B")]
-		[KeptInterface ("Mono.Linker.Tests.Cases.VirtualMethods.ClassImplemtingInterfaceMethodsThroughBaseClass4/IFoo")] // FIXME: Why is it not removed
+		[KeptBaseType (typeof (B))]
+		[KeptInterface (typeof (IFoo))] // FIXME: Why is it not removed
 		class A : B, IFoo {
 			//my IFoo.Foo() is actually implemented by B which doesn't know about it.
 		}

--- a/linker/Tests/Mono.Linker.Tests.Cases/VirtualMethods/ClassImplemtingInterfaceMethodsThroughBaseClass5.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/VirtualMethods/ClassImplemtingInterfaceMethodsThroughBaseClass5.cs
@@ -20,8 +20,8 @@ namespace Mono.Linker.Tests.Cases.VirtualMethods {
 		}
 
 		[KeptMember (".ctor()")]
-		[KeptBaseType ("Mono.Linker.Tests.Cases.VirtualMethods.ClassImplemtingInterfaceMethodsThroughBaseClass5/B")]
-		[KeptInterface ("Mono.Linker.Tests.Cases.VirtualMethods.ClassImplemtingInterfaceMethodsThroughBaseClass5/IFoo")]
+		[KeptBaseType (typeof (B))]
+		[KeptInterface (typeof (IFoo))]
 		class A : B, IFoo {
 			//my IFoo.Foo() is actually implemented by B which doesn't know about it.
 		}

--- a/linker/Tests/Mono.Linker.Tests.Cases/VirtualMethods/ClassImplemtingInterfaceMethodsThroughBaseClass6.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/VirtualMethods/ClassImplemtingInterfaceMethodsThroughBaseClass6.cs
@@ -27,7 +27,7 @@ namespace Mono.Linker.Tests.Cases.VirtualMethods {
 		}
 
 		[KeptMember (".ctor()")]
-		[KeptInterface ("Mono.Linker.Tests.Cases.VirtualMethods.ClassImplemtingInterfaceMethodsThroughBaseClass6/IFoo")]
+		[KeptInterface (typeof (IFoo))]
 		class C : IFoo {
 			[Kept]
 			public void Foo ()

--- a/linker/Tests/Mono.Linker.Tests.Cases/VirtualMethods/TypeGetsMarkedThatImplementsAlreadyMarkedInterfaceMethod.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/VirtualMethods/TypeGetsMarkedThatImplementsAlreadyMarkedInterfaceMethod.cs
@@ -14,7 +14,7 @@ namespace Mono.Linker.Tests.Cases.VirtualMethods {
 		}
 
 		[KeptMember (".ctor()")]
-		[KeptInterface ("Mono.Linker.Tests.Cases.VirtualMethods.TypeGetsMarkedThatImplementsAlreadyMarkedInterfaceMethod/IFoo")]
+		[KeptInterface (typeof (IFoo))]
 		class B : IFoo {
 			[Kept]
 			public void Foo ()
@@ -23,7 +23,7 @@ namespace Mono.Linker.Tests.Cases.VirtualMethods {
 		}
 
 		[KeptMember (".ctor()")]
-		[KeptInterface ("Mono.Linker.Tests.Cases.VirtualMethods.TypeGetsMarkedThatImplementsAlreadyMarkedInterfaceMethod/IFoo")]
+		[KeptInterface (typeof (IFoo))]
 		class A : IFoo {
 			[Kept]
 			public void Foo ()

--- a/linker/Tests/Mono.Linker.Tests.Cases/VirtualMethods/UsedVirtualMethodNotRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/VirtualMethods/UsedVirtualMethodNotRemoved.cs
@@ -18,7 +18,7 @@ namespace Mono.Linker.Tests.Cases.VirtualMethods {
 		}
 
 		[KeptMember (".ctor()")]
-		[KeptBaseType ("Mono.Linker.Tests.Cases.VirtualMethods.UsedVirtualMethodNotRemoved/Base")]
+		[KeptBaseType (typeof (Base))]
 		class B : Base {
 			[Kept]
 			public override void Call ()

--- a/linker/Tests/Mono.Linker.Tests.Cases/VirtualMethods/VirtualMethodGetsPerservedIfBaseMethodGetsInvoked.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/VirtualMethods/VirtualMethodGetsPerservedIfBaseMethodGetsInvoked.cs
@@ -17,7 +17,7 @@ namespace Mono.Linker.Tests.Cases.VirtualMethods {
 		}
 
 		[KeptMember (".ctor()")]
-		[KeptBaseType ("Mono.Linker.Tests.Cases.VirtualMethods.VirtualMethodGetsPerservedIfBaseMethodGetsInvoked/B")]
+		[KeptBaseType (typeof (B))]
 		class A : B {
 			[Kept]
 			public override void Foo ()

--- a/linker/Tests/Mono.Linker.Tests.Cases/VirtualMethods/VirtualMethodGetsStrippedIfImplementingMethodGetsInvokedDirectly.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/VirtualMethods/VirtualMethodGetsStrippedIfImplementingMethodGetsInvokedDirectly.cs
@@ -16,7 +16,7 @@ namespace Mono.Linker.Tests.Cases.VirtualMethods {
 		}
 
 		[KeptMember (".ctor()")]
-		[KeptBaseType ("Mono.Linker.Tests.Cases.VirtualMethods.VirtualMethodGetsStrippedIfImplementingMethodGetsInvokedDirectly/B")]
+		[KeptBaseType (typeof (B))]
 		class A : B {
 			[Kept]
 			public override void Foo ()


### PR DESCRIPTION
This makes writing tests easier since it removes the need to craft & maintain the string type names.

While the tests all pass for this PR, this PR does assume that https://github.com/mono/linker/pull/96 will be landed and that PR should be landed first.