### PR TITLE
Build cecil in desktop configuration for net46 target

### DIFF
--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.csproj
@@ -174,7 +174,8 @@
           AfterTargets="AssignProjectConfiguration">
     <ItemGroup>
       <ProjectReferenceWithConfiguration Condition=" '%(Filename)%(Extension)' == 'Mono.Cecil.csproj' Or '%(Filename)%(Extension)' == 'Mono.Cecil.Pdb.csproj' ">
-        <SetConfiguration>Configuration=netstandard_$(Configuration)</SetConfiguration>
+	<SetConfiguration Condition=" '$(TargetFramework)' == 'net46' ">Configuration=net_4_0_$(Configuration)</SetConfiguration>
+	<SetConfiguration Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">Configuration=netstandard_$(Configuration)</SetConfiguration>
       </ProjectReferenceWithConfiguration>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
The linker depends on cecil, shipping with a netstandard1.3 build of
Mono.Cecil. Some of the reference assemblies for netstandard1.3 have
lower versions than the implementation shims that forward types to
mscorlib on desktop. To run the linker on desktop, we need to ensure
that this version mismatch doesn't cause binding problems. This is the
same issue described in https://github.com/dotnet/corefx/issues/16322.

Because illink ships as an msbuild task, we can't use binding
redirects (msbuild doesn't respect them) to fix this. One option is to
implement a custom AssemblyResolve event hook, but this is not robust
because it may cause problems when used in combination with other
msbuild tasks.

Instead, we avoid the version mismatch by using a build of cecil that
targets net46 directly, so that we don't need to ship with shims for
System.IO.FileSystem.dl and other assemblies.

@swaroop-sridhar, @ericstj, please review.