### PR TITLE
Prevent linker from interfering with ref assemblies

### DIFF
--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
@@ -100,6 +100,31 @@
     </ItemGroup>
   </Target>
   
+  <!-- The SDK has a target called ComputeRefAssembliesToPublish that
+       runs after ComputeFilesToPublish and rewrites
+       ResolvedFileToPublish to include any reference assemblies that
+       aren't in ResolvedAssembliesToPublish. Because
+       ComputeLinkedFilesToPublish changes ResolvedAssembliesToPublish
+       (replacing the original assemblies with linked assemblies),
+       this would change the behavior of
+       ComputeRefAssembliesToPublish, resulting in extra assemblies
+       being placed in the refs directory of the output. To prevent
+       this, we save ResolvedAssembliesToPublish before linking, and
+       restore it to its pre-link state before
+       ComputeRefAssembliesToPublish. -->
+  <Target Name="SaveResolvedAssembliesToPublish"
+          BeforeTargets="ComputeLinkedFilesToPublish">
+    <ItemGroup>
+      <PreLinkResolvedAssembliesToPublish Include="@(ResolvedAssembliesToPublish)" />
+    </ItemGroup>
+  </Target>
+  <Target Name="RestoreResolvedAssembliesToPublish"
+          BeforeTargets="ComputeRefAssembliesToPublish">
+    <ItemGroup>
+      <ResolvedAssembliesToPublish Remove="@(ResolvedAssembliesToPublish)" />
+      <ResolvedAssembliesToPublish Include="@(PreLinkResolvedAssembliesToPublish)" />
+    </ItemGroup>
+  </Target>
 
   <!-- Print out a size comparison report for the linked
        assemblies. This is disabled by default, but can be turned on


### PR DESCRIPTION
With this change, the refs directory of the publish output should not
change when using the linker.

@erozenfeld please review.