### PR TITLE
Extracted dependency dumping into the new Tracer class

### DIFF
--- a/linker/Linker.Steps/BaseStep.cs
+++ b/linker/Linker.Steps/BaseStep.cs
@@ -42,6 +42,10 @@ namespace Mono.Linker.Steps {
 			get { return _context.Annotations; }
 		}
 
+		public Tracer Tracer {
+			get { return _context.Tracer; }
+		}
+
 		public MarkingHelpers MarkingHelpers => _context.MarkingHelpers;
 
 		public void Process (LinkContext context)

--- a/linker/Linker.Steps/OutputStep.cs
+++ b/linker/Linker.Steps/OutputStep.cs
@@ -71,7 +71,7 @@ namespace Mono.Linker.Steps {
 		protected override void Process ()
 		{
 			CheckOutputDirectory ();
-			Annotations.SaveDependencies ();
+			Tracer.Finish ();
 		}
 
 		void CheckOutputDirectory ()
@@ -117,11 +117,11 @@ namespace Mono.Linker.Steps {
 			case AssemblyAction.Save:
 			case AssemblyAction.Link:
 			case AssemblyAction.AddBypassNGen:
-				Context.Annotations.AddDependency (assembly);
+				Context.Tracer.AddDependency (assembly);
 				WriteAssembly (assembly, directory);
 				break;
 			case AssemblyAction.Copy:
-				Context.Annotations.AddDependency (assembly);
+				Context.Tracer.AddDependency (assembly);
 				CloseSymbols (assembly);
 				CopyAssembly (GetOriginalAssemblyFileInfo (assembly), directory, Context.LinkSymbols);
 				break;

--- a/linker/Linker.Steps/ResolveFromAssemblyStep.cs
+++ b/linker/Linker.Steps/ResolveFromAssemblyStep.cs
@@ -101,7 +101,7 @@ namespace Mono.Linker.Steps
 			var action = rootVisibility == RootVisibility.Any ? AssemblyAction.Copy : AssemblyAction.Link;
 			SetAction (context, assembly, action);
 
-			context.Annotations.Push (assembly);
+			context.Tracer.Push (assembly);
 
 			foreach (TypeDefinition type in assembly.MainModule.Types)
 				MarkType (context, type, rootVisibility);
@@ -148,7 +148,7 @@ namespace Mono.Linker.Steps
 				}
 			}
 
-			context.Annotations.Pop ();
+			context.Tracer.Pop ();
 		}
 
 		static void MarkType (LinkContext context, TypeDefinition type, RootVisibility rootVisibility)
@@ -182,20 +182,20 @@ namespace Mono.Linker.Steps
 				foreach (var nested in type.NestedTypes)
 					MarkType (context, nested, rootVisibility);
 
-			context.Annotations.Pop ();
+			context.Tracer.Pop ();
 		}
 
 		void ProcessExecutable (AssemblyDefinition assembly)
 		{
 			SetAction (Context, assembly, AssemblyAction.Link);
 
-			Annotations.Push (assembly);
+			Tracer.Push (assembly);
 
 			Annotations.Mark (assembly.EntryPoint.DeclaringType);
 
 			MarkMethod (Context, assembly.EntryPoint, MethodAction.Parse, RootVisibility.Any);
 
-			Annotations.Pop ();
+			Tracer.Pop ();
 		}
 
 		static void MarkFields (LinkContext context, Collection<FieldDefinition> fields, RootVisibility rootVisibility)

