### PR TITLE
Run apps and validate output in integration tests

### DIFF
--- a/corebuild/integration/test/HelloWorldTest.cs
+++ b/corebuild/integration/test/HelloWorldTest.cs
@@ -36,6 +36,10 @@ namespace ILLink.Tests
 			AddLinkerReference(csproj);
 
 			BuildAndLink(csproj, null);
+
+			int ret = RunApp(csproj, out string commandOutput);
+			Assert.True(ret == 0);
+			Assert.True(commandOutput.Contains("Hello World!"));
 		}
 	}
 }

--- a/corebuild/integration/test/MusicStoreTest.cs
+++ b/corebuild/integration/test/MusicStoreTest.cs
@@ -33,6 +33,9 @@ namespace ILLink.Tests
 			AddLinkerReference(csproj);
 
 			BuildAndLink(csproj, rootFiles);
+
+			int ret = RunApp(csproj, out string commandOutput);
+			Assert.True(ret == 0);
 		}
 
 		// returns path to .csproj project file
@@ -48,7 +51,7 @@ namespace ILLink.Tests
 				Directory.Delete(repoName, true);
 			}
 
-			ret = RunCommand("git", $"clone {gitRepo}", null, null);
+			ret = RunCommand("git", $"clone {gitRepo}");
 			if (ret != 0) {
 				output.WriteLine("git failed");
 				Assert.True(false);
@@ -59,7 +62,7 @@ namespace ILLink.Tests
 				Assert.True(false);
 			}
 
-			ret = RunCommand("git", $"checkout {gitBranch}", demoRoot, null);
+			ret = RunCommand("git", $"checkout {gitBranch}", demoRoot);
 			if (ret != 0) {
 				output.WriteLine($"problem checking out branch {gitBranch}");
 				Assert.True(false);

--- a/corebuild/integration/test/WebApiTest.cs
+++ b/corebuild/integration/test/WebApiTest.cs
@@ -58,6 +58,10 @@ namespace ILLink.Tests
 			AddLinkerReference(csproj);
 
 			BuildAndLink(csproj);
+
+			int ret = RunApp(csproj, out string commandOutput, 5000);
+			Assert.True(commandOutput.Contains("Application started. Press Ctrl+C to shut down."));
+			Assert.True(commandOutput.Contains("Now listening on: http://localhost:5000"));
 		}
 	}
 }


### PR DESCRIPTION
Currently we only link apps in our integration tests, but we do not run them. This change runs the apps and does some basic output validation.

The MusicStore test is currently broken (we're missing reflection roots), so I'm holding off on adding output validation to this one until we get that fixed.

@swaroop-sridhar, @erozenfeld, please review.