### PR TITLE
Add missing null checks to TypeReferenceExtensions

### DIFF
--- a/linker/Linker/TypeReferenceExtensions.cs
+++ b/linker/Linker/TypeReferenceExtensions.cs
@@ -28,7 +28,7 @@ namespace Mono.Linker
 
 			var genericInstance = type as GenericInstanceType;
 			if (genericInstance != null) {
-				var baseType = type.Resolve ().BaseType;
+				var baseType = type.Resolve ()?.BaseType;
 				var baseTypeGenericInstance = baseType as GenericInstanceType;
 
 				if (baseTypeGenericInstance != null)
@@ -37,14 +37,14 @@ namespace Mono.Linker
 				return baseType;
 			}
 
-			return type.Resolve ().BaseType;
+			return type.Resolve ()?.BaseType;
 		}
 
 		public static IEnumerable<TypeReference> GetInflatedInterfaces (this TypeReference typeRef)
 		{
 			var typeDef = typeRef.Resolve ();
 
-			if (!typeDef.HasInterfaces)
+			if (typeDef?.HasInterfaces != true)
 				yield break;
 
 			var genericInstance = typeRef as GenericInstanceType;
@@ -166,7 +166,7 @@ namespace Mono.Linker
 		{
 			var typeDef = type.Resolve ();
 
-			if (!typeDef.HasMethods)
+			if (typeDef?.HasMethods != true)
 				yield break;
 
 			var genericInstanceType = type as GenericInstanceType;


### PR DESCRIPTION
Cecil's MetadataResolver returns null if it cannot resolve something.

This requires the callers, like TypeReferenceExtensions, to do null
checks, otherwise a  `NullReferenceException` can happens in the linker
code and it's not possible to give a useful error message to the
developer.

This is what's happening in
https://github.com/xamarin/xamarin-macios/issues/3215 (with test case)
and likely in
https://github.com/xamarin/xamarin-macios/issues/3210 (without test case)