### PR TITLE
Prevent removal of resource assemblies by native trimming logic

### DIFF
--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
@@ -241,6 +241,7 @@
     <ItemGroup>
       <_NativeResolvedDepsToPublish Include="@(ResolvedAssembliesToPublish)" />
       <_NativeResolvedDepsToPublish Remove="@(_ManagedResolvedAssembliesToPublish)" />
+      <_NativeResolvedDepsToPublish Remove="@(_NativeResolvedDepsToPublish->WithMetadataValue('AssetType', 'resources'))" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
We already avoid linking passing resource assemblies to the linker
since change fe21568643da93dfdfec3698ddefe5ba633df43d. However,
removing resource assemblies from the set of managed assemblies causes
them to be included in the set of native trimming candidates.

This change excludes resources from the native trimming candidates.

This fixes https://github.com/mono/linker/issues/218.

@erozenfeld, @JosephTremoulet PTAL