### PR TITLE
Provide 'event' and 'property' elements support with Link XML step.

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptBackingFieldAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptBackingFieldAttribute.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 
-namespace Mono.Linker.Tests.Cases.Expectations.Assertions
-{
-	[AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+namespace Mono.Linker.Tests.Cases.Expectations.Assertions {
+	[AttributeUsage(AttributeTargets.Property | AttributeTargets.Event, AllowMultiple = false, Inherited = false)]
 	public sealed class KeptBackingFieldAttribute : KeptAttribute {
 	}
 }

--- a/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/UnusedEventPreservedByLinkXmlIsKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/UnusedEventPreservedByLinkXmlIsKept.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.LinkXml {
+	class UnusedEventPreservedByLinkXmlIsKept {
+		public static void Main ()
+		{
+		}
+
+		[Kept]
+		class Unused {
+			[Kept]
+			[KeptBackingField]
+			public event EventHandler<EventArgs> Preserved;
+
+			[Kept]
+			public event EventHandler<EventArgs> Preserved1 { [Kept] add { } [Kept] remove { } }
+
+			public event EventHandler<EventArgs> NotPreserved;
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/UnusedEventPreservedByLinkXmlIsKept.xml
+++ b/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/UnusedEventPreservedByLinkXmlIsKept.xml
@@ -1,0 +1,8 @@
+﻿<linker>
+  <assembly fullname="test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+    <type fullname="Mono.Linker.Tests.Cases.LinkXml.UnusedEventPreservedByLinkXmlIsKept/Unused">
+      <event signature="System.EventHandler`1&lt;System.EventArgs&gt; Preserved" />
+      <event signature="System.EventHandler`1&lt;System.EventArgs&gt; Preserved1" />
+    </type>
+  </assembly>
+</linker>

--- a/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/UnusedPropertyPreservedByLinkXmlIsKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/UnusedPropertyPreservedByLinkXmlIsKept.cs
@@ -20,6 +20,22 @@ namespace Mono.Linker.Tests.Cases.LinkXml {
 			[KeptBackingField]
 			public int PreservedProperty3 { get; [Kept] set; }
 
+			[Kept]
+			[KeptBackingField]
+			public int PreservedProperty4 { [Kept] get; [Kept] set; }
+
+			[Kept]
+			[KeptBackingField]
+			public int PreservedProperty5 { [Kept] get; [Kept] set; }
+
+			[Kept]
+			[KeptBackingField]
+			public int PreservedProperty6 { [Kept] get; set; }
+
+			[Kept]
+			[KeptBackingField]
+			public int PreservedProperty7 { get; [Kept] set; }
+
 			public int NotPreservedProperty { get; set; }
 		}
 	}

--- a/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/UnusedPropertyPreservedByLinkXmlIsKept.xml
+++ b/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/UnusedPropertyPreservedByLinkXmlIsKept.xml
@@ -5,6 +5,11 @@
       <method signature="System.Void set_PreservedProperty1(System.Int32)" />
       <method signature="System.Int32 get_PreservedProperty2()" />
       <method signature="System.Void set_PreservedProperty3(System.Int32)" />
+
+      <property signature="System.Int32 PreservedProperty4" />
+      <property signature="System.Int32 PreservedProperty5" accessors="all" />
+      <property signature="System.Int32 PreservedProperty6" accessors="get" />
+      <property signature="System.Int32 PreservedProperty7" accessors="set" />
     </type>
   </assembly>
 </linker>

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Basic\UsedPropertyIsKept.cs" />
     <Compile Include="Basic\UsedStructIsKept.cs" />
     <Compile Include="LinkXml\UnusedAssemblyWithNoDefinedPreserveHasAllTypesPreserved.cs" />
+    <Compile Include="LinkXml\UnusedEventPreservedByLinkXmlIsKept.cs" />
     <Compile Include="LinkXml\UnusedTypeWithNoDefinedPreserveHasAllMembersPreserved.cs" />
     <Compile Include="VirtualMethods\ClassUsedFromConcreteTypeHasInterfaceMethodRemoved.cs" />
     <Compile Include="VirtualMethods\ClassUsedFromInterfaceHasInterfaceMethodKept.cs" />
@@ -133,6 +134,7 @@
   <ItemGroup>
     <Content Include="LinkXml\TypeWithPreserveFieldsHasBackingFieldsOfPropertiesRemoved.xml" />
     <Content Include="LinkXml\UnusedAssemblyWithNoDefinedPreserveHasAllTypesPreserved.xml" />
+    <Content Include="LinkXml\UnusedEventPreservedByLinkXmlIsKept.xml" />
     <Content Include="LinkXml\UnusedFieldPreservedByLinkXmlIsKept.xml" />
     <Content Include="LinkXml\UnusedMethodPreservedByLinkXmlIsKept.xml" />
     <Content Include="LinkXml\UnusedNestedTypePreservedByLinkXmlIsKept.xml" />


### PR DESCRIPTION
Greetings! 

Mono linker is a great tool that is used heavily by our team with Xamarin. But there is a little drawback with it's configuration on that platform: it requires way too much XML text to specify for C# event or property to be kept. In our project we prefer to retreat back to some kind of `LinkerPleaseInclude.cs` file, where we specify in C# all the explicit references to all the symbols that we'd wanted to keep. Personally I find this approach disgusting as it makes me to maintain both 'LinkerDescription' XML and that `LinkerPleaseInclude.cs` file where the former is referencing the latter.

So, here's my suggestion on how to improve the XML linker configuration, allowing to write less text in order to keep either an event or property. Please refer to [this](https://github.com/mono/linker/compare/master...vrishe:master#diff-17190c368aaed2d1c4cc9ea32e9bdcbd) and [this](https://github.com/mono/linker/compare/master...vrishe:master#diff-e5a8a8784668a384c0a6dbc15b53afab) file to get closer with an idea.

P.S.: I also dared to modify testing facility a bit. The first change is focused on `PEVerify.exe` location which is under `NETFXSDK`, rather than `Windows` folder on my machine. I don't know whether that is appropriate change (sorry I'm not that great on figuring out how .Net is designed internally, I just wanted tests to run). The second change is targeted towards the new coming changes verification and touches the `AssemblyChecker.cs` file the most.
