### PR TITLE
Only record dependency info for nodes in assemblies that will be linked

### DIFF
--- a/linker/Linker/Driver.cs
+++ b/linker/Linker/Driver.cs
@@ -113,6 +113,11 @@ namespace Mono.Linker {
 							continue;
 						}
 
+						if (token == "--reduced-tracing") {
+							context.EnableReducedTracing = bool.Parse (GetParam ());
+							continue;
+						}
+
 						switch (token [2]) {
 						case 'v':
 							Version ();
@@ -328,6 +333,7 @@ namespace Mono.Linker {
 			Console.WriteLine ("   --skip-unresolved   Ignore unresolved types and methods (true or false)");
 			Console.WriteLine ("   --dependencies-file Specify the dependencies file path, if unset the default path is used: <output directory>/linker-dependencies.xml.gz");
 			Console.WriteLine ("   --dump-dependencies Dump dependencies for the linker analyzer tool");
+			Console.WriteLine ("   --reduced-tracing   Reduces dependency output related to assemblies that will not be modified");
 			Console.WriteLine ("   -out                Specify the output directory, default to `output'");
 			Console.WriteLine ("   -c                  Action on the core assemblies, skip, copy, copyused, addbypassngen, addbypassngenused or link, default to skip");
 			Console.WriteLine ("   -u                  Action on the user assemblies, skip, copy, copyused, addbypassngen, addbypassngenused or link, default to link");

--- a/linker/Linker/LinkContext.cs
+++ b/linker/Linker/LinkContext.cs
@@ -107,6 +107,8 @@ namespace Mono.Linker {
 			set { _ignoreUnresolved = value; }
 		}
 
+		public bool EnableReducedTracing { get; set; }
+
 		public System.Collections.IDictionary Actions {
 			get { return _actions; }
 		}

--- a/linker/Linker/Tracer.cs
+++ b/linker/Linker/Tracer.cs
@@ -29,20 +29,22 @@
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
-
+using System.Xml;
 using Mono.Cecil;
+using Mono.Linker.Steps;
 
 namespace Mono.Linker
 {
 	public class Tracer {
+		public const string DefaultDependenciesFileName = "linker-dependencies.xml.gz";
 
-		public string DependenciesFileName { get; set; } = "linker-dependencies.xml.gz";
+		public string DependenciesFileName { get; set; } = DefaultDependenciesFileName;
 
 		protected readonly LinkContext context;
 
 		Stack<object> dependency_stack;
 		System.Xml.XmlWriter writer;
-		GZipStream zipStream;
+		Stream stream;
 
 		public Tracer (LinkContext context) => this.context = context;
 
@@ -53,10 +55,19 @@ namespace Mono.Linker
 				Indent = true,
 				IndentChars = "\t"
 			};
-			var depsFile = File.OpenWrite (DependenciesFileName);
-			zipStream = new GZipStream (depsFile, CompressionMode.Compress);
 
-			writer = System.Xml.XmlWriter.Create (zipStream, settings);
+			if (string.IsNullOrEmpty (Path.GetDirectoryName (DependenciesFileName)) && !string.IsNullOrEmpty (context.OutputDirectory)) {
+				DependenciesFileName = Path.Combine (context.OutputDirectory, DependenciesFileName);
+			}
+
+			var depsFile = File.OpenWrite (DependenciesFileName);
+
+			if (Path.GetExtension (DependenciesFileName) == ".xml")
+				stream = depsFile;
+			else
+				stream = new GZipStream (depsFile, CompressionMode.Compress);
+
+			writer = System.Xml.XmlWriter.Create (stream, settings);
 			writer.WriteStartDocument ();
 			writer.WriteStartElement ("dependencies");
 			writer.WriteStartAttribute ("version");
@@ -73,9 +84,9 @@ namespace Mono.Linker
 			writer.WriteEndDocument ();
 			writer.Flush ();
 			writer.Dispose ();
-			zipStream.Dispose ();
+			stream.Dispose ();
 			writer = null;
-			zipStream = null;
+			stream = null;
 			dependency_stack = null;
 		}
 
@@ -152,6 +163,18 @@ namespace Mono.Linker
 				return;
 
 			KeyValuePair<object, object> pair = new KeyValuePair<object, object> (dependency_stack.Count > 0 ? dependency_stack.Peek () : null, o);
+
+			if (!ShouldRecord (pair.Key) && !ShouldRecord (pair.Value))
+				return;
+
+			// This is a hack to work around a quirk of MarkStep that results in outputting ~6k edges even with the above ShouldRecord checks.
+			// What happens is that due to the method queueing in MarkStep, the dependency chain is broken in many cases.  And in these cases
+			// we end up adding an edge for MarkStep -> <queued Method>
+			// This isn't particularly useful information since it's incomplete, but it's especially not useful in ReducedTracing mode when there is one of these for
+			// every class library method that was queued.
+			if (context.EnableReducedTracing && pair.Key is MarkStep && !ShouldRecord (pair.Value))
+				return;
+
 			if (pair.Key != pair.Value) {
 				writer.WriteStartElement ("edge");
 				if (marked)
@@ -160,6 +183,63 @@ namespace Mono.Linker
 				writer.WriteAttributeString ("e", TokenString (pair.Value));
 				writer.WriteEndElement ();
 			}
+		}
+
+		bool WillAssemblyBeModified (AssemblyDefinition assembly)
+		{
+			switch (context.Annotations.GetAction (assembly)) {
+				case AssemblyAction.Link:
+				case AssemblyAction.AddBypassNGen:
+				case AssemblyAction.AddBypassNGenUsed:
+					return true;
+				default:
+					return false;
+			}
+		}
+
+		bool ShouldRecord (object o)
+		{
+			if (!context.EnableReducedTracing)
+				return true;
+
+			if (o is TypeDefinition t)
+				return WillAssemblyBeModified (t.Module.Assembly);
+
+			if (o is IMemberDefinition m)
+				return WillAssemblyBeModified (m.DeclaringType.Module.Assembly);
+
+			if (o is TypeReference typeRef) {
+				var resolved = typeRef.Resolve ();
+
+				// Err on the side of caution if we can't resolve
+				if (resolved == null)
+					return true;
+
+				return WillAssemblyBeModified (resolved.Module.Assembly);
+			}
+
+			if (o is MemberReference mRef) {
+				var resolved = mRef.Resolve ();
+
+				// Err on the side of caution if we can't resolve
+				if (resolved == null)
+					return true;
+
+				return WillAssemblyBeModified (resolved.DeclaringType.Module.Assembly);
+			}
+
+			if (o is ModuleDefinition module)
+				return WillAssemblyBeModified (module.Assembly);
+
+			if (o is AssemblyDefinition assembly)
+				return WillAssemblyBeModified (assembly);
+
+			if (o is ParameterDefinition parameter) {
+				if (parameter.Method is MethodDefinition parameterMethodDefinition)
+					return WillAssemblyBeModified (parameterMethodDefinition.DeclaringType.Module.Assembly);
+			}
+
+			return true;
 		}
 	}
 }

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -79,6 +79,9 @@
     <Compile Include="TestFramework\VerifyDefineAttributeBehavior.cs" />
     <None Include="TypeForwarding\Dependencies\ForwarderLibrary.cs" />
     <Compile Include="TestFramework\VerifyResourceInAssemblyAttributesBehavior.cs" />
