### PR TITLE
Add CopyUsed assembly action.

### DIFF
--- a/linker/Mono.Linker.Steps/MarkStep.cs
+++ b/linker/Mono.Linker.Steps/MarkStep.cs
@@ -1444,7 +1444,14 @@ namespace Mono.Linker.Steps {
 				return true;
 			case MethodAction.Parse:
 				AssemblyDefinition assembly = ResolveAssembly (method.DeclaringType.Scope);
-				return Annotations.GetAction (assembly) == AssemblyAction.Link;
+				switch (Annotations.GetAction (assembly)) {
+				case AssemblyAction.Link:
+				case AssemblyAction.Copy:
+				case AssemblyAction.CopyUsed:
+					return true;
+				default:
+					return false;
+				}
 			default:
 				return false;
 			}

--- a/linker/Mono.Linker.Steps/SweepStep.cs
+++ b/linker/Mono.Linker.Steps/SweepStep.cs
@@ -75,11 +75,23 @@ namespace Mono.Linker.Steps {
 
 		void SweepAssembly (AssemblyDefinition assembly)
 		{
-			if (Annotations.GetAction (assembly) != AssemblyAction.Link)
+			switch (Annotations.GetAction (assembly)) {
+			case AssemblyAction.Link:
+				if (!IsMarkedAssembly (assembly)) {
+					RemoveAssembly (assembly);
+					return;
+				}
+				break;
+
+			case AssemblyAction.CopyUsed:
+				if (!IsMarkedAssembly (assembly)) {
+					RemoveAssembly (assembly);
+				} else {
+					Annotations.SetAction (assembly, AssemblyAction.Copy);
+				}
 				return;
 
-			if (!IsMarkedAssembly (assembly)) {
-				RemoveAssembly (assembly);
+			default:
 				return;
 			}
 
@@ -166,8 +178,8 @@ namespace Mono.Linker.Steps {
 				case AssemblyAction.Copy:
 					// Copy means even if "unlinked" we still want that assembly to be saved back 
 					// to disk (OutputStep) without the (removed) reference
-					Annotations.SetAction (assembly, AssemblyAction.Save);
 					if (!Context.KeepTypeForwarderOnlyAssemblies) {
+						Annotations.SetAction (assembly, AssemblyAction.Save);
 						ResolveAllTypeReferences (assembly);
 					}
 					break;

--- a/linker/Mono.Linker/AssemblyAction.cs
+++ b/linker/Mono.Linker/AssemblyAction.cs
@@ -32,8 +32,12 @@ namespace Mono.Linker {
 		// Ignore the assembly
 		Skip,
 		// Copy the existing files, assembly and symbols, into the output destination. E.g. .dll and .mdb
-		// The linker still analyze the assemblies (to know what they require) but does not modify them
+		// The linker still analyzes the assemblies (to know what they require) but does not modify them.
 		Copy,
+		// Copy the existing files, assembly and symbols, into the output destination if and only if
+		// anything from the assembly is used.
+		// The linker still analyzes the assemblies (to know what they require) but does not modify them.
+		CopyUsed,
 		// Link the assembly
 		Link,
 		// Remove the assembly from the output

--- a/linker/Mono.Linker/Driver.cs
+++ b/linker/Mono.Linker/Driver.cs
@@ -303,8 +303,8 @@ namespace Mono.Linker {
 			Console.WriteLine ("   --version           Print the version number of the {0}", _linker);
 			Console.WriteLine ("   --skip-unresolved   Ignore unresolved types and methods (true or false)");
 			Console.WriteLine ("   -out                Specify the output directory, default to `output'");
-			Console.WriteLine ("   -c                  Action on the core assemblies, skip, copy or link, default to skip");
-			Console.WriteLine ("   -u                  Action on the user assemblies, skip, copy or link, default to link");
+			Console.WriteLine ("   -c                  Action on the core assemblies, skip, copy, copyused or link, default to skip");
+			Console.WriteLine ("   -u                  Action on the user assemblies, skip, copy, copyused or link, default to link");
 			Console.WriteLine ("   -p                  Action per assembly");
 			Console.WriteLine ("   -s                  Add a new step to the pipeline.");
 			Console.WriteLine ("   -t                  Keep assemblies in which only type forwarders are referenced.");


### PR DESCRIPTION
CopyUsed action specifies that the assembly should be copied intact if and only if
it is used (i.e., marked).