### PR TITLE
Allow custom loggers in Driver, use MSBuild log in ILLink

### DIFF
--- a/corebuild/integration/ILLink.Tasks/AdapterLogger.cs
+++ b/corebuild/integration/ILLink.Tasks/AdapterLogger.cs
@@ -1,0 +1,37 @@
+using System;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace ILLink.Tasks
+{
+	class AdapterLogger : Mono.Linker.ILogger
+	{
+		private TaskLoggingHelper log;
+
+		public AdapterLogger (TaskLoggingHelper log)
+		{
+			this.log = log;
+		}
+
+		public void LogMessage (Mono.Linker.MessageImportance importance, string message, params object[] values)
+		{
+			Microsoft.Build.Framework.MessageImportance msBuildImportance;
+			switch (importance)
+			{
+				case Mono.Linker.MessageImportance.High:
+					msBuildImportance = MessageImportance.High;
+					break;
+				case Mono.Linker.MessageImportance.Normal:
+					msBuildImportance = MessageImportance.Normal;
+					break;
+				case Mono.Linker.MessageImportance.Low:
+					msBuildImportance = MessageImportance.Low;
+					break;
+				default:
+					throw new ArgumentException ($"Unrecognized importance level {importance}", nameof(importance));
+			}
+
+			log.LogMessageFromText (String.Format (message, values), msBuildImportance);
+		}
+	}
+}

--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.csproj
@@ -97,6 +97,7 @@
   </Target>
 
   <ItemGroup>
+    <Compile Include="AdapterLogger.cs" />
     <Compile Include="LinkTask.cs" />
     <Compile Include="CompareSizes.cs" />
     <Compile Include="ComputeManagedAssemblies.cs" />

--- a/corebuild/integration/ILLink.Tasks/LinkTask.cs
+++ b/corebuild/integration/ILLink.Tasks/LinkTask.cs
@@ -61,7 +61,8 @@ namespace ILLink.Tasks
 			string [] args = GenerateCommandLineCommands ();
 			var argsString = String.Join (" ", args);
 			Log.LogMessageFromText ($"illink {argsString}", MessageImportance.Normal);
-			int ret = Mono.Linker.Driver.Main (args);
+			var logger = new AdapterLogger (Log);
+			int ret = Mono.Linker.Driver.Execute (args, logger);
 			return ret == 0;
 		}
 

--- a/linker/Linker/Driver.cs
+++ b/linker/Linker/Driver.cs
@@ -45,13 +45,18 @@ namespace Mono.Linker {
 
 		public static int Main (string [] args)
 		{
+			return Execute (args);
+		}
+
+		public static int Execute (string[] args, ILogger customLogger = null)
+		{
 			if (args.Length == 0)
 				Usage ("No parameters specified");
 
 			try {
 
 				Driver driver = new Driver (args);
-				driver.Run ();
+				driver.Run (customLogger);
 
 			} catch (Exception e) {
 				Console.WriteLine ("Fatal error in {0}", _linker);
@@ -75,10 +80,13 @@ namespace Mono.Linker {
 			return _queue.Count > 0;
 		}
 
-		public void Run ()
+		public void Run (ILogger customLogger = null)
 		{
 			Pipeline p = GetStandardPipeline ();
 			using (LinkContext context = GetDefaultContext (p)) {
+				if (customLogger != null)
+					context.Logger = customLogger;
+
 				I18nAssemblies assemblies = I18nAssemblies.All;
 				var custom_steps = new List<string> ();
 				bool dumpDependencies = false;


### PR DESCRIPTION
Currently, attempts to log messages when the linker is invoked by the ILLink MSBuild task get swallowed because MSBuild swallows tasks' stdout.  The linker already has an ILogger interface, so enable passing one to the Driver, and update the ILLink task to pass one to the Driver which will forward messages to any attached MSBuild loggers.