### PR TITLE
Test framework defines TEST_FW_DEFINED_WINDOWS on windows

### DIFF
--- a/linker/Tests/TestCasesRunner/TestCaseMetadaProvider.cs
+++ b/linker/Tests/TestCasesRunner/TestCaseMetadaProvider.cs
@@ -106,9 +106,13 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 
 		public virtual IEnumerable<string> GetDefines ()
 		{
-			return _testCaseTypeDefinition.CustomAttributes
-				.Where (attr => attr.AttributeType.Name == nameof (DefineAttribute))
-				.Select (attr => (string) attr.ConstructorArguments.First ().Value);
+			// There are a few tests related to native pdbs where the assertions are different between windows and non-windows
+			// To enable test cases to define different expected behavior we set this special define
+			if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+				yield return "WIN32";
+
+			foreach (var attr in  _testCaseTypeDefinition.CustomAttributes.Where (attr => attr.AttributeType.Name == nameof (DefineAttribute)))
+				yield return (string) attr.ConstructorArguments.First ().Value;
 		}
 
 		public virtual string GetAssemblyName ()


### PR DESCRIPTION
In some new symbol handling tests I'm working on, I need to define slight differences in expected outcome from a test between windows & non-windows.

This PR has the test framework set a special define when running on windows.

Here's a part of the test I have that highlights why this is needed

```
	[Reference ("LibraryWithPdb.dll")]
	[SandboxDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll", "input/LibraryWithPdb.dll")]
	[SandboxDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb", "input/LibraryWithPdb.pdb")]
	[SetupLinkerLinkSymbols( "true")]

#if TEST_FW_DEFINED_WINDOWS
	[KeptSymbols ("LibraryWithPdb.dll")]
#else
	[RemovedSymbols("LibraryWithPdb.dll")]
#endif
	[KeptMemberInAssembly ("LibraryWithPdb.dll", typeof (LibraryWithPdb), "SomeMethod()")]
	[RemovedMemberInAssembly ("LibraryWithPdb.dll", typeof (LibraryWithPdb), "NotUsed()")]
	class ReferenceWithPdbAndSymbolLinkingEnabled {
```

On Windows I'll expect the symbols to be included in the output.  On OSX and Linux, I will expect the linker to behave normally aside from ignoring the native pdb.