### PR TITLE
Add two new assembly actions: AddBypassNGen and AddBypassNGenUsed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ bin/
 
 corebuild/Tools
 corebuild/bootstrap.log
+/corebuild/global.json

--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.csproj
@@ -190,8 +190,8 @@
           AfterTargets="AssignProjectConfiguration">
     <ItemGroup>
       <ProjectReferenceWithConfiguration Condition=" '%(Filename)%(Extension)' == 'Mono.Cecil.csproj' Or '%(Filename)%(Extension)' == 'Mono.Cecil.Pdb.csproj' ">
-	<SetConfiguration Condition=" '$(TargetFramework)' == 'net46' ">Configuration=net_4_0_$(Configuration)</SetConfiguration>
-	<SetConfiguration Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">Configuration=netstandard_$(Configuration)</SetConfiguration>
+        <SetConfiguration Condition=" '$(TargetFramework)' == 'net46' ">Configuration=net_4_0_$(Configuration)</SetConfiguration>
+        <SetConfiguration Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">Configuration=netstandard_$(Configuration)</SetConfiguration>
       </ProjectReferenceWithConfiguration>
     </ItemGroup>
   </Target>

--- a/linker/Mono.Linker.Steps/AddBypassNGenStep.cs
+++ b/linker/Mono.Linker.Steps/AddBypassNGenStep.cs
@@ -1,0 +1,120 @@
+﻿//
+// AddBypassNGenStep.cs
+//
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Mono.Cecil;
+using Mono.Collections.Generic;
+using Mono.Cecil.Cil;
+
+namespace Mono.Linker.Steps {
+
+	public class AddBypassNGenStep : BaseStep{
+
+		AssemblyDefinition coreLibAssembly;
+		CustomAttribute bypassNGenAttribute;
+		
+		protected override void ProcessAssembly (AssemblyDefinition assembly)
+		{
+			if (Annotations.GetAction (assembly) == AssemblyAction.AddBypassNGen) {
+				coreLibAssembly = Context.Resolve (assembly.MainModule.TypeSystem.CoreLibrary);
+				bypassNGenAttribute = null;
+				if (assembly == coreLibAssembly) {
+					EnsureBypassNGenAttribute (assembly.MainModule);
+				}
+
+				foreach (var type in assembly.MainModule.Types)
+					ProcessType (type);
+			}
+		}
+
+		void ProcessType (TypeDefinition type)
+		{
+			if (type.HasMethods)
+				ProcessMethods (type.Methods, type.Module);
+
+			if (type.HasNestedTypes)
+				ProcessNestedTypes (type);
+		}
+
+		void ProcessMethods (Collection<MethodDefinition> methods, ModuleDefinition module)
+		{
+			foreach (var method in methods)
+				if (!Annotations.IsMarked (method)) {
+					EnsureBypassNGenAttribute (module);
+					method.CustomAttributes.Add (bypassNGenAttribute);
+				}
+		}
+
+		void ProcessNestedTypes (TypeDefinition type)
+		{
+			for (int i = 0; i < type.NestedTypes.Count; i++) {
+				var nested = type.NestedTypes [i];
+				ProcessType (nested);
+			}
+		}
+
+		private void EnsureBypassNGenAttribute (ModuleDefinition targetModule)
+		{
+			if (bypassNGenAttribute != null) {
+				return;
+			}
+			ModuleDefinition corelibMainModule = coreLibAssembly.MainModule;
+			TypeReference bypassNGenAttributeRef = new TypeReference ("System.Runtime", "BypassNGenAttribute", corelibMainModule, targetModule.TypeSystem.CoreLibrary);
+			TypeDefinition bypassNGenAttributeDef = corelibMainModule.MetadataResolver.Resolve (bypassNGenAttributeRef);
+			MethodDefinition bypassNGenAttributeDefaultConstructor = null;
+
+			if (bypassNGenAttributeDef == null) {
+				// System.Runtime.BypassNGenAttribute is not found in corelib. Add it.
+				TypeReference systemAttributeRef = new TypeReference ("System", "Attribute", corelibMainModule, targetModule.TypeSystem.CoreLibrary);
+				TypeReference systemAttribute = corelibMainModule.MetadataResolver.Resolve (systemAttributeRef);
+				systemAttribute = corelibMainModule.ImportReference (systemAttribute);
+
+				if (systemAttribute == null)
+					throw new System.ApplicationException ("System.Attribute is not found in " + targetModule.TypeSystem.CoreLibrary.Name);
+
+				MethodReference systemAttributeDefaultConstructorRef = new MethodReference (".ctor", corelibMainModule.TypeSystem.Void, systemAttributeRef);
+				MethodReference systemAttributeDefaultConstructor = corelibMainModule.MetadataResolver.Resolve (systemAttributeDefaultConstructorRef);
+				systemAttributeDefaultConstructor = corelibMainModule.ImportReference (systemAttributeDefaultConstructor);
+
+				if (systemAttributeDefaultConstructor == null)
+					throw new System.ApplicationException ("System.Attribute has no default constructor");
+
+				bypassNGenAttributeDef = new TypeDefinition ("System.Runtime", "BypassNGenAttribute", TypeAttributes.NotPublic | TypeAttributes.Sealed, systemAttribute);
+
+				coreLibAssembly.MainModule.Types.Add (bypassNGenAttributeDef);
+
+				if (Annotations.GetAction (coreLibAssembly) == AssemblyAction.Copy) {
+					Annotations.SetAction (coreLibAssembly, AssemblyAction.Save);
+				}
+
+				const MethodAttributes ctorAttributes = MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName;
+				bypassNGenAttributeDefaultConstructor = new MethodDefinition (".ctor", ctorAttributes, coreLibAssembly.MainModule.TypeSystem.Void);
+				var instructions = bypassNGenAttributeDefaultConstructor.Body.Instructions;
+				instructions.Add (Instruction.Create (OpCodes.Ldarg_0));
+				instructions.Add (Instruction.Create (OpCodes.Call, systemAttributeDefaultConstructor));
+				instructions.Add (Instruction.Create (OpCodes.Ret));
+
+				bypassNGenAttributeDef.Methods.Add (bypassNGenAttributeDefaultConstructor);
+			}
+			else {
+				foreach (MethodDefinition method in bypassNGenAttributeDef.Methods) {
+					if (method.IsConstructor && !method.IsStatic && !method.HasParameters) {
+						bypassNGenAttributeDefaultConstructor = method;
+						break;
+					}
+				}
+
+				if (bypassNGenAttributeDefaultConstructor == null) {
+					throw new System.ApplicationException ("System.Runtime.BypassNGenAttribute has no default constructor");
+				}
+			}
+
+			MethodReference defaultConstructorReference = targetModule.ImportReference (bypassNGenAttributeDefaultConstructor);
+			bypassNGenAttribute = new CustomAttribute (defaultConstructorReference);
+		}
+	}
+}

