### PR TITLE
Fix ReferencesAreRemovedWhenAllUsagesAreRemoved, was incorrectly passing

### DIFF
--- a/linker/Mono.Linker/Driver.cs
+++ b/linker/Mono.Linker/Driver.cs
@@ -162,6 +162,10 @@ namespace Mono.Linker {
 						if (!bool.Parse (GetParam ()))
 							p.RemoveStep (typeof (RegenerateGuidStep));
 						break;
+					case 'z':
+							if (!bool.Parse (GetParam ()))
+								p.RemoveStep (typeof (BlacklistStep));
+							break;
 					case 'v':
 						context.KeepMembersForDebuggerAttributes = bool.Parse (GetParam ());
 						break;
@@ -304,6 +308,7 @@ namespace Mono.Linker {
 			Console.WriteLine ("   -a          Link from a list of assemblies");
 			Console.WriteLine ("   -r          Link from a list of assemblies using roots visible outside of the assembly");
 			Console.WriteLine ("   -i          Link from an mono-api-info descriptor");
+			Console.WriteLine ("   -z          Include default preservations (true or false), default to true");
 			Console.WriteLine ("");
 
 			Environment.Exit (1);

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/Il8nAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/Il8nAttribute.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Metadata {
+	[AttributeUsage (AttributeTargets.Class)]
+	public sealed class Il8nAttribute : BaseMetadataAttribute {
+		public readonly string Value;
+
+		public Il8nAttribute (string value)
+		{
+			Value = value;
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/IncludeBlacklistStepAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/IncludeBlacklistStepAttribute.cs
@@ -1,0 +1,10 @@
+﻿namespace Mono.Linker.Tests.Cases.Expectations.Metadata {
+	public sealed class IncludeBlacklistStepAttribute : BaseMetadataAttribute {
+		public readonly string Value;
+
+		public IncludeBlacklistStepAttribute (string value)
+		{
+			Value = value;
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
@@ -50,6 +50,8 @@
     <Compile Include="Assertions\RemovedTypeInAssemblyAttribute.cs" />
     <Compile Include="Metadata\BaseMetadataAttribute.cs" />
     <Compile Include="Metadata\CoreLinkAttribute.cs" />
+    <Compile Include="Metadata\IncludeBlacklistStepAttribute.cs" />
+    <Compile Include="Metadata\Il8nAttribute.cs" />
     <Compile Include="Metadata\NotATestCaseAttribute.cs" />
     <Compile Include="Metadata\ReferenceAttribute.cs" />
     <Compile Include="Metadata\SandboxDependencyAttribute.cs" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/References/ReferencesAreRemovedWhenAllUsagesAreRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/References/ReferencesAreRemovedWhenAllUsagesAreRemoved.cs
@@ -4,6 +4,10 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.References {
 	[CoreLink ("link")]
+	// Il8n & the blacklist step pollute the results with extra stuff that didn't need to be
+	// preserved for this test case so we need to disable them
+	[Il8n("none")]
+	[IncludeBlacklistStep("false")]
 	[Reference ("System.dll")]
 	[RemovedAssembly ("System.dll")]
 	class ReferencesAreRemovedWhenAllUsagesAreRemoved {

--- a/linker/Tests/TestCasesRunner/LinkerArgumentBuilder.cs
+++ b/linker/Tests/TestCasesRunner/LinkerArgumentBuilder.cs
@@ -29,6 +29,18 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			Append (value);
 		}
 
+		public virtual void IncludeBlacklist (string value)
+		{
+			Append ("-z");
+			Append (value);
+		}
+
+		public virtual void AddIl8n (string value)
+		{
+			Append ("-l");
+			Append (value);
+		}
+
 		public string [] ToArgs ()
 		{
 			return _arguments.ToArray ();

--- a/linker/Tests/TestCasesRunner/ResultChecker.cs
+++ b/linker/Tests/TestCasesRunner/ResultChecker.cs
@@ -79,7 +79,13 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			foreach (var assemblyAttr in assembliesToCheck) {
 				var name = (string) assemblyAttr.ConstructorArguments.First ().Value;
 				var expectedPath = outputDirectory.Combine (name);
-				Assert.IsTrue (expectedPath.FileExists (), $"Expected the assembly {name} to exist in {outputDirectory}, but it did not");
+
+				if (assemblyAttr.AttributeType.Name == nameof (RemovedAssemblyAttribute))
+					Assert.IsFalse (expectedPath.FileExists (), $"Expected the assembly {name} to not exist in {outputDirectory}, but it did");
+				else if (assemblyAttr.AttributeType.Name == nameof (KeptAssemblyAttribute))
+					Assert.IsTrue (expectedPath.FileExists (), $"Expected the assembly {name} to exist in {outputDirectory}, but it did not");
+				else
+					throw new NotImplementedException($"Unknown assembly assertion of type {assemblyAttr.AttributeType}");
 			}
 		}
 

--- a/linker/Tests/TestCasesRunner/TestCaseLinkerOptions.cs
+++ b/linker/Tests/TestCasesRunner/TestCaseLinkerOptions.cs
@@ -1,5 +1,7 @@
 ﻿namespace Mono.Linker.Tests.TestCasesRunner {
 	public class TestCaseLinkerOptions {
 		public string CoreLink;
+		public string Il8n;
+		public string IncludeBlacklistStep;
 	}
 }

--- a/linker/Tests/TestCasesRunner/TestCaseMetadaProvider.cs
+++ b/linker/Tests/TestCasesRunner/TestCaseMetadaProvider.cs
@@ -28,11 +28,10 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 		{
 			// This will end up becoming more complicated as we get into more complex test cases that require additional
 			// data
-			var value = "skip";
-			var coreLinkAttribute = _testCaseTypeDefinition.CustomAttributes.FirstOrDefault (attr => attr.AttributeType.Name == nameof (CoreLinkAttribute));
-			if (coreLinkAttribute != null)
-				value = (string) coreLinkAttribute.ConstructorArguments.First ().Value;
-			return new TestCaseLinkerOptions {CoreLink = value};
+			var coreLink = GetOptionAttributeValue (nameof (CoreLinkAttribute), "skip");
+			var il8n = GetOptionAttributeValue (nameof (Il8nAttribute), string.Empty);
+			var blacklist = GetOptionAttributeValue (nameof (IncludeBlacklistStepAttribute), string.Empty);
+			return new TestCaseLinkerOptions {CoreLink = coreLink, Il8n = il8n, IncludeBlacklistStep = blacklist};
 		}
 
 		public virtual IEnumerable<string> GetReferencedAssemblies ()
@@ -70,6 +69,15 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 				var relativeDepPath = ((string) attr.ConstructorArguments.First ().Value).ToNPath ();
 				yield return _testCase.SourceFile.Parent.Combine (relativeDepPath);
 			}
+		}
+
+		T GetOptionAttributeValue<T> (string attributeName, T defaultValue)
+		{
+			var attribute = _testCaseTypeDefinition.CustomAttributes.FirstOrDefault (attr => attr.AttributeType.Name == attributeName);
+			if (attribute != null)
+				return (T) attribute.ConstructorArguments.First ().Value;
+
+			return defaultValue;
 		}
 	}
 }

--- a/linker/Tests/TestCasesRunner/TestRunner.cs
+++ b/linker/Tests/TestCasesRunner/TestRunner.cs
@@ -70,6 +70,15 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 
 			builder.AddCoreLink (caseDefinedOptions.CoreLink);
 
+			// Running the blacklist step causes a ton of stuff to be preserved.  That's good for normal use cases, but for
+			// our test cases that pollutes the results
+			if (!string.IsNullOrEmpty (caseDefinedOptions.IncludeBlacklistStep))
+				builder.IncludeBlacklist (caseDefinedOptions.IncludeBlacklistStep);
+
+			// Internationalization assemblies pollute our test case results as well so disable them
+			if (!string.IsNullOrEmpty (caseDefinedOptions.Il8n))
+				builder.AddIl8n (caseDefinedOptions.Il8n);
+
 			linker.Link (builder.ToArgs ());
 
 			return new LinkedTestCaseResult (testCase, compilationResult.InputAssemblyPath, sandbox.OutputDirectory.Combine (compilationResult.InputAssemblyPath.FileName), compilationResult.ExpectationsAssemblyPath);


### PR DESCRIPTION
ReferencesAreRemovedWhenAllUsagesAreRemoved was passing when it should have been failing due to a bug in ResultChecker treating [RemovedAssembly] the same as [KeptAssembly].  Once the ResultChecker was fixed, it took a couple more changes before the test would pass.

Add a command line option to disable the blacklist step

For the test cases, disable options that tend to pollute the linked output with a bunch of preservations that are not needed for our test cases

Make assembly and module attribute marking slightly less conservative. Currently we mark them all.  With this change we will not mark assembly and module attributes when their defining module has not been marked after processing all types.

This fixes the test ReferencesAreRemovedWhenAllUsagesAreRemoved when ran against the .NET Framework.  When this test was ran against the .NET Framework, System.dll was being kept around because of the assembly attribute BitmapSuffixInSatelliteAssemblyAttribute, which is itself defined in System.dll.

I did not write a unit test for this case because (a) it would be tricky to do at the moment and (b) we are overly conservative with attributes as a whole and attribute linking need to be reviewed.  When that happens, we can pin down the exact behavior we want.  The goal of this PR is to get ReferencesAreRemovedWhenAllUsagesAreRemoved passing.
