### PR TITLE
Support for removing CustomAttributes

### DIFF
--- a/linker/Linker/Driver.cs
+++ b/linker/Linker/Driver.cs
@@ -118,6 +118,11 @@ namespace Mono.Linker {
 							continue;
 						}
 
+						if (token == "--used-attrs-only") {
+							context.KeepUsedAttributeTypesOnly = bool.Parse (GetParam ());
+							continue;
+						}
+
 						switch (token [2]) {
 						case 'v':
 							Version ();
@@ -334,6 +339,7 @@ namespace Mono.Linker {
 			Console.WriteLine ("   --dependencies-file Specify the dependencies file path, if unset the default path is used: <output directory>/linker-dependencies.xml.gz");
 			Console.WriteLine ("   --dump-dependencies Dump dependencies for the linker analyzer tool");
 			Console.WriteLine ("   --reduced-tracing   Reduces dependency output related to assemblies that will not be modified");
+			Console.WriteLine ("   --used-attrs-only   Attributes on types, methods, etc will be removed if the attribute type is not used");
 			Console.WriteLine ("   -out                Specify the output directory, default to `output'");
 			Console.WriteLine ("   -c                  Action on the core assemblies, skip, copy, copyused, addbypassngen, addbypassngenused or link, default to skip");
 			Console.WriteLine ("   -u                  Action on the user assemblies, skip, copy, copyused, addbypassngen, addbypassngenused or link, default to link");

--- a/linker/Linker/LinkContext.cs
+++ b/linker/Linker/LinkContext.cs
@@ -109,6 +109,8 @@ namespace Mono.Linker {
 
 		public bool EnableReducedTracing { get; set; }
 
+		public bool KeepUsedAttributeTypesOnly { get; set; }
+
 		public System.Collections.IDictionary Actions {
 			get { return _actions; }
 		}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/AttributeDefinedAndUsedInOtherAssemblyIsKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/AttributeDefinedAndUsedInOtherAssemblyIsKept.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed.Dependencies;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
+	[SetupLinkerArgument ("--used-attrs-only", "true")]
+	[SetupCompileBefore ("library.dll", new [] { "Dependencies/AttributeDefinedAndUsedInOtherAssemblyIsKept_Lib.cs" })]
+	[KeptMemberInAssembly ("library.dll", typeof (AttributeDefinedAndUsedInOtherAssemblyIsKept_Lib.FooAttribute), ".ctor()")]
+	class AttributeDefinedAndUsedInOtherAssemblyIsKept {
+		static void Main ()
+		{
+			Method ();
+		}
+
+		[AttributeDefinedAndUsedInOtherAssemblyIsKept_Lib.Foo]
+		[Kept]
+		[KeptAttributeAttribute (typeof (AttributeDefinedAndUsedInOtherAssemblyIsKept_Lib.FooAttribute))]
+		static void Method ()
+		{
+			AttributeDefinedAndUsedInOtherAssemblyIsKept_Lib.UseTheAttributeType ();
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/AttributeUsedByAttributeIsKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/AttributeUsedByAttributeIsKept.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
+	[SetupLinkerArgument ("--used-attrs-only", "true")]
+	class AttributeUsedByAttributeIsKept {
+		static void Main ()
+		{
+			var jar = new Jar ();
+			jar.SomeMethod ();
+		}
+
+		[Foo]
+		[Bar]
+		[Kar]
+		[NotUsed]
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptAttributeAttribute (typeof(FooAttribute))]
+		[KeptAttributeAttribute (typeof(BarAttribute))]
+		[KeptAttributeAttribute (typeof(KarAttribute))]
+		class Jar {
+			[Kept]
+			public void SomeMethod ()
+			{
+				var attr = typeof (Jar).GetCustomAttributes (typeof (FooAttribute), false) [0];
+				var asFooAttr = (FooAttribute) attr;
+				asFooAttr.MethodWeWillCall ();
+			}
+		}
+
+		[Kept]
+		[KeptBaseType (typeof(Attribute))]
+		class FooAttribute : Attribute {
+			[Kept]
+			public FooAttribute ()
+			{
+				// This ctor should be marked lazy.  So let's use another attribute type here which should then trigger that attribute
+				// to be marked
+				var str = typeof (BarAttribute).ToString ();
+				MethodsUsedFromLateMarking.Method1 ();
+			}
+
+			[Foo]
+			[Bar]
+			[Kar]
+			[NotUsed]
+			[Kept]
+			[KeptAttributeAttribute (typeof (FooAttribute))]
+			[KeptAttributeAttribute (typeof (BarAttribute))]
+			[KeptAttributeAttribute (typeof (KarAttribute))]
+			public void MethodWeWillCall ()
+			{
+			}
+		}
+
+		[Kept]
+		[KeptBaseType (typeof(Attribute))]
+		class BarAttribute : Attribute {
+			[Kept]
+			public BarAttribute ()
+			{
+				// Let's do this one more time to make sure we catch everything
+				var str = typeof (KarAttribute).ToString ();
+				MethodsUsedFromLateMarking.Method2 ();
+			}
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (Attribute))]
+		class KarAttribute : Attribute {
+			[Kept]
+			public KarAttribute ()
+			{
+				MethodsUsedFromLateMarking.Method3 ();
+			}
+		}
+
+		class NotUsedAttribute : Attribute {
+		}
+
+		[Kept]
+		static class MethodsUsedFromLateMarking {
+			[Kept]
+			public static void Method1 ()
+			{
+			}
+
+			[Kept]
+			public static void Method2 ()
+			{
+			}
+
+			[Kept]
+			public static void Method3 ()
+			{
+			}
+		}
+
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/CanLinkCoreLibrariesWithOnlyKeepUsedAttributes.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/CanLinkCoreLibrariesWithOnlyKeepUsedAttributes.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Timers;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
+	[SetupLinkerCoreAction ("link")]
+	[SetupLinkerArgument ("--used-attrs-only", "true")]
+	[Reference ("System.dll")]
+
+	// Fails with `Runtime critical type System.Reflection.CustomAttributeData not found`
+	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
+	class CanLinkCoreLibrariesWithOnlyKeepUsedAttributes {
+		static void Main ()
+		{
+			// Use something from System so that the entire reference isn't linked away
+			var system = new Timer ();
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/Dependencies/AttributeDefinedAndUsedInOtherAssemblyIsKept_Lib.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/Dependencies/AttributeDefinedAndUsedInOtherAssemblyIsKept_Lib.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed.Dependencies {
+	public class AttributeDefinedAndUsedInOtherAssemblyIsKept_Lib {
+		public static void UseTheAttributeType ()
+		{
+			var str = typeof (FooAttribute).ToString ();
+		}
+
+		public class FooAttribute : Attribute {
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/Dependencies/UnusedAttributeWithTypeForwarderIsRemoved_Forwarder.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/Dependencies/UnusedAttributeWithTypeForwarderIsRemoved_Forwarder.cs
@@ -1,0 +1,6 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed.Dependencies;
+
+[assembly: TypeForwardedTo (typeof (UnusedAttributeWithTypeForwarderIsRemoved_LibAttribute))]
+[assembly: TypeForwardedTo (typeof (UnusedAttributeWithTypeForwarderIsRemoved_OtherUsedClass))]

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/Dependencies/UnusedAttributeWithTypeForwarderIsRemoved_Lib.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/Dependencies/UnusedAttributeWithTypeForwarderIsRemoved_Lib.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed.Dependencies {
+	public class UnusedAttributeWithTypeForwarderIsRemoved_LibAttribute : Attribute {
+		public UnusedAttributeWithTypeForwarderIsRemoved_LibAttribute (string arg)
+		{
+		}
+	}
+
+	public class UnusedAttributeWithTypeForwarderIsRemoved_OtherUsedClass {
+		public static void UsedMethod ()
+		{
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributePreservedViaLinkXmlIsKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributePreservedViaLinkXmlIsKept.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
+	[SetupLinkerArgument ("--used-attrs-only", "true")]
+	class UnusedAttributePreservedViaLinkXmlIsKept {
+		static void Main ()
+		{
+			var tmp = new Bar ();
+			tmp.Method ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptAttributeAttribute (typeof (FooAttribute))]
+		[Foo]
+		class Bar {
+			[Kept]
+			[KeptAttributeAttribute (typeof (FooAttribute))]
+			[Foo]
+			public void Method ()
+			{
+			}
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof (Attribute))]
+		class FooAttribute : Attribute {
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributePreservedViaLinkXmlIsKept.xml
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributePreservedViaLinkXmlIsKept.xml
@@ -1,0 +1,6 @@
+﻿<linker>
+  <assembly fullname="test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+    <type fullname="Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed.UnusedAttributePreservedViaLinkXmlIsKept/FooAttribute" preserve="all">
+    </type>
+  </assembly>
+</linker>

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeTypeOnAssemblyIsRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeTypeOnAssemblyIsRemoved.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+[assembly: UnusedAttributeTypeOnAssemblyIsRemoved.Foo]
+
+namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
+	[SetupLinkerArgument ("--used-attrs-only", "true")]
+	class UnusedAttributeTypeOnAssemblyIsRemoved {
+		static void Main ()
+		{
+		}
+
+		public class FooAttribute : Attribute {
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeTypeOnEventIsRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeTypeOnEventIsRemoved.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
+	[SetupLinkerArgument ("--used-attrs-only", "true")]
+	[KeptDelegateCacheField ("0")]
+	class UnusedAttributeTypeOnEventIsRemoved {
+		static void Main ()
+		{
+			var tmp = new Bar ();
+			tmp.Something += Tmp_Something;
+		}
+
+		[Kept]
+		private static void Tmp_Something (object sender, EventArgs e)
+		{
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		class Bar {
+			[Foo]
+			[Kept]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
+			public event EventHandler<EventArgs> Something { [Foo] add { } [Foo] remove { } }
+		}
+
+		class FooAttribute : Attribute {
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeTypeOnMethodIsRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeTypeOnMethodIsRemoved.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
+	[SetupLinkerArgument ("--used-attrs-only", "true")]
+	class UnusedAttributeTypeOnMethodIsRemoved {
+		static void Main ()
+		{
+			new Bar ().Method ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		class Bar {
+			[Foo]
+			[Kept]
+			public void Method ()
+			{
+			}
+		}
+
+		class FooAttribute : Attribute {
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeTypeOnModuleIsRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeTypeOnModuleIsRemoved.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+[module: UnusedAttributeTypeOnModuleIsRemoved.Foo]
+
+namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
+	[SetupLinkerArgument ("--used-attrs-only", "true")]
+	class UnusedAttributeTypeOnModuleIsRemoved {
+		static void Main ()
+		{
+		}
+
+		public class FooAttribute : Attribute {
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeTypeOnParameterIsRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeTypeOnParameterIsRemoved.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
+	[SetupLinkerArgument ("--used-attrs-only", "true")]
+	class UnusedAttributeTypeOnParameterIsRemoved {
+		static void Main ()
+		{
+			new Bar ().Method ("Hello");
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		class Bar {
+			[Kept]
+			public void Method ([Foo] string arg)
+			{
+			}
+		}
+
+		class FooAttribute : Attribute {
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeTypeOnPropertyIsRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeTypeOnPropertyIsRemoved.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
+	[SetupLinkerArgument ("--used-attrs-only", "true")]
+	class UnusedAttributeTypeOnPropertyIsRemoved {
+		static void Main ()
+		{
+			var bar = new Bar ();
+			bar.Value = "Hello";
+			var tmp = bar.Value;
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		class Bar {
+			[Foo]
+			[Kept]
+			[KeptBackingField]
+			public string Value { [Foo] [Kept] get; [Foo] [Kept] set; }
+		}
+
+		class FooAttribute : Attribute {
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeTypeOnTypeIsRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeTypeOnTypeIsRemoved.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
+	[SetupLinkerArgument ("--used-attrs-only", "true")]
+	class UnusedAttributeTypeOnTypeIsRemoved {
+		static void Main ()
+		{
+			new Bar ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[Foo]
+		class Bar {
+		}
+
+		class FooAttribute : Attribute {
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeWithTypeForwarderIsRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeWithTypeForwarderIsRemoved.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed.Dependencies;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
+	[KeepTypeForwarderOnlyAssemblies ("true")]
+	[SetupLinkerArgument ("--used-attrs-only", "true")]
+	[SetupCompileBefore ("library.dll", new[] { "Dependencies/UnusedAttributeWithTypeForwarderIsRemoved_Lib.cs" })]
+	[SetupCompileAfter ("implementation.dll", new[] { "Dependencies/UnusedAttributeWithTypeForwarderIsRemoved_Lib.cs" })]
+	[SetupCompileAfter ("library.dll", new[] { "Dependencies/UnusedAttributeWithTypeForwarderIsRemoved_Forwarder.cs" }, new[] { "implementation.dll" })]
+
+	[RemovedTypeInAssembly ("library.dll", typeof(UnusedAttributeWithTypeForwarderIsRemoved_LibAttribute))]
+	[RemovedTypeInAssembly ("implementation.dll", typeof (UnusedAttributeWithTypeForwarderIsRemoved_LibAttribute))]
+	class UnusedAttributeWithTypeForwarderIsRemoved {
+		static void Main ()
+		{
+			Method (null);
+		}
+
+		[Kept]
+		
+		static void Method ([UnusedAttributeWithTypeForwarderIsRemoved_Lib ("")] string arg)
+		{
+			UnusedAttributeWithTypeForwarderIsRemoved_OtherUsedClass.UsedMethod ();
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UsedAttributeTypeOnAssemblyIsKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UsedAttributeTypeOnAssemblyIsKept.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+[assembly: UsedAttributeTypeOnAssemblyIsKept.Foo]
+[assembly: KeptAttributeAttribute (typeof (UsedAttributeTypeOnAssemblyIsKept.FooAttribute))]
+
+namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
+	[SetupLinkerArgument("--used-attrs-only", "true")]
+	class UsedAttributeTypeOnAssemblyIsKept {
+		static void Main ()
+		{
+			var str = typeof (FooAttribute).ToString ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof (Attribute))]
+		public class FooAttribute : Attribute {
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UsedAttributeTypeOnEventIsKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UsedAttributeTypeOnEventIsKept.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
+	[SetupLinkerArgument ("--used-attrs-only", "true")]
+	[KeptDelegateCacheField ("0")]
+	class UsedAttributeTypeOnEventIsKept {
+		static void Main ()
+		{
+			var tmp = new Bar ();
+			tmp.Something += Tmp_Something;
+			var str = typeof (FooAttribute).ToString ();
+		}
+
+		[Kept]
+		private static void Tmp_Something (object sender, EventArgs e)
+		{
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		class Bar {
+			[Foo]
+			[Kept]
+			[KeptAttributeAttribute (typeof (FooAttribute))]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
+			public event EventHandler<EventArgs> Something { [Foo] [KeptAttributeAttribute (typeof (FooAttribute))] add { } [Foo] [KeptAttributeAttribute (typeof (FooAttribute))] remove { } }
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof(Attribute))]
+		class FooAttribute : Attribute {
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UsedAttributeTypeOnMethodIsKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UsedAttributeTypeOnMethodIsKept.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
+	[SetupLinkerArgument ("--used-attrs-only", "true")]
+	class UsedAttributeTypeOnMethodIsKept {
+		static void Main ()
+		{
+			new Bar ().Method ();
+			var tmp = new Bar ();
+			var str = typeof (FooAttribute).ToString ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		class Bar {
+			[Foo]
+			[Kept]
+			[KeptAttributeAttribute (typeof (FooAttribute))]
+			public void Method ()
+			{
+			}
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof(Attribute))]
+		class FooAttribute : Attribute {
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UsedAttributeTypeOnModuleIsKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UsedAttributeTypeOnModuleIsKept.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+[module: UsedAttributeTypeOnModuleIsKept.Foo]
+[module: KeptAttributeAttribute (typeof (UsedAttributeTypeOnModuleIsKept.FooAttribute))]
+
+namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
+	[SetupLinkerArgument ("--used-attrs-only", "true")]
+	class UsedAttributeTypeOnModuleIsKept {
+		static void Main ()
+		{
+			var str = typeof (FooAttribute).ToString ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof (Attribute))]
+		public class FooAttribute : Attribute {
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UsedAttributeTypeOnParameterIsKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UsedAttributeTypeOnParameterIsKept.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
+	[SetupLinkerArgument ("--used-attrs-only", "true")]
+	class UsedAttributeTypeOnParameterIsKept {
+		static void Main ()
+		{
+			new Bar ().Method ("Hello");
+			var str = typeof (FooAttribute).ToString ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		class Bar {
+			[Kept]
+			public void Method ([Foo] [KeptAttributeAttribute (typeof (FooAttribute))] string arg)
+			{
+			}
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof(Attribute))]
+		class FooAttribute : Attribute {
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UsedAttributeTypeOnPropertyIsKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UsedAttributeTypeOnPropertyIsKept.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
+	[SetupLinkerArgument ("--used-attrs-only", "true")]
+	class UsedAttributeTypeOnPropertyIsKept {
+		static void Main ()
+		{
+			var bar = new Bar ();
+			bar.Value = "Hello";
+			var tmp = bar.Value;
+			var str = typeof (FooAttribute).ToString ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		class Bar {
+			[Foo]
+			[Kept]
+			[KeptBackingField]
+			[KeptAttributeAttribute (typeof (FooAttribute))]
+			public string Value { [Foo] [Kept] [KeptAttributeAttribute (typeof (FooAttribute))] get; [Foo] [Kept] [KeptAttributeAttribute (typeof (FooAttribute))]set; }
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof(Attribute))]
+		class FooAttribute : Attribute {
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UsedAttributeTypeOnTypeIsKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UsedAttributeTypeOnTypeIsKept.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
+
+	[SetupLinkerArgument ("--used-attrs-only", "true")]
+	class UsedAttributeTypeOnTypeIsKept {
+		static void Main ()
+		{
+			var tmp = new Bar ();
+			var str = typeof (FooAttribute).ToString ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptAttributeAttribute (typeof (FooAttribute))]
+		[Foo]
+		class Bar {
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof (Attribute))]
+		class FooAttribute : Attribute {
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -50,6 +50,28 @@
     <Compile Include="Attributes\AttributeOnPreservedTypeWithUsedSetter.cs" />
     <Compile Include="Attributes\AttributeOnUsedMethodIsKept.cs" />
     <Compile Include="Attributes\AttributeOnUsedPropertyIsKept.cs" />
+    <None Include="Attributes\OnlyKeepUsed\Dependencies\UnusedAttributeWithTypeForwarderIsRemoved_Forwarder.cs" />
+    <Compile Include="Attributes\OnlyKeepUsed\Dependencies\UnusedAttributeWithTypeForwarderIsRemoved_Lib.cs" />
+    <Compile Include="Attributes\OnlyKeepUsed\AttributeDefinedAndUsedInOtherAssemblyIsKept.cs" />
+    <Compile Include="Attributes\OnlyKeepUsed\AttributeUsedByAttributeIsKept.cs" />
+    <Compile Include="Attributes\OnlyKeepUsed\UnusedAttributeTypeOnModuleIsRemoved.cs" />
+    <Compile Include="Attributes\OnlyKeepUsed\UnusedAttributeWithTypeForwarderIsRemoved.cs" />
+    <Compile Include="Attributes\OnlyKeepUsed\CanLinkCoreLibrariesWithOnlyKeepUsedAttributes.cs" />
+    <Compile Include="Attributes\OnlyKeepUsed\Dependencies\AttributeDefinedAndUsedInOtherAssemblyIsKept_Lib.cs" />
+    <Compile Include="Attributes\OnlyKeepUsed\UnusedAttributePreservedViaLinkXmlIsKept.cs" />
+    <Compile Include="Attributes\OnlyKeepUsed\UnusedAttributeTypeOnAssemblyIsRemoved.cs" />
+    <Compile Include="Attributes\OnlyKeepUsed\UnusedAttributeTypeOnEventIsRemoved.cs" />
+    <Compile Include="Attributes\OnlyKeepUsed\UnusedAttributeTypeOnMethodIsRemoved.cs" />
+    <Compile Include="Attributes\OnlyKeepUsed\UnusedAttributeTypeOnParameterIsRemoved.cs" />
+    <Compile Include="Attributes\OnlyKeepUsed\UnusedAttributeTypeOnPropertyIsRemoved.cs" />
+    <Compile Include="Attributes\OnlyKeepUsed\UnusedAttributeTypeOnTypeIsRemoved.cs" />
+    <Compile Include="Attributes\OnlyKeepUsed\UsedAttributeTypeOnAssemblyIsKept.cs" />
+    <Compile Include="Attributes\OnlyKeepUsed\UsedAttributeTypeOnEventIsKept.cs" />
+    <Compile Include="Attributes\OnlyKeepUsed\UsedAttributeTypeOnMethodIsKept.cs" />
+    <Compile Include="Attributes\OnlyKeepUsed\UsedAttributeTypeOnModuleIsKept.cs" />
+    <Compile Include="Attributes\OnlyKeepUsed\UsedAttributeTypeOnParameterIsKept.cs" />
+    <Compile Include="Attributes\OnlyKeepUsed\UsedAttributeTypeOnPropertyIsKept.cs" />
+    <Compile Include="Attributes\OnlyKeepUsed\UsedAttributeTypeOnTypeIsKept.cs" />
     <Compile Include="Attributes\SecurityAttributesOnUsedMethodAreKept.cs" />
     <Compile Include="Attributes\SecurityAttributesOnUsedTypeAreKept.cs" />
     <Compile Include="Attributes\Dependencies\AssemblyAttributeIsRemovedIfOnlyTypesUsedInAssembly_Lib.cs" />
@@ -185,6 +207,7 @@
     <Compile Include="LinkXml\PreserveBackingFieldWhenPropertyIsKept.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="Attributes\OnlyKeepUsed\UnusedAttributePreservedViaLinkXmlIsKept.xml" />
     <Content Include="LinkXml\CanPreserveTypesUsingRegex.xml" />
     <Content Include="LinkXml\CanPreserveAnExportedType.xml" />
     <Content Include="LinkXml\CanPreserveExportedTypesUsingRegex.xml" />

--- a/linker/Tests/TestCasesRunner/AssemblyChecker.cs
+++ b/linker/Tests/TestCasesRunner/AssemblyChecker.cs
@@ -29,6 +29,9 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			VerifyCustomAttributes (originalAssembly, linkedAssembly);
 			VerifySecurityAttributes (originalAssembly, linkedAssembly);
 
+			foreach (var originalModule in originalAssembly.Modules)
+				VerifyModule (originalModule, linkedAssembly.Modules.FirstOrDefault (m => m.Name == originalModule.Name));
+
 			VerifyResources (originalAssembly, linkedAssembly);
 
 			linkedMembers = new HashSet<string> (linkedAssembly.MainModule.AllMembers ().Select (s => {
@@ -55,6 +58,15 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			}
 
 			Assert.IsEmpty (linkedMembers, "Linked output includes unexpected member");
+		}
+
+		protected virtual void VerifyModule (ModuleDefinition original, ModuleDefinition linked)
+		{
+			// We never link away a module today so let's make sure the linked one isn't null
+			if (linked == null)
+				Assert.Fail ($"Linked assembly `{original.Assembly.Name.Name}` is missing module `{original.Name}`");
+
+			VerifyCustomAttributes (original, linked);
 		}
 
 		protected virtual void VerifyTypeDefinition (TypeDefinition original, TypeDefinition linked)


### PR DESCRIPTION
The way attributes work currently is that once a type, method, etc is marked, all of it's CustomAttributes are marked. Which marks the attribute type, it's fields and properties.

What this PR does is add a new option that causes the CustomAttributes marking to be queued. Later, after we've traversed all the calls, we process this queue. If the attribute type of a CustomAttribute was marked, then we mark instances of that CustomAttribute. If not, we don't mark these CustomAttributes and they will be removed by the SweepStep.

If a user wants to explicitly preserve a CustomAttribute, they would preserve the attribute type via link.xml. Once they do that, all CustomAttribute instances of that type will be kept.

I've made this an opt-in option since it is a rather significant behavior change.  If you'd prefer it be opt-out, let me know and I can flip it around.