### PR TITLE
Base attribute for InAssembly attrs

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/BaseInAssemblyAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/BaseInAssemblyAttribute.cs
@@ -1,0 +1,5 @@
+﻿namespace Mono.Linker.Tests.Cases.Expectations.Assertions
+{
+	public abstract class BaseInAssemblyAttribute : BaseExpectedLinkedBehaviorAttribute {
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptMemberInAssemblyAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptMemberInAssemblyAttribute.cs
@@ -3,7 +3,7 @@
 
 namespace Mono.Linker.Tests.Cases.Expectations.Assertions {
 	[AttributeUsage (AttributeTargets.Class | AttributeTargets.Delegate, AllowMultiple = true, Inherited = false)]
-	public class KeptMemberInAssemblyAttribute : BaseExpectedLinkedBehaviorAttribute {
+	public class KeptMemberInAssemblyAttribute : BaseInAssemblyAttribute {
 
 		public KeptMemberInAssemblyAttribute (string assemblyFileName, Type type, params string [] memberNames)
 		{

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptTypeInAssemblyAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptTypeInAssemblyAttribute.cs
@@ -3,8 +3,7 @@
 namespace Mono.Linker.Tests.Cases.Expectations.Assertions
 {
 	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Delegate, AllowMultiple = true, Inherited = false)]
-	public class KeptTypeInAssemblyAttribute : BaseExpectedLinkedBehaviorAttribute
-	{
+	public class KeptTypeInAssemblyAttribute : BaseInAssemblyAttribute {
 		public KeptTypeInAssemblyAttribute (string assemblyFileName, Type type)
 		{
 			if (type == null)

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/RemovedMemberInAssemblyAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/RemovedMemberInAssemblyAttribute.cs
@@ -2,7 +2,7 @@
 
 namespace Mono.Linker.Tests.Cases.Expectations.Assertions {
 	[AttributeUsage (AttributeTargets.Class | AttributeTargets.Delegate, AllowMultiple = true, Inherited = false)]
-	public class RemovedMemberInAssemblyAttribute : BaseExpectedLinkedBehaviorAttribute {
+	public class RemovedMemberInAssemblyAttribute : BaseInAssemblyAttribute {
 
 		public RemovedMemberInAssemblyAttribute (string assemblyFileName, Type type, params string [] memberNames)
 		{

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/RemovedTypeInAssemblyAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/RemovedTypeInAssemblyAttribute.cs
@@ -3,7 +3,7 @@
 namespace Mono.Linker.Tests.Cases.Expectations.Assertions
 {
 	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Delegate, AllowMultiple = true, Inherited = false)]
-	public class RemovedTypeInAssemblyAttribute : BaseExpectedLinkedBehaviorAttribute {
+	public class RemovedTypeInAssemblyAttribute : BaseInAssemblyAttribute {
 		public RemovedTypeInAssemblyAttribute (string assemblyFileName, Type type)
 		{
 			if (type == null)

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
@@ -37,6 +37,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Assertions\BaseInAssemblyAttribute.cs" />
     <Compile Include="Assertions\IgnoreTestCaseAttribute.cs" />
     <Compile Include="Assertions\KeptAssemblyAttribute.cs" />
     <Compile Include="Assertions\KeptAttribute.cs" />


### PR DESCRIPTION
I have an upcoming PR that will make use of this change.  The upcoming PR will change ResultChecker.IsTypeInOtherAssemblyAssertion to leverage this new base attribute instead of explicitly checking for each of the attributes.  It wasn't worth the hassle of pulling the change to IsTypeInOtherAssemblyAssertion out of my other PR and into this one.
