### PR TITLE
Implement core link tests

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptMemberInAssemblyAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptMemberInAssemblyAttribute.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+
+namespace Mono.Linker.Tests.Cases.Expectations.Assertions {
+	[AttributeUsage (AttributeTargets.Class | AttributeTargets.Delegate, AllowMultiple = true, Inherited = false)]
+	public class KeptMemberInAssemblyAttribute : BaseExpectedLinkedBehaviorAttribute {
+		public readonly string AssemblyFileName;
+		public readonly Type Type;
+		public readonly string [] MemberNames;
+
+		public KeptMemberInAssemblyAttribute (string assemblyFileName, Type type, params string [] memberNames)
+		{
+			AssemblyFileName = assemblyFileName;
+			Type = type;
+			MemberNames = memberNames;
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptTypeInAssemblyAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptTypeInAssemblyAttribute.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Assertions
+{
+	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Delegate, AllowMultiple = true, Inherited = false)]
+	public class KeptTypeInAssemblyAttribute : BaseExpectedLinkedBehaviorAttribute
+	{
+		public readonly string AssemblyFileName;
+		public readonly Type Type;
+
+		public KeptTypeInAssemblyAttribute(string assemblyFileName, Type type)
+		{
+			AssemblyFileName = assemblyFileName;
+			Type = type;
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/RemovedMemberInAssemblyAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/RemovedMemberInAssemblyAttribute.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Assertions {
+	[AttributeUsage (AttributeTargets.Class | AttributeTargets.Delegate, AllowMultiple = true, Inherited = false)]
+	public class RemovedMemberInAssemblyAttribute : BaseExpectedLinkedBehaviorAttribute {
+		public readonly string AssemblyFileName;
+		public readonly Type Type;
+		public readonly string [] MemberNames;
+
+		public RemovedMemberInAssemblyAttribute (string assemblyFileName, Type type, params string [] memberNames)
+		{
+			AssemblyFileName = assemblyFileName;
+			Type = type;
+			MemberNames = memberNames;
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/RemovedTypeInAssemblyAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/RemovedTypeInAssemblyAttribute.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Assertions
+{
+	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Delegate, AllowMultiple = true, Inherited = false)]
+	public class RemovedTypeInAssemblyAttribute : BaseExpectedLinkedBehaviorAttribute {
+		public readonly string AssemblyFileName;
+		public readonly Type Type;
+
+		public RemovedTypeInAssemblyAttribute (string assemblyFileName, Type type)
+		{
+			AssemblyFileName = assemblyFileName;
+			Type = type;
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
@@ -43,7 +43,9 @@
     <Compile Include="Assertions\BaseExpectedLinkedBehaviorAttribute.cs" />
     <Compile Include="Assertions\KeptBackingFieldAttribute.cs" />
     <Compile Include="Assertions\KeptMemberAttribute.cs" />
+    <Compile Include="Assertions\KeptTypeInAssemblyAttribute.cs" />
     <Compile Include="Assertions\RemovedAssemblyAttribute.cs" />
+    <Compile Include="Assertions\RemovedTypeInAssemblyAttribute.cs" />
     <Compile Include="Metadata\BaseMetadataAttribute.cs" />
     <Compile Include="Metadata\CoreLinkAttribute.cs" />
     <Compile Include="Metadata\NotATestCaseAttribute.cs" />

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
@@ -43,8 +43,10 @@
     <Compile Include="Assertions\BaseExpectedLinkedBehaviorAttribute.cs" />
     <Compile Include="Assertions\KeptBackingFieldAttribute.cs" />
     <Compile Include="Assertions\KeptMemberAttribute.cs" />
+    <Compile Include="Assertions\KeptMemberInAssemblyAttribute.cs" />
     <Compile Include="Assertions\KeptTypeInAssemblyAttribute.cs" />
     <Compile Include="Assertions\RemovedAssemblyAttribute.cs" />
+    <Compile Include="Assertions\RemovedMemberInAssemblyAttribute.cs" />
     <Compile Include="Assertions\RemovedTypeInAssemblyAttribute.cs" />
     <Compile Include="Metadata\BaseMetadataAttribute.cs" />
     <Compile Include="Metadata\CoreLinkAttribute.cs" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/CoreLink/CopyOfCoreLibrariesKeepsUnusedTypes.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/CoreLink/CopyOfCoreLibrariesKeepsUnusedTypes.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.CoreLink
+{
+	[CoreLink ("copy")]
+	[KeptAssembly ("mscorlib.dll")]
+	// These types are normally removed when the core libraries are linked
+	[KeptTypeInAssembly ("mscorlib.dll", typeof (ConsoleKeyInfo))]
+	[KeptTypeInAssembly ("mscorlib.dll", typeof (System.Collections.ObjectModel.KeyedCollection<,>))]
+	class CopyOfCoreLibrariesKeepsUnusedTypes
+	{
+		public static void Main()
+		{
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/CoreLink/LinkingOfCoreLibrariesRemovesUnusedMethods.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/CoreLink/LinkingOfCoreLibrariesRemovesUnusedMethods.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections;
+using System.IO;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.CoreLink
+{
+	[CoreLink ("link")]
+
+	[KeptAssembly ("mscorlib.dll")]
+	[KeptMemberInAssembly ("mscorlib.dll", typeof (Stack), ".ctor(System.Int32)", "Pop()", "Push(System.Object)")]
+	// We can't check everything that should be removed, but we should be able to check a few niche things that
+	// we known should be removed which will at least verify that the core library was processed
+	[RemovedMemberInAssembly ("mscorlib.dll", typeof (Stack), ".ctor(System.Collections.ICollection)")]
+	class LinkingOfCoreLibrariesRemovesUnusedMethods {
+		public static void Main()
+		{
+			Stack stack = new Stack (2);
+			stack.Push (1);
+			var val = stack.Pop ();
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/CoreLink/LinkingOfCoreLibrariesRemovesUnusedTypes.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/CoreLink/LinkingOfCoreLibrariesRemovesUnusedTypes.cs
@@ -3,6 +3,7 @@ using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.CoreLink {
+	[IgnoreTestCase("Requires mono 5.2 to pass.  [Conditional] is not working with mcs on OSX agent")]
 	[CoreLink ("link")]
 	[Reference("System.dll")]
 

--- a/linker/Tests/Mono.Linker.Tests.Cases/CoreLink/LinkingOfCoreLibrariesRemovesUnusedTypes.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/CoreLink/LinkingOfCoreLibrariesRemovesUnusedTypes.cs
@@ -1,14 +1,29 @@
-﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.CoreLink {
 	[CoreLink ("link")]
+	[Reference("System.dll")]
+
 	[KeptAssembly ("mscorlib.dll")]
+	[KeptAssembly("System.dll")]
 	// We can't check everything that should be removed, but we should be able to check a few niche things that
 	// we known should be removed which will at least verify that the core library was processed
-	// TODO by Mike : List a few types
+	[KeptTypeInAssembly ("mscorlib.dll", typeof (System.Collections.Generic.IEnumerable<>))]
+	[KeptTypeInAssembly ("System.dll", typeof (Uri))]
+
+	[RemovedTypeInAssembly ("mscorlib.dll", typeof (System.Resources.ResourceWriter))]
+	[RemovedTypeInAssembly ("System.dll", typeof (System.CodeDom.Compiler.CodeCompiler))]
 	class LinkingOfCoreLibrariesRemovesUnusedTypes {
 		public static void Main ()
+		{
+			// Use something from system that would normally be removed if we didn't use it
+			OtherMethods2 (new Uri ("dont care"));
+		}
+
+		[Kept]
+		static void OtherMethods2 (Uri uri)
 		{
 		}
 	}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Basic\UnusedPropertyGetsRemoved.cs" />
     <Compile Include="Basic\UnusedPropertySetterRemoved.cs" />
     <Compile Include="Basic\UsedPropertyIsKept.cs" />
+    <Compile Include="CoreLink\LinkingOfCoreLibrariesRemovesUnusedMethods.cs" />
     <Compile Include="CoreLink\LinkingOfCoreLibrariesRemovesUnusedTypes.cs" />
     <Compile Include="Advanced\DeadCodeElimination1.cs" />
     <Compile Include="Advanced\FieldThatOnlyGetsSetIsRemoved.cs" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Basic\UnusedPropertyGetsRemoved.cs" />
     <Compile Include="Basic\UnusedPropertySetterRemoved.cs" />
     <Compile Include="Basic\UsedPropertyIsKept.cs" />
+    <Compile Include="CoreLink\CopyOfCoreLibrariesKeepsUnusedTypes.cs" />
     <Compile Include="CoreLink\LinkingOfCoreLibrariesRemovesUnusedMethods.cs" />
     <Compile Include="CoreLink\LinkingOfCoreLibrariesRemovesUnusedTypes.cs" />
     <Compile Include="Advanced\DeadCodeElimination1.cs" />


### PR DESCRIPTION
Implemented expectation attributes for verifying the outcome of types & methods in other assemblies.

Used these new attributes to implement the core link tests which verify that core assemblies are linked when linking of core libraries is requested

Also implemented a test to verify the behavior when the 'copy' mode is used for core libraries.

I didn't write many tests for a variety of reasons, but one is that tests like this will be a bit fragile.  A few tests will give us some level of coverage on the linker behavior.  And they will also verify that the *InAssemblyAttributes remain working.

Unity's plans for the *InAssemblyAttributes is to use them for some more integration type tests that verify a few special preservations we make.

