### PR TITLE
More resolution clean up in ResultChecker

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/ReferenceAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/ReferenceAttribute.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 
 namespace Mono.Linker.Tests.Cases.Expectations.Metadata {
-	[AttributeUsage (AttributeTargets.Class)]
+	[AttributeUsage (AttributeTargets.Class, AllowMultiple = true)]
 	public class ReferenceAttribute : BaseMetadataAttribute {
 		public readonly string Value;
 


### PR DESCRIPTION
* Fix an issue where [KeptTypeInAssembly("System.Core", ....)] would lead to System.dll being loaded because of a bug in the Resolve logic.  This was happening on line 91.

* Standardize on one way to call Resolve in result checker.

* Allow multiple [Reference] attributes