### PR TITLE
Add ability to customize the name of the output assembly in tests

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupCompileAssemblyNameAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupCompileAssemblyNameAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Metadata {
+	[AttributeUsage (AttributeTargets.Class, AllowMultiple = false)]
+	public class SetupCompileAssemblyNameAttribute : BaseMetadataAttribute {
+		public SetupCompileAssemblyNameAttribute (string outputName)
+		{
+			if (string.IsNullOrEmpty (outputName))
+				throw new ArgumentNullException (nameof (outputName));
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Assertions\SkipPeVerifyAttribute.cs" />
     <Compile Include="Metadata\BaseMetadataAttribute.cs" />
     <Compile Include="Metadata\SetupCompileAfterAttribute.cs" />
+    <Compile Include="Metadata\SetupCompileAssemblyNameAttribute.cs" />
     <Compile Include="Metadata\SetupCompileBeforeAttribute.cs" />
     <Compile Include="Metadata\DefineAttribute.cs" />
     <Compile Include="Metadata\IncludeBlacklistStepAttribute.cs" />

--- a/linker/Tests/TestCasesRunner/TestCaseMetadaProvider.cs
+++ b/linker/Tests/TestCasesRunner/TestCaseMetadaProvider.cs
@@ -101,6 +101,11 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 				.Select (attr => (string) attr.ConstructorArguments.First ().Value);
 		}
 
+		public virtual string GetAssemblyName ()
+		{
+			return GetOptionAttributeValue (nameof (SetupCompileAssemblyNameAttribute), "test.exe");
+		}
+
 		T GetOptionAttributeValue<T> (string attributeName, T defaultValue)
 		{
 			var attribute = _testCaseTypeDefinition.CustomAttributes.FirstOrDefault (attr => attr.AttributeType.Name == attributeName);

--- a/linker/Tests/TestCasesRunner/TestRunner.cs
+++ b/linker/Tests/TestCasesRunner/TestRunner.cs
@@ -40,11 +40,13 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			var compiler = _factory.CreateCompiler (sandbox, metadataProvider);
 			var sourceFiles = sandbox.SourceFiles.Select(s => s.ToString()).ToArray();
 
+			var assemblyName = metadataProvider.GetAssemblyName ();
+
 			var references = metadataProvider.GetReferencedAssemblies(sandbox.InputDirectory);
-			var inputAssemblyPath = compiler.CompileTestIn (sandbox.InputDirectory, "test.exe", sourceFiles, references, null);
+			var inputAssemblyPath = compiler.CompileTestIn (sandbox.InputDirectory, assemblyName, sourceFiles, references, null);
 
 			references = metadataProvider.GetReferencedAssemblies(sandbox.ExpectationsDirectory);
-			var expectationsAssemblyPath = compiler.CompileTestIn (sandbox.ExpectationsDirectory, "test.exe", sourceFiles, references, new [] { "INCLUDE_EXPECTATIONS" });
+			var expectationsAssemblyPath = compiler.CompileTestIn (sandbox.ExpectationsDirectory, assemblyName, sourceFiles, references, new [] { "INCLUDE_EXPECTATIONS" });
 			return new ManagedCompilationResult (inputAssemblyPath, expectationsAssemblyPath);
 		}
 /*


### PR DESCRIPTION
The UnityLinker has some logic to behave differently for "UnityEngine.*" assemblies, in order to test this logic we need to control the name of the assembly for the test case.