### PR TITLE
Make interface marking overridable by derived classes.

### DIFF
--- a/linker/Mono.Linker.Steps/MarkStep.cs
+++ b/linker/Mono.Linker.Steps/MarkStep.cs
@@ -647,8 +647,7 @@ namespace Mono.Linker.Steps {
 
 			if (type.HasInterfaces) {
 				foreach (var iface in type.Interfaces) {
-					MarkCustomAttributes (iface);
-					MarkType (iface.InterfaceType);
+					MarkInterfaceImplementation (type, iface);
 				}
 			}
 
@@ -1567,6 +1566,12 @@ namespace Mono.Linker.Steps {
 			if (!_context.IgnoreUnresolved) {
 				throw new ResolutionException (reference);
 			}
+		}
+
+		protected virtual void MarkInterfaceImplementation (TypeDefinition type, InterfaceImplementation iface)
+		{
+			MarkCustomAttributes (iface);
+			MarkType (iface.InterfaceType);
 		}
 	}
 }

--- a/linker/Mono.Linker.Steps/SweepStep.cs
+++ b/linker/Mono.Linker.Steps/SweepStep.cs
@@ -255,6 +255,9 @@ namespace Mono.Linker.Steps {
 
 			if (type.HasNestedTypes)
 				SweepNestedTypes (type);
+
+			if (type.HasInterfaces)
+				SweepInterfaces (type);
 		}
 
 		protected void SweepNestedTypes (TypeDefinition type)
@@ -267,6 +270,17 @@ namespace Mono.Linker.Steps {
 					ElementRemoved (type.NestedTypes [i]);
 					type.NestedTypes.RemoveAt (i--);
 				}
+			}
+		}
+
+		protected void SweepInterfaces (TypeDefinition type)
+		{
+			for (int i = type.Interfaces.Count - 1; i >= 0; i--) {
+				var iface = type.Interfaces [i];
+				if (Annotations.IsMarked (iface.InterfaceType.Resolve ()))
+					continue;
+				InterfaceRemoved (type, iface);
+				type.Interfaces.RemoveAt (i);
 			}
 		}
 
@@ -350,6 +364,10 @@ namespace Mono.Linker.Steps {
 		}
 
 		protected virtual void ReferenceRemoved (AssemblyDefinition assembly, AssemblyNameReference reference)
+		{
+		}
+
+		protected virtual void InterfaceRemoved (TypeDefinition type, InterfaceImplementation iface)
 		{
 		}
 	}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Basic/UsedInterfaceIsKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Basic/UsedInterfaceIsKept.cs
@@ -1,0 +1,24 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Basic
+{
+	class UsedInterfaceIsKept
+	{
+		public static void Main ()
+		{
+			A a = new A ();
+		}
+
+		[Kept]
+		[KeptInterface (typeof (I))]
+		[KeptMember (".ctor()")]
+		class A : I
+		{
+		}
+
+		[Kept]
+		interface I
+		{ 
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -147,6 +147,7 @@
     <Compile Include="VirtualMethods\VirtualMethodGetsStrippedIfImplementingMethodGetsInvokedDirectly.cs" />
     <Compile Include="TypeForwarding\MissingTargetReference.cs" />
     <None Include="TypeForwarding\Dependencies\TypeForwarderMissingReference.il" />
+    <Compile Include="Basic\UsedInterfaceIsKept.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="LinkXml\TypeWithPreserveFieldsHasBackingFieldsOfPropertiesRemoved.xml" />


### PR DESCRIPTION
Make interface marking overridable by derived classes, so that derived classes
can decide whether an interface implementation should be marked or not.

Also remove any non-marked interface implementations.