### PR TITLE
Add mark attribute, avoid some deps duplicating

### DIFF
--- a/linker/Linker.Steps/ResolveFromAssemblyStep.cs
+++ b/linker/Linker.Steps/ResolveFromAssemblyStep.cs
@@ -172,9 +172,7 @@ namespace Mono.Linker.Steps
 				return;
 			}
 
-			context.Annotations.Mark (type);
-
-			context.Annotations.Push (type);
+			context.Annotations.MarkAndPush (type);
 
 			if (type.HasFields)
 				MarkFields (context, type.Fields, rootVisibility);

--- a/linker/Linker.Steps/ResolveFromXmlStep.cs
+++ b/linker/Linker.Steps/ResolveFromXmlStep.cs
@@ -136,8 +136,7 @@ namespace Mono.Linker.Steps {
 
 		void MarkAndPreserveAll (TypeDefinition type)
 		{
-			Annotations.Mark (type);
-			Annotations.Push (type);
+			Annotations.MarkAndPush (type);
 			Annotations.SetPreserve (type, TypePreserve.All);
 
 			if (!type.HasNestedTypes) {
@@ -251,8 +250,7 @@ namespace Mono.Linker.Steps {
 				return;
 			}
 
-			Annotations.Mark (type);
-			Annotations.Push (type);
+			Annotations.MarkAndPush (type);
 			Annotations.AddDirectDependency (this, type);
 
 			if (type.IsNested) {

--- a/linker/Linker/Annotations.cs
+++ b/linker/Linker/Annotations.cs
@@ -74,7 +74,7 @@ namespace Mono.Linker {
 			writer.WriteStartDocument ();
 			writer.WriteStartElement ("dependencies");
 			writer.WriteStartAttribute ("version");
-			writer.WriteString ("1.1");
+			writer.WriteString ("1.2");
 			writer.WriteEndAttribute ();
 		}
 
@@ -119,7 +119,17 @@ namespace Mono.Linker {
 		public void Mark (IMetadataTokenProvider provider)
 		{
 			marked.Add (provider);
-			AddDependency (provider);
+			AddDependency (provider, true);
+		}
+
+		public void MarkAndPush (IMetadataTokenProvider provider)
+		{
+			Mark (provider);
+
+			if (writer == null)
+				return;
+
+			dependency_stack.Push (provider);
 		}
 
 		public bool IsMarked (IMetadataTokenProvider provider)
@@ -327,7 +337,7 @@ namespace Mono.Linker {
 			writer.WriteEndElement ();
 		}
 
-		public void AddDependency (object o)
+		public void AddDependency (object o, bool marked=false)
 		{
 			if (writer == null)
 				return;
@@ -336,6 +346,8 @@ namespace Mono.Linker {
 			if (pair.Key != pair.Value)
 			{
 				writer.WriteStartElement ("edge");
+				if (marked)
+					writer.WriteAttributeString ("mark", "1");
 				writer.WriteAttributeString ("b", TokenString (pair.Key));
 				writer.WriteAttributeString ("e", TokenString (pair.Value));
 				writer.WriteEndElement ();


### PR DESCRIPTION
Add `mark` attribute to the dependencies edge element, for these edges
added when marking.

Introduce `MarkAndPush` method. It simplifies common case, where we
called `Annotations::Mark` and `Annotations::Push`. It also avoids
adding duplicate edge in this case.