### PR TITLE
Prevent overriding custom LinkerRootAssemblies

### DIFF
--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
@@ -238,9 +238,10 @@
          assembly, because we root it separately using an xml file,
          which lets us explicitly root everything. -->
     <ItemGroup>
-      <LinkerRootAssemblies Include="@(_ManagedResolvedAssembliesToPublish->'%(Filename)')" />
-      <LinkerRootAssemblies Remove="@(PlatformLibraries->'%(Filename)')" />
-      <LinkerRootAssemblies Include="System.Private.CoreLib" />
+      <_LinkerRootAssemblies Include="@(_ManagedResolvedAssembliesToPublish->'%(Filename)')" />
+      <_LinkerRootAssemblies Remove="@(PlatformLibraries->'%(Filename)')" />
+      <_LinkerRootAssemblies Include="System.Private.CoreLib" />
+      <LinkerRootAssemblies Include="@(_LinkerRootAssemblies)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Before this change, setting LinkerRootAssemblies from a project
referencing the linker would have no effect when the extra root
assemblies were platform assemblies or resolved assemblies from project
dependencies.

@swaroop-sridhar please review.