### PR TITLE
Extract the reflection marking code to a method

### DIFF
--- a/linker/Linker.Steps/MarkStep.cs
+++ b/linker/Linker.Steps/MarkStep.cs
@@ -1574,6 +1574,11 @@ namespace Mono.Linker.Steps {
 			foreach (Instruction instruction in body.Instructions)
 				MarkInstruction (instruction);
 
+			MarkThingsUsedViaReflection (body);
+		}
+
+		protected virtual void MarkThingsUsedViaReflection (MethodBody body)
+		{
 			MarkSomethingUsedViaReflection ("GetConstructor", MarkConstructorsUsedViaReflection, body.Instructions);
 			MarkSomethingUsedViaReflection ("GetMethod", MarkMethodsUsedViaReflection, body.Instructions);
 			MarkSomethingUsedViaReflection ("GetProperty", MarkPropertyUsedViaReflection, body.Instructions);


### PR DESCRIPTION
We need to specialize this behavior in the Unity linker, so extract it
to a virtual method that the Unity linker can override. This should not
change its behavior at all.