### PR TITLE
Add support for writing pure IL for R2R assemblies

### DIFF
--- a/linker/Mono.Linker.Steps/OutputStep.cs
+++ b/linker/Mono.Linker.Steps/OutputStep.cs
@@ -27,14 +27,38 @@
 //
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 
 using Mono.Cecil;
 using Mono.Cecil.Cil;
+using Mono.Cecil.PE;
 
 namespace Mono.Linker.Steps {
 
 	public class OutputStep : BaseStep {
+
+		private Dictionary<UInt16, TargetArchitecture> architectureMap;
+
+		private enum NativeOSOverride {
+			Apple = 0x4644,
+			FreeBSD = 0xadc4,
+			Linux = 0x7b79,
+			NetBSD = 0x1993,
+			Default = 0
+		}
+
+		public OutputStep ()
+		{
+			architectureMap = new Dictionary<UInt16, TargetArchitecture> ();
+			foreach (var os in Enum.GetValues (typeof (NativeOSOverride))) {
+				ushort osVal = (ushort) (NativeOSOverride) os;
+				foreach (var arch in Enum.GetValues (typeof (TargetArchitecture))) {
+					ushort archVal = (ushort) (TargetArchitecture)arch;
+					architectureMap.Add ((ushort) (archVal ^ osVal), (TargetArchitecture) arch);
+				}
+			}
+		}
 
 		protected override void Process ()
 		{
@@ -55,6 +79,29 @@ namespace Mono.Linker.Steps {
 			OutputAssembly (assembly);
 		}
 
+		private bool isR2R(ModuleDefinition module) {
+			return ((module.Attributes & ModuleAttributes.ILOnly) == 0 &&
+					(module.Attributes & (ModuleAttributes) 0x04) != 0);
+		}
+
+		void WriteAssembly (AssemblyDefinition assembly, string directory)
+		{
+			foreach (var module in assembly.Modules) {
+				// Write back pure IL even for R2R assemblies
+				if (isR2R (module)) {
+					module.Attributes |= ModuleAttributes.ILOnly;
+					module.Attributes ^= (ModuleAttributes) (uint) 0x04;
+					if (!architectureMap.ContainsKey ((ushort) module.Architecture)) {
+						throw new BadImageFormatException ("unrecognized module attributes");
+					} else {
+						module.Architecture = architectureMap [(ushort) module.Architecture];
+					}
+				}
+			}
+
+			assembly.Write (GetAssemblyFileName (assembly, directory), SaveSymbols (assembly));
+		}
+
 		void OutputAssembly (AssemblyDefinition assembly)
 		{
 			string directory = Context.OutputDirectory;
@@ -65,7 +112,7 @@ namespace Mono.Linker.Steps {
 			case AssemblyAction.Save:
 			case AssemblyAction.Link:
 				Context.Annotations.AddDependency (assembly);
-				assembly.Write (GetAssemblyFileName (assembly, directory), SaveSymbols (assembly));
+				WriteAssembly (assembly, directory);
 				break;
 			case AssemblyAction.Copy:
 				Context.Annotations.AddDependency (assembly);


### PR DESCRIPTION
Whenever the linker writes an assembly, we now check the attributes of
each module in the assembly to determine whether it has been
ready-to-run crossgen'd. We detect this by checking the module
attributes: R2R images have the flag COMIMAGE_FLAGS_IL_LIBRARY
(0x00000004) set in the CLI header.

To write back valid IL images, we unset the IL_LIBRARY flag, and set
the IL_ONLY flag. We also adjust the target architecture in the COFF
header, which for R2R images contains an xor of OS values with the
normal architecture values. From coreclr:
```
 #define IMAGE_FILE_MACHINE_NATIVE_NI (IMAGE_FILE_MACHINE_NATIVE ^
  IMAGE_FILE_MACHINE_NATIVE_OS_OVERRIDE)
```
We determine the target architecture from this value and write it back
without the os override used in R2R images.

@swaroop-sridhar please review