### PR TITLE
Fix for embedded pdb when copy and no link symbols

### DIFF
--- a/linker/Linker.Steps/OutputStep.cs
+++ b/linker/Linker.Steps/OutputStep.cs
@@ -93,7 +93,12 @@ namespace Mono.Linker.Steps {
 				(module.Attributes & (ModuleAttributes) 0x04) != 0;
 		}
 
-		protected virtual void WriteAssembly (AssemblyDefinition assembly, string directory)
+		protected void WriteAssembly (AssemblyDefinition assembly, string directory)
+		{
+			WriteAssembly (assembly, directory, SaveSymbols (assembly));
+		}
+
+		protected virtual void WriteAssembly (AssemblyDefinition assembly, string directory, WriterParameters writerParameters)
 		{
 			foreach (var module in assembly.Modules) {
 				// Write back pure IL even for R2R assemblies
@@ -104,7 +109,7 @@ namespace Mono.Linker.Steps {
 				}
 			}
 
-			assembly.Write (GetAssemblyFileName (assembly, directory), SaveSymbols (assembly));
+			assembly.Write (GetAssemblyFileName (assembly, directory), writerParameters);
 		}
 
 		void OutputAssembly (AssemblyDefinition assembly)
@@ -196,6 +201,14 @@ namespace Mono.Linker.Steps {
 
 		protected virtual void CopyAssembly (AssemblyDefinition assembly, string directory)
 		{
+			// Special case.  When an assembly has embedded pdbs, link symbols is not enabled, and the assembly's action is copy,
+			// we want to match the behavior of assemblies with the other symbol types and end up with an assembly that does not have symbols.
+			// In order to do that, we can't simply copy files.  We need to write the assembly without symbols
+			if (assembly.MainModule.HasSymbols && !Context.LinkSymbols && assembly.MainModule.SymbolReader is EmbeddedPortablePdbReader) {
+				WriteAssembly (assembly, directory, new WriterParameters ());
+				return;
+			}
+
 			FileInfo fi = GetOriginalAssemblyFileInfo (assembly);
 			string target = Path.GetFullPath (Path.Combine (directory, fi.Name));
 			string source = fi.FullName;

--- a/linker/Tests/Mono.Linker.Tests.Cases/Symbols/ReferenceWithEmbeddedPdbCopyAction.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Symbols/ReferenceWithEmbeddedPdbCopyAction.cs
@@ -3,7 +3,6 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Symbols {
-	[IgnoreTestCase ("Will fix in follow on PR.  Fails due to embedded symbols not being removed")]
 	[SetupCompileBefore ("LibraryWithEmbeddedPdbSymbols.dll", new[] { "Dependencies/LibraryWithEmbeddedPdbSymbols.cs" }, additionalArguments: "/debug:embedded", compilerToUse: "csc")]
 	[SetupLinkerLinkSymbols ("false")]
 	[SetupLinkerAction ("copy", "LibraryWithEmbeddedPdbSymbols")]


### PR DESCRIPTION
This one was a bit tricky to figure out how best to fix.  The dilemma I ran into was

* When symbol linking is not enabled, we were never reading the symbols

* In order to know we are copying an assembly with embedded pdbs, we need to read the symbols.

The path I went with was to 

* Always try to read symbols regardless of whether or not symbol linking is enabled

* When about to Copy an assembly with embedded pdbs and symbol linking off, don't copy, and instead save the assembly without symbols.

An alternative idea I had was to leave SafeReadSymbols alone and leave the copying as is.  Then do another pass after the copy to read in each assembly and see if any have embedded pdbs, and if they do rewrite them without.  That seemed less efficient, but potentially have less chance of causing unintended consequences.

Another choice is that we do nothing.  Let assemblies with embedded pdbs that have assembly action copy simply retain their symbols.  I think it's a little confusing since all other symbol types are lost when copying and symbol linking not enabled, but from the perspective of simply copying a file it makes sense.




