### PR TITLE
Added cmd line option and property to the ILLink

### DIFF
--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
@@ -15,6 +15,7 @@
     <LinkDuringPublish Condition=" '$(LinkDuringPublish)' == '' ">true</LinkDuringPublish>
     <LinkDuringPublish Condition=" '$(LinkDuringPublish)' != 'true' ">false</LinkDuringPublish>
     <ShowLinkerSizeComparison Condition=" '$(ShowLinkerSizeComparison)' == '' ">false</ShowLinkerSizeComparison>
+    <LinkerDumpDependencies Condition=" '$(LinkerDumpDependencies)' == '' ">false</LinkerDumpDependencies>
   </PropertyGroup>
   
   <ItemGroup>
@@ -186,6 +187,7 @@
             RootAssemblyNames="@(LinkerRootAssemblies)"
             RootDescriptorFiles="@(LinkerRootDescriptors)"
             OutputDirectory="$(IntermediateLinkDir)"
+            DumpDependencies="$(LinkerDumpDependencies)"
             ExtraArgs="$(ExtraLinkerArgs)" />
 
     <Touch Files="$(_LinkSemaphore)" AlwaysCreate="true">

--- a/corebuild/integration/ILLink.Tasks/LinkTask.cs
+++ b/corebuild/integration/ILLink.Tasks/LinkTask.cs
@@ -54,6 +54,11 @@ namespace ILLink.Tasks
 		/// </summary>
 		public string ExtraArgs { get; set; }
 
+		/// <summary>
+		///   Make illink dump dependencies file for linker analyzer tool.
+		/// </summary>
+		public bool DumpDependencies { get; set; }
+
 		public override bool Execute()
 		{
 			string[] args = GenerateCommandLineCommands();
@@ -94,6 +99,9 @@ namespace ILLink.Tasks
 			if (ExtraArgs != null) {
 				args.AddRange(ExtraArgs.Split(' '));
 			}
+
+			if (DumpDependencies)
+				args.Add ("--dump-dependencies");
 
 			return args.ToArray();
 		}

--- a/linker/Mono.Linker/Driver.cs
+++ b/linker/Mono.Linker/Driver.cs
@@ -101,6 +101,14 @@ namespace Mono.Linker {
 							continue;
 						}
 
+						if (token == "--dump-dependencies")
+						{
+							var prepareDependenciesDump = context.Annotations.GetType ().GetMethod ("PrepareDependenciesDump", new Type [] { });
+							if (prepareDependenciesDump != null)
+								prepareDependenciesDump.Invoke (context.Annotations, null);
+							continue;
+						}
+
 						switch (token [2]) {
 						case 'v':
 							Version ();
@@ -311,6 +319,7 @@ namespace Mono.Linker {
 			Console.WriteLine ("   --about             About the {0}", _linker);
 			Console.WriteLine ("   --version           Print the version number of the {0}", _linker);
 			Console.WriteLine ("   --skip-unresolved   Ignore unresolved types and methods (true or false)");
+			Console.WriteLine ("   --dump-dependencies Dump dependencies for the linker analyzer tool");
 			Console.WriteLine ("   -out                Specify the output directory, default to `output'");
 			Console.WriteLine ("   -c                  Action on the core assemblies, skip, copy, copyused, addbypassngen, addbypassngenused or link, default to skip");
 			Console.WriteLine ("   -u                  Action on the user assemblies, skip, copy, copyused, addbypassngen, addbypassngenused or link, default to link");


### PR DESCRIPTION
Made it possible to enable dumping dependencies for the
linker-analyzer tool with the command line argument
`--dump-dependencies` to the illink.

Or by setting the `LinkerDumpDependencies` msbuild property to true.