### PR TITLE
Add test to verify the default user assembly action

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -61,6 +61,8 @@
     <Compile Include="LinkXml\UnusedEventPreservedByLinkXmlIsKept.cs" />
     <Compile Include="LinkXml\UnusedTypePreservedByLinkXmlWithCommentIsKept.cs" />
     <Compile Include="LinkXml\UnusedTypeWithNoDefinedPreserveHasAllMembersPreserved.cs" />
+    <Compile Include="References\Dependencies\UserAssembliesAreLinkedByDefault_Library1.cs" />
+    <Compile Include="References\UserAssembliesAreLinkedByDefault.cs" />
     <Compile Include="Resources\EmbeddedLinkXmlFileIsNotProcessedIfNameDoesNotMatchAnAssembly.cs" />
     <Compile Include="Resources\EmbeddedLinkXmlFileIsNotProcessedWhenBlacklistStepIsDisabled.cs" />
     <Compile Include="Resources\EmbeddedLinkXmlFileIsNotProcessedWhenCoreLinkActionIsSkip.cs" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/References/Dependencies/UserAssembliesAreLinkedByDefault_Library1.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/References/Dependencies/UserAssembliesAreLinkedByDefault_Library1.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Mono.Linker.Tests.Cases.References.Dependencies {
+	public class UserAssembliesAreLinkedByDefault_Library1 {
+		public void UsedMethod ()
+		{
+			Console.WriteLine ("Used");
+		}
+
+		public void UnusedMethod ()
+		{
+			Console.WriteLine ("NotUsed");
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/References/UserAssembliesAreLinkedByDefault.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/References/UserAssembliesAreLinkedByDefault.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.References.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.References {
+	[SetupCompileBefore ("library1.dll", new [] { "Dependencies/UserAssembliesAreLinkedByDefault_Library1.cs" })]
+
+	[KeptAssembly ("library1.dll")]
+	[KeptMemberInAssembly ("library1.dll", typeof (UserAssembliesAreLinkedByDefault_Library1), "UsedMethod()")]
+	[RemovedMemberInAssembly ("library1.dll", typeof (UserAssembliesAreLinkedByDefault_Library1), "UnusedMethod()")]
+	class UserAssembliesAreLinkedByDefault {
+		public static void Main ()
+		{
+			new UserAssembliesAreLinkedByDefault_Library1 ().UsedMethod ();
+		}
+	}
+}


### PR DESCRIPTION
There was a change made about a month ago that required us to make a corresponding change to our version of Driver.cs in our UnityLinker

https://github.com/mono/linker/commit/4d2362d8083e3c71560ba1225d468a0080aeea27

This PR adds a test to verify the default user assembly behavior.