### PR TITLE
Add back edge mark behavior to ResolveFromXmlStep

### DIFF
--- a/linker/Linker.Steps/ResolveFromXmlStep.cs
+++ b/linker/Linker.Steps/ResolveFromXmlStep.cs
@@ -250,6 +250,7 @@ namespace Mono.Linker.Steps {
 
 			Annotations.Mark (type);
 			Annotations.Push (type);
+			Annotations.AddDirectDependency (this, type);
 
 			if (type.IsNested) {
 				var parent = type;
@@ -404,6 +405,7 @@ namespace Mono.Linker.Steps {
 		void MarkMethod (MethodDefinition method)
 		{
 			Annotations.Mark (method);
+			Annotations.AddDirectDependency (this, method);
 			Annotations.SetAction (method, MethodAction.Parse);
 		}
 

--- a/linker/Linker/Annotations.cs
+++ b/linker/Linker/Annotations.cs
@@ -316,6 +316,17 @@ namespace Mono.Linker {
 			return slots;
 		}
 
+		public void AddDirectDependency (object b, object e)
+		{
+			if (writer == null)
+				return;
+
+			writer.WriteStartElement ("edge");
+			writer.WriteAttributeString ("b", TokenString (b));
+			writer.WriteAttributeString ("e", TokenString (e));
+			writer.WriteEndElement ();
+		}
+
 		public void AddDependency (object o)
 		{
 			if (writer == null)


### PR DESCRIPTION
Prior to https://github.com/mono/linker/commit/9cf2bb80616f1473efcfd1e651d949ef78b4e94b

ResolveFromXmlStep would produce an edge element in the dependency xml directly mapping the "link.xml" file to the methods it preserved.  We have a test in our test framework that asserts this and after updating our ResolveFromXmlStep to be based off of the latest upstream, it started failing.

The changes in this PR leave the current behavior in place, but also adds in a edge so that previous information is also available.

Prior to 9cf2bb80616f1473efcfd1e651d949ef78b4e94b, the dependency info in the xml file would look something like this for a method preserved by a link.xml

link.xml => Main()

We have a simple html visualization we output based on the dependency info and it would clearly tell you that Main() was preserved because of "link.xml"

The latest results look like
link.xml => MyAssembly => MyType => Main()

I understand there might be cases where this extra info is desired, but I think it's equally important to be able to quickly see that "The link.xml preserved this method that I'm trying to figure out how to remove".  There's also some cases that are wrong in my opinion and end up being misleading.  For example, if the <type> element had preserve=nothing, there will still be that MyType => Main() edge and it's not true to say "Preserving MyType caused Main() to be preserved"

I want our linker to maintain the old behavior and the extra methods I would have to expose to give us the ability to customize the behavior here didn't seem worth the effort.  Ultimately, this little bit of extra info doesn't cause any harm.

I'm not including any tests and I'm not doing the same thing for Fields, Properties, etc, because I would prefer to do the bare minimum at the moment.  

I think the dependency stuff, and especially the dependency stuff in ResolveFromXmlStep needs to be reviewed, refactored, and improved.  We also need to figure out a testing strategy.  This is on my radar to do, but I'm not ready to dive in yet.