### PR TITLE
Don't root System.Private.CoreLib if it has an embedded root xml resource.

### DIFF
--- a/corebuild/integration/ILLink.Tasks/CheckEmbeddedRootDescriptor.cs
+++ b/corebuild/integration/ILLink.Tasks/CheckEmbeddedRootDescriptor.cs
@@ -1,0 +1,37 @@
+using Microsoft.Build.Utilities; // Task
+using Microsoft.Build.Framework; // ITaskItem
+using Mono.Cecil;
+
+namespace ILLink.Tasks
+{
+	public class CheckEmbeddedRootDescriptor : Task
+	{
+		/// <summary>
+		///   Path to the assembly.
+		/// </summary>
+		[Required]
+		public ITaskItem AssemblyPath { get; set; }
+
+		/// <summary>
+		///   This will be set to true if the assembly has an embedded root descriptor.
+		/// </summary>
+		[Output]
+		public bool HasEmbeddedRootDescriptor { get; set; }
+
+		public override bool Execute()
+		{
+			ModuleDefinition module = ModuleDefinition.ReadModule (AssemblyPath.ItemSpec);
+			string assemblyName = module.Assembly.Name.Name;
+			string expectedResourceName = assemblyName + ".xml";
+			HasEmbeddedRootDescriptor = false;
+			foreach (var resource in module.Resources) {
+				if (resource.Name == expectedResourceName) {
+					HasEmbeddedRootDescriptor = true;
+					break;
+				}
+			}
+
+			return true;
+		}
+	}
+}

--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.csproj
@@ -107,6 +107,7 @@
     <Compile Include="Microsoft.NET.Build.Tasks/BuildErrorException.cs" />
     <Compile Include="FindNativeDeps.cs" />
     <Compile Include="ComputeRemovedAssemblies.cs" />
+    <Compile Include="CheckEmbeddedRootDescriptor.cs" />
   </ItemGroup>
 
   <!-- TODO: Uncomment this once we can avoid hard-coding this in a

--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
@@ -293,20 +293,29 @@
        be part of the build step or pack step, OR pack could be made
        to work on the publish output. -->
   <Target Name="_ComputeLinkerRootAssemblies"
-          DependsOnTargets="_ComputeManagedResolvedAssembliesToPublish;_ComputePlatformLibraries">
+          DependsOnTargets="_ComputeManagedResolvedAssembliesToPublish;_ComputePlatformLibraries;_CheckSystemPrivateCorelibEmbeddedRoots">
     <!-- By default, roots are everything minus the framework
-         assemblies (except for System.Private.CoreLib, which we
-         always root for now). This doesn't include the intermediate
+         assemblies. This doesn't include the intermediate
          assembly, because we root it separately using an xml file,
-         which lets us explicitly root everything. -->
+         which lets us explicitly root everything. 
+         System.Private.CoreLib is rooted unless it has an embedded
+         xml descriptor file. -->
     <ItemGroup>
       <_LinkerRootAssemblies Include="@(_ManagedResolvedAssembliesToPublish->'%(Filename)')" />
       <_LinkerRootAssemblies Remove="@(PlatformLibraries->'%(Filename)')" />
-      <_LinkerRootAssemblies Include="System.Private.CoreLib" />
+      <_LinkerRootAssemblies Remove="System.Private.CoreLib" Condition=" '$(_SPCHasEmbeddedRootDescriptor)' == 'true' "/>
       <LinkerRootAssemblies Include="@(_LinkerRootAssemblies)" />
     </ItemGroup>
   </Target>
 
+    
+  <UsingTask TaskName="CheckEmbeddedRootDescriptor" AssemblyFile="$(LinkTaskDllPath)" />
+  <Target Name="_CheckSystemPrivateCorelibEmbeddedRoots"
+          DependsOnTargets="_ComputeManagedAssembliesToLink">
+    <CheckEmbeddedRootDescriptor AssemblyPath="@(_ManagedAssembliesToLink->WithMetadataValue('Filename', 'System.Private.CoreLib'))">
+      <Output TaskParameter="HasEmbeddedRootDescriptor" PropertyName="_SPCHasEmbeddedRootDescriptor" />
+    </CheckEmbeddedRootDescriptor>
+  </Target>
 
   <!-- Platform libraries are the managed runtime assets needed by the
        "platform", currently Microsoft.NETCore.App. -->


### PR DESCRIPTION
Once we start computing System.Private.CoreLib roots during coreclr build (https://github.com/dotnet/coreclr/pull/15525)
we won't need to root all of System.Private.CoreLib if the embedded xml
root file is present.