### PR TITLE
Add functionality to terminate a test process upon output

### DIFF
--- a/corebuild/integration/test/CommandRunner.cs
+++ b/corebuild/integration/test/CommandRunner.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ILLink.Tests
+{
+	public class CommandRunner
+	{
+		protected readonly ITestOutputHelper outputHelper;
+
+		private string command;
+		private string args;
+		private string workingDir;
+		private string additionalPath;
+		private int timeout = Int32.MaxValue;
+		private string terminatingOutput;
+
+		public CommandRunner(string command, ITestOutputHelper outputHelper) {
+			this.command = command;
+			this.outputHelper = outputHelper;
+		}
+
+		public CommandRunner WithArguments(string args) {
+			this.args = args;
+			return this;
+		}
+
+		public CommandRunner WithWorkingDir(string workingDir) {
+			this.workingDir = workingDir;
+			return this;
+		}
+
+		public CommandRunner WithAdditionalPath(string additionalPath) {
+			this.additionalPath = additionalPath;
+			return this;
+		}
+
+		public CommandRunner WithTimeout(int timeout) {
+			this.timeout = timeout;
+			return this;
+		}
+
+		public CommandRunner WithTerminatingOutput(string terminatingOutput) {
+			this.terminatingOutput = terminatingOutput;
+			return this;
+		}
+
+		public int Run()
+		{
+			return Run(out string commandOutputUnused);
+		}
+
+		public int Run(out string commandOutput)
+		{
+			if (String.IsNullOrEmpty(command)) {
+				throw new Exception("No command was specified specified.");
+			}
+			if (outputHelper == null) {
+				throw new Exception("No output helper present.");
+			}
+			var psi = new ProcessStartInfo
+			{
+				FileName = command,
+				UseShellExecute = false,
+				RedirectStandardOutput = true,
+				RedirectStandardError = true,
+			};
+			if (!String.IsNullOrEmpty(args)) {
+				psi.Arguments = args;
+				outputHelper.WriteLine($"{command} {args}");
+			} else {
+				outputHelper.WriteLine($"{command}");
+			}
+			if (!String.IsNullOrEmpty(workingDir)) {
+				outputHelper.WriteLine("$working directory: {workingDir}");
+				psi.WorkingDirectory = workingDir;
+			}
+			if (!String.IsNullOrEmpty(additionalPath)) {
+				string path = psi.Environment["PATH"];
+				psi.Environment["PATH"] = path + ";" + additionalPath;
+			}
+			var process = new Process();
+			process.StartInfo = psi;
+
+			// dotnet sets some environment variables that
+			// may cause problems in the child process.
+			psi.Environment.Remove("MSBuildExtensionsPath");
+			psi.Environment.Remove("MSBuildLoadMicrosoftTargetsReadOnly");
+			psi.Environment.Remove("MSBuildSDKsPath");
+			psi.Environment.Remove("VbcToolExe");
+			psi.Environment.Remove("CscToolExe");
+			psi.Environment.Remove("MSBUILD_EXE_PATH");
+
+			outputHelper.WriteLine("environment:");
+			foreach (var item in psi.Environment) {
+				outputHelper.WriteLine($"\t{item.Key}={item.Value}");
+			}
+
+			StringBuilder processOutput = new StringBuilder();
+			DataReceivedEventHandler handler = (sender, e) => {
+				processOutput.Append(e.Data);
+				processOutput.AppendLine();
+			};
+			StringBuilder processError = new StringBuilder();
+			DataReceivedEventHandler ehandler = (sender, e) => {
+				processError.Append(e.Data);
+				processError.AppendLine();
+			};
+			process.OutputDataReceived += handler;
+			process.ErrorDataReceived += ehandler;
+
+			// terminate process if output contains specified string
+			if (!String.IsNullOrEmpty(terminatingOutput)) {
+				DataReceivedEventHandler terminatingOutputHandler = (sender, e) => {
+					if (!String.IsNullOrEmpty(e.Data) && e.Data.Contains(terminatingOutput)) {
+						process.Kill();
+					}
+				};
+				process.OutputDataReceived += terminatingOutputHandler;
+			}
+
+			// start the process
+			process.Start();
+			process.BeginOutputReadLine();
+			process.BeginErrorReadLine();
+			if (!process.WaitForExit(timeout)) {
+				outputHelper.WriteLine($"killing process after {timeout} ms");
+				process.Kill();
+			}
+			// WaitForExit with timeout doesn't guarantee
+			// that the async output handlers have been
+			// called, so WaitForExit needs to be called
+			// afterwards.
+			process.WaitForExit();
+			string processOutputStr = processOutput.ToString();
+			string processErrorStr = processError.ToString();
+			outputHelper.WriteLine(processOutputStr);
+			outputHelper.WriteLine(processErrorStr);
+			commandOutput = processOutputStr;
+			return process.ExitCode;
+		}
+	}
+}

--- a/corebuild/integration/test/IntegrationTestBase.cs
+++ b/corebuild/integration/test/IntegrationTestBase.cs
@@ -30,7 +30,7 @@ namespace ILLink.Tests
 		protected int Dotnet(string args, string workingDir, string additionalPath = null)
 		{
 			return RunCommand(Path.GetFullPath(context.DotnetToolPath), args,
-							  workingDir, additionalPath, out string commandOutput);
+				workingDir, additionalPath, out string commandOutput);
 		}
 
 		protected int RunCommand(string command, string args, int timeout = Int32.MaxValue)
@@ -43,71 +43,16 @@ namespace ILLink.Tests
 			return RunCommand(command, args, workingDir, null, out string commandOutput);
 		}
 
