### PR TITLE
Don't catch and wrap if already an XmlResolutionException

### DIFF
--- a/linker/Linker.Steps/ResolveFromXmlStep.cs
+++ b/linker/Linker.Steps/ResolveFromXmlStep.cs
@@ -95,7 +95,7 @@ namespace Mono.Linker.Steps {
 
 				if (!string.IsNullOrEmpty (_resourceName))
 					Context.Annotations.AddResourceToRemove (_resourceAssembly, _resourceName);
-			} catch (Exception ex) {
+			} catch (Exception ex) when (!(ex is XmlResolutionException)) {
 				throw new XmlResolutionException (string.Format ("Failed to process XML description: {0}", _xmlDocumentLocation), ex);
 			}
 		}


### PR DESCRIPTION
We have some error cases we would like to bubble up as the culprit, this behavior of catching all exceptions and throwing a new exception was interfering with that.

I changed our code to throw XmlResolutionExceptions in cases we don't want caught