### PR TITLE
[linker] added workaround for invalid type forwards

### DIFF
--- a/linker/Mono.Linker.Steps/ResolveFromAssemblyStep.cs
+++ b/linker/Mono.Linker.Steps/ResolveFromAssemblyStep.cs
@@ -123,6 +123,19 @@ namespace Mono.Linker.Steps
 					} catch (AssemblyResolutionException) {
 						continue;
 					}
+					if (resolvedExportedType == null) {
+						// we ignore the nested forwarders here as a workaround for older csc bug,
+						// where it was adding nested forwarders to exported types, even when the nested type was not public
+						// see https://bugzilla.xamarin.com/show_bug.cgi?id=57645#c13
+						if (exported.DeclaringType != null) {
+							if (context.LogInternalExceptions)
+								System.Console.WriteLine ($"warning: unable to resolve exported nested type: {exported} (declaring type: {exported.DeclaringType}) from the assembly: {assembly}");
+
+							continue;
+						}
+						throw new LoadException ($"unable to resolve exported forwarded type: {exported} from the assembly: {assembly}");
+					}
+
 					context.Resolve (resolvedExportedType.Scope);
 					MarkType (context, resolvedExportedType, rootVisibility);
 					context.Annotations.Mark (exported);


### PR DESCRIPTION
 - fixes #57645

 - ignore invalid forwards of nested types of exported forwarded
   types, which were added by a bug in csc. description by Marek Safar
   from https://bugzilla.xamarin.com/show_bug.cgi?id=57645#c13

     Native csc (pre-Roslyn version) when encountered typeforwarded
     type it added automatically all its nested types including
     private/protected/internal ones.  This bug was fixed in Roslyn
     csc but there are still many assemblies compiled with native csc
     (pre VS2015) which can have typeforwarded typeref to a type which
     is not available because it's not included in public API.

 - ignoring these forwarders here should be harmless, because if these
   types were used somewhere in the application, the linker would fail
   in the mark step, when trying to resolve the typereference to them