### PR TITLE
Testing infrastructure changes to prepare for symbol tests

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupCompileAfterAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupCompileAfterAttribute.cs
@@ -6,7 +6,7 @@ namespace Mono.Linker.Tests.Cases.Expectations.Metadata {
 	/// </summary>
 	[AttributeUsage (AttributeTargets.Class, AllowMultiple = true)]
 	public class SetupCompileAfterAttribute : BaseMetadataAttribute {
-		public SetupCompileAfterAttribute (string outputName, string[] sourceFiles, string[] references = null, string[] defines = null)
+		public SetupCompileAfterAttribute (string outputName, string[] sourceFiles, string[] references = null, string[] defines = null, string additionalArguments = null)
 		{
 			if (sourceFiles == null)
 				throw new ArgumentNullException (nameof (sourceFiles));

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupCompileBeforeAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupCompileBeforeAttribute.cs
@@ -6,7 +6,7 @@ namespace Mono.Linker.Tests.Cases.Expectations.Metadata {
 	/// </summary>
 	[AttributeUsage (AttributeTargets.Class, AllowMultiple = true)]
 	public class SetupCompileBeforeAttribute : BaseMetadataAttribute {
-		public SetupCompileBeforeAttribute (string outputName, string[] sourceFiles, string[] references = null, string[] defines = null, bool addAsReference = true)
+		public SetupCompileBeforeAttribute (string outputName, string[] sourceFiles, string[] references = null, string[] defines = null, string additionalArguments = null, bool addAsReference = true)
 		{
 			if (sourceFiles == null)
 				throw new ArgumentNullException (nameof (sourceFiles));

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupLinkerLinkSymbolsAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupLinkerLinkSymbolsAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Metadata {
+	[AttributeUsage (AttributeTargets.Class)]
+	public class SetupLinkerLinkSymbolsAttribute : BaseMetadataAttribute {
+		public SetupLinkerLinkSymbolsAttribute (string value)
+		{
+			if (string.IsNullOrEmpty (value))
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (value));
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Metadata\SetupLinkerArgumentAttribute.cs" />
     <Compile Include="Metadata\SetupLinkerCoreActionAttribute.cs" />
     <Compile Include="Metadata\SetupCompileResourceAttribute.cs" />
+    <Compile Include="Metadata\SetupLinkerLinkSymbolsAttribute.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/linker/Tests/TestCasesRunner/LinkerArgumentBuilder.cs
+++ b/linker/Tests/TestCasesRunner/LinkerArgumentBuilder.cs
@@ -52,6 +52,12 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			if (bool.Parse (value))
 				Append ("-t");
 		}
+		
+		public virtual void AddLinkSymbols (string value)
+		{
+			Append ("-b");
+			Append (value);
+		}
 
 		public virtual void AddAssemblyAction (string action, string assembly)
 		{
@@ -98,6 +104,9 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 
 			if (!string.IsNullOrEmpty (options.KeepTypeForwarderOnlyAssemblies))
 				AddKeepTypeForwarderOnlyAssemblies (options.KeepTypeForwarderOnlyAssemblies);
+			
+			if (!string.IsNullOrEmpty (options.LinkSymbols))
+				AddLinkSymbols (options.LinkSymbols);
 
 			// Unity uses different argument format and needs to be able to translate to their format.  In order to make that easier
 			// we keep the information in flag + values format for as long as we can so that this information doesn't have to be parsed out of a single string

--- a/linker/Tests/TestCasesRunner/SetupCompileInfo.cs
+++ b/linker/Tests/TestCasesRunner/SetupCompileInfo.cs
@@ -7,6 +7,7 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 		public NPath[] SourceFiles;
 		public string[] Defines;
 		public string[] References;
+		public string AdditionalArguments;
 		public bool AddAsReference;
 	}
 }

--- a/linker/Tests/TestCasesRunner/TestCaseLinkerOptions.cs
+++ b/linker/Tests/TestCasesRunner/TestCaseLinkerOptions.cs
@@ -10,6 +10,7 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 		public string Il8n;
 		public bool IncludeBlacklistStep;
 		public string KeepTypeForwarderOnlyAssemblies;
+		public string LinkSymbols;
 
 		public List<KeyValuePair<string, string[]>> AdditionalArguments = new List<KeyValuePair<string, string[]>> ();
 	}

--- a/linker/Tests/TestCasesRunner/TestCaseMetadaProvider.cs
+++ b/linker/Tests/TestCasesRunner/TestCaseMetadaProvider.cs
@@ -30,6 +30,7 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 				Il8n = GetOptionAttributeValue (nameof (Il8nAttribute), "none"),
 				IncludeBlacklistStep = GetOptionAttributeValue (nameof (IncludeBlacklistStepAttribute), false),
 				KeepTypeForwarderOnlyAssemblies = GetOptionAttributeValue (nameof (KeepTypeForwarderOnlyAssembliesAttribute), string.Empty),
+				LinkSymbols = GetOptionAttributeValue (nameof (SetupLinkerLinkSymbolsAttribute), string.Empty),
 				CoreAssembliesAction = GetOptionAttributeValue<string> (nameof (SetupLinkerCoreActionAttribute), null)
 			};
 
@@ -49,13 +50,21 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			return tclo;
 		}
 
-		public virtual IEnumerable<string> GetReferencedAssemblies (NPath workingDirectory)
+		public virtual IEnumerable<string> GetCommonReferencedAssemblies (NPath workingDirectory)
 		{
 			yield return workingDirectory.Combine ("Mono.Linker.Tests.Cases.Expectations.dll").ToString ();
 			yield return "mscorlib.dll";
+		}
 
+		public virtual IEnumerable<string> GetReferencedAssemblies (NPath workingDirectory)
+		{
 			foreach (var referenceAttr in _testCaseTypeDefinition.CustomAttributes.Where (attr => attr.AttributeType.Name == nameof (ReferenceAttribute))) {
-				yield return (string) referenceAttr.ConstructorArguments.First ().Value;
+				var fileName = (string) referenceAttr.ConstructorArguments.First ().Value;
+				if (fileName.StartsWith ("System.", StringComparison.Ordinal) || fileName.StartsWith ("Mono.", StringComparison.Ordinal) || fileName.StartsWith ("Microsoft.", StringComparison.Ordinal))
+					yield return fileName;
+				else
+					yield return workingDirectory.Combine (fileName);
+
 			}
 		}
 
@@ -153,7 +162,8 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 				SourceFiles = ((CustomAttributeArgument []) ctorArguments [1].Value).Select (arg => _testCase.SourceFile.Parent.Combine (arg.Value.ToString ())).ToArray (),
 				References = ((CustomAttributeArgument []) ctorArguments [2].Value)?.Select (arg => arg.Value.ToString ()).ToArray (),
 				Defines = ((CustomAttributeArgument []) ctorArguments [3].Value)?.Select (arg => arg.Value.ToString ()).ToArray (),
-				AddAsReference = ctorArguments.Count >= 5 ? (bool) ctorArguments [4].Value : true
+				AdditionalArguments = (string) ctorArguments [4].Value,
+				AddAsReference = ctorArguments.Count >= 6 ? (bool) ctorArguments [5].Value : true
 			};
 		}
 	}

--- a/linker/Tests/TestCasesRunner/TestCaseSandbox.cs
+++ b/linker/Tests/TestCasesRunner/TestCaseSandbox.cs
@@ -67,7 +67,14 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			CopyToInputAndExpectations (GetExpectationsAssemblyPath ());
 
 			foreach (var dep in metadataProvider.AdditionalFilesToSandbox ()) {
-				dep.Source.FileMustExist ().Copy (_directory.Combine (dep.DestinationFileName));
+				var destination = _directory.Combine (dep.DestinationFileName);
+				dep.Source.FileMustExist ().Copy (destination);
+
+				// In a few niche tests we need to copy pre-built assemblies directly into the input directory.
+				// When this is done, we also need to copy them into the expectations directory so that if they are used
+				// as references we can still compile the expectations version of the assemblies
+				if (destination.Parent == InputDirectory)
+					dep.Source.Copy (ExpectationsDirectory.Combine (destination.RelativeTo (InputDirectory)));
 			}
 
 			foreach (var res in metadataProvider.GetResources ()) {

--- a/linker/Tests/TestCasesRunner/TestRunner.cs
+++ b/linker/Tests/TestCasesRunner/TestRunner.cs
@@ -42,13 +42,15 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 
 			var assemblyName = metadataProvider.GetAssemblyName ();
 
-			var references = metadataProvider.GetReferencedAssemblies(sandbox.InputDirectory);
+			var commonReferences = metadataProvider.GetCommonReferencedAssemblies(sandbox.InputDirectory).ToArray ();
+			var mainAssemblyReferences = metadataProvider.GetReferencedAssemblies(sandbox.InputDirectory).ToArray ();
 			var resources = sandbox.ResourceFiles.ToArray ();
 			var additionalArguments = metadataProvider.GetSetupCompilerArguments ().ToArray ();
-			var inputAssemblyPath = compiler.CompileTestIn (sandbox.InputDirectory, assemblyName, sourceFiles, references, null, resources, additionalArguments);
+			var inputAssemblyPath = compiler.CompileTestIn (sandbox.InputDirectory, assemblyName, sourceFiles, commonReferences, mainAssemblyReferences, null, resources, additionalArguments);
 
-			references = metadataProvider.GetReferencedAssemblies(sandbox.ExpectationsDirectory);
-			var expectationsAssemblyPath = compiler.CompileTestIn (sandbox.ExpectationsDirectory, assemblyName, sourceFiles, references, new [] { "INCLUDE_EXPECTATIONS" }, resources, additionalArguments);
+			commonReferences = metadataProvider.GetCommonReferencedAssemblies(sandbox.ExpectationsDirectory).ToArray ();
+			mainAssemblyReferences = metadataProvider.GetReferencedAssemblies(sandbox.ExpectationsDirectory).ToArray ();
+			var expectationsAssemblyPath = compiler.CompileTestIn (sandbox.ExpectationsDirectory, assemblyName, sourceFiles,  commonReferences, mainAssemblyReferences, new [] { "INCLUDE_EXPECTATIONS" }, resources, additionalArguments);
 			return new ManagedCompilationResult (inputAssemblyPath, expectationsAssemblyPath);
 		}
 


### PR DESCRIPTION
This PR contains a few small changes that will be needed by upcoming work to add a full suite of symbol tests to get coverage on handling all the various types of symbol files.

* Support defining additional compiler arguments when compiling extra assemblies for test cases

* Adjustments to how test cases setup references.  No longer will the extra assemblies inherit references added via [Reference] to the main test case.  This was done out of convenience, but it started to cause problems with the symbol tests that are coming. 

* Test case support for [SetupLinkerLinkSymbols]