### PR TITLE
Improve logging

### DIFF
--- a/linker/Mono.Linker.Steps/BlacklistStep.cs
+++ b/linker/Mono.Linker.Steps/BlacklistStep.cs
@@ -51,13 +51,11 @@ namespace Mono.Linker.Steps {
 					continue;
 
 				try {
-					if (Context.LogInternalExceptions)
-						Console.WriteLine ("Processing resource linker descriptor: {0}", name);
+					Context.LogMessage ("Processing resource linker descriptor: {0}", name);
 					Context.Pipeline.AddStepAfter (typeof (TypeMapStep), GetResolveStep (name));
 				} catch (XmlException ex) {
 					/* This could happen if some broken XML file is included. */
-					if (Context.LogInternalExceptions)
-						Console.WriteLine ("Error processing {0}: {1}", name, ex);
+					Context.LogMessage ("Error processing {0}: {1}", name, ex);
 				}
 			}
 
@@ -69,14 +67,12 @@ namespace Mono.Linker.Steps {
 									.Where (res => IsReferenced (GetAssemblyName (res.Name)))
 									.Cast<EmbeddedResource> ()) {
 					try {
-						if (Context.LogInternalExceptions)
-							Console.WriteLine ("Processing embedded resource linker descriptor: {0}", rsc.Name);
+						Context.LogMessage ("Processing embedded resource linker descriptor: {0}", rsc.Name);
 
 						Context.Pipeline.AddStepAfter (typeof (TypeMapStep), GetExternalResolveStep (rsc, asm));
 					} catch (XmlException ex) {
 						/* This could happen if some broken XML file is embedded. */
-						if (Context.LogInternalExceptions)
-							Console.WriteLine ("Error processing {0}: {1}", rsc.Name, ex);
+						Context.LogMessage ("Error processing {0}: {1}", rsc.Name, ex);
 					}
 				}
 			}

--- a/linker/Mono.Linker.Steps/ResolveFromAssemblyStep.cs
+++ b/linker/Mono.Linker.Steps/ResolveFromAssemblyStep.cs
@@ -137,8 +137,7 @@ namespace Mono.Linker.Steps
 						// Both cases are bugs not on our end but we still want to link all assemblies
 						// especially when such types cannot be used anyway
 						//
-						if (context.LogInternalExceptions)
-							System.Console.WriteLine ($"Cannot find declaration of exported type '{exported}' from the assembly '{assembly}'");
+						context.LogMessage ($"Cannot find declaration of exported type '{exported}' from the assembly '{assembly}'");
 
 						continue;
 					}

--- a/linker/Mono.Linker.csproj
+++ b/linker/Mono.Linker.csproj
@@ -91,6 +91,8 @@
     <Compile Include="Mono.Linker\TypeReferenceExtensions.cs" />
     <Compile Include="Mono.Linker\XApiReader.cs" />
     <Compile Include="Mono.Linker.Steps\TypeMapStep.cs" />
+    <Compile Include="Mono.Linker\ILogger.cs" />
+    <Compile Include="Mono.Linker\ConsoleLogger.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/linker/Mono.Linker/ConsoleLogger.cs
+++ b/linker/Mono.Linker/ConsoleLogger.cs
@@ -1,0 +1,11 @@
+﻿using System;
+namespace Mono.Linker
+{
+	public class ConsoleLogger : ILogger
+	{
+		public void LogMessage (MessageImportance importance, string message, params object[] values)
+		{
+			Console.WriteLine (message, values);
+		}
+	}
+}

--- a/linker/Mono.Linker/ILogger.cs
+++ b/linker/Mono.Linker/ILogger.cs
@@ -1,0 +1,15 @@
+﻿using System;
+namespace Mono.Linker
+{
+	public enum MessageImportance
+	{
+		High,
+		Low,
+		Normal,
+	}
+
+	public interface ILogger
+	{
+		void LogMessage (MessageImportance importance, string message, params object[] values);
+	}
+}

--- a/linker/Mono.Linker/LinkContext.cs
+++ b/linker/Mono.Linker/LinkContext.cs
@@ -112,6 +112,8 @@ namespace Mono.Linker {
 
 		public bool LogInternalExceptions { get; set; } = false;
 
+		public ILogger Logger { get; set; } = new ConsoleLogger ();
+
 		public LinkContext (Pipeline pipeline)
 			: this (pipeline, new AssemblyResolver ())
 		{
@@ -300,6 +302,17 @@ namespace Mono.Linker {
 		public void Dispose ()
 		{
 			_resolver.Dispose ();
+		}
+
+		public void LogMessage (string message, params object[] values)
+		{
+			LogMessage (MessageImportance.Normal, message, values);
+		}
+
+		public void LogMessage (MessageImportance importance, string message, params object [] values)
+		{
+			if (LogInternalExceptions && Logger != null)
+				Logger.LogMessage (importance, message, values);
 		}
 	}
 }


### PR DESCRIPTION
Added the ILogger interface for logging messages from the
linker. There is a new default implementation, the DefaultLogger
class, which just continues to use simple S.C.WriteLine as before.

The LinkerContext newly contains Logger property, which can be set to
instance of class implementing ILogger interface. As an example,
Xamarin.Android linker will be able to provide own logger, forwarding
the messages to Microsoft.Build.Utilities.TaskLoggingHelper. This way
it will be possible to see linker messages, depending on the actual
msbuild's verbosity level, in the XA build output.