+    <Compile Include="Tracing\Individual\CanDumpDependenciesToUncompressedXml.cs" />
+    <Compile Include="Tracing\Individual\CanEnableDependenciesDump.cs" />
+    <Compile Include="Tracing\Individual\CanEnableReducedTracing.cs" />
     <Compile Include="TypeForwarding\Dependencies\ImplementationLibrary.cs" />
     <Compile Include="TypeForwarding\Dependencies\LibraryUsingForwarder.cs" />
     <Compile Include="TypeForwarding\Dependencies\ReferenceImplementationLibrary.cs" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/Tracing/Individual/CanDumpDependenciesToUncompressedXml.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Tracing/Individual/CanDumpDependenciesToUncompressedXml.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Tracing.Individual {
+
+	[SetupLinkerArgument ("--dump-dependencies")]
+	[SetupLinkerArgument ("--dependencies-file", "linker-dependencies.xml")]
+	public class CanDumpDependenciesToUncompressedXml {
+		public static void Main ()
+		{
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Tracing/Individual/CanEnableDependenciesDump.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Tracing/Individual/CanEnableDependenciesDump.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Tracing.Individual {
+
+	[SetupLinkerArgument ("--dump-dependencies")]
+	public class CanEnableDependenciesDump {
+		public static void Main ()
+		{
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Tracing/Individual/CanEnableReducedTracing.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Tracing/Individual/CanEnableReducedTracing.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Tracing.Individual {
+
+	[SetupLinkerArgument ("--dump-dependencies")]
+	[SetupLinkerArgument ("--reduced-tracing", "true")]
+
+	// Need to define a custom name so that the linker outputs in uncompressed format, which is more useful for making assertions
+	[SetupLinkerArgument ("--dependencies-file", "linker-dependencies.xml")]
+	public class CanEnableReducedTracing {
+		public static void Main ()
+		{
+		}
+	}
+}

--- a/linker/Tests/TestCases/IndividualTests.cs
+++ b/linker/Tests/TestCases/IndividualTests.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.IO;
+using System.Xml;
 using Mono.Linker.Tests.Cases.References.Individual;
+using Mono.Linker.Tests.Cases.Tracing.Individual;
 using Mono.Linker.Tests.TestCases;
 using Mono.Linker.Tests.TestCasesRunner;
 using NUnit.Framework;
@@ -20,6 +23,59 @@ namespace Mono.Linker.Tests.TestCases
 			// missing types/methods
 			if (!result.OutputAssemblyPath.Exists ())
 				Assert.Fail ($"The linked assembly is missing.  Should have existed at {result.OutputAssemblyPath}");
+		}
+
+		[Test]
+		public void CanEnableDependenciesDump ()
+		{
+			var testcase = CreateIndividualCase (typeof (CanEnableDependenciesDump));
+			var result = Run (testcase);
+
+			var outputPath = result.OutputAssemblyPath.Parent.Combine (Tracer.DefaultDependenciesFileName);
+			if (!outputPath.Exists ())
+				Assert.Fail ($"The dependency dump file is missing.  Expected it to exist at {outputPath}");
+		}
+
+		[Test]
+		public void CanDumpDependenciesToUncompressedXml ()
+		{
+			var testcase = CreateIndividualCase (typeof (CanDumpDependenciesToUncompressedXml));
+			var result = Run (testcase);
+
+			var outputPath = result.OutputAssemblyPath.Parent.Combine ("linker-dependencies.xml");
+			if (!outputPath.Exists ())
+				Assert.Fail($"The dependency dump file is missing.  Expected it to exist at {outputPath}");
+
+			// Do a basic check to verify that the contents of the file are uncompressed xml
+			using (var reader = new XmlTextReader (outputPath.ToString ())) {
+				reader.Read ();
+				reader.Read ();
+				reader.Read ();
+				Assert.That (reader.Name, Is.EqualTo ("dependencies"), $"Expected to be at the dependencies element, but the current node name is `{reader.Name}`");
+			}
+		}
+
+		[Test]
+		public void CanEnableReducedTracing ()
+		{
+			var testcase = CreateIndividualCase (typeof (CanEnableReducedTracing));
+			var result = Run (testcase);
+
+			// Note: This name needs to match what is setup in the test case arguments to the linker
+			const string expectedDependenciesFileName = "linker-dependencies.xml";
+			var outputPath = result.OutputAssemblyPath.Parent.Combine (expectedDependenciesFileName);
+			if (!outputPath.Exists ())
+				Assert.Fail($"The dependency dump file is missing.  Expected it to exist at {outputPath}");
+
+			// Let's go a little bit further and make sure it looks like reducing tracking actually worked.
+			// This is intentionally a loose assertion.  This test isn't meant to verify how reduced tracing works,
+			// it's here to make sure that enabling the option enables the behavior.
+			var lineCount = outputPath.ReadAllLines ().Length;
+
+			// When reduced tracing is not enabled there are around 16k of lines in the output file.
+			// With reduced tracing there should be less than 20, but to be safe, we'll check for less than 50.
+			const int expectedMaxLines = 50;
+			Assert.That (lineCount, Is.LessThan (expectedMaxLines), $"There were `{lineCount}` lines in the dump file.  This is more than expected max of {expectedMaxLines} and likely indicates reduced tracing was not enabled.  Dump file can be found at: {outputPath}");
 		}
 
 		private TestCase CreateIndividualCase (Type testCaseType)


### PR DESCRIPTION
There's a lot of output in the linker-dependencies.xml.  I find it hard to reason about what is going on with so much noise.

I was thinking of ways to reduce the noise, mainly to start writing some tests for the xml output and I thought, if the assembly won't be modified, then do we really care about reporting these edges?

This PR makes it so that edges are only written to the xml when the assembly of one, or both, of the items will be modified.  This greatly reduces the output size of linker-dependencies.xml during tests and it makes it much easier to read the file and understand what is going on.

Sure there are some edge cases that would be odd, for example, code that calls into an assembly that is not linked and then a callback calls back into an assembly that is linked.  You would loose some useful edges there, but I think for all real world cases you will link all assemblies, so it would mainly only be tests that run into that scenario.

Having said that, I can see the argument for putting this behavior behind an opt-in command line flag.  If you would like me to add that, let me know.