### PR TITLE
Support for explicitly using csc to compile test case

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupCSharpCompilerToUseAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupCSharpCompilerToUseAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Metadata {
+	[AttributeUsage (AttributeTargets.Class, AllowMultiple = false)]
+	public class SetupCSharpCompilerToUseAttribute : BaseMetadataAttribute {
+		public SetupCSharpCompilerToUseAttribute (string name)
+		{
+			if (string.IsNullOrEmpty (name))
+				throw new ArgumentNullException (nameof (name));
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupCompileAfterAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupCompileAfterAttribute.cs
@@ -6,7 +6,7 @@ namespace Mono.Linker.Tests.Cases.Expectations.Metadata {
 	/// </summary>
 	[AttributeUsage (AttributeTargets.Class, AllowMultiple = true)]
 	public class SetupCompileAfterAttribute : BaseMetadataAttribute {
-		public SetupCompileAfterAttribute (string outputName, string[] sourceFiles, string[] references = null, string[] defines = null, string additionalArguments = null)
+		public SetupCompileAfterAttribute (string outputName, string[] sourceFiles, string[] references = null, string[] defines = null, string additionalArguments = null, string compilerToUse = null)
 		{
 			if (sourceFiles == null)
 				throw new ArgumentNullException (nameof (sourceFiles));

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupCompileBeforeAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupCompileBeforeAttribute.cs
@@ -6,7 +6,7 @@ namespace Mono.Linker.Tests.Cases.Expectations.Metadata {
 	/// </summary>
 	[AttributeUsage (AttributeTargets.Class, AllowMultiple = true)]
 	public class SetupCompileBeforeAttribute : BaseMetadataAttribute {
-		public SetupCompileBeforeAttribute (string outputName, string[] sourceFiles, string[] references = null, string[] defines = null, string additionalArguments = null, bool addAsReference = true)
+		public SetupCompileBeforeAttribute (string outputName, string[] sourceFiles, string[] references = null, string[] defines = null, string additionalArguments = null, string compilerToUse = null, bool addAsReference = true)
 		{
 			if (sourceFiles == null)
 				throw new ArgumentNullException (nameof (sourceFiles));

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Assertions\KeptInterfaceAttribute.cs" />
     <Compile Include="Assertions\KeptAttributeAttribute.cs" />
     <Compile Include="Assertions\RemovedForwarderAttribute.cs" />
+    <Compile Include="Metadata\SetupCSharpCompilerToUseAttribute.cs" />
     <Compile Include="Metadata\SetupLinkerActionAttribute.cs" />
     <Compile Include="Metadata\SetupLinkerArgumentAttribute.cs" />
     <Compile Include="Metadata\SetupLinkerCoreActionAttribute.cs" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -100,6 +100,10 @@
     <Compile Include="Resources\NonLinkerEmbeddedResourceHasNoImpact.cs" />
     <Compile Include="TestFramework\CanCompileILAssembly.cs" />
     <Compile Include="TestFramework\CanCompileTestCaseWithDebugPdbs.cs" />
+    <Compile Include="TestFramework\CanCompileTestCaseWithCsc.cs" />
+    <Compile Include="TestFramework\CanCompileTestCaseWithMsc.cs" />
+    <Compile Include="TestFramework\Dependencies\CanCompileTestCaseWithCsc_Lib.cs" />
+    <Compile Include="TestFramework\Dependencies\CanCompileTestCaseWithMcs_Lib.cs" />
     <Compile Include="TestFramework\VerifyDefineAttributeBehavior.cs" />
     <None Include="TypeForwarding\Dependencies\ForwarderLibrary.cs" />
     <Compile Include="TestFramework\VerifyResourceInAssemblyAttributesBehavior.cs" />
@@ -211,6 +215,8 @@
     <Content Include="Resources\Dependencies\EmbeddedLinkXmlFileIsNotProcessedWhenCoreLinkActionIsSkip.xml" />
     <Content Include="Resources\Dependencies\EmbeddedLinkXmlFileIsProcessed.xml" />
     <Content Include="Resources\Dependencies\NonLinkerEmbeddedResourceHasNoImpact.xml" />
+    <Content Include="TestFramework\Dependencies\CanCompileTestCaseWithCsc.txt" />
+    <Content Include="TestFramework\Dependencies\CanCompileTestCaseWithMcs.txt" />
     <Content Include="TestFramework\Dependencies\VerifyResourceInAssemblyAttributesBehavior.txt" />
     <Content Include="LinkXml\PreserveBackingFieldWhenPropertyIsKept.xml" />
   </ItemGroup>

--- a/linker/Tests/Mono.Linker.Tests.Cases/TestFramework/CanCompileTestCaseWithCsc.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/TestFramework/CanCompileTestCaseWithCsc.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.TestFramework.Dependencies;
+
+[assembly: KeptAttributeAttribute (typeof (System.Diagnostics.DebuggableAttribute))]
+
+namespace Mono.Linker.Tests.Cases.TestFramework {
+	[SetupCSharpCompilerToUse ("csc")]
+
+	// Use all of the compiler setup attributes so that we can verify they all work
+	// when roslyn is used
+	[SetupCompileArgument ("/debug:pdbonly")]
+	[SetupCompileResource ("Dependencies/CanCompileTestCaseWithCsc.txt")]
+	[Define ("VERIFY_DEFINE_WORKS")]
+	[Reference ("System.dll")]
+
+	[SetupCompileBefore ("library.dll", new [] { "Dependencies/CanCompileTestCaseWithCsc_Lib.cs" }, compilerToUse: "csc")]
+
+	[KeptResource ("CanCompileTestCaseWithCsc.txt")]
+	[KeptMemberInAssembly ("library.dll", typeof (CanCompileTestCaseWithCsc_Lib), "Used()")]
+	class CanCompileTestCaseWithCsc {
+		static void Main ()
+		{
+#if VERIFY_DEFINE_WORKS
+			UsedByDefine ();
+#endif
+			// Use something from System.dll so that we can verify the reference attribute works
+			var timer = new System.Timers.Timer ();
+
+			CanCompileTestCaseWithCsc_Lib.Used ();
+		}
+
+		[Kept]
+		static void UsedByDefine ()
+		{
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/TestFramework/CanCompileTestCaseWithMsc.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/TestFramework/CanCompileTestCaseWithMsc.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.TestFramework.Dependencies;
+
+[assembly: KeptAttributeAttribute (typeof (System.Diagnostics.DebuggableAttribute))]
+
+namespace Mono.Linker.Tests.Cases.TestFramework {
+	[SetupCSharpCompilerToUse ("mcs")]
+
+	// Use all of the compiler setup attributes so that we can verify they all work
+	// when roslyn is used
+	[SetupCompileArgument ("/debug:pdbonly")]
+	[SetupCompileResource ("Dependencies/CanCompileTestCaseWithMcs.txt")]
+	[Define ("VERIFY_DEFINE_WORKS")]
+	[Reference ("System.dll")]
+
+	[SetupCompileBefore ("library.dll", new[] { "Dependencies/CanCompileTestCaseWithMcs_Lib.cs" }, compilerToUse: "mcs")]
+
+	[KeptResource ("CanCompileTestCaseWithMcs.txt")]
+	[KeptMemberInAssembly ("library.dll", typeof (CanCompileTestCaseWithMcs_Lib), "Used()")]
+	class CanCompileTestCaseWithMsc {
+		static void Main ()
+		{
+#if VERIFY_DEFINE_WORKS
+			UsedByDefine ();
+#endif
+			// Use something from System.dll so that we can verify the reference attribute works
+			var timer = new System.Timers.Timer ();
+
+			CanCompileTestCaseWithMcs_Lib.Used ();
+		}
+
+		[Kept]
+		static void UsedByDefine ()
+		{
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/TestFramework/Dependencies/CanCompileTestCaseWithCsc.txt
+++ b/linker/Tests/Mono.Linker.Tests.Cases/TestFramework/Dependencies/CanCompileTestCaseWithCsc.txt
@@ -1,0 +1,1 @@
+﻿Resource that is kept

--- a/linker/Tests/Mono.Linker.Tests.Cases/TestFramework/Dependencies/CanCompileTestCaseWithCsc_Lib.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/TestFramework/Dependencies/CanCompileTestCaseWithCsc_Lib.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Mono.Linker.Tests.Cases.TestFramework.Dependencies {
+	public class CanCompileTestCaseWithCsc_Lib {
+		public static void Used ()
+		{
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/TestFramework/Dependencies/CanCompileTestCaseWithMcs.txt
+++ b/linker/Tests/Mono.Linker.Tests.Cases/TestFramework/Dependencies/CanCompileTestCaseWithMcs.txt
@@ -1,0 +1,1 @@
+﻿Resource that is kept

--- a/linker/Tests/Mono.Linker.Tests.Cases/TestFramework/Dependencies/CanCompileTestCaseWithMcs_Lib.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/TestFramework/Dependencies/CanCompileTestCaseWithMcs_Lib.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Mono.Linker.Tests.Cases.TestFramework.Dependencies {
+	public class CanCompileTestCaseWithMcs_Lib {
+		public static void Used ()
+		{
+		}
+	}
+}

--- a/linker/Tests/TestCasesRunner/CompilerOptions.cs
+++ b/linker/Tests/TestCasesRunner/CompilerOptions.cs
@@ -9,5 +9,6 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 		public NPath[] References;
 		public NPath[] Resources;
 		public string[] AdditionalArguments;
+		public string CompilerToUse;
 	}
 }

--- a/linker/Tests/TestCasesRunner/SetupCompileInfo.cs
+++ b/linker/Tests/TestCasesRunner/SetupCompileInfo.cs
@@ -8,6 +8,7 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 		public string[] Defines;
 		public string[] References;
 		public string AdditionalArguments;
+		public string CompilerToUse;
 		public bool AddAsReference;
 	}
 }

--- a/linker/Tests/TestCasesRunner/TestCaseCompiler.cs
+++ b/linker/Tests/TestCasesRunner/TestCaseCompiler.cs
@@ -1,13 +1,16 @@
 ﻿﻿using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
 using Mono.Linker.Tests.Extensions;
+using NUnit.Framework;
 
 namespace Mono.Linker.Tests.TestCasesRunner {
 	public class TestCaseCompiler {
+		static string _cachedWindowsCscPath = null;
 		protected readonly TestCaseMetadaProvider _metadataProvider;
 		protected readonly TestCaseSandbox _sandbox;
 		protected readonly ILCompiler _ilCompiler;
@@ -69,7 +72,8 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 				References = references,
 				Defines = defines.Concat (_metadataProvider.GetDefines ()).ToArray (),
 				Resources = resources,
-				AdditionalArguments = additionalArguments
+				AdditionalArguments = additionalArguments,
+				CompilerToUse = _metadataProvider.GetCSharpCompilerToUse ()
 			};
 		}
 
@@ -84,7 +88,8 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 				SourceFiles = sourceFiles,
 				References = allReferences,
 				Defines = allDefines,
-				AdditionalArguments = additionalArguments
+				AdditionalArguments = additionalArguments,
+				CompilerToUse = setupCompileInfo.CompilerToUse?.ToLower ()
 			};
 		}
 
@@ -155,7 +160,7 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			throw new NotSupportedException ($"Unable to compile sources files with extension `{options.SourceFiles.First ().ExtensionWithDot}`");
 		}
 
-		protected virtual NPath CompileCSharpAssembly (CompilerOptions options)
+		protected virtual NPath CompileCSharpAssemblyWithDefaultCompiler (CompilerOptions options)
 		{
 			var compilerOptions = CreateCodeDomCompilerOptions (options);
 			var provider = CodeDomProvider.CreateProvider ("C#");
@@ -167,6 +172,135 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			foreach (var error in result.Errors)
 				errors.AppendLine (error.ToString ());
 			throw new Exception ("Compilation errors: " + errors);
+		}
+
+		protected virtual NPath CompileCSharpAssemblyWithCsc (CompilerOptions options)
+		{
+			return CompileCSharpAssemblyWithExternalCompiler (LocateCscExecutable (), options);
+		}
+
+		protected virtual NPath CompileCSharpAssemblyWithMsc(CompilerOptions options)
+		{
+			if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+				CompileCSharpAssemblyWithExternalCompiler (LocateMcsExecutable (), options);
+
+			return CompileCSharpAssemblyWithDefaultCompiler (options);
+		}
+
+		protected NPath CompileCSharpAssemblyWithExternalCompiler (string executable, CompilerOptions options)
+		{
+			var capturedOutput = new List<string> ();
+			var process = new Process ();
+			process.StartInfo.FileName = executable;
+			process.StartInfo.Arguments = OptionsToCompilerCommandLineArguments (options);
+			process.StartInfo.UseShellExecute = false;
+			process.StartInfo.CreateNoWindow = true;
+			process.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
+			process.StartInfo.RedirectStandardOutput = true;
+			process.OutputDataReceived += (sender, args) => capturedOutput.Add (args.Data);
+			process.Start ();
+			process.BeginOutputReadLine ();
+			process.WaitForExit ();
+
+			if (process.ExitCode != 0)
+				Assert.Fail ($"Failed to compile assembly with csc: {options.OutputPath}\n{capturedOutput.Aggregate ((buff, s) => buff + Environment.NewLine + s)}");
+
+			return options.OutputPath;
+		}
+
+		static string LocateCscExecutable ()
+		{
+			if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+				return "csc";
+
+			if (_cachedWindowsCscPath != null)
+				return _cachedWindowsCscPath;
+
+			var capturedOutput = new List<string> ();
+			var process = new Process ();
+
+			var vswherePath = Environment.ExpandEnvironmentVariables ("%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\vswhere.exe");
+			if (!File.Exists (vswherePath))
+				Assert.Fail ($"Unable to locate csc.exe on windows because vshwere.exe was not found at {vswherePath}");
+
+			process.StartInfo.FileName = vswherePath;
+			process.StartInfo.Arguments = "-latest -products * -requires Microsoft.Component.MSBuild -property installationPath";
+			process.StartInfo.UseShellExecute = false;
+			process.StartInfo.CreateNoWindow = true;
+			process.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
+			process.StartInfo.RedirectStandardOutput = true;
+			process.OutputDataReceived += (sender, args) => capturedOutput.Add (args.Data);
+			process.Start ();
+			process.BeginOutputReadLine ();
+			process.WaitForExit ();
+
+			if (process.ExitCode != 0)
+				Assert.Fail ($"vswhere.exe failed with :\n{capturedOutput.Aggregate ((buff, s) => buff + Environment.NewLine + s)}");
+
+			if (capturedOutput.Count == 0 || string.IsNullOrEmpty (capturedOutput [0]))
+				Assert.Fail ("vswhere.exe was unable to locate an install directory");
+
+			var installPath = capturedOutput [0].Trim ().ToNPath ();
+
+			if (!installPath.Exists ())
+				Assert.Fail ($"No install found at {installPath}");
+
+			// Do a search for the roslyn directory for a little bit of furture proofing since it normally lives under
+			// a versioned msbuild directory
+			foreach (var roslynDirectory in installPath.Directories ("Roslyn", true)) {
+				var possibleCscPath = roslynDirectory.Combine ("csc.exe");
+				if (possibleCscPath.Exists ()) {
+					_cachedWindowsCscPath = possibleCscPath.ToString ();
+					return _cachedWindowsCscPath;
+				}
+			}
+
+			Assert.Fail ("Unable to locate a roslyn csc.exe");
+			return null;
+		}
+
+		static string LocateMcsExecutable ()
+		{
+			if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+				Assert.Ignore ("We don't have a universal way of locating mcs on Windows");
+
+			return "mcs";
+		}
+
+		protected string OptionsToCompilerCommandLineArguments (CompilerOptions options)
+		{
+			var builder = new StringBuilder ();
+			builder.Append ($"/out:{options.OutputPath}");
+			var target = options.OutputPath.ExtensionWithDot == ".exe" ? "exe" : "library";
+			builder.Append ($" /target:{target}");
+			if (options.Defines != null && options.Defines.Length > 0)
+				builder.Append (options.Defines.Aggregate (string.Empty, (buff, arg) => $"{buff} /define:{arg}"));
+
+			builder.Append (options.References.Aggregate (string.Empty, (buff, arg) => $"{buff} /r:{arg}"));
+
+			if (options.Resources != null && options.Resources.Length > 0)
+				builder.Append (options.Resources.Aggregate (string.Empty, (buff, arg) => $"{buff} /res:{arg}"));
+
+			if (options.AdditionalArguments != null && options.AdditionalArguments.Length > 0)
+				builder.Append (options.AdditionalArguments.Aggregate (string.Empty, (buff, arg) => $"{buff} {arg}"));
+
+			builder.Append (options.SourceFiles.Aggregate (string.Empty, (buff, arg) => $"{buff} {arg}"));
+
+			return builder.ToString ();
+		}
+
+		protected NPath CompileCSharpAssembly (CompilerOptions options)
+		{
+			if (string.IsNullOrEmpty (options.CompilerToUse))
+				return CompileCSharpAssemblyWithDefaultCompiler (options);
+
+			if (options.CompilerToUse == "csc")
+				return CompileCSharpAssemblyWithCsc (options);
+
+			if (options.CompilerToUse == "mcs")
+				return CompileCSharpAssemblyWithMsc (options);
+
+			throw new ArgumentException ($"Invalid compiler value `{options.CompilerToUse}`");
 		}
 
 		protected NPath CompileIlAssembly (CompilerOptions options)

--- a/linker/Tests/TestCasesRunner/TestCaseMetadaProvider.cs
+++ b/linker/Tests/TestCasesRunner/TestCaseMetadaProvider.cs
@@ -125,6 +125,11 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			return GetOptionAttributeValue (nameof (SetupCompileAssemblyNameAttribute), "test.exe");
 		}
 
+		public virtual string GetCSharpCompilerToUse ()
+		{
+			return GetOptionAttributeValue (nameof (SetupCSharpCompilerToUseAttribute), string.Empty).ToLower ();
+		}
+
 		public virtual IEnumerable<string> GetSetupCompilerArguments ()
 		{
 			return _testCaseTypeDefinition.CustomAttributes
@@ -163,7 +168,8 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 				References = ((CustomAttributeArgument []) ctorArguments [2].Value)?.Select (arg => arg.Value.ToString ()).ToArray (),
 				Defines = ((CustomAttributeArgument []) ctorArguments [3].Value)?.Select (arg => arg.Value.ToString ()).ToArray (),
 				AdditionalArguments = (string) ctorArguments [4].Value,
-				AddAsReference = ctorArguments.Count >= 6 ? (bool) ctorArguments [5].Value : true
+				CompilerToUse = (string) ctorArguments [5].Value,
+				AddAsReference = ctorArguments.Count >= 7 ? (bool) ctorArguments [6].Value : true
 			};
 		}
 	}


### PR DESCRIPTION
A requirement for symbol tests that are coming is access to a roslyn compiler so that we can generate portable and embedded pdbs.

This PR adds a general mechanism for tests to define which compiler they need to use when compiling a test case.