### PR TITLE
Switch to explicit references only.  

### DIFF
--- a/linker/Tests/TestCasesRunner/TestCaseMetadaProvider.cs
+++ b/linker/Tests/TestCasesRunner/TestCaseMetadaProvider.cs
@@ -35,8 +35,9 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			return new TestCaseLinkerOptions {CoreLink = value};
 		}
 
-		public virtual IEnumerable<string> GetReferencedAssemblies ()
+		public virtual IEnumerable<string> GetReferencedAssemblies (NPath workingDirectory)
 		{
+			yield return workingDirectory.Combine ("Mono.Linker.Tests.Cases.Expectations.dll").ToString ();
 			yield return "mscorlib.dll";
 
 			foreach (var referenceAttr in _testCaseTypeDefinition.CustomAttributes.Where (attr => attr.AttributeType.Name == nameof (ReferenceAttribute))) {

--- a/linker/Tests/TestCasesRunner/TestCaseSandbox.cs
+++ b/linker/Tests/TestCasesRunner/TestCaseSandbox.cs
@@ -47,14 +47,6 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			get { return _directory.Files ("*.cs"); }
 		}
 
-		public IEnumerable<NPath> InputDirectoryReferences {
-			get { return InputDirectory.Files ("*.dll"); }
-		}
-
-		public IEnumerable<NPath> ExpectationsDirectoryReferences {
-			get { return ExpectationsDirectory.Files ("*.dll"); }
-		}
-
 		public IEnumerable<NPath> LinkXmlFiles {
 			get { return InputDirectory.Files ("*.xml"); }
 		}
@@ -66,18 +58,22 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			if (_testCase.HasLinkXmlFile)
 				_testCase.LinkXmlFile.Copy (InputDirectory);
 
-			GetExpectationsAssemblyPath ().Copy (InputDirectory);
+			CopyToInputAndExpectations (GetExpectationsAssemblyPath ());
 
 			foreach (var dep in metadataProvider.AdditionalFilesToSandbox ()) {
 				dep.FileMustExist ().Copy (_directory);
 			}
-
-			InputDirectoryReferences.Copy (ExpectationsDirectory);
 		}
 
 		private static NPath GetExpectationsAssemblyPath ()
 		{
 			return new Uri (typeof (KeptAttribute).Assembly.CodeBase).LocalPath.ToNPath ();
+		}
+
+		protected void CopyToInputAndExpectations (NPath source)
+		{
+			source.Copy (InputDirectory);
+			source.Copy (ExpectationsDirectory);
 		}
 	}
 }

--- a/linker/Tests/TestCasesRunner/TestRunner.cs
+++ b/linker/Tests/TestCasesRunner/TestRunner.cs
@@ -40,10 +40,10 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			var compiler = _factory.CreateCompiler ();
 			var sourceFiles = sandbox.SourceFiles.Select(s => s.ToString()).ToArray();
 
-			var references = metadataProvider.GetReferencedAssemblies ().Concat (sandbox.InputDirectoryReferences.Select (r => r.ToString ())).ToArray ();
+			var references = metadataProvider.GetReferencedAssemblies(sandbox.InputDirectory);
 			var inputAssemblyPath = compiler.CompileTestIn (sandbox.InputDirectory, sourceFiles, references, null);
 
-			references = metadataProvider.GetReferencedAssemblies ().Concat (sandbox.ExpectationsDirectoryReferences.Select (r => r.ToString ())).ToArray ();
+			references = metadataProvider.GetReferencedAssemblies(sandbox.ExpectationsDirectory);
 			var expectationsAssemblyPath = compiler.CompileTestIn (sandbox.ExpectationsDirectory, sourceFiles, references, new [] { "INCLUDE_EXPECTATIONS" });
 			return new ManagedCompilationResult (inputAssemblyPath, expectationsAssemblyPath);
 		}


### PR DESCRIPTION
No more assuming all .dlls that were copied into the sandbox directory are meant to be passed as references when compiling the test cases.

While moving our WinRT tests over to the new test structure I ran into cases where we have native dlls in the sandbox.  Assuming all .dlls in the sandbox directory should be passed as references was causing problems.  Since we only depended on this implicit way of figuring out references for the Expectations dll, I thought it would be easiest to handle that case specially and then require that the [Reference] mechanism be used to define each additional reference for a test case