### PR TITLE
Make arg builder more extensible

### DIFF
--- a/linker/Tests/TestCasesRunner/LinkerArgumentBuilder.cs
+++ b/linker/Tests/TestCasesRunner/LinkerArgumentBuilder.cs
@@ -50,5 +50,19 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 		{
 			_arguments.Add (arg);
 		}
+
+		public virtual void ProcessOptions (TestCaseLinkerOptions options)
+		{
+			AddCoreLink (options.CoreLink);
+
+			// Running the blacklist step causes a ton of stuff to be preserved.  That's good for normal use cases, but for
+			// our test cases that pollutes the results
+			if (!string.IsNullOrEmpty (options.IncludeBlacklistStep))
+				IncludeBlacklist (options.IncludeBlacklistStep);
+
+			// Internationalization assemblies pollute our test case results as well so disable them
+			if (!string.IsNullOrEmpty (options.Il8n))
+				AddIl8n (options.Il8n);
+		}
 	}
 }

--- a/linker/Tests/TestCasesRunner/TestRunner.cs
+++ b/linker/Tests/TestCasesRunner/TestRunner.cs
@@ -68,20 +68,17 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			foreach (var extraSearchDir in metadataProvider.GetExtraLinkerSearchDirectories ())
 				builder.AddSearchDirectory (extraSearchDir);
 
-			builder.AddCoreLink (caseDefinedOptions.CoreLink);
+			builder.ProcessOptions (caseDefinedOptions);
 
-			// Running the blacklist step causes a ton of stuff to be preserved.  That's good for normal use cases, but for
-			// our test cases that pollutes the results
-			if (!string.IsNullOrEmpty (caseDefinedOptions.IncludeBlacklistStep))
-				builder.IncludeBlacklist (caseDefinedOptions.IncludeBlacklistStep);
-
-			// Internationalization assemblies pollute our test case results as well so disable them
-			if (!string.IsNullOrEmpty (caseDefinedOptions.Il8n))
-				builder.AddIl8n (caseDefinedOptions.Il8n);
+			AddAdditionalLinkOptions (builder, metadataProvider);
 
 			linker.Link (builder.ToArgs ());
 
 			return new LinkedTestCaseResult (testCase, compilationResult.InputAssemblyPath, sandbox.OutputDirectory.Combine (compilationResult.InputAssemblyPath.FileName), compilationResult.ExpectationsAssemblyPath);
+		}
+
+		protected virtual void AddAdditionalLinkOptions (LinkerArgumentBuilder builder, TestCaseMetadaProvider metadataProvider)
+		{
 		}
 	}
 }


### PR DESCRIPTION
Some of our tests need to use custom options.  This PR refactors the argument building so that we have some options for including custom options during our tests.