### PR TITLE
Add some tests for situation where interface method is removed

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -57,6 +57,9 @@
     <Compile Include="Basic\UnusedPropertySetterRemoved.cs" />
     <Compile Include="Basic\UsedPropertyIsKept.cs" />
     <Compile Include="Basic\UsedStructIsKept.cs" />
+    <Compile Include="VirtualMethods\ClassUsedFromConcreteTypeHasInterfaceMethodRemoved.cs" />
+    <Compile Include="VirtualMethods\ClassUsedFromInterfaceHasInterfaceMethodKept.cs" />
+    <Compile Include="VirtualMethods\StructUsedFromConcreteTypeHasInterfaceMethodRemoved.cs" />
     <Compile Include="VirtualMethods\StructUsedFromInterfaceHasInterfaceMethodKept.cs" />
     <Compile Include="CoreLink\CopyOfCoreLibrariesKeepsUnusedTypes.cs" />
     <Compile Include="CoreLink\LinkingOfCoreLibrariesRemovesUnusedMethods.cs" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/VirtualMethods/ClassUsedFromConcreteTypeHasInterfaceMethodRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/VirtualMethods/ClassUsedFromConcreteTypeHasInterfaceMethodRemoved.cs
@@ -1,0 +1,26 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.VirtualMethods
+{
+	class ClassUsedFromConcreteTypeHasInterfaceMethodRemoved {
+		public static void Main ()
+		{
+			A a = new A ();
+			a.Foo ();
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IFoo))]
+		struct A : IFoo {
+			[Kept]
+			public void Foo ()
+			{
+			}
+		}
+
+		[Kept]
+		public interface IFoo {
+			void Foo ();
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/VirtualMethods/ClassUsedFromInterfaceHasInterfaceMethodKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/VirtualMethods/ClassUsedFromInterfaceHasInterfaceMethodKept.cs
@@ -1,0 +1,27 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.VirtualMethods
+{
+	class ClassUsedFromInterfaceHasInterfaceMethodKept {
+		public static void Main ()
+		{
+			IFoo a = new A ();
+			a.Foo ();
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IFoo))]
+		struct A : IFoo {
+			[Kept]
+			public void Foo ()
+			{
+			}
+		}
+
+		[Kept]
+		public interface IFoo {
+			[Kept]
+			void Foo ();
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/VirtualMethods/StructUsedFromConcreteTypeHasInterfaceMethodRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/VirtualMethods/StructUsedFromConcreteTypeHasInterfaceMethodRemoved.cs
@@ -1,0 +1,26 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.VirtualMethods
+{
+	class StructUsedFromConcreteTypeHasInterfaceMethodRemoved {
+		public static void Main ()
+		{
+			A a = new A ();
+			a.Foo ();
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IFoo))]
+		struct A : IFoo {
+			[Kept]
+			public void Foo ()
+			{
+			}
+		}
+
+		[Kept]
+		public interface IFoo {
+			void Foo ();
+		}
+	}
+}


### PR DESCRIPTION
I wrote StructUsedFromConcreteTypeHasInterfaceMethodRemoved and was initially a little surprised that IFoo.Method was removed.  However this is valid.  I thought I would add some tests covering this behavior since we did not have them already.