### PR TITLE
Extension point for setting up pedump process

### DIFF
--- a/linker/Tests/TestCasesRunner/PeVerifier.cs
+++ b/linker/Tests/TestCasesRunner/PeVerifier.cs
@@ -78,13 +78,8 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 		private void CheckAssembly (NPath assemblyPath)
 		{
 			var capturedOutput = new List<string> ();
-			var exeArgs = Environment.OSVersion.Platform == PlatformID.Win32NT ? $"/nologo {assemblyPath.InQuotes ()}" : $"--verify metadata,code {assemblyPath.InQuotes ()}";
 			var process = new Process ();
-			process.StartInfo.FileName = _peExecutable;
-			process.StartInfo.Arguments = exeArgs;
-			process.StartInfo.UseShellExecute = false;
-			process.StartInfo.CreateNoWindow = true;
-			process.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
+			SetupProcess (process, assemblyPath);
 			process.StartInfo.RedirectStandardOutput = true;
 			process.OutputDataReceived += (sender, args) => capturedOutput.Add (args.Data);
 			process.Start ();
@@ -94,6 +89,16 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			if (process.ExitCode != 0) {
 				Assert.Fail ($"Invalid IL detected in {assemblyPath}\n{capturedOutput.Aggregate ((buff, s) => buff + Environment.NewLine + s)}");
 			}
+		}
+
+		protected virtual void SetupProcess (Process process, NPath assemblyPath)
+		{
+			var exeArgs = Environment.OSVersion.Platform == PlatformID.Win32NT ? $"/nologo {assemblyPath.InQuotes ()}" : $"--verify metadata,code {assemblyPath.InQuotes ()}";
+			process.StartInfo.FileName = _peExecutable;
+			process.StartInfo.Arguments = exeArgs;
+			process.StartInfo.UseShellExecute = false;
+			process.StartInfo.CreateNoWindow = true;
+			process.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
 		}
 
 		public static NPath FindPeExecutableFromRegistry ()


### PR DESCRIPTION
In our Unity Linker test suite I'm playing around with setting MONO_PATH before running pedump so that pedump picks up the mscorlib.dll that we want.

There are two cases where setting MONO_PATH is desirable

1) During [CoreLink("link")] test cases we want to pick up the mscorlib that was linked when running pedump.  This change would be desirable upstream, however, currently all of the [CoreLink("link")] test cases have PeVerify disabled, so it's pointless to bring this change upstream.  We'd also have to then go down the path of getting the test cases to preserve the minimum set of info required by the runtime (ex: the first error I hit is CustomAttributeData).  Dealing with these issues is not a priority right now in upstream, or in our UnityLinker tests.

2) For our UnityLinker, we run all of the linker tests against multiple profiles, and this is the real motivation for this change.  We want to make sure that when we test our "UnityAot" profile, that pedump picks up the mscorlib for the "UnityAot" profile rather than the mscorlib for 4.5.