### PR TITLE
Change some test cases to use types that have not been moved around

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases/Generics/MethodWithParameterWhichHasGenericParametersAndOverrideUsesADifferentNameForGenericParameter.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Generics/MethodWithParameterWhichHasGenericParametersAndOverrideUsesADifferentNameForGenericParameter.cs
@@ -1,4 +1,5 @@
-﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using System.Collections.Generic;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Generics {
 	class MethodWithParameterWhichHasGenericParametersAndOverrideUsesADifferentNameForGenericParameter {
@@ -11,16 +12,16 @@ namespace Mono.Linker.Tests.Cases.Generics {
 		[KeptMember (".ctor()")]
 		public abstract class Base<TSource> {
 			[Kept]
-			public abstract TResult1 Method<TResult1> (System.Func<TSource, TResult1> arg);
+			public abstract TResult1 Method<TResult1> (IDictionary<TSource, TResult1> arg);
 		}
 
 		[KeptMember (".ctor()")]
 		[KeptBaseType (typeof (Base<>), "TResult1")]
 		public class Derived<TSource, TResult1> : Base<TResult1> {
 			[Kept]
-			public override TResult2 Method<TResult2> (System.Func<TResult1, TResult2> arg)
+			public override TResult2 Method<TResult2> (IDictionary<TResult1, TResult2> arg)
 			{
-				return arg (default (TResult1));
+				return default (TResult2);
 			}
 		}
 	}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Generics/MethodWithParameterWhichHasGenericParametersAndOverrideUsesADifferentNameForGenericParameterNestedCase.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Generics/MethodWithParameterWhichHasGenericParametersAndOverrideUsesADifferentNameForGenericParameterNestedCase.cs
@@ -1,4 +1,5 @@
-﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using System.Collections.Generic;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Generics {
 	class MethodWithParameterWhichHasGenericParametersAndOverrideUsesADifferentNameForGenericParameterNestedCase {
@@ -14,7 +15,7 @@ namespace Mono.Linker.Tests.Cases.Generics {
 			[KeptMember (".ctor()")]
 			public abstract class Nested {
 				[Kept]
-				public abstract TResult1 Method<TResult1> (System.Func<TSource, TResult1> arg);
+				public abstract TResult1 Method<TResult1> (IDictionary<TSource, TResult1> arg);
 			}
 		}
 
@@ -22,9 +23,9 @@ namespace Mono.Linker.Tests.Cases.Generics {
 		[KeptBaseType (typeof (Base<>.Nested), "TResult1")]
 		public class Derived<TSource, TResult1> : Base<TResult1>.Nested {
 			[Kept]
-			public override TResult2 Method<TResult2> (System.Func<TResult1, TResult2> arg)
+			public override TResult2 Method<TResult2> (IDictionary<TResult1, TResult2> arg)
 			{
-				return arg (default (TResult1));
+				return default (TResult2);
 			}
 		}
 	}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Generics/MethodWithParameterWhichHasGenericParametersAndOverrideUsesADifferentNameForGenericParameterNestedCase2.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Generics/MethodWithParameterWhichHasGenericParametersAndOverrideUsesADifferentNameForGenericParameterNestedCase2.cs
@@ -1,4 +1,5 @@
-﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using System.Collections.Generic;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Generics {
 	class MethodWithParameterWhichHasGenericParametersAndOverrideUsesADifferentNameForGenericParameterNestedCase2 {
@@ -14,7 +15,7 @@ namespace Mono.Linker.Tests.Cases.Generics {
 			[KeptMember (".ctor()")]
 			public abstract class Nested<T1, T2, T3> {
 				[Kept]
-				public abstract TResult1 Method<TResult1> (System.Func<TSource, TResult1> arg);
+				public abstract TResult1 Method<TResult1> (IDictionary<TSource, TResult1> arg);
 			}
 		}
 
@@ -22,9 +23,9 @@ namespace Mono.Linker.Tests.Cases.Generics {
 		[KeptBaseType (typeof (Base<>.Nested<,,>), "TResult1", typeof (int), typeof (int), typeof (string))]
 		public class Derived<TSource, TResult1> : Base<TResult1>.Nested<int, int, string> {
 			[Kept]
-			public override TResult2 Method<TResult2> (System.Func<TResult1, TResult2> arg)
+			public override TResult2 Method<TResult2> (IDictionary<TResult1, TResult2> arg)
 			{
-				return arg (default (TResult1));
+				return default (TResult2);
 			}
 		}
 	}


### PR DESCRIPTION
in newer framework versions

System.Func used to live in System.Core, now it's in mscorlib.  As a result, when we run our unit tests against our old mono they fail because the tests only reference mscorlib right now.

We could add a reference to System.Core.dll, but there's really no reason why we need to use System.Func, so let's use IDictionary isntead