--- a/linker/Mono.Linker.Steps/MarkStep.cs
+++ b/linker/Mono.Linker.Steps/MarkStep.cs
@@ -1447,6 +1447,8 @@ namespace Mono.Linker.Steps {
 				case AssemblyAction.Link:
 				case AssemblyAction.Copy:
 				case AssemblyAction.CopyUsed:
+				case AssemblyAction.AddBypassNGen:
+				case AssemblyAction.AddBypassNGenUsed:
 					return true;
 				default:
 					return false;

--- a/linker/Mono.Linker.Steps/OutputStep.cs
+++ b/linker/Mono.Linker.Steps/OutputStep.cs
@@ -116,6 +116,7 @@ namespace Mono.Linker.Steps {
 			switch (Annotations.GetAction (assembly)) {
 			case AssemblyAction.Save:
 			case AssemblyAction.Link:
+			case AssemblyAction.AddBypassNGen:
 				Context.Annotations.AddDependency (assembly);
 				WriteAssembly (assembly, directory);
 				break;

--- a/linker/Mono.Linker.csproj
+++ b/linker/Mono.Linker.csproj
@@ -75,6 +75,7 @@
     <Compile Include="Mono.Linker.Steps\ResolveFromXmlStep.cs" />
     <Compile Include="Mono.Linker.Steps\ResolveStep.cs" />
     <Compile Include="Mono.Linker.Steps\SweepStep.cs" />
+    <Compile Include="Mono.Linker.Steps\AddBypassNGenStep.cs" />
     <Compile Include="Mono.Linker\Annotations.cs" />
     <Compile Include="Mono.Linker\AssemblyAction.cs" />
     <Compile Include="Mono.Linker\AssemblyInfo.cs" />

--- a/linker/Mono.Linker/AssemblyAction.cs
+++ b/linker/Mono.Linker/AssemblyAction.cs
@@ -45,6 +45,11 @@ namespace Mono.Linker {
 		// Save the assembly/symbols in memory without linking it. 
 		// E.g. useful to remove unneeded assembly references (as done in SweepStep), 
 		//  resolving [TypeForwardedTo] attributes (like PCL) to their final location
-		Save
+		Save,
+		// Keep all types, methods, and fields but add System.Runtime.BypassNGenAttribute to unmarked methods.
+		AddBypassNGen,
+		// Keep all types, methods, and fields in marked assemblies but add System.Runtime.BypassNGenAttribute to unmarked methods.
+		// Delete unmarked assemblies.
+		AddBypassNGenUsed
 	}
 }

--- a/linker/Mono.Linker/Driver.cs
+++ b/linker/Mono.Linker/Driver.cs
@@ -63,6 +63,7 @@ namespace Mono.Linker {
 		}
 
 		Queue<string> _queue;
+		bool _needAddBypassNGenStep;
 
 		public Driver (string [] args)
 		{
@@ -191,6 +192,10 @@ namespace Mono.Linker {
 
 				p.AddStepAfter (typeof (LoadReferencesStep), new LoadI18nAssemblies (assemblies));
 
+				if (_needAddBypassNGenStep) {
+					p.AddStepAfter (typeof (SweepStep), new AddBypassNGenStep ());
+				}
+
 				p.Process (context);
 			}
 		}
@@ -266,9 +271,13 @@ namespace Mono.Linker {
 			return assemblies;
 		}
 
-		static AssemblyAction ParseAssemblyAction (string s)
+		AssemblyAction ParseAssemblyAction (string s)
 		{
-			return (AssemblyAction) Enum.Parse (typeof (AssemblyAction), s, true);
+			var assemblyAction = (AssemblyAction)Enum.Parse(typeof(AssemblyAction), s, true);
+			if ((assemblyAction == AssemblyAction.AddBypassNGen) || (assemblyAction == AssemblyAction.AddBypassNGenUsed)) {
+				_needAddBypassNGenStep = true;
+			}
+			return assemblyAction;
 		}
 
 		string GetParam ()
@@ -303,8 +312,8 @@ namespace Mono.Linker {
 			Console.WriteLine ("   --version           Print the version number of the {0}", _linker);
 			Console.WriteLine ("   --skip-unresolved   Ignore unresolved types and methods (true or false)");
 			Console.WriteLine ("   -out                Specify the output directory, default to `output'");
-			Console.WriteLine ("   -c                  Action on the core assemblies, skip, copy, copyused or link, default to skip");
-			Console.WriteLine ("   -u                  Action on the user assemblies, skip, copy, copyused or link, default to link");
+			Console.WriteLine ("   -c                  Action on the core assemblies, skip, copy, copyused, addbypassngen, addbypassngenused or link, default to skip");
+			Console.WriteLine ("   -u                  Action on the user assemblies, skip, copy, copyused, addbypassngen, addbypassngenused or link, default to link");
 			Console.WriteLine ("   -p                  Action per assembly");
 			Console.WriteLine ("   -s                  Add a new step to the pipeline.");
 			Console.WriteLine ("   -t                  Keep assemblies in which only type forwarders are referenced.");
@@ -329,7 +338,7 @@ namespace Mono.Linker {
 		{
 			Console.WriteLine ("{0} Version {1}",
 				_linker,
-			    System.Reflection.Assembly.GetExecutingAssembly ().GetName ().Version);
+				System.Reflection.Assembly.GetExecutingAssembly ().GetName ().Version);
 
 			Environment.Exit(1);
 		}


### PR DESCRIPTION
AddBypassNGen specifies that instead of removing unreached methods
they should be marked with System.Runtime.BypassNGenAttribute. Types and fields
should be preserved.

AddBypassNGenUsed is the same as AddBypassNGen except unmarked assemblies should
be deleted.

ngen/crossgen will skip compilation of methods marked with
System.Runtime.BypassNGenAttribute so these actions can be used for conservative
linking: all msil is preserved but ngen/crossgen is run only on reachable methods.

System.Runtime.BypassNGenAttribute may not be present in the core library.
If that's the case, the linker will inject it.