### PR TITLE
Don't pass satellite assemblies to the linker

### DIFF
--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
@@ -213,6 +213,11 @@
     <ItemGroup>
       <_ManagedResolvedAssembliesToPublish Remove="@(_ManagedResolvedAssembliesToPublish->WithMetadataValue('Filename', 'System.Private.CoreLib.ni'))" />
     </ItemGroup>
+    <!-- Some of the managed dlls are satellite assemblies containing
+         binary resources that we don't want to link. -->
+    <ItemGroup>
+      <_ManagedResolvedAssembliesToPublish Remove="@(_ManagedResolvedAssembliesToPublish->WithMetadataValue('AssetType', 'resources'))" />
+    </ItemGroup>
   </Target>
 
 


### PR DESCRIPTION
This fixes an issue in which illink was placing the same version of a
resource dll into different language directories.

@swaroop-sridhar please review