### PR TITLE
Work around GetAssemblyName issue

### DIFF
--- a/corebuild/integration/ILLink.Tasks/CompareSizes.cs
+++ b/corebuild/integration/ILLink.Tasks/CompareSizes.cs
@@ -39,10 +39,7 @@ namespace ILLink.Tasks
 
 			long totalUnlinked = 0;
 			foreach (string unlinkedFile in unlinkedFiles) {
-				try {
-					AssemblyName.GetAssemblyName (unlinkedFile);
-				}
-				catch (BadImageFormatException) {
+				if (!Utils.IsManagedAssembly (unlinkedFile)) {
 					continue;
 				}
 				string fileName = Path.GetFileName (unlinkedFile);
@@ -54,10 +51,7 @@ namespace ILLink.Tasks
 
 			long totalLinked = 0;
 			foreach (string linkedFile in linkedFiles) {
-				try {
-					AssemblyName.GetAssemblyName (linkedFile);
-				}
-				catch (BadImageFormatException) {
+				if (!Utils.IsManagedAssembly (linkedFile)) {
 					continue;
 				}
 				string fileName = Path.GetFileName (linkedFile);
@@ -72,14 +66,29 @@ namespace ILLink.Tasks
 			}
 
 			Console.WriteLine ("{0, -60} {1,-20:N0} {2, -20:N0} {3, -10:P}",
+				"",
+				"Before linking (B)",
+				"After linking (B)",
+				"Size decrease");
+			Console.WriteLine ("{0, -60} {1,-20:N0} {2, -20:N0} {3, -10:P}",
+				"-----------",
+				"-----------",
+				"-----------",
+				"-----------"
+			);
+
+			Console.WriteLine ("{0, -60} {1,-20:N0} {2, -20:N0} {3, -10:P}",
 				"Total size of assemblies",
 				totalUnlinked,
 				totalLinked,
 				((double)totalUnlinked - (double)totalLinked) / (double)totalUnlinked);
 
-			Console.WriteLine ("-----------");
-			Console.WriteLine ("Details");
-			Console.WriteLine ("-----------");
+			Console.WriteLine ("{0, -60} {1,-20:N0} {2, -20:N0} {3, -10:P}",
+				"-----------",
+				"-----------",
+				"-----------",
+				"-----------"
+			);
 
 			foreach (string assembly in sizes.Keys) {
 				Console.WriteLine ("{0, -60} {1,-20:N0} {2, -20:N0} {3, -10:P}",

--- a/corebuild/integration/ILLink.Tasks/ComputeManagedAssemblies.cs
+++ b/corebuild/integration/ILLink.Tasks/ComputeManagedAssemblies.cs
@@ -10,6 +10,7 @@ using Microsoft.Build.Framework; // MessageImportance
 using Microsoft.NET.Build.Tasks; // LockFileCache
 using NuGet.ProjectModel; // LockFileTargetLibrary
 using NuGet.Frameworks; // NuGetFramework.Parse(targetframework)
+using Mono.Cecil;
 
 namespace ILLink.Tasks
 {
@@ -33,10 +34,8 @@ namespace ILLink.Tasks
 		{
 			var managedAssemblies = new List<ITaskItem>();
 			foreach (var f in Assemblies) {
-				try {
-					AssemblyName.GetAssemblyName(f.ItemSpec);
+				if (Utils.IsManagedAssembly(f.ItemSpec)) {
 					managedAssemblies.Add(f);
-				} catch (BadImageFormatException) {
 				}
 			}
 			ManagedAssemblies = managedAssemblies.ToArray();

--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.csproj
@@ -91,6 +91,7 @@
     <Compile Include="ComputeManagedAssemblies.cs" />
     <Compile Include="GetRuntimeLibraries.cs" />
     <Compile Include="CreateRootDescriptorFile.cs" />
+    <Compile Include="Utils.cs" />
     <Compile Include="Microsoft.NET.Build.Tasks/LockFileCache.cs" />
     <Compile Include="Microsoft.NET.Build.Tasks/BuildErrorException.cs" />
   </ItemGroup>
@@ -165,6 +166,7 @@
       -->
       <SetConfiguration>Configuration=illink_$(Configuration)</SetConfiguration>
     </ProjectReference>
+    <ProjectReference Include="../../../cecil/Mono.Cecil.csproj" />
   </ItemGroup>
 
   <!-- Workaround for the SetConfiguration issue described above. -->

--- a/corebuild/integration/ILLink.Tasks/Utils.cs
+++ b/corebuild/integration/ILLink.Tasks/Utils.cs
@@ -1,0 +1,15 @@
+using System;
+using Mono.Cecil;
+
+public class Utils
+{
+	public static bool IsManagedAssembly (string fileName)
+	{
+		try {
+			ModuleDefinition module = ModuleDefinition.ReadModule (fileName);
+			return true;
+		} catch (BadImageFormatException) {
+			return false;
+		}
+	}
+}


### PR DESCRIPTION
GetAssemblyName currently sometimes fails for crossgen'd assemblies for a different platform (see https://github.com/dotnet/coreclr/issues/13230). Until that is fixed, we use cecil to determine whether an assembly is managed.

Also includes some formatting fixes for the CompareSizes output.

@swaroop-sridhar, @erozenfeld please review.