### PR TITLE
Extensibility changes

### DIFF
--- a/linker/Mono.Linker.Steps/MarkStep.cs
+++ b/linker/Mono.Linker.Steps/MarkStep.cs
@@ -1433,7 +1433,7 @@ namespace Mono.Linker.Steps {
 			}
 		}
 
-		bool ShouldParseMethodBody (MethodDefinition method)
+		protected virtual bool ShouldParseMethodBody (MethodDefinition method)
 		{
 			if (!method.HasBody)
 				return false;

--- a/linker/Mono.Linker.Steps/SweepStep.cs
+++ b/linker/Mono.Linker.Steps/SweepStep.cs
@@ -356,10 +356,15 @@ namespace Mono.Linker.Steps {
 		protected void SweepCollection<T> (IList<T> list) where T : IMetadataTokenProvider
 		{
 			for (int i = 0; i < list.Count; i++)
-				if (!Annotations.IsMarked (list [i])) {
+				if (ShouldRemove (list [i])) {
 					ElementRemoved (list [i]);
 					list.RemoveAt (i--);
 				}
+		}
+
+		protected virtual bool ShouldRemove<T> (T element) where T : IMetadataTokenProvider
+		{
+			return !Annotations.IsMarked (element);
 		}
 
 		static bool AreSameReference (AssemblyNameReference a, AssemblyNameReference b)

--- a/linker/Tests/TestCasesRunner/ResultChecker.cs
+++ b/linker/Tests/TestCasesRunner/ResultChecker.cs
@@ -39,7 +39,7 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 
 				var linked = ResolveLinkedAssembly (linkResult.OutputAssemblyPath.FileNameWithoutExtension);
 
-				new AssemblyChecker (original, linked).Verify ();
+				CreateAssemblyChecker (original, linked).Verify ();
 
 				VerifyLinkingOfOtherAssemblies (original);
 
@@ -52,6 +52,11 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 				_originalsResolver.Dispose ();
 				_linkedResolver.Dispose ();
 			}
+		}
+
+		protected virtual AssemblyChecker CreateAssemblyChecker (AssemblyDefinition original, AssemblyDefinition linked)
+		{
+			return new AssemblyChecker (original, linked);
 		}
 
 		void InitializeResolvers (LinkedTestCaseResult linkedResult)


### PR DESCRIPTION
These are extension points we needed to implement our experimental "stub"  feature in the UnityLinker which lets you replace the implementation of a method with a throw Exception().