### PR TITLE
Use portable instead of pdbonly to avoid error on windows with mono csc

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases/TestFramework/CanCompileTestCaseWithCsc.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/TestFramework/CanCompileTestCaseWithCsc.cs
@@ -10,7 +10,7 @@ namespace Mono.Linker.Tests.Cases.TestFramework {
 
 	// Use all of the compiler setup attributes so that we can verify they all work
 	// when roslyn is used
-	[SetupCompileArgument ("/debug:pdbonly")]
+	[SetupCompileArgument ("/debug:portable")]
 	[SetupCompileResource ("Dependencies/CanCompileTestCaseWithCsc.txt")]
 	[Define ("VERIFY_DEFINE_WORKS")]
 	[Reference ("System.dll")]


### PR DESCRIPTION
The purpose of this test is simply to verify that a test case can use csc.  The mono csc can error with the following on Windows

```error CS0041: Unexpected error writing debug information -- 'The version of Windows PDB writer is older than required: 'diasymreader.dll''```

In our UnityLinker test suite we use the csc with mono instead of a system install csc from MSBuild.

To get around this, use /debug:portable which is supported by both and doesn't undermine the goal of the test