### PR TITLE
Added UnintializedContextFactory class

### DIFF
--- a/linker/Linker/Annotations.cs
+++ b/linker/Linker/Annotations.cs
@@ -36,7 +36,7 @@ namespace Mono.Linker {
 
 	public class AnnotationStore {
 
-		readonly Tracer tracer;
+		protected readonly LinkContext context;
 
 		readonly Dictionary<AssemblyDefinition, AssemblyAction> assembly_actions = new Dictionary<AssemblyDefinition, AssemblyAction> ();
 		readonly Dictionary<MethodDefinition, MethodAction> method_actions = new Dictionary<MethodDefinition, MethodAction> ();
@@ -52,22 +52,25 @@ namespace Mono.Linker {
 		readonly Dictionary<object, Dictionary<IMetadataTokenProvider, object>> custom_annotations = new Dictionary<object, Dictionary<IMetadataTokenProvider, object>> ();
 		readonly Dictionary<AssemblyDefinition, HashSet<string>> resources_to_remove = new Dictionary<AssemblyDefinition, HashSet<string>> ();
 
-		public AnnotationStore (Tracer tracer)
-		{
-			this.tracer = tracer;
+		public AnnotationStore (LinkContext context) => this.context = context;
+
+		protected Tracer Tracer {
+			get {
+				return context.Tracer;
+			}
 		}
 
 		[Obsolete ("Use Tracer in LinkContext directly")]
 		public void PrepareDependenciesDump ()
 		{
-			tracer.Start ();
+			Tracer.Start ();
 		}
 
 		[Obsolete ("Use Tracer in LinkContext directly")]
 		public void PrepareDependenciesDump (string filename)
 		{
-			tracer.DependenciesFileName = filename;
-			tracer.Start ();
+			Tracer.DependenciesFileName = filename;
+			Tracer.Start ();
 		}
 
 		public ICollection<AssemblyDefinition> GetAssemblies ()
@@ -111,13 +114,13 @@ namespace Mono.Linker {
 		public void Mark (IMetadataTokenProvider provider)
 		{
 			marked.Add (provider);
-			tracer.AddDependency (provider, true);
+			Tracer.AddDependency (provider, true);
 		}
 
 		public void MarkAndPush (IMetadataTokenProvider provider)
 		{
 			Mark (provider);
-			tracer.Push (provider, false); 
+			Tracer.Push (provider, false);
 		}
 
 		public bool IsMarked (IMetadataTokenProvider provider)

--- a/linker/Linker/Tracer.cs
+++ b/linker/Linker/Tracer.cs
@@ -38,9 +38,13 @@ namespace Mono.Linker
 
 		public string DependenciesFileName { get; set; } = "linker-dependencies.xml.gz";
 
+		protected readonly LinkContext context;
+
 		Stack<object> dependency_stack;
 		System.Xml.XmlWriter writer;
 		GZipStream zipStream;
+
+		public Tracer (LinkContext context) => this.context = context;
 
 		public void Start ()
 		{


### PR DESCRIPTION
This is a helper class, which is used in LinkContext to create
AnnotationStore, MarkingHelpers and Tracer. As the name suggest, it
uses uninitialized LinkContext. It is a slightly better than using
virtual methods in the LinkContext constructor as the class name hints
about the state of the context it uses.

It is added for Unity developers to be able to create their own
AnnotationStore, MarkingHelpers and Tracer. It is also needed for
https://github.com/mono/linker/pull/208

The class itself might be replaced later by interface with default
implementations.