### PR TITLE
Get assemblies from Annotations instead of from the Resolver

### DIFF
--- a/linker/Mono.Linker/LinkContext.cs
+++ b/linker/Mono.Linker/LinkContext.cs
@@ -274,9 +274,9 @@ namespace Mono.Linker {
 
 		public AssemblyDefinition [] GetAssemblies ()
 		{
-			var cache = _resolver.AssemblyCache;
-			AssemblyDefinition [] asms = new AssemblyDefinition [cache.Count];
-			cache.Values.CopyTo (asms, 0);
+			var assemblies = Annotations.GetAssemblies ();
+			AssemblyDefinition [] asms = new AssemblyDefinition [assemblies.Count];
+			assemblies.CopyTo (asms, 0);
 			return asms;
 		}
 


### PR DESCRIPTION
The situation we have is that we end up resolving new assemblies during the MarkStep as part of our WinRT support.  That leads to problems during the CleanStep when ProcessAssemblies makes a call to GetAction on one of these assemblies that was resolved during marking because the assembly is not in the `assembly_actions` from Annoations.