### PR TITLE
.gitignore more corebuild build/test artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,10 @@ bin/
 
 **/Dependencies/*.dll
 
+# corebuild build/test artifacts
 corebuild/Tools
 corebuild/bootstrap.log
-/corebuild/global.json
+corebuild/global.json
+corebuild/**/bin
+corebuild/**/obj
+corebuild/testbin


### PR DESCRIPTION
Also add a comment header for the corebuild section, and normalize the
prefix used in it.