### PR TITLE
Implement mechanism for removing CustomAttributes

### DIFF
--- a/linker/Linker.Steps/MarkStep.cs
+++ b/linker/Linker.Steps/MarkStep.cs
@@ -278,8 +278,12 @@ namespace Mono.Linker.Steps {
 
 		protected virtual void MarkCustomAttribute (CustomAttribute ca)
 		{
+			if (!ShouldMarkCustomAttribute (ca))
+				return;
+
 			Tracer.Push ((object)ca.AttributeType ?? (object)ca);
 			try {
+				Annotations.Mark (ca);
 				MarkMethod (ca.Constructor);
 
 				MarkCustomAttributeArguments (ca);
@@ -297,6 +301,11 @@ namespace Mono.Linker.Steps {
 			} finally {
 				Tracer.Pop ();
 			}
+		}
+
+		protected virtual bool ShouldMarkCustomAttribute (CustomAttribute ca)
+		{
+			return true;
 		}
 
 		protected void MarkSecurityDeclarations (ISecurityDeclarationProvider provider)

--- a/linker/Linker/Annotations.cs
+++ b/linker/Linker/Annotations.cs
@@ -51,6 +51,7 @@ namespace Mono.Linker {
 
 		readonly Dictionary<object, Dictionary<IMetadataTokenProvider, object>> custom_annotations = new Dictionary<object, Dictionary<IMetadataTokenProvider, object>> ();
 		readonly Dictionary<AssemblyDefinition, HashSet<string>> resources_to_remove = new Dictionary<AssemblyDefinition, HashSet<string>> ();
+		readonly HashSet<CustomAttribute> marked_attributes = new HashSet<CustomAttribute> ();
 
 		public AnnotationStore (LinkContext context) => this.context = context;
 
@@ -117,6 +118,11 @@ namespace Mono.Linker {
 			Tracer.AddDependency (provider, true);
 		}
 
+		public void Mark (CustomAttribute attribute)
+		{
+			marked_attributes.Add (attribute);
+		}
+
 		public void MarkAndPush (IMetadataTokenProvider provider)
 		{
 			Mark (provider);
@@ -126,6 +132,11 @@ namespace Mono.Linker {
 		public bool IsMarked (IMetadataTokenProvider provider)
 		{
 			return marked.Contains (provider);
+		}
+
+		public bool IsMarked (CustomAttribute attribute)
+		{
+			return marked_attributes.Contains (attribute);
 		}
 
 		public void Processed (IMetadataTokenProvider provider)


### PR DESCRIPTION
This PR exposes `MarkStep.ShouldMarkCustomAttribute` which allows a linker implementation to control which CustomAttributes should be kept.

For now, everything will be kept by default, which is the current behavior.