-		protected int RunCommand(string command, string args, string workingDir, string additionalPath, out string commandOutput, int timeout = Int32.MaxValue)
+		protected int RunCommand(string command, string args, string workingDir, string additionalPath,
+			out string commandOutput, int timeout = Int32.MaxValue, string terminatingOutput = null)
 		{
-			output.WriteLine($"{command} {args}");
-			if (workingDir != null)
-				output.WriteLine($"working directory: {workingDir}");
-			var psi = new ProcessStartInfo
-			{
-				FileName = command,
-				Arguments = args,
-				UseShellExecute = false,
-				RedirectStandardOutput = true,
-				RedirectStandardError = true,
-				WorkingDirectory = workingDir,
-			};
-
-			if (additionalPath != null) {
-				string path = psi.Environment["PATH"];
-				psi.Environment["PATH"] = path + ";" + additionalPath;
-			}
-			var process = new Process();
-			process.StartInfo = psi;
-
-			// dotnet sets some environment variables that
-			// may cause problems in the child process.
-			psi.Environment.Remove("MSBuildExtensionsPath");
-			psi.Environment.Remove("MSBuildLoadMicrosoftTargetsReadOnly");
-			psi.Environment.Remove("MSBuildSDKsPath");
-			psi.Environment.Remove("VbcToolExe");
-			psi.Environment.Remove("CscToolExe");
-			psi.Environment.Remove("MSBUILD_EXE_PATH");
-
-			StringBuilder processOutput = new StringBuilder();
-			DataReceivedEventHandler handler = (sender, e) => {
-				processOutput.Append(e.Data);
-				processOutput.AppendLine();
-			};
-			StringBuilder processError = new StringBuilder();
-			DataReceivedEventHandler ehandler = (sender, e) => {
-				processError.Append(e.Data);
-				processError.AppendLine();
-			};
-			process.OutputDataReceived += handler;
-			process.ErrorDataReceived += ehandler;
-			output.WriteLine("environment:");
-			foreach (var item in psi.Environment) {
-				output.WriteLine($"\t{item.Key}={item.Value}");
-			}
-			process.Start();
-			process.BeginOutputReadLine();
-			process.BeginErrorReadLine();
-			if (!process.WaitForExit(timeout)) {
-				output.WriteLine($"killing process after {timeout} ms");
-				process.Kill();
-			}
-			// WaitForExit with timeout doesn't guarantee
-			// that the async output handlers have been
-			// called, so WaitForExit needs to be called
-			// afterwards.
-			process.WaitForExit();
-			string processOutputStr = processOutput.ToString();
-			string processErrorStr = processError.ToString();
-			output.WriteLine(processOutputStr);
-			output.WriteLine(processErrorStr);
-			commandOutput = processOutputStr;
-			return process.ExitCode;
+			return (new CommandRunner(command, output))
+				.WithArguments(args)
+				.WithWorkingDir(workingDir)
+				.WithAdditionalPath(additionalPath)
+				.WithTimeout(timeout)
+				.WithTerminatingOutput(terminatingOutput)
+				.Run(out commandOutput);
 		}
 
 		/// <summary>
@@ -142,7 +87,7 @@ namespace ILLink.Tests
 			}
 		}
 
-		public int RunApp(string csproj, out string processOutput, int timeout = Int32.MaxValue)
+		public int RunApp(string csproj, out string processOutput, int timeout = Int32.MaxValue, string terminatingOutput = null)
 		{
 			string demoRoot = Path.GetDirectoryName(csproj);
 			// detect the target framework for which the app was published
@@ -159,7 +104,7 @@ namespace ILLink.Tests
 
 			int ret = RunCommand(executablePath, null,
 				Directory.GetParent(executablePath).FullName,
-				null, out processOutput, timeout);
+				null, out processOutput, timeout, terminatingOutput);
 			return ret;
 		}
 

--- a/corebuild/integration/test/WebApiTest.cs
+++ b/corebuild/integration/test/WebApiTest.cs
@@ -59,9 +59,10 @@ namespace ILLink.Tests
 
 			BuildAndLink(csproj);
 
-			int ret = RunApp(csproj, out string commandOutput, 10000);
+			string terminatingOutput = "Now listening on: http://localhost:5000";
+			int ret = RunApp(csproj, out string commandOutput, 60000, terminatingOutput);
 			Assert.True(commandOutput.Contains("Application started. Press Ctrl+C to shut down."));
-			Assert.True(commandOutput.Contains("Now listening on: http://localhost:5000"));
+			Assert.True(commandOutput.Contains(terminatingOutput));
 		}
 	}
 }

--- a/corebuild/integration/test/test.csproj
+++ b/corebuild/integration/test/test.csproj
@@ -22,6 +22,7 @@
   </Target>
 
   <ItemGroup>
+    <Compile Include="CommandRunner.cs" />
     <Compile Include="IntegrationTestBase.cs" />
     <Compile Include="TestContext.cs" />
     <Compile Include="MusicStoreTest.cs" />


### PR DESCRIPTION
The webapi test starts a process that does not terminate
automatically, but stops when it hits the timeout. We then expect the
output to contain some well-known string.

This was causing problems in ci because the ci machines were slow,
causing the test to frequently time out before printing the
string. Increasing the timeout to a large value caused the test to run
for too long.

This fix makes it possible to specify a termination condition. Now the
test process is killed when it prints the expected string, or hits a
timeout, currently set to 60 seconds.

As part of the change, the core process running logic has been moved
to a new class.

@erozenfeld, @JosephTremoulet PTAL