--- a/linker/Linker.Steps/ResolveFromXmlStep.cs
+++ b/linker/Linker.Steps/ResolveFromXmlStep.cs
@@ -110,7 +110,7 @@ namespace Mono.Linker.Steps {
 
 		protected void ProcessAssembly (AssemblyDefinition assembly, XPathNodeIterator iterator)
 		{
-			Annotations.Push (assembly);
+			Tracer.Push (assembly);
 			if (GetTypePreserve (iterator.Current) == TypePreserve.All) {
 				foreach (var type in assembly.MainModule.Types)
 					MarkAndPreserveAll (type);
@@ -118,7 +118,7 @@ namespace Mono.Linker.Steps {
 				ProcessTypes (assembly, iterator.Current.SelectChildren ("type", _ns));
 				ProcessNamespaces (assembly, iterator.Current.SelectChildren ("namespace", _ns));
 			}
-			Annotations.Pop ();
+			Tracer.Pop ();
 		}
 
 		void ProcessNamespaces (AssemblyDefinition assembly, XPathNodeIterator iterator)
@@ -140,14 +140,14 @@ namespace Mono.Linker.Steps {
 			Annotations.SetPreserve (type, TypePreserve.All);
 
 			if (!type.HasNestedTypes) {
-				Annotations.Pop ();
+				Tracer.Pop ();
 				return;
 			}
 
 			foreach (TypeDefinition nested in type.NestedTypes)
 				MarkAndPreserveAll (nested);
 
-			Annotations.Pop ();
+			Tracer.Pop ();
 		}
 
 		void ProcessTypes (AssemblyDefinition assembly, XPathNodeIterator iterator)
@@ -167,10 +167,10 @@ namespace Mono.Linker.Steps {
 					if (assembly.MainModule.HasExportedTypes) {
 						foreach (var exported in assembly.MainModule.ExportedTypes) {
 							if (fullname == exported.FullName) {
-								Annotations.Push (exported);
+								Tracer.Push (exported);
 								MarkingHelpers.MarkExportedType (exported, assembly.MainModule);
 								var resolvedExternal = exported.Resolve ();
-								Annotations.Pop ();
+								Tracer.Pop ();
 								if (resolvedExternal != null) {
 									type = resolvedExternal;
 									break;
@@ -251,7 +251,7 @@ namespace Mono.Linker.Steps {
 			}
 
 			Annotations.MarkAndPush (type);
-			Annotations.AddDirectDependency (this, type);
+			Tracer.AddDirectDependency (this, type);
 
 			if (type.IsNested) {
 				var parent = type;
@@ -270,7 +270,7 @@ namespace Mono.Linker.Steps {
 				MarkSelectedEvents (nav, type);
 				MarkSelectedProperties (nav, type);
 			}
-			Annotations.Pop ();
+			Tracer.Pop ();
 		}
 
 		void MarkSelectedFields (XPathNavigator nav, TypeDefinition type)
@@ -409,7 +409,7 @@ namespace Mono.Linker.Steps {
 		void MarkMethod (MethodDefinition method)
 		{
 			Annotations.Mark (method);
-			Annotations.AddDirectDependency (this, method);
+			Tracer.AddDirectDependency (this, method);
 			Annotations.SetAction (method, MethodAction.Parse);
 		}
 

--- a/linker/Linker/Annotations.cs
+++ b/linker/Linker/Annotations.cs
@@ -28,8 +28,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.IO.Compression;
 
 using Mono.Cecil;
 using Mono.Cecil.Cil;
@@ -37,6 +35,8 @@ using Mono.Cecil.Cil;
 namespace Mono.Linker {
 
 	public class AnnotationStore {
+
+		readonly Tracer tracer;
 
 		readonly Dictionary<AssemblyDefinition, AssemblyAction> assembly_actions = new Dictionary<AssemblyDefinition, AssemblyAction> ();
 		readonly Dictionary<MethodDefinition, MethodAction> method_actions = new Dictionary<MethodDefinition, MethodAction> ();
@@ -52,30 +52,22 @@ namespace Mono.Linker {
 		readonly Dictionary<object, Dictionary<IMetadataTokenProvider, object>> custom_annotations = new Dictionary<object, Dictionary<IMetadataTokenProvider, object>> ();
 		readonly Dictionary<AssemblyDefinition, HashSet<string>> resources_to_remove = new Dictionary<AssemblyDefinition, HashSet<string>> ();
 
-		Stack<object> dependency_stack;
-		System.Xml.XmlWriter writer;
-		GZipStream zipStream;
-
-		public void PrepareDependenciesDump ()
+		public AnnotationStore (Tracer tracer)
 		{
-			PrepareDependenciesDump ("linker-dependencies.xml.gz");
+			this.tracer = tracer;
 		}
 
+		[Obsolete ("Use Tracer in LinkContext directly")]
+		public void PrepareDependenciesDump ()
+		{
+			tracer.Start ();
+		}
+
+		[Obsolete ("Use Tracer in LinkContext directly")]
 		public void PrepareDependenciesDump (string filename)
 		{
-			dependency_stack = new Stack<object> ();
-			System.Xml.XmlWriterSettings settings = new System.Xml.XmlWriterSettings();
-			settings.Indent = true;
-			settings.IndentChars = "\t";
-			var depsFile = File.OpenWrite (filename);
-			zipStream = new GZipStream (depsFile, CompressionMode.Compress);
-
-			writer = System.Xml.XmlWriter.Create (zipStream, settings);
-			writer.WriteStartDocument ();
-			writer.WriteStartElement ("dependencies");
-			writer.WriteStartAttribute ("version");
-			writer.WriteString ("1.2");
-			writer.WriteEndAttribute ();
+			tracer.DependenciesFileName = filename;
+			tracer.Start ();
 		}
 
 		public ICollection<AssemblyDefinition> GetAssemblies ()
@@ -119,17 +111,13 @@ namespace Mono.Linker {
 		public void Mark (IMetadataTokenProvider provider)
 		{
 			marked.Add (provider);
-			AddDependency (provider, true);
+			tracer.AddDependency (provider, true);
 		}
 
 		public void MarkAndPush (IMetadataTokenProvider provider)
 		{
 			Mark (provider);
-
-			if (writer == null)
-				return;
-
-			dependency_stack.Push (provider);
+			tracer.Push (provider, false); 
 		}
 
 		public bool IsMarked (IMetadataTokenProvider provider)
@@ -324,104 +312,6 @@ namespace Mono.Linker {
 			slots = new Dictionary<IMetadataTokenProvider, object> ();
 			custom_annotations.Add (key, slots);
 			return slots;
-		}
-
-		public void AddDirectDependency (object b, object e)
-		{
-			if (writer == null)
-				return;
-
-			writer.WriteStartElement ("edge");
-			writer.WriteAttributeString ("b", TokenString (b));
-			writer.WriteAttributeString ("e", TokenString (e));
-			writer.WriteEndElement ();
-		}
-
-		public void AddDependency (object o, bool marked=false)
-		{
-			if (writer == null)
-				return;
-
-			KeyValuePair<object, object> pair = new KeyValuePair<object, object> (dependency_stack.Count > 0 ? dependency_stack.Peek () : null, o);
-			if (pair.Key != pair.Value)
-			{
-				writer.WriteStartElement ("edge");
-				if (marked)
-					writer.WriteAttributeString ("mark", "1");
-				writer.WriteAttributeString ("b", TokenString (pair.Key));
-				writer.WriteAttributeString ("e", TokenString (pair.Value));
-				writer.WriteEndElement ();
-			}
-		}
-
-		public void Push (object o)
-		{
-			if (writer == null)
-				return;
-
-			if (dependency_stack.Count > 0)
-				AddDependency (o);
-			dependency_stack.Push (o);
-		}
-
-		public void Pop ()
-		{
-			if (writer == null)
-				return;
-
-			dependency_stack.Pop ();
-		}
-
-		static bool IsAssemblyBound (TypeDefinition td)
-		{
-			do {
-				if (td.IsNestedPrivate || td.IsNestedAssembly || td.IsNestedFamilyAndAssembly)
-					return true;
-
-				td = td.DeclaringType;
-			} while (td != null);
-
-			return false;
-		}
-
-		string TokenString (object o)
-		{
-			if (o == null)
-				return "N:null";
-
-			if (o is TypeReference t) {
-				bool addAssembly = true;
-				var td = t as TypeDefinition ?? t.Resolve ();
-
-				if (td != null) {
-					addAssembly = td.IsNotPublic || IsAssemblyBound (td);
-					t = td;
-				}
-
-				var addition = addAssembly ? $":{t.Module}" : "";
-
-				return $"{(o as IMetadataTokenProvider).MetadataToken.TokenType}:{o}{addition}";
-			}
-
-			if (o is IMetadataTokenProvider)
-				return (o as IMetadataTokenProvider).MetadataToken.TokenType + ":" + o;
-
-			return "Other:" + o;
-		}
-
-		public void SaveDependencies ()
-		{
-			if (writer == null)
-				return;
-
-			writer.WriteEndElement ();
-			writer.WriteEndDocument ();
-			writer.Flush ();
-			writer.Dispose ();
-			zipStream.Dispose ();
-			writer = null;
-			zipStream = null;
-			dependency_stack = null;
 		}
 	}
 }

--- a/linker/Linker/LinkContext.cs
+++ b/linker/Linker/LinkContext.cs
@@ -34,6 +34,10 @@ using Mono.Cecil.Cil;
 
 namespace Mono.Linker {
 
+	public interface IAnnotationStoreFactory {
+		AnnotationStore Create (Tracer tracer);
+	}
+
 	public class LinkContext : IDisposable {
 
 		Pipeline _pipeline;
@@ -129,6 +133,8 @@ namespace Mono.Linker {
 
 		public MarkingHelpers MarkingHelpers { get; private set; }
 
+		public Tracer Tracer { get; private set; } = new Tracer ();
+
 		public LinkContext (Pipeline pipeline)
 			: this (pipeline, new AssemblyResolver ())
 		{
@@ -138,20 +144,19 @@ namespace Mono.Linker {
 			: this(pipeline, resolver, new ReaderParameters
 			{
 				AssemblyResolver = resolver
-			},
-			new AnnotationStore ())
+			})
 		{
 		}
 
-		public LinkContext (Pipeline pipeline, AssemblyResolver resolver, ReaderParameters readerParameters, AnnotationStore annotations)
+		public LinkContext (Pipeline pipeline, AssemblyResolver resolver, ReaderParameters readerParameters, IAnnotationStoreFactory storeFactory = null)
 		{
 			_pipeline = pipeline;
 			_resolver = resolver;
 			_actions = new Dictionary<string, AssemblyAction> ();
 			_parameters = new Dictionary<string, string> ();
-			_annotations = annotations;
 			_readerParameters = readerParameters;
 			MarkingHelpers = CreateMarkingHelpers ();
+			_annotations = storeFactory != null ? storeFactory.Create (Tracer) : new AnnotationStore (Tracer);
 		}
 
 		public TypeDefinition GetType (string fullName)

--- a/linker/Linker/Pipeline.cs
+++ b/linker/Linker/Pipeline.cs
@@ -123,9 +123,9 @@ namespace Mono.Linker {
 		{
 			while (_steps.Count > 0) {
 				IStep step = _steps [0];
-				context.Annotations.Push (step);
+				context.Tracer.Push (step);
 				step.Process (context);
-				context.Annotations.Pop ();
+				context.Tracer.Pop ();
 				_steps.Remove (step);
 			}
 		}

--- a/linker/Linker/Tracer.cs
+++ b/linker/Linker/Tracer.cs
@@ -1,0 +1,161 @@
+﻿//
+// Tracer.cs
+//
+// Author:
+//  Radek Doulik <radou@microsoft.com>
+//
+// Copyright (C) 2017 Microsoft Corporation (http://www.microsoft.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+
+using Mono.Cecil;
+
+namespace Mono.Linker
+{
+	public class Tracer {
+
+		public string DependenciesFileName { get; set; } = "linker-dependencies.xml.gz";
+
+		Stack<object> dependency_stack;
+		System.Xml.XmlWriter writer;
+		GZipStream zipStream;
+
+		public void Start ()
+		{
+			dependency_stack = new Stack<object> ();
+			System.Xml.XmlWriterSettings settings = new System.Xml.XmlWriterSettings {
+				Indent = true,
+				IndentChars = "\t"
+			};
+			var depsFile = File.OpenWrite (DependenciesFileName);
+			zipStream = new GZipStream (depsFile, CompressionMode.Compress);
+
+			writer = System.Xml.XmlWriter.Create (zipStream, settings);
+			writer.WriteStartDocument ();
+			writer.WriteStartElement ("dependencies");
+			writer.WriteStartAttribute ("version");
+			writer.WriteString ("1.2");
+			writer.WriteEndAttribute ();
+		}
+
+		public void Finish ()
+		{
+			if (writer == null)
+				return;
+
+			writer.WriteEndElement ();
+			writer.WriteEndDocument ();
+			writer.Flush ();
+			writer.Dispose ();
+			zipStream.Dispose ();
+			writer = null;
+			zipStream = null;
+			dependency_stack = null;
+		}
+
+		public void Push (object o, bool addDependency = true)
+		{
+			if (writer == null)
+				return;
+
+			if (addDependency && dependency_stack.Count > 0)
+				AddDependency (o);
+
+			dependency_stack.Push (o);
+		}
+
+		public void Pop ()
+		{
+			if (writer == null)
+				return;
+
+			dependency_stack.Pop ();
+		}
+
+		static bool IsAssemblyBound (TypeDefinition td)
+		{
+			do {
+				if (td.IsNestedPrivate || td.IsNestedAssembly || td.IsNestedFamilyAndAssembly)
+					return true;
+
+				td = td.DeclaringType;
+			} while (td != null);
+
+			return false;
+		}
+
+		string TokenString (object o)
+		{
+			if (o == null)
+				return "N:null";
+
+			if (o is TypeReference t) {
+				bool addAssembly = true;
+				var td = t as TypeDefinition ?? t.Resolve ();
+
+				if (td != null) {
+					addAssembly = td.IsNotPublic || IsAssemblyBound (td);
+					t = td;
+				}
+
+				var addition = addAssembly ? $":{t.Module}" : "";
+
+				return $"{(o as IMetadataTokenProvider).MetadataToken.TokenType}:{o}{addition}";
+			}
+
+			if (o is IMetadataTokenProvider)
+				return (o as IMetadataTokenProvider).MetadataToken.TokenType + ":" + o;
+
+			return "Other:" + o;
+		}
+
+		public void AddDirectDependency (object b, object e)
+		{
+			if (writer == null)
+				return;
+
+			writer.WriteStartElement ("edge");
+			writer.WriteAttributeString ("b", TokenString (b));
+			writer.WriteAttributeString ("e", TokenString (e));
+			writer.WriteEndElement ();
+		}
+
+		public void AddDependency (object o, bool marked = false)
+		{
+			if (writer == null)
+				return;
+
+			KeyValuePair<object, object> pair = new KeyValuePair<object, object> (dependency_stack.Count > 0 ? dependency_stack.Peek () : null, o);
+			if (pair.Key != pair.Value) {
+				writer.WriteStartElement ("edge");
+				if (marked)
+					writer.WriteAttributeString ("mark", "1");
+				writer.WriteAttributeString ("b", TokenString (pair.Key));
+				writer.WriteAttributeString ("e", TokenString (pair.Value));
+				writer.WriteEndElement ();
+			}
+		}
+	}
+}

--- a/linker/Mono.Linker.csproj
+++ b/linker/Mono.Linker.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Linker.Steps\TypeMapStep.cs" />
     <Compile Include="Linker\ILogger.cs" />
     <Compile Include="Linker\ConsoleLogger.cs" />
+    <Compile Include="Linker\Tracer.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />


### PR DESCRIPTION
Kept the Annotations::PrepareDependenciesDump methods, as they are
still needed for the mobile linkers. They will be removed once we
update them.