### PR TITLE
Verify behavior with no preserve attribute in XML

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/UnusedAssemblyWithNoDefinedPreserveHasAllTypesPreserved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/UnusedAssemblyWithNoDefinedPreserveHasAllTypesPreserved.cs
@@ -1,0 +1,15 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.LinkXml {
+	[KeptMember (".ctor()")]
+	public class UnusedAssemblyWithNoDefinedPreserveHasAllTypesPreserved {
+		public static void Main ()
+		{
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		class Unused {
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/UnusedAssemblyWithNoDefinedPreserveHasAllTypesPreserved.xml
+++ b/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/UnusedAssemblyWithNoDefinedPreserveHasAllTypesPreserved.xml
@@ -1,0 +1,4 @@
+﻿<linker>
+    <assembly fullname="test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+    </assembly>
+</linker>

--- a/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/UnusedTypeWithNoDefinedPreserveHasAllMembersPreserved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/UnusedTypeWithNoDefinedPreserveHasAllMembersPreserved.cs
@@ -1,0 +1,86 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.LinkXml {
+	class UnusedTypeWithNoDefinedPreserveHasAllMembersPreserved
+	{
+		public static void Main ()
+		{
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		class Unused {
+			[Kept]
+			public int Field1;
+
+			[Kept]
+			private int Field2;
+
+			[Kept]
+			internal int Field3;
+
+			[Kept]
+			public static int Field4;
+
+			[Kept]
+			private static int Field5;
+
+			[Kept]
+			internal static int Field6;
+
+			[Kept]
+			[KeptBackingField]
+			public string Property1 { [Kept] get; [Kept] set;}
+
+			[Kept]
+			[KeptBackingField]
+			private string Property2 { [Kept] get; [Kept] set; }
+
+			[Kept]
+			[KeptBackingField]
+			internal string Property3 { [Kept] get; [Kept] set; }
+
+			[Kept]
+			[KeptBackingField]
+			public static string Property4 { [Kept] get; [Kept] set; }
+
+			[Kept]
+			[KeptBackingField]
+			private static string Property5 { [Kept] get; [Kept] set; }
+
+			[Kept]
+			[KeptBackingField]
+			internal static string Property6 { [Kept] get; [Kept] set; }
+
+			[Kept]
+			public void Method1 ()
+			{
+			}
+
+			[Kept]
+			private void Method2 ()
+			{
+			}
+
+			[Kept]
+			internal void Method3 ()
+			{
+			}
+
+			[Kept]
+			public static void Method4 ()
+			{
+			}
+
+			[Kept]
+			private static void Method5 ()
+			{
+			}
+
+			[Kept]
+			internal static void Method6 ()
+			{
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/UnusedTypeWithNoDefinedPreserveHasAllMembersPreserved.xml
+++ b/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/UnusedTypeWithNoDefinedPreserveHasAllMembersPreserved.xml
@@ -1,0 +1,5 @@
+﻿<linker>
+    <assembly fullname="test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+        <type fullname="Mono.Linker.Tests.Cases.LinkXml.UnusedTypeWithNoDefinedPreserveHasAllMembersPreserved/Unused" />
+    </assembly>
+</linker>

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -57,6 +57,8 @@
     <Compile Include="Basic\UnusedPropertySetterRemoved.cs" />
     <Compile Include="Basic\UsedPropertyIsKept.cs" />
     <Compile Include="Basic\UsedStructIsKept.cs" />
+    <Compile Include="LinkXml\UnusedAssemblyWithNoDefinedPreserveHasAllTypesPreserved.cs" />
+    <Compile Include="LinkXml\UnusedTypeWithNoDefinedPreserveHasAllMembersPreserved.cs" />
     <Compile Include="VirtualMethods\ClassUsedFromConcreteTypeHasInterfaceMethodRemoved.cs" />
     <Compile Include="VirtualMethods\ClassUsedFromInterfaceHasInterfaceMethodKept.cs" />
     <Compile Include="VirtualMethods\StructUsedFromConcreteTypeHasInterfaceMethodRemoved.cs" />
@@ -130,12 +132,14 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="LinkXml\TypeWithPreserveFieldsHasBackingFieldsOfPropertiesRemoved.xml" />
+    <Content Include="LinkXml\UnusedAssemblyWithNoDefinedPreserveHasAllTypesPreserved.xml" />
     <Content Include="LinkXml\UnusedFieldPreservedByLinkXmlIsKept.xml" />
     <Content Include="LinkXml\UnusedMethodPreservedByLinkXmlIsKept.xml" />
     <Content Include="LinkXml\UnusedNestedTypePreservedByLinkXmlIsKept.xml" />
     <Content Include="LinkXml\UnusedPropertyPreservedByLinkXmlIsKept.xml" />
     <Content Include="LinkXml\UnusedTypeIsPresservedWhenEntireAssemblyIsPreserved.xml" />
     <Content Include="LinkXml\UnusedTypePreservedByLinkXmlIsKept.xml" />
+    <Content Include="LinkXml\UnusedTypeWithNoDefinedPreserveHasAllMembersPreserved.xml" />
     <Content Include="LinkXml\UnusedTypeWithPreserveAllHasAllMembersPreserved.xml" />
     <Content Include="LinkXml\UnusedTypeWithPreserveFieldsHasMethodsRemoved.xml" />
     <Content Include="LinkXml\UnusedTypeWithPreserveMethodsHasFieldsRemoved.xml" />


### PR DESCRIPTION
If a link.xml file has an assembly or type element that does not have
a preserve atttribute, treat that as if it is preserve="all". These two
tests verify the existing behavior.