### PR TITLE
Expose assembly actions in ILLink.

### DIFF
--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.csproj
@@ -111,6 +111,7 @@
     <Compile Include="FindNativeDeps.cs" />
     <Compile Include="ComputeRemovedAssemblies.cs" />
     <Compile Include="CheckEmbeddedRootDescriptor.cs" />
+    <Compile Include="SetAssemblyActions.cs" />
   </ItemGroup>
 
   <!-- TODO: Uncomment this once we can avoid hard-coding this in a

--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
@@ -16,6 +16,10 @@
     <LinkDuringPublish Condition=" '$(LinkDuringPublish)' != 'true' ">false</LinkDuringPublish>
     <ShowLinkerSizeComparison Condition=" '$(ShowLinkerSizeComparison)' == '' ">false</ShowLinkerSizeComparison>
     <LinkerDumpDependencies Condition=" '$(LinkerDumpDependencies)' == '' ">false</LinkerDumpDependencies>
+    <UsedApplicationAssemblyAction Condition=" '$(UsedApplicationAssemblyAction)' == '' ">Copy</UsedApplicationAssemblyAction>
+    <UnusedApplicationAssemblyAction Condition=" '$(UnusedApplicationAssemblyAction)' == '' ">Delete</UnusedApplicationAssemblyAction>
+    <UsedPlatformAssemblyAction Condition=" '$(UsedPlatformAssemblyAction)' == '' ">Link</UsedPlatformAssemblyAction>
+    <UnusedPlatformAssemblyAction Condition=" '$(UnusedPlatformAssemblyAction)' == '' ">Delete</UnusedPlatformAssemblyAction>
   </PropertyGroup>
 
   <!-- This depends on LinkDuringPublish, so it needs to be imported
@@ -170,14 +174,41 @@
                            Condition="Exists('%(Identity)') And '$(_DebugSymbolsProduced)' == 'true' " />
     </ItemGroup>
   </Target>
-  
+
+  <UsingTask TaskName="SetAssemblyActions" AssemblyFile="$(LinkTaskDllPath)" />
+  <Target Name="_SetAssemblyActions"
+          DependsOnTargets="_ComputeManagedAssembliesToLink;_ComputePlatformLibraries">
+
+      <ItemGroup>
+          <_PlatformAssembliesToLink Include="@(PlatformLibraries->'%(Filename)')" />
+          <_PlatformAssembliesToLink Include="System.Private.CoreLib" />
+          <_ApplicationAssembliesToLink Include="@(_ManagedAssembliesToLink->'%(Filename)')" />
+          <_ApplicationAssembliesToLink Remove="@(_PlatformAssembliesToLink)" />
+      </ItemGroup>
+
+      <SetAssemblyActions AssemblyPaths="@(_ManagedAssembliesToLink)"
+                          ApplicationAssemblyNames="@(_ApplicationAssembliesToLink)"
+                          PlatformAssemblyNames="@(_PlatformAssembliesToLink)"
+                          UsedApplicationAssemblyAction="$(UsedApplicationAssemblyAction)"
+                          UnusedApplicationAssemblyAction="$(UnusedApplicationAssemblyAction)"
+                          UsedPlatformAssemblyAction="$(UsedPlatformAssemblyAction)"
+                          UnusedPlatformAssemblyAction="$(UnusedPlatformAssemblyAction)">
+        <Output TaskParameter="AssemblyPathsWithActions" ItemName="_ManagedAssembliesToLinkWithActions" />
+      </SetAssemblyActions>
+
+      <ItemGroup>
+          <_ManagedAssembliesToLink Remove="@(_ManagedAssembliesToLink)" />
+          <_ManagedAssembliesToLink Include="@(_ManagedAssembliesToLinkWithActions)" />
+      </ItemGroup>
+  </Target>
+    
   <!-- This calls the linker. Inputs are the managed assemblies to
        link, and root specifications. The semaphore enables msbuild to
        skip linking during an incremental build, when the semaphore is
        up to date with respect to _ManagedAssembliesToLink. -->
   <UsingTask TaskName="ILLink" AssemblyFile="$(LinkTaskDllPath)" />
   <Target Name="ILLink"
-          DependsOnTargets="_ComputeManagedAssembliesToLink;_ComputeLinkerRootAssemblies;_ComputeLinkerRootDescriptors"
+          DependsOnTargets="_ComputeManagedAssembliesToLink;_ComputeLinkerRootAssemblies;_ComputeLinkerRootDescriptors;_SetAssemblyActions"
           Inputs="@(_ManagedAssembliesToLink);@(LinkerRootDescriptors);$(MSBuildAllProjects)"
           Outputs="$(_LinkSemaphore)">
     <!-- These extra arguments have been hard-coded for now, as this
@@ -185,7 +216,7 @@
          the future we will want to generate these depending on the
          scenario in which the linker is invoked. -->
     <PropertyGroup>
-      <ExtraLinkerArgs Condition=" '$(ExtraLinkerArgs)' == '' ">-t -c link -l none -b true</ExtraLinkerArgs>
+      <ExtraLinkerArgs Condition=" '$(ExtraLinkerArgs)' == '' ">-t -l none -b true</ExtraLinkerArgs>
     </PropertyGroup>
     <ILLink AssemblyPaths="@(_ManagedAssembliesToLink)"
             RootAssemblyNames="@(LinkerRootAssemblies)"
@@ -229,7 +260,6 @@
     </FindNativeDeps>
 
   </Target>
-
 
   <!-- Computes the managed assemblies that are input to the
        linker. Includes managed assemblies from

--- a/corebuild/integration/ILLink.Tasks/SetAssemblyActions.cs
+++ b/corebuild/integration/ILLink.Tasks/SetAssemblyActions.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System.IO;
+
+namespace ILLink.Tasks
+{
+	public class SetAssemblyActions : Task
+	{
+		/// <summary>
+		///   Paths to the assembly files that should be considered as
+		///   input to the linker.
+		/// </summary>
+		[Required]
+		public ITaskItem [] AssemblyPaths { get; set; }
+
+		/// <summary>
+		///   Application assembly names.
+		/// </summary>
+		[Required]
+		public ITaskItem [] ApplicationAssemblyNames { get; set; }
+
+		/// <summary>
+		///   Platform assembly names.
+		/// </summary>
+		[Required]
+		public ITaskItem [] PlatformAssemblyNames { get; set; }
+
+		/// <summary>
+		///   Action to perform on used application assemblies.
+		/// </summary>
+		[Required]
+		public ITaskItem UsedApplicationAssemblyAction { get; set; }
+
+		/// <summary>
+		///   Action to perform on unused application assemblies.
+		/// </summary>
+		[Required]
+		public ITaskItem UnusedApplicationAssemblyAction { get; set; }
+
+		/// <summary>
+		///   Action to perform on used platform assemblies.
+		/// </summary>
+		[Required]
+		public ITaskItem UsedPlatformAssemblyAction { get; set; }
+
+		/// <summary>
+		///   Action to perform on unused platform assemblies.
+		/// </summary>
+		[Required]
+		public ITaskItem UnusedPlatformAssemblyAction { get; set; }
+
+		[Output]
+		public ITaskItem [] AssemblyPathsWithActions { get; set; }
+
+		public override bool Execute ()
+		{
+			string applicationAssemblyAction;
+			string usedApplicationAssemblyAction = UsedApplicationAssemblyAction.ItemSpec;
+			string unusedApplicationAssemblyAction = UnusedApplicationAssemblyAction.ItemSpec;
+			if (!GetAssemblyAction (usedApplicationAssemblyAction.ToLower (), unusedApplicationAssemblyAction.ToLower (), out applicationAssemblyAction)) {
+				Log.LogError ("Unsupported combination of application assembly actions: {0}, {1}.",
+							  usedApplicationAssemblyAction, unusedApplicationAssemblyAction);
+				return false;
+			}
+
+			string platformAssemblyAction;
+			string usedPlatformAssemblyAction = UsedPlatformAssemblyAction.ItemSpec;
+			string unusedPlatformAssemblyAction = UnusedPlatformAssemblyAction.ItemSpec;
+			if (!GetAssemblyAction (usedPlatformAssemblyAction.ToLower (), unusedPlatformAssemblyAction.ToLower (), out platformAssemblyAction)) {
+				Log.LogError ("Unsupported combination of platform assembly actions: {0}, {1}.",
+							  usedPlatformAssemblyAction, unusedPlatformAssemblyAction);
+				return false;
+			}
+
+			List<ITaskItem> resultAssemblies = new List<ITaskItem> ();
+
+			AddAssemblyActionMetadata (ApplicationAssemblyNames, applicationAssemblyAction, resultAssemblies);
+			AddAssemblyActionMetadata (PlatformAssemblyNames, platformAssemblyAction, resultAssemblies);
+
+			AssemblyPathsWithActions = resultAssemblies.ToArray ();
+
+			return true;
+		}
+
+		bool GetAssemblyAction (string usedAssemblyAction, string unusedAssemblyAction, out string assemblyAction)
+		{
+			assemblyAction = "illegal";
+			if ((unusedAssemblyAction != usedAssemblyAction) && (unusedAssemblyAction != "delete")) {
+				return false;
+			}
+
+			switch (usedAssemblyAction) {
+			case "link":
+				assemblyAction = "link";
+				break;
+
+			case "copy":
+				assemblyAction = (unusedAssemblyAction == "delete") ? "copyused" : "copy";
+				break;
+
+			case "addbypassngen":
+				assemblyAction = (unusedAssemblyAction == "delete") ? "addbypassngenused" : "addbypassngen";
+				break;
+
+			case "skip":
+				if (unusedAssemblyAction != usedAssemblyAction) {
+					return false;
+				}
+				assemblyAction = "skip";
+				break;
+
+			default:
+				return false;
+			}
+
+			return true;
+		}
+
+		void AddAssemblyActionMetadata (ITaskItem [] assemblies, string action, List<ITaskItem> resultList)
+		{
+			HashSet<string> assemblyHashSet = new HashSet<string> ();
+			foreach (var assembly in assemblies) {
+				assemblyHashSet.Add (assembly.ItemSpec);
+			}
+
+			foreach (var assembly in AssemblyPaths) {
+				if (assemblyHashSet.Contains (Path.GetFileNameWithoutExtension (assembly.ItemSpec))) {
+					assembly.SetMetadata ("action", action);
+					resultList.Add (assembly);
+				}
+			}
+		}
+
+	}
+}


### PR DESCRIPTION
This change adds 4 linker publish options:
UsedApplicationAssemblyAction, UnusedApplicationAssemblyAction,
UsedNetCoreFrameworkAssemblyAction, and UnusedNetCoreFrameworkAssemblyAction.

ILLink task takes two sets of assemblies as inputs: application assemblies and
framework assemblies.
ILLink task emits the appropriate -p switches for each assembly.
ILLink task no longer emits -c switch.