### PR TITLE
Test framework extensibility improvements

### DIFF
--- a/linker/Tests/TestCasesRunner/TestCaseCompiler.cs
+++ b/linker/Tests/TestCasesRunner/TestCaseCompiler.cs
@@ -7,9 +7,9 @@ using Mono.Linker.Tests.Extensions;
 
 namespace Mono.Linker.Tests.TestCasesRunner {
 	public class TestCaseCompiler {
-		public virtual NPath CompileTestIn (NPath outputDirectory, IEnumerable<string> sourceFiles, IEnumerable<string> references, IEnumerable<string> defines)
+		public virtual NPath CompileTestIn (NPath outputDirectory, string outputName, IEnumerable<string> sourceFiles, IEnumerable<string> references, IEnumerable<string> defines)
 		{
-			var compilerOptions = CreateCompilerOptions (outputDirectory, references, defines);
+			var compilerOptions = CreateCompilerOptions (outputDirectory, outputName, references, defines);
 			var provider = CodeDomProvider.CreateProvider ("C#");
 			var result = provider.CompileAssemblyFromFile (compilerOptions, sourceFiles.ToArray ());
 			if (!result.Errors.HasErrors)
@@ -21,14 +21,14 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			throw new Exception ("Compilation errors: " + errors);
 		}
 
-		protected virtual CompilerParameters CreateCompilerOptions (NPath outputDirectory, IEnumerable<string> references, IEnumerable<string> defines)
+		protected virtual CompilerParameters CreateCompilerOptions (NPath outputDirectory, string outputName, IEnumerable<string> references, IEnumerable<string> defines)
 		{
-			var outputPath = outputDirectory.Combine ("test.exe");
+			var outputPath = outputDirectory.Combine (outputName);
 
 			var compilerParameters = new CompilerParameters
 			{
 				OutputAssembly = outputPath.ToString (),
-				GenerateExecutable = true
+				GenerateExecutable = outputName.EndsWith(".exe")
 			};
 
 			compilerParameters.CompilerOptions = defines?.Aggregate (string.Empty, (buff, arg) => $"{buff} /define:{arg}");

--- a/linker/Tests/TestCasesRunner/TestRunner.cs
+++ b/linker/Tests/TestCasesRunner/TestRunner.cs
@@ -41,10 +41,10 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			var sourceFiles = sandbox.SourceFiles.Select(s => s.ToString()).ToArray();
 
 			var references = metadataProvider.GetReferencedAssemblies(sandbox.InputDirectory);
-			var inputAssemblyPath = compiler.CompileTestIn (sandbox.InputDirectory, sourceFiles, references, null);
+			var inputAssemblyPath = compiler.CompileTestIn (sandbox.InputDirectory, "test.exe", sourceFiles, references, null);
 
 			references = metadataProvider.GetReferencedAssemblies(sandbox.ExpectationsDirectory);
-			var expectationsAssemblyPath = compiler.CompileTestIn (sandbox.ExpectationsDirectory, sourceFiles, references, new [] { "INCLUDE_EXPECTATIONS" });
+			var expectationsAssemblyPath = compiler.CompileTestIn (sandbox.ExpectationsDirectory, "test.exe", sourceFiles, references, new [] { "INCLUDE_EXPECTATIONS" });
 			return new ManagedCompilationResult (inputAssemblyPath, expectationsAssemblyPath);
 		}
 


### PR DESCRIPTION
I have finished moving over all of our old tests to the new test framework.  The last of the tests were the most complex and I had to make some adjustments to the core of the test framework so that we could extend it to meet our needs.

In ResultChecker

* AdditionalChecking - We use this to do a few extra things before the AssemblyDefinitions are disposed of.

* UnhandledOtherAssemblyAssertion - This is where we put the logic to handle our [StubbedMemberInAssembly] attribute.

* The change to GetOriginalTypeFromInAssemblyAttribute is simply for improved error reporting when you write a bad test

In TestCaseCompiler I had to shift a few things around  to make TestCaseCompiler a bit more reusable.  We have some tests now that use TestCaseCompiler to compile supporting .dll's so we needed the ability to pass in the output name instead of having it hard coded to "test.exe"