### PR TITLE
Use Run to run the linker instead of Main so that exceptions are not caught

### DIFF
--- a/linker/Linker/Driver.cs
+++ b/linker/Linker/Driver.cs
@@ -75,7 +75,7 @@ namespace Mono.Linker {
 			return _queue.Count > 0;
 		}
 
-		void Run ()
+		public void Run ()
 		{
 			Pipeline p = GetStandardPipeline ();
 			using (LinkContext context = GetDefaultContext (p)) {

--- a/linker/Tests/TestCasesRunner/LinkerDriver.cs
+++ b/linker/Tests/TestCasesRunner/LinkerDriver.cs
@@ -2,7 +2,7 @@
 	public class LinkerDriver {
 		public virtual void Link (string [] args)
 		{
-			Driver.Main (args);
+			new Driver (args).Run ();
 		}
 	}
 }


### PR DESCRIPTION
When the linker hits an exception today during a test, the exception is caught and the test framework continues on and you get some odd failure message.