### PR TITLE
LinkContext.UserAction defaults to AssemblyAction.Link

### DIFF
--- a/linker/Linker/LinkContext.cs
+++ b/linker/Linker/LinkContext.cs
@@ -149,6 +149,7 @@ namespace Mono.Linker {
 			_resolver = resolver;
 			_actions = new Dictionary<string, AssemblyAction> ();
 			_parameters = new Dictionary<string, string> ();
+			_userAction = AssemblyAction.Link;
 			_annotations = annotations;
 			_readerParameters = readerParameters;
 			MarkingHelpers = CreateMarkingHelpers ();


### PR DESCRIPTION
Commit 4d2362d8 [broke the xamarin-android linker][0], as assemblies
which should have been linked were no longer being linked.

[0]: https://github.com/xamarin/xamarin-android/pull/1112#issuecomment-352154692

The apparent cause is that before commit 4d2362d8, the "default"
action would be `AssemblyAction.Link`. Starting with 4d2362d8, the
default action was instead `AssemblyAction.Skip`, as
`LinkContext._userAction` would be zero-initialized during
construction, and `AssemblyAction.Skip` is the default (0) enum value.

Set `AssemblyAction._userAction` in the constructor to
`AssemblyAction.Link`, so that pre-4d2362d8 linker behavior is
retained. This should allow the Xamarin.Android linker to work without
further changes.