### PR TITLE
Fix LinkingOfCoreLibrariesRemovesUnusedTypes failing on Windows

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases/CoreLink/LinkingOfCoreLibrariesRemovesUnusedTypes.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/CoreLink/LinkingOfCoreLibrariesRemovesUnusedTypes.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
@@ -11,22 +12,26 @@ namespace Mono.Linker.Tests.Cases.CoreLink {
 	// We can't check everything that should be removed, but we should be able to check a few niche things that
 	// we known should be removed which will at least verify that the core library was processed
 	[KeptTypeInAssembly ("mscorlib.dll", typeof (System.Collections.Generic.IEnumerable<>))]
-	[KeptTypeInAssembly ("System.dll", typeof (Uri))]
+	[KeptTypeInAssembly ("System.dll", typeof (System.Collections.Generic.SortedList<,>))]
 
 	[RemovedTypeInAssembly ("mscorlib.dll", typeof (System.Resources.ResourceWriter))]
-	[RemovedTypeInAssembly ("System.dll", typeof (System.CodeDom.Compiler.CodeCompiler))]
+	[RemovedTypeInAssembly ("System.dll", typeof (System.Collections.Generic.SortedDictionary<,>))]
 
 	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168
 	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
+
+	//  All sorts of stuff is flagged as invalid even in the original System.dll and System.Configuration.dll for mono class libraries
+	[SkipPeVerify("System.dll")]
+	[SkipPeVerify("System.Configuration.dll")]
 	class LinkingOfCoreLibrariesRemovesUnusedTypes {
 		public static void Main ()
 		{
 			// Use something from system that would normally be removed if we didn't use it
-			OtherMethods2 (new Uri ("dont care"));
+			OtherMethods2 (new SortedList<string, string>());
 		}
 
 		[Kept]
-		static void OtherMethods2 (Uri uri)
+		static void OtherMethods2 (SortedList<string, string> list)
 		{
 		}
 	}


### PR DESCRIPTION
Skip PeVerifying of System.dll and System.Configuration.dll.  PeVerify
reports problems in the unlinked mono class lib version of these
assemblies as well as the .NET Framework version. 

Also change the types
used by this test.  Use types that exist in mono AOT profiles