### PR TITLE
Don't preserve forwarding assemblies when exported type preserved by xml

### DIFF
--- a/linker/Linker.Steps/BaseStep.cs
+++ b/linker/Linker.Steps/BaseStep.cs
@@ -42,6 +42,8 @@ namespace Mono.Linker.Steps {
 			get { return _context.Annotations; }
 		}
 
+		public MarkingHelpers MarkingHelpers => _context.MarkingHelpers;
+
 		public void Process (LinkContext context)
 		{
 			_context = context;

--- a/linker/Linker.Steps/MarkStep.cs
+++ b/linker/Linker.Steps/MarkStep.cs
@@ -51,6 +51,8 @@ namespace Mono.Linker.Steps {
 			get { return _context.Annotations; }
 		}
 
+		private MarkingHelpers MarkingHelpers => _context.MarkingHelpers;
+
 		public MarkStep ()
 		{
 			_methods = new Queue<MethodDefinition> ();
@@ -159,10 +161,7 @@ namespace Mono.Linker.Steps {
 						continue;
 					Annotations.Push (type);
 					try {
-						Annotations.Mark (exported);
-						if (_context.KeepTypeForwarderOnlyAssemblies) {
-							Annotations.Mark (assembly.MainModule);
-						}
+						MarkingHelpers.MarkExportedType (exported, assembly.MainModule);
 					} finally {
 						Annotations.Pop ();
 					}

--- a/linker/Linker.Steps/ResolveFromAssemblyStep.cs
+++ b/linker/Linker.Steps/ResolveFromAssemblyStep.cs
@@ -144,10 +144,7 @@ namespace Mono.Linker.Steps
 
 					context.Resolve (resolvedExportedType.Scope);
 					MarkType (context, resolvedExportedType, rootVisibility);
-					context.Annotations.Mark (exported);
-					if (context.KeepTypeForwarderOnlyAssemblies) {
-						context.Annotations.Mark (assembly.MainModule);
-					}
+					context.MarkingHelpers.MarkExportedType (exported, assembly.MainModule);
 				}
 			}
 

--- a/linker/Linker.Steps/ResolveFromXmlStep.cs
+++ b/linker/Linker.Steps/ResolveFromXmlStep.cs
@@ -163,9 +163,8 @@ namespace Mono.Linker.Steps {
 					if (assembly.MainModule.HasExportedTypes) {
 						foreach (var exported in assembly.MainModule.ExportedTypes) {
 							if (fullname == exported.FullName) {
-								Annotations.Mark (exported);
 								Annotations.Push (exported);
-								Annotations.Mark (assembly.MainModule);
+								MarkingHelpers.MarkExportedType (exported, assembly.MainModule);
 								var resolvedExternal = exported.Resolve ();
 								Annotations.Pop ();
 								if (resolvedExternal != null) {
@@ -209,8 +208,7 @@ namespace Mono.Linker.Steps {
 		void MatchExportedType (ExportedType exportedType, ModuleDefinition module, Regex regex, XPathNavigator nav)
 		{
 			if (regex.Match (exportedType.FullName).Success) {
-				Annotations.Mark (exportedType);
-				Annotations.Mark (module);
+				MarkingHelpers.MarkExportedType (exportedType, module);
 				TypeDefinition type = null;
 				try {
 					type = exportedType.Resolve ();

--- a/linker/Linker/LinkContext.cs
+++ b/linker/Linker/LinkContext.cs
@@ -127,6 +127,8 @@ namespace Mono.Linker {
 
 		public ILogger Logger { get; set; } = new ConsoleLogger ();
 
+		public MarkingHelpers MarkingHelpers { get; private set; }
+
 		public LinkContext (Pipeline pipeline)
 			: this (pipeline, new AssemblyResolver ())
 		{
@@ -149,6 +151,7 @@ namespace Mono.Linker {
 			_parameters = new Dictionary<string, string> ();
 			_annotations = annotations;
 			_readerParameters = readerParameters;
+			MarkingHelpers = CreateMarkingHelpers ();
 		}
 
 		public TypeDefinition GetType (string fullName)
@@ -326,6 +329,11 @@ namespace Mono.Linker {
 		{
 			if (LogInternalExceptions && Logger != null)
 				Logger.LogMessage (importance, message, values);
+		}
+
+		protected virtual MarkingHelpers CreateMarkingHelpers ()
+		{
+			return new MarkingHelpers (this);
 		}
 	}
 }

--- a/linker/Linker/MarkingHelpers.cs
+++ b/linker/Linker/MarkingHelpers.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Mono.Cecil;
+
+namespace Mono.Linker {
+	public class MarkingHelpers {
+		protected readonly LinkContext _context;
+
+		public MarkingHelpers (LinkContext context)
+		{
+			_context = context;
+		}
+
+		public void MarkExportedType (ExportedType type, ModuleDefinition module)
+		{
+			_context.Annotations.Mark (type);
+			if (_context.KeepTypeForwarderOnlyAssemblies)
+				_context.Annotations.Mark (module);
+		}
+	}
+}

--- a/linker/Mono.Linker.csproj
+++ b/linker/Mono.Linker.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Linker\LinkContext.cs" />
     <Compile Include="Linker\LoadException.cs" />
     <Compile Include="Linker\MarkException.cs" />
+    <Compile Include="Linker\MarkingHelpers.cs" />
     <Compile Include="Linker\MethodAction.cs" />
     <Compile Include="Linker\MethodReferenceExtensions.cs" />
     <Compile Include="Linker\Pipeline.cs" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/CanPreserveAnExportedType.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/CanPreserveAnExportedType.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.LinkXml.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.LinkXml
+{
+	[KeepTypeForwarderOnlyAssemblies ("false")]
+	[SetupCompileBefore ("Library.dll", new[] { "Dependencies/CanPreserveAnExportedType_Library.cs" })]
+	// Add another assembly in that uses the forwarder just to make things a little more complex
+	[SetupCompileBefore ("Forwarder.dll", new[] { "Dependencies/CanPreserveAnExportedType_Forwarder.cs" }, references: new[] { "Library.dll" })]
+
+	[RemovedAssembly ("Forwarder.dll")]
+	[KeptMemberInAssembly ("Library.dll", typeof (CanPreserveAnExportedType_Library), "Field1", "Method()", ".ctor()")]
+	class CanPreserveAnExportedType {
+		public static void Main () {
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/CanPreserveAnExportedType.xml
+++ b/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/CanPreserveAnExportedType.xml
@@ -1,0 +1,6 @@
+﻿<linker>
+  <assembly fullname="Forwarder, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+    <type fullname="Mono.Linker.Tests.Cases.LinkXml.Dependencies.CanPreserveAnExportedType_Library" preserve="all">
+    </type>
+  </assembly>
+</linker>

--- a/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/CanPreserveExportedTypesUsingRegex.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/CanPreserveExportedTypesUsingRegex.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.LinkXml.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.LinkXml
+{
+	[KeepTypeForwarderOnlyAssemblies ("false")]
+	[SetupCompileBefore ("Library.dll", new [] { "Dependencies/CanPreserveAnExportedType_Library.cs" })]
+	// Add another assembly in that uses the forwarder just to make things a little more complex
+	[SetupCompileBefore ("Forwarder.dll", new [] { "Dependencies/CanPreserveAnExportedType_Forwarder.cs" }, references: new [] { "Library.dll" })]
+
+	[RemovedAssembly ("Forwarder.dll")]
+	[KeptMemberInAssembly ("Library.dll", typeof (CanPreserveAnExportedType_Library), "Field1", "Method()", ".ctor()")]
+	class CanPreserveExportedTypesUsingRegex {
+		public static void Main () {
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/CanPreserveExportedTypesUsingRegex.xml
+++ b/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/CanPreserveExportedTypesUsingRegex.xml
@@ -1,0 +1,6 @@
+﻿<linker>
+  <assembly fullname="Forwarder, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+    <type fullname="Can*" preserve="all">
+    </type>
+  </assembly>
+</linker>

--- a/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/Dependencies/CanPreserveAnExportedType_Forwarder.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/Dependencies/CanPreserveAnExportedType_Forwarder.cs
@@ -1,0 +1,3 @@
+﻿using System;
+
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo (typeof (Mono.Linker.Tests.Cases.LinkXml.Dependencies.CanPreserveAnExportedType_Library))]

--- a/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/Dependencies/CanPreserveAnExportedType_Library.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/Dependencies/CanPreserveAnExportedType_Library.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Mono.Linker.Tests.Cases.LinkXml.Dependencies
+{
+	public class CanPreserveAnExportedType_Library {
+		public int Field1;
+
+		public void Method () {
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -58,6 +58,10 @@
     <Compile Include="Basic\UsedPropertyIsKept.cs" />
     <Compile Include="Basic\UsedStructIsKept.cs" />
     <Compile Include="LinkXml\CanPreserveTypesUsingRegex.cs" />
+    <Compile Include="LinkXml\CanPreserveAnExportedType.cs" />
+    <None Include="LinkXml\Dependencies\CanPreserveAnExportedType_Forwarder.cs" />
+    <Compile Include="LinkXml\CanPreserveExportedTypesUsingRegex.cs" />
+    <Compile Include="LinkXml\Dependencies\CanPreserveAnExportedType_Library.cs" />
     <Compile Include="LinkXml\UnusedAssemblyWithNoDefinedPreserveHasAllTypesPreserved.cs" />
     <Compile Include="LinkXml\UnusedEventPreservedByLinkXmlIsKept.cs" />
     <Compile Include="LinkXml\UnusedTypePreservedByLinkXmlWithCommentIsKept.cs" />
@@ -154,6 +158,8 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="LinkXml\CanPreserveTypesUsingRegex.xml" />
+    <Content Include="LinkXml\CanPreserveAnExportedType.xml" />
+    <Content Include="LinkXml\CanPreserveExportedTypesUsingRegex.xml" />
     <Content Include="LinkXml\TypeWithPreserveFieldsHasBackingFieldsOfPropertiesRemoved.xml" />
     <Content Include="LinkXml\UnusedAssemblyWithNoDefinedPreserveHasAllTypesPreserved.xml" />
     <Content Include="LinkXml\UnusedEventPreservedByLinkXmlIsKept.xml" />


### PR DESCRIPTION
When KeepTypeForwarderOnlyAssemblies=false we shouldn't preserve forwarding only assemblies just because a type was preserved via link.xml