### PR TITLE
Reframe alternate destination as file name only rather than relative path.

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/SandboxDependencyAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/SandboxDependencyAttribute.cs
@@ -4,7 +4,7 @@ namespace Mono.Linker.Tests.Cases.Expectations.Metadata {
 	[AttributeUsage (AttributeTargets.Class)]
 	public class SandboxDependencyAttribute : BaseMetadataAttribute {
 
-		public SandboxDependencyAttribute (string relativePathToFile, string relativeDestinationPathToFile = null)
+		public SandboxDependencyAttribute (string relativePathToFile, string destinationFileName = null)
 		{
 			if (string.IsNullOrEmpty (relativePathToFile))
 				throw new ArgumentException ("Value cannot be null or empty.", nameof (relativePathToFile));

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupCompileResourceAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupCompileResourceAttribute.cs
@@ -3,7 +3,7 @@
 namespace Mono.Linker.Tests.Cases.Expectations.Metadata {
 	[AttributeUsage (AttributeTargets.Class, AllowMultiple = true)]
 	public class SetupCompileResourceAttribute : BaseMetadataAttribute {
-		public SetupCompileResourceAttribute (string relativePathToFile, string relativeDestinationPathToFile = null)
+		public SetupCompileResourceAttribute (string relativePathToFile, string destinationFileName = null)
 		{
 			if (string.IsNullOrEmpty (relativePathToFile))
 				throw new ArgumentException ("Value cannot be null or empty.", nameof (relativePathToFile));

--- a/linker/Tests/Mono.Linker.Tests.csproj
+++ b/linker/Tests/Mono.Linker.Tests.csproj
@@ -74,7 +74,7 @@
   <ItemGroup>
     <Compile Include="TestCasesRunner\CompilerOptions.cs" />
     <Compile Include="TestCasesRunner\ILCompiler.cs" />
-    <Compile Include="TestCasesRunner\SourceAndRelativeDestinationPair.cs" />
+    <Compile Include="TestCasesRunner\SourceAndDestinationPair.cs" />
     <Compile Include="TestCasesRunner\SetupCompileInfo.cs" />
     <Compile Include="TestCasesRunner\PeVerifier.cs" />
     <Compile Include="TestCases\TestSuites.cs" />

--- a/linker/Tests/TestCasesRunner/SourceAndDestinationPair.cs
+++ b/linker/Tests/TestCasesRunner/SourceAndDestinationPair.cs
@@ -2,8 +2,8 @@
 using Mono.Linker.Tests.Extensions;
 
 namespace Mono.Linker.Tests.TestCasesRunner {
-	public class SourceAndRelativeDestinationPair {
+	public class SourceAndDestinationPair {
 		public NPath Source;
-		public string RelativeDestination;
+		public string DestinationFileName;
 	}
 }

--- a/linker/Tests/TestCasesRunner/TestCaseMetadaProvider.cs
+++ b/linker/Tests/TestCasesRunner/TestCaseMetadaProvider.cs
@@ -52,7 +52,7 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			}
 		}
 
-		public virtual IEnumerable<SourceAndRelativeDestinationPair> GetResources ()
+		public virtual IEnumerable<SourceAndDestinationPair> GetResources ()
 		{
 			return _testCaseTypeDefinition.CustomAttributes
 				.Where (attr => attr.AttributeType.Name == nameof (SetupCompileResourceAttribute))
@@ -76,7 +76,7 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			return false;
 		}
 
-		public virtual IEnumerable<SourceAndRelativeDestinationPair> AdditionalFilesToSandbox ()
+		public virtual IEnumerable<SourceAndDestinationPair> AdditionalFilesToSandbox ()
 		{
 			return _testCaseTypeDefinition.CustomAttributes
 				.Where (attr => attr.AttributeType.Name == nameof (SandboxDependencyAttribute))
@@ -118,14 +118,15 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			return defaultValue;
 		}
 
-		SourceAndRelativeDestinationPair GetSourceAndRelativeDestinationValue (CustomAttribute attribute)
+		SourceAndDestinationPair GetSourceAndRelativeDestinationValue (CustomAttribute attribute)
 		{
 			var relativeSource = (string) attribute.ConstructorArguments.First ().Value;
-			var relativeDestination = (string) attribute.ConstructorArguments [1].Value;
-			return new SourceAndRelativeDestinationPair
+			var destinationFileName = (string) attribute.ConstructorArguments [1].Value;
+			var fullSource = _testCase.SourceFile.Parent.Combine (relativeSource);
+			return new SourceAndDestinationPair
 			{
-				Source = _testCase.SourceFile.Parent.Combine (relativeSource),
-				RelativeDestination = string.IsNullOrEmpty (relativeDestination) ? relativeSource : relativeDestination
+				Source = fullSource,
+				DestinationFileName = string.IsNullOrEmpty (destinationFileName) ? fullSource.FileName : destinationFileName
 			};
 		}
 

--- a/linker/Tests/TestCasesRunner/TestCaseSandbox.cs
+++ b/linker/Tests/TestCasesRunner/TestCaseSandbox.cs
@@ -67,11 +67,11 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			CopyToInputAndExpectations (GetExpectationsAssemblyPath ());
 
 			foreach (var dep in metadataProvider.AdditionalFilesToSandbox ()) {
-				dep.Source.FileMustExist ().Copy (_directory.Combine (dep.RelativeDestination));
+				dep.Source.FileMustExist ().Copy (_directory.Combine (dep.DestinationFileName));
 			}
 
 			foreach (var res in metadataProvider.GetResources ()) {
-				res.Source.FileMustExist ().Copy (ResourcesDirectory.Combine (res.RelativeDestination));
+				res.Source.FileMustExist ().Copy (ResourcesDirectory.Combine (res.DestinationFileName));
 			}
 
 			foreach (var compileRefInfo in metadataProvider.GetSetupCompileAssembliesBefore ())


### PR DESCRIPTION
The sandboxing code isn't really setup to allow files being placed in arbitrary sub directories. 

Change the default destination file name from relative path to the source (ex : 'Depedencies/somefile.txt'), to just the sources file name (ex: 'somefile.txt').  This wasn't causing any issues in the tests we have today, but it would have in some new resource tests that are coming.
