### PR TITLE
Default to no i18n assemblies during tests

### DIFF
--- a/linker/Tests/TestCasesRunner/LinkerArgumentBuilder.cs
+++ b/linker/Tests/TestCasesRunner/LinkerArgumentBuilder.cs
@@ -93,7 +93,6 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			// our test cases that pollutes the results
 			IncludeBlacklist (options.IncludeBlacklistStep);
 
-			// Internationalization assemblies pollute our test case results as well so disable them
 			if (!string.IsNullOrEmpty (options.Il8n))
 				AddIl8n (options.Il8n);
 

--- a/linker/Tests/TestCasesRunner/TestCaseMetadaProvider.cs
+++ b/linker/Tests/TestCasesRunner/TestCaseMetadaProvider.cs
@@ -27,7 +27,7 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 		public virtual TestCaseLinkerOptions GetLinkerOptions ()
 		{
 			var tclo = new TestCaseLinkerOptions {
-				Il8n = GetOptionAttributeValue (nameof (Il8nAttribute), string.Empty),
+				Il8n = GetOptionAttributeValue (nameof (Il8nAttribute), "none"),
 				IncludeBlacklistStep = GetOptionAttributeValue (nameof (IncludeBlacklistStepAttribute), false),
 				KeepTypeForwarderOnlyAssemblies = GetOptionAttributeValue (nameof (KeepTypeForwarderOnlyAssembliesAttribute), string.Empty),
 				CoreAssembliesAction = GetOptionAttributeValue<string> (nameof (SetupLinkerCoreActionAttribute), null)


### PR DESCRIPTION
This avoids polluting test case results with extra assemblies which can throw off assertions