### PR TITLE
Add an option to remove only completely unused assemblies.

### DIFF
--- a/linker/Mono.Linker.Steps/SweepStep.cs
+++ b/linker/Mono.Linker.Steps/SweepStep.cs
@@ -83,6 +83,10 @@ namespace Mono.Linker.Steps {
 				return;
 			}
 
+			if (Context.FullAssemblyOnlyRemoval) {
+				return;
+			}
+
 			var types = new List<TypeDefinition> ();
 
 			foreach (TypeDefinition type in assembly.MainModule.Types) {

--- a/linker/Mono.Linker/Driver.cs
+++ b/linker/Mono.Linker/Driver.cs
@@ -117,6 +117,9 @@ namespace Mono.Linker {
 					case 'o':
 						context.OutputDirectory = GetParam ();
 						break;
+					case 'f':
+						context.FullAssemblyOnlyRemoval = true;
+						break;
 					case 'c':
 						context.CoreAction = ParseAssemblyAction (GetParam ());
 						break;
@@ -289,6 +292,8 @@ namespace Mono.Linker {
 			Console.WriteLine ("   --about     About the {0}", _linker);
 			Console.WriteLine ("   --version   Print the version number of the {0}", _linker);
 			Console.WriteLine ("   -out        Specify the output directory, default to `output'");
+			Console.WriteLine ("   -f          Remove only full assemblies when they are unused;");
+			Console.WriteLine ("                 keep partially used assemblies intact");
 			Console.WriteLine ("   -c          Action on the core assemblies, skip, copy or link, default to skip");
 			Console.WriteLine ("   -p          Action per assembly");
 			Console.WriteLine ("   -s          Add a new step to the pipeline.");

--- a/linker/Mono.Linker/LinkContext.cs
+++ b/linker/Mono.Linker/LinkContext.cs
@@ -40,6 +40,7 @@ namespace Mono.Linker {
 		AssemblyAction _coreAction;
 		Dictionary<string, AssemblyAction> _actions;
 		string _outputDirectory;
+		bool _fullAssemblyOnlyRemoval;
 		readonly Dictionary<string, string> _parameters;
 		bool _linkSymbols;
 		bool _keepTypeForwarderOnlyAssemblies;
@@ -64,6 +65,12 @@ namespace Mono.Linker {
 		public string OutputDirectory {
 			get { return _outputDirectory; }
 			set { _outputDirectory = value; }
+		}
+
+		public bool FullAssemblyOnlyRemoval
+		{
+			get { return _fullAssemblyOnlyRemoval; }
+			set { _fullAssemblyOnlyRemoval = value; }
 		}
 
 		public AssemblyAction CoreAction {


### PR DESCRIPTION
Partially used assemblies are kept intact.

The new monolinker flag is -f.

Split from https://github.com/mono/linker/pull/98
@erozenfeld PTAL