### PR TITLE
Log output actions

### DIFF
--- a/linker/Linker.Steps/OutputStep.cs
+++ b/linker/Linker.Steps/OutputStep.cs
@@ -113,7 +113,10 @@ namespace Mono.Linker.Steps {
 
 			CopyConfigFileIfNeeded (assembly, directory);
 
-			switch (Annotations.GetAction (assembly)) {
+			var action = Annotations.GetAction (assembly);
+			Context.LogMessage (MessageImportance.Low, $"Output action: {action,8} assembly: {assembly}");
+
+			switch (action) {
 			case AssemblyAction.Save:
 			case AssemblyAction.Link:
 			case AssemblyAction.AddBypassNGen:


### PR DESCRIPTION
Log output action for every assembly in the OutputStep. It uses
`MessageImportance.Low` so it will be visible in the diagnostic log
output of the mobile linkers.

It helps to quickly diagnose issues, where we want to know how was the
assembly processed. Typically whether it was dropped completely,
linked, saved or copied.