### PR TITLE
Improve dependency dumping

### DIFF
--- a/linker/Mono.Linker.Steps/MarkStep.cs
+++ b/linker/Mono.Linker.Steps/MarkStep.cs
@@ -275,7 +275,7 @@ namespace Mono.Linker.Steps {
 
 		protected virtual void MarkCustomAttribute (CustomAttribute ca)
 		{
-			Annotations.Push (ca);
+			Annotations.Push ((object)ca.AttributeType ?? (object)ca);
 			try {
 				MarkMethod (ca.Constructor);
 
@@ -986,11 +986,8 @@ namespace Mono.Linker.Steps {
 		protected void MarkMethodsIf (Collection<MethodDefinition> methods, Func<MethodDefinition, bool> predicate)
 		{
 			foreach (MethodDefinition method in methods)
-				if (predicate (method)) {
-					Annotations.Push (predicate);
+				if (predicate (method))
 					MarkMethod (method);
-					Annotations.Pop ();
-				}
 		}
 
 		static bool IsDefaultConstructor (MethodDefinition method)


### PR DESCRIPTION
Push actual custom attribute type instead of cecil custom attribute
instance. It also makes dependency graph more spread as we have more
vertices instead of one overused.

    So for example we now have:
    `TypeDef:System.Runtime.InteropServices.ComVisibleAttribute`
    vertex instead of `Other:Mono.Cecil.CustomAttribute`

Do not add predicate method to the dependencies. It doesn't add much
value and makes the graph having vertex with too many edges, so we had
a lot of vertices with 15k+ total dependencies in flat view for XA
template application. Like:

```
Distance | TypeDef:Android.App.ActivityAttribute [total deps: 15100]
------------------------------------------------------------------------
       1 | Method:System.Void Android.App.ActivityAttribute::.ctor()
       2 | Other:Mono.Cecil.CustomAttribute
       3 | TypeDef:System.Object
       ...
```
Now we have:

```
Distance | TypeDef:Android.App.ActivityAttribute [total deps: 9]
------------------------------------------------------------------------
       1 | Method:System.Void Android.App.ActivityAttribute::.ctor()
       2 | TypeRef:Android.App.ActivityAttribute
       3 | TypeDef:XATemplateLA.MainActivity
       ...
```