### PR TITLE
Tweak what we Resolve when processing attributes

### DIFF
--- a/linker/Linker.Steps/MarkStep.cs
+++ b/linker/Linker.Steps/MarkStep.cs
@@ -523,9 +523,9 @@ namespace Mono.Linker.Steps {
 			while (_topLevelAttributes.Count != 0) {
 				var customAttribute = _topLevelAttributes.Dequeue ();
 
-				var resolved = customAttribute.AttributeType.Resolve ();
+				var resolved = customAttribute.Constructor.Resolve ();
 				if (resolved == null) {
-					HandleUnresolvedType (customAttribute.AttributeType);
+					HandleUnresolvedMethod (customAttribute.Constructor);
 					continue;
 				}
 


### PR DESCRIPTION
Attempt to Resolve the attributes constructor rather than the AttributeType.  This is slightly more correct, technically the type could have existed but the constructor be missing and we would have tried to process it.

A secondary benefit is that we have a feature to stub missing methods and by attempting to resolve the constructor, we can call our stub method code path if it fails to resolve