### PR TITLE
Allow link xml files to start with comments

### DIFF
--- a/linker/Mono.Linker.Steps/ResolveFromXmlStep.cs
+++ b/linker/Mono.Linker.Steps/ResolveFromXmlStep.cs
@@ -69,11 +69,10 @@ namespace Mono.Linker.Steps {
 		protected override void Process ()
 		{
 			XPathNavigator nav = _document.CreateNavigator ();
-			nav.MoveToFirstChild ();
 
 			// This step can be created with XML files that aren't necessarily
 			// linker descriptor files. So bail if we don't have a <linker> element.
-			if (nav.LocalName != "linker")
+			if (!nav.MoveToChild("linker", _ns))
 				return;
 
 			try {

--- a/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/UnusedTypePreservedByLinkXmlWithCommentIsKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/UnusedTypePreservedByLinkXmlWithCommentIsKept.cs
@@ -1,0 +1,15 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.LinkXml {
+	class UnusedTypePreservedByLinkXmlWithCommentIsKept {
+		public static void Main ()
+		{
+		}
+	}
+
+	[Kept]
+	[KeptMember (".ctor()")]
+	class UnusedTypePreservedByLinkXmlWithCommentIsKeptUnusedType
+	{
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/UnusedTypePreservedByLinkXmlWithCommentIsKept.xml
+++ b/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/UnusedTypePreservedByLinkXmlWithCommentIsKept.xml
@@ -1,0 +1,6 @@
+﻿<!-- this is a comment -->
+<linker>
+  <assembly fullname="test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+    <type fullname="Mono.Linker.Tests.Cases.LinkXml.UnusedTypePreservedByLinkXmlWithCommentIsKeptUnusedType" />
+  </assembly>
+</linker>

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Basic\UsedStructIsKept.cs" />
     <Compile Include="LinkXml\UnusedAssemblyWithNoDefinedPreserveHasAllTypesPreserved.cs" />
     <Compile Include="LinkXml\UnusedEventPreservedByLinkXmlIsKept.cs" />
+    <Compile Include="LinkXml\UnusedTypePreservedByLinkXmlWithCommentIsKept.cs" />
     <Compile Include="LinkXml\UnusedTypeWithNoDefinedPreserveHasAllMembersPreserved.cs" />
     <Compile Include="TestFramework\CanCompileILAssembly.cs" />
     <Compile Include="TestFramework\VerifyDefineAttributeBehavior.cs" />
@@ -151,6 +152,7 @@
     <Content Include="LinkXml\UnusedPropertyPreservedByLinkXmlIsKept.xml" />
     <Content Include="LinkXml\UnusedTypeIsPresservedWhenEntireAssemblyIsPreserved.xml" />
     <Content Include="LinkXml\UnusedTypePreservedByLinkXmlIsKept.xml" />
+    <Content Include="LinkXml\UnusedTypePreservedByLinkXmlWithCommentIsKept.xml" />
     <Content Include="LinkXml\UnusedTypeWithNoDefinedPreserveHasAllMembersPreserved.xml" />
     <Content Include="LinkXml\UnusedTypeWithPreserveAllHasAllMembersPreserved.xml" />
     <Content Include="LinkXml\UnusedTypeWithPreserveFieldsHasMethodsRemoved.xml" />


### PR DESCRIPTION
Find 'linker' child element rather than assuming it's the first element in the file. This allows link xml files to contain comments at the start.