### PR TITLE
Improve assembly resolution in ResultChecker

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptMemberInAssemblyAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptMemberInAssemblyAttribute.cs
@@ -5,13 +5,20 @@ namespace Mono.Linker.Tests.Cases.Expectations.Assertions {
 	[AttributeUsage (AttributeTargets.Class | AttributeTargets.Delegate, AllowMultiple = true, Inherited = false)]
 	public class KeptMemberInAssemblyAttribute : BaseExpectedLinkedBehaviorAttribute {
 		public readonly string AssemblyFileName;
-		public readonly Type Type;
+		public readonly string TypeName;
 		public readonly string [] MemberNames;
 
 		public KeptMemberInAssemblyAttribute (string assemblyFileName, Type type, params string [] memberNames)
 		{
 			AssemblyFileName = assemblyFileName;
-			Type = type;
+			TypeName = type.ToString ();
+			MemberNames = memberNames;
+		}
+
+		public KeptMemberInAssemblyAttribute (string assemblyFileName, string typeName, params string [] memberNames)
+		{
+			AssemblyFileName = assemblyFileName;
+			TypeName = typeName;
 			MemberNames = memberNames;
 		}
 	}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptTypeInAssemblyAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptTypeInAssemblyAttribute.cs
@@ -6,12 +6,18 @@ namespace Mono.Linker.Tests.Cases.Expectations.Assertions
 	public class KeptTypeInAssemblyAttribute : BaseExpectedLinkedBehaviorAttribute
 	{
 		public readonly string AssemblyFileName;
-		public readonly Type Type;
+		public readonly string TypeName;
 
-		public KeptTypeInAssemblyAttribute(string assemblyFileName, Type type)
+		public KeptTypeInAssemblyAttribute (string assemblyFileName, Type type)
 		{
 			AssemblyFileName = assemblyFileName;
-			Type = type;
+			TypeName = type.ToString ();
+		}
+
+		public KeptTypeInAssemblyAttribute (string assemblyFileName, string typeName)
+		{
+			AssemblyFileName = assemblyFileName;
+			TypeName = typeName;
 		}
 	}
 }

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/RemovedMemberInAssemblyAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/RemovedMemberInAssemblyAttribute.cs
@@ -4,13 +4,20 @@ namespace Mono.Linker.Tests.Cases.Expectations.Assertions {
 	[AttributeUsage (AttributeTargets.Class | AttributeTargets.Delegate, AllowMultiple = true, Inherited = false)]
 	public class RemovedMemberInAssemblyAttribute : BaseExpectedLinkedBehaviorAttribute {
 		public readonly string AssemblyFileName;
-		public readonly Type Type;
+		public readonly string TypeName;
 		public readonly string [] MemberNames;
 
 		public RemovedMemberInAssemblyAttribute (string assemblyFileName, Type type, params string [] memberNames)
 		{
 			AssemblyFileName = assemblyFileName;
-			Type = type;
+			TypeName = type.ToString ();
+			MemberNames = memberNames;
+		}
+
+		public RemovedMemberInAssemblyAttribute (string assemblyFileName, string typeName, params string [] memberNames)
+		{
+			AssemblyFileName = assemblyFileName;
+			TypeName = typeName;
 			MemberNames = memberNames;
 		}
 	}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/RemovedTypeInAssemblyAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/RemovedTypeInAssemblyAttribute.cs
@@ -5,12 +5,18 @@ namespace Mono.Linker.Tests.Cases.Expectations.Assertions
 	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Delegate, AllowMultiple = true, Inherited = false)]
 	public class RemovedTypeInAssemblyAttribute : BaseExpectedLinkedBehaviorAttribute {
 		public readonly string AssemblyFileName;
-		public readonly Type Type;
+		public readonly string TypeName;
 
 		public RemovedTypeInAssemblyAttribute (string assemblyFileName, Type type)
 		{
 			AssemblyFileName = assemblyFileName;
-			Type = type;
+			TypeName = type.ToString ();
+		}
+
+		public RemovedTypeInAssemblyAttribute (string assemblyFileName, string typeName)
+		{
+			AssemblyFileName = assemblyFileName;
+			TypeName = typeName;
 		}
 	}
 }


### PR DESCRIPTION
Add support for string type name in *InAssemblyAttributes so that non-public types can be checked