### PR TITLE
Fix case where assembly attribute wouldn't be correctly marked

### DIFF
--- a/linker/Linker.Steps/MarkStep.cs
+++ b/linker/Linker.Steps/MarkStep.cs
@@ -131,13 +131,7 @@ namespace Mono.Linker.Steps {
 			if (QueueIsEmpty ())
 				throw new InvalidOperationException ("No entry methods");
 
-			ProcessEntireQueue ();
-
-			// After all types have been processed then we can process the lazily marked attributes
-			ProcessLazyAttributes ();
-
-			// We need to process the queue again in case marking the attributes enqueued more work
-			ProcessEntireQueue ();
+			while (ProcessPrimaryQueue () || ProcessLazyAttributes ())
 
 			// deal with [TypeForwardedTo] pseudo-attributes
 			foreach (AssemblyDefinition assembly in _context.GetAssemblies ()) {
@@ -173,13 +167,18 @@ namespace Mono.Linker.Steps {
 			}
 		}
 
-		void ProcessEntireQueue ()
+		bool ProcessPrimaryQueue ()
 		{
+			if (QueueIsEmpty ())
+				return false;
+
 			while (!QueueIsEmpty ()) {
 				ProcessQueue ();
 				ProcessVirtualMethods ();
 				DoAdditionalProcessing ();
 			}
+
+			return true;
 		}
 
 		void ProcessQueue ()
@@ -260,8 +259,12 @@ namespace Mono.Linker.Steps {
 
 			Tracer.Push (provider);
 			try {
-				foreach (CustomAttribute ca in provider.CustomAttributes)
+				foreach (CustomAttribute ca in provider.CustomAttributes) {
+					if (!ShouldMarkCustomAttribute (ca))
+						continue;
+
 					MarkCustomAttribute (ca);
+				}
 			} finally {
 				Tracer.Pop ();
 			}
@@ -278,9 +281,6 @@ namespace Mono.Linker.Steps {
 
 		protected virtual void MarkCustomAttribute (CustomAttribute ca)
 		{
-			if (!ShouldMarkCustomAttribute (ca))
-				return;
-
 			Tracer.Push ((object)ca.AttributeType ?? (object)ca);
 			try {
 				Annotations.Mark (ca);
@@ -305,6 +305,16 @@ namespace Mono.Linker.Steps {
 
 		protected virtual bool ShouldMarkCustomAttribute (CustomAttribute ca)
 		{
+			return true;
+		}
+
+		protected virtual bool ShouldMarkTopLevelCustomAttribute (CustomAttribute ca, MethodDefinition resolvedConstructor)
+		{
+			// If an attribute's module has not been marked after processing all types in all assemblies and the attribute itself has not been marked,
+			// then surely nothing is using this attribute and there is no need to mark it
+			if (!Annotations.IsMarked (resolvedConstructor.Module) && !Annotations.IsMarked (ca.AttributeType))
+				return false;
+
 			return true;
 		}
 
@@ -530,8 +540,15 @@ namespace Mono.Linker.Steps {
 			}
 		}
 
-		void ProcessLazyAttributes ()
+		bool ProcessLazyAttributes ()
 		{
+			var startingQueueCount = _topLevelAttributes.Count;
+			if (startingQueueCount == 0)
+				return false;
+
+			var skippedItems = new List<CustomAttribute> ();
+			var markOccurred = false;
+
 			while (_topLevelAttributes.Count != 0) {
 				var customAttribute = _topLevelAttributes.Dequeue ();
 
@@ -541,13 +558,20 @@ namespace Mono.Linker.Steps {
 					continue;
 				}
 
-				// If an attribute's module has not been marked after processing all types in all assemblies and the attribute itself has not been marked,
-				// then surely nothing is using this attribute and there is no need to mark it
-				if (!Annotations.IsMarked (resolved.Module) && !Annotations.IsMarked (customAttribute.AttributeType))
+				if (!ShouldMarkTopLevelCustomAttribute (customAttribute, resolved)) {
+					skippedItems.Add (customAttribute);
 					continue;
+				}
 
+				markOccurred = true;
 				MarkCustomAttribute (customAttribute);
 			}
+
+			// requeue the items we skipped in case we need to make another pass
+			foreach (var item in skippedItems)
+				_topLevelAttributes.Enqueue (item);
+
+			return markOccurred;
 		}
 
 		protected void MarkField (FieldReference reference)

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/AssemblyAttributeIsRemovedIfOnlyTypesUsedInAssembly.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/AssemblyAttributeIsRemovedIfOnlyTypesUsedInAssembly.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Attributes.Dependencies;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+[assembly: AttributeInReference]
+
+namespace Mono.Linker.Tests.Cases.Attributes {
+	[SetupCompileBefore ("library.dll", new [] { "Dependencies/AssemblyAttributeIsRemovedIfOnlyTypesUsedInAssembly_Lib.cs" })]
+	[RemovedAssembly ("library.dll")]
+	class AssemblyAttributeIsRemovedIfOnlyTypesUsedInAssembly {
+		static void Main ()
+		{
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/AssemblyAttributeKeptInComplexCase.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/AssemblyAttributeKeptInComplexCase.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Attributes;
+using Mono.Linker.Tests.Cases.Attributes.Dependencies;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+// This attribute is defined in this assembly so it will be kept
+[assembly: AssemblyAttributeKeptInComplexCase.Foo]
+
+// This attribute is not going to get marked on the first pass because the reference
+// it is defined in will not have been marked yet.
+// The catch is, Foo's ctor() will mark a method in `library`, at which point we now expect this
+// attribute to be kept
+[assembly: AssemblyAttributeKeptInComplexCase_Lib.OtherAssembly]
+
+[assembly: KeptAttributeAttribute (typeof (AssemblyAttributeKeptInComplexCase.FooAttribute))]
+[assembly: KeptAttributeAttribute (typeof (AssemblyAttributeKeptInComplexCase_Lib.OtherAssemblyAttribute))]
+
+namespace Mono.Linker.Tests.Cases.Attributes {
+	[SetupCompileBefore ("library.dll", new [] { "Dependencies/AssemblyAttributeKeptInComplexCase_Lib.cs" })]
+	[KeptAssembly ("library.dll")]
+	[KeptMemberInAssembly ("library.dll", typeof (AssemblyAttributeKeptInComplexCase_Lib.OtherAssemblyAttribute), ".ctor()")]
+	[KeptMemberInAssembly ("library.dll", typeof (AssemblyAttributeKeptInComplexCase_Lib), "MethodThatWillBeUsed()")]
+	public class AssemblyAttributeKeptInComplexCase {
+		static void Main ()
+		{
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (Attribute))]
+		public class FooAttribute : Attribute {
+			[Kept]
+			public FooAttribute ()
+			{
+				// This ctor will be marked late after processing the queue
+				// This method we call will be the first marked in the referenced library
+				AssemblyAttributeKeptInComplexCase_Lib.MethodThatWillBeUsed ();
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/Dependencies/AssemblyAttributeIsRemovedIfOnlyTypesUsedInAssembly_Lib.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/Dependencies/AssemblyAttributeIsRemovedIfOnlyTypesUsedInAssembly_Lib.cs
@@ -1,0 +1,6 @@
+﻿using System;
+
+namespace Mono.Linker.Tests.Cases.Attributes.Dependencies {
+	public class AttributeInReferenceAttribute : Attribute {
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/Dependencies/AssemblyAttributeKeptInComplexCase_Lib.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/Dependencies/AssemblyAttributeKeptInComplexCase_Lib.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Mono.Linker.Tests.Cases.Attributes.Dependencies {
+	public class AssemblyAttributeKeptInComplexCase_Lib {
+		public class OtherAssemblyAttribute : Attribute {
+		}
+
+		public static void MethodThatWillBeUsed ()
+		{
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -37,6 +37,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Attributes\AssemblyAttributeIsRemovedIfOnlyTypesUsedInAssembly.cs" />
+    <Compile Include="Attributes\AssemblyAttributeKeptInComplexCase.cs" />
     <Compile Include="Attributes\AttributeOnAssemblyIsKept.cs" />
     <Compile Include="Attributes\AttributeOnParameterInUsedMethodIsKept.cs" />
     <Compile Include="Attributes\AttributeOnPreservedTypeWithTypeUsedInConstructorIsKept.cs" />
@@ -50,6 +52,8 @@
     <Compile Include="Attributes\AttributeOnUsedPropertyIsKept.cs" />
     <Compile Include="Attributes\SecurityAttributesOnUsedMethodAreKept.cs" />
     <Compile Include="Attributes\SecurityAttributesOnUsedTypeAreKept.cs" />
+    <Compile Include="Attributes\Dependencies\AssemblyAttributeIsRemovedIfOnlyTypesUsedInAssembly_Lib.cs" />
+    <Compile Include="Attributes\Dependencies\AssemblyAttributeKeptInComplexCase_Lib.cs" />
     <Compile Include="Basic\ComplexNestedClassesHasUnusedRemoved.cs" />
     <Compile Include="Basic\InterfaceMethodImplementedOnBaseClassDoesNotGetStripped.cs" />
     <Compile Include="Basic\MultiLevelNestedClassesAllRemovedWhenNonUsed.cs" />

--- a/linker/Tests/TestCasesRunner/PeVerifier.cs
+++ b/linker/Tests/TestCasesRunner/PeVerifier.cs
@@ -98,6 +98,10 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			process.StartInfo.UseShellExecute = false;
 			process.StartInfo.CreateNoWindow = true;
 			process.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
+
+			if (Environment.OSVersion.Platform != PlatformID.Win32NT) {
+				process.StartInfo.Environment ["MONO_PATH"] = assemblyPath.Parent.ToString ();
+			}
 		}
 
 		public static NPath FindPeExecutableFromRegistry ()


### PR DESCRIPTION
Top level CustomAttributes are marked late, after all of the main marking happens.  This lets us remove attributes when the attribute type would be the only thing used from a reference.  After marking these attributes we would process the queue one more time.  However, if that second processing pass gave us a reason to keep another top level attribute, we wouldn't circle back and process the top level attributes again

Now, we will process the main queues and the late marked attributes repeatedly until no more items are being marked