### PR TITLE
Add a switch to specify action on user assemblies.

### DIFF
--- a/linker/Mono.Linker/Driver.cs
+++ b/linker/Mono.Linker/Driver.cs
@@ -120,6 +120,9 @@ namespace Mono.Linker {
 					case 'c':
 						context.CoreAction = ParseAssemblyAction (GetParam ());
 						break;
+					case 'u':
+						context.UserAction = ParseAssemblyAction (GetParam ());
+						break;
 					case 'p':
 						AssemblyAction action = ParseAssemblyAction (GetParam ());
 						context.Actions [GetParam ()] = action;
@@ -275,6 +278,7 @@ namespace Mono.Linker {
 		{
 			LinkContext context = new LinkContext (pipeline);
 			context.CoreAction = AssemblyAction.Skip;
+			context.UserAction = AssemblyAction.Link;
 			context.OutputDirectory = "output";
 			return context;
 		}
@@ -294,6 +298,7 @@ namespace Mono.Linker {
 			Console.WriteLine ("   --version   Print the version number of the {0}", _linker);
 			Console.WriteLine ("   -out        Specify the output directory, default to `output'");
 			Console.WriteLine ("   -c          Action on the core assemblies, skip, copy or link, default to skip");
+			Console.WriteLine("    -u          Action on the user assemblies, skip, copy or link, default to link");
 			Console.WriteLine ("   -p          Action per assembly");
 			Console.WriteLine ("   -s          Add a new step to the pipeline.");
 			Console.WriteLine ("   -t          Keep assemblies in which only type forwarders are referenced.");

--- a/linker/Mono.Linker/LinkContext.cs
+++ b/linker/Mono.Linker/LinkContext.cs
@@ -38,6 +38,7 @@ namespace Mono.Linker {
 
 		Pipeline _pipeline;
 		AssemblyAction _coreAction;
+		AssemblyAction _userAction;
 		Dictionary<string, AssemblyAction> _actions;
 		string _outputDirectory;
 		readonly Dictionary<string, string> _parameters;
@@ -69,6 +70,11 @@ namespace Mono.Linker {
 		public AssemblyAction CoreAction {
 			get { return _coreAction; }
 			set { _coreAction = value; }
+		}
+
+		public AssemblyAction UserAction {
+			get { return _userAction; }
+			set { _userAction = value; }
 		}
 
 		public bool LinkSymbols {
@@ -247,7 +253,7 @@ namespace Mono.Linker {
 			} else if (IsCore (name)) {
 				action = _coreAction;
 			} else {
-				action = AssemblyAction.Link;
+				action = _userAction;
 			}
 
 			_annotations.SetAction (assembly, action);


### PR DESCRIPTION
Add -u switch to specify action on user (non-core) assemblies similar
to -c switch for core assemblies.
