### PR TITLE
Add more delegate and event test cases

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptDelegateCacheFieldAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptDelegateCacheFieldAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Assertions {
+	[AttributeUsage (AttributeTargets.Class | AttributeTargets.Struct, Inherited = false, AllowMultiple = true)]
+	public class KeptDelegateCacheFieldAttribute : KeptAttribute {
+		public KeptDelegateCacheFieldAttribute (string uniquePartOfName)
+		{
+			if (string.IsNullOrEmpty (uniquePartOfName))
+				throw new ArgumentNullException (nameof (uniquePartOfName));
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptEventAddMethodAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptEventAddMethodAttribute.cs
@@ -1,0 +1,7 @@
+﻿using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Assertions {
+	[AttributeUsage (AttributeTargets.Event, Inherited = false, AllowMultiple = false)]
+	public class KeptEventAddMethodAttribute : KeptAttribute {
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptEventRemoveMethodAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptEventRemoveMethodAttribute.cs
@@ -1,0 +1,7 @@
+﻿using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Assertions {
+	[AttributeUsage (AttributeTargets.Event, Inherited = false, AllowMultiple = false)]
+	public class KeptEventRemoveMethodAttribute : KeptAttribute {
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
@@ -43,6 +43,9 @@
     <Compile Include="Assertions\KeptAttribute.cs" />
     <Compile Include="Assertions\BaseExpectedLinkedBehaviorAttribute.cs" />
     <Compile Include="Assertions\KeptBackingFieldAttribute.cs" />
+    <Compile Include="Assertions\KeptDelegateCacheFieldAttribute.cs" />
+    <Compile Include="Assertions\KeptEventAddMethodAttribute.cs" />
+    <Compile Include="Assertions\KeptEventRemoveMethodAttribute.cs" />
     <Compile Include="Assertions\KeptMemberAttribute.cs" />
     <Compile Include="Assertions\KeptMemberInAssemblyAttribute.cs" />
     <Compile Include="Assertions\KeptResourceAttribute.cs" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/Basic/UnusedDelegateGetsRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Basic/UnusedDelegateGetsRemoved.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Mono.Linker.Tests.Cases.Basic {
+	class UnusedDelegateGetsRemoved {
+		static void Main ()
+		{
+		}
+
+		public delegate void Foo ();
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Basic/UnusedEventGetsRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Basic/UnusedEventGetsRemoved.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Basic {
+	class UnusedEventGetsRemoved {
+		public static void Main ()
+		{
+			var tmp = new Foo ();
+		}
+
+		[KeptMember (".ctor()")]
+		public class Foo
+		{
+			public delegate void CustomDelegate ();
+
+			public event CustomDelegate Bar;
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Basic/UsedEventIsKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Basic/UsedEventIsKept.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Basic {
+	[KeptDelegateCacheField ("0")]
+	[KeptDelegateCacheField ("1")]
+	class UsedEventIsKept {
+		public static void Main ()
+		{
+			var tmp = new Foo ();
+
+			tmp.Bar += Tmp_Bar;
+			tmp.Fire ();
+			tmp.Bar -= Tmp_Bar;
+		}
+
+		[Kept]
+		private static void Tmp_Bar ()
+		{
+		}
+
+		[KeptMember (".ctor()")]
+		public class Foo {
+			[Kept]
+			[KeptBaseType (typeof(MulticastDelegate))]
+			[KeptMember (".ctor(System.Object,System.IntPtr)")]
+			[KeptMember ("Invoke()")]
+			[KeptMember ("BeginInvoke(System.AsyncCallback,System.Object)")]
+			[KeptMember ("EndInvoke(System.IAsyncResult)")]
+			public delegate void CustomDelegate ();
+
+			[Kept]
+			[KeptBackingField]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
+			public event CustomDelegate Bar;
+
+			[Kept]
+			public void Fire ()
+			{
+				Bar ();
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Basic/UsedEventOnInterfaceIsKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Basic/UsedEventOnInterfaceIsKept.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Basic {
+	[KeptDelegateCacheField ("0")]
+	class UsedEventOnInterfaceIsKept {
+		static void Main ()
+		{
+			IFoo bar = new Bar ();
+			IFoo jar = new Jar ();
+
+			bar.Ping += Bar_Ping;
+		}
+
+		[Kept]
+		private static void Bar_Ping (object sender, EventArgs e)
+		{
+		}
+
+		[Kept]
+		interface IFoo {
+			[Kept]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
+			event EventHandler Ping;
+		}
+
+		[KeptMember (".ctor()")]
+		[KeptInterface (typeof (IFoo))]
+		class Bar : IFoo {
+			[Kept]
+			[KeptBackingField]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
+			public event EventHandler Ping;
+		}
+
+		[KeptMember (".ctor()")]
+		[KeptInterface (typeof (IFoo))]
+		class Jar : IFoo {
+			[Kept]
+			[KeptBackingField]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
+			public event EventHandler Ping;
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Basic/UsedEventOnInterfaceIsRemovedWhenUsedFromClass.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Basic/UsedEventOnInterfaceIsRemovedWhenUsedFromClass.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Basic {
+	[KeptDelegateCacheField ("0")]
+	class UsedEventOnInterfaceIsRemovedWhenUsedFromClass {
+		static void Main ()
+		{
+			var bar = new Bar ();
+			var jar = new Jar ();
+
+			bar.Ping += Bar_Ping;
+		}
+
+		[Kept]
+		private static void Bar_Ping (object sender, EventArgs e)
+		{
+		}
+
+		[Kept]
+		interface IFoo {
+		}
+
+		[KeptMember (".ctor()")]
+		[KeptInterface (typeof (IFoo))]
+		class Bar : IFoo {
+			[Kept]
+			[KeptBackingField]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
+			public event EventHandler Ping;
+		}
+
+		[KeptMember (".ctor()")]
+		[KeptInterface (typeof (IFoo))]
+		class Jar : IFoo {
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/UnusedEventPreservedByLinkXmlIsKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/UnusedEventPreservedByLinkXmlIsKept.cs
@@ -12,6 +12,8 @@ namespace Mono.Linker.Tests.Cases.LinkXml {
 		class Unused {
 			[Kept]
 			[KeptBackingField]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
 			public event EventHandler<EventArgs> Preserved;
 
 			[Kept]

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -59,10 +59,15 @@
     <Compile Include="Basic\MultiLevelNestedClassesAllRemovedWhenNonUsed.cs" />
     <Compile Include="Basic\NestedDelegateInvokeMethodsPreserved.cs" />
     <Compile Include="Basic\UninvokedInterfaceMemberGetsRemoved.cs" />
+    <Compile Include="Basic\UnusedDelegateGetsRemoved.cs" />
+    <Compile Include="Basic\UnusedEventGetsRemoved.cs" />
+    <Compile Include="Basic\UsedEventOnInterfaceIsKept.cs" />
     <Compile Include="Basic\UnusedFieldGetsRemoved.cs" />
     <Compile Include="Basic\UnusedMethodGetsRemoved.cs" />
     <Compile Include="Basic\UnusedPropertyGetsRemoved.cs" />
     <Compile Include="Basic\UnusedPropertySetterRemoved.cs" />
+    <Compile Include="Basic\UsedEventIsKept.cs" />
+    <Compile Include="Basic\UsedEventOnInterfaceIsRemovedWhenUsedFromClass.cs" />
     <Compile Include="Basic\UsedPropertyIsKept.cs" />
     <Compile Include="Basic\UsedStructIsKept.cs" />
     <Compile Include="LinkXml\CanPreserveTypesUsingRegex.cs" />


### PR DESCRIPTION
I added new [KeptEventAddMethod] and [KeptEventRemoveMethod] attributes so that the expected result could be different for the two in the future.

A new [KeptDelegateCacheField] was introduced to help with asserting that the `<>f__mg$cache` fields generated by mcs are kept.