### PR TITLE
Unresolved type handling for top level attributes

### DIFF
--- a/linker/Mono.Linker.Steps/MarkStep.cs
+++ b/linker/Mono.Linker.Steps/MarkStep.cs
@@ -508,9 +508,15 @@ namespace Mono.Linker.Steps {
 			while (_topLevelAttributes.Count != 0) {
 				var customAttribute = _topLevelAttributes.Dequeue ();
 
+				var resolved = customAttribute.AttributeType.Resolve ();
+				if (resolved == null) {
+					HandleUnresolvedType (customAttribute.AttributeType);
+					continue;
+				}
+
 				// If an attribute's module has not been marked after processing all types in all assemblies and the attribute itself has not been marked,
 				// then surely nothing is using this attribute and there is no need to mark it
-				if (!Annotations.IsMarked (customAttribute.AttributeType.Resolve ().Module) && !Annotations.IsMarked (customAttribute.AttributeType))
+				if (!Annotations.IsMarked (resolved.Module) && !Annotations.IsMarked (customAttribute.AttributeType))
 					continue;
 
 				MarkCustomAttribute (customAttribute);


### PR DESCRIPTION
Follow the same UnresolvedType handling scheme used else where in the MarkStep