### PR TITLE
Update managed app action defaults

### DIFF
--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
@@ -18,8 +18,10 @@
     <LinkerDumpDependencies Condition=" '$(LinkerDumpDependencies)' == '' ">false</LinkerDumpDependencies>
     <UsedApplicationAssemblyAction Condition=" '$(UsedApplicationAssemblyAction)' == '' ">Copy</UsedApplicationAssemblyAction>
     <UnusedApplicationAssemblyAction Condition=" '$(UnusedApplicationAssemblyAction)' == '' ">Delete</UnusedApplicationAssemblyAction>
-    <UsedPlatformAssemblyAction Condition=" '$(UsedPlatformAssemblyAction)' == '' ">Link</UsedPlatformAssemblyAction>
-    <UnusedPlatformAssemblyAction Condition=" '$(UnusedPlatformAssemblyAction)' == '' ">Delete</UnusedPlatformAssemblyAction>
+    <UsedPlatformAssemblyAction Condition=" '$(UsedPlatformAssemblyAction)' == '' and '$(SelfContained)' == 'true' ">AddBypassNGen</UsedPlatformAssemblyAction>
+    <UsedPlatformAssemblyAction Condition=" '$(UsedPlatformAssemblyAction)' == '' ">Skip</UsedPlatformAssemblyAction>
+    <UnusedPlatformAssemblyAction Condition=" '$(UnusedPlatformAssemblyAction)' == '' and '$(SelfContained)' == 'true' ">Delete</UnusedPlatformAssemblyAction>
+    <UnusedPlatformAssemblyAction Condition=" '$(UnusedPlatformAssemblyAction)' == '' ">Skip</UnusedPlatformAssemblyAction>
     <RootAllApplicationAssemblies Condition=" '$(RootAllApplicationAssemblies)' == '' ">true</RootAllApplicationAssemblies>
     <RootAllApplicationAssemblies Condition=" '$(RootAllApplicationAssemblies)' != 'true' ">false</RootAllApplicationAssemblies>
   </PropertyGroup>


### PR DESCRIPTION
Use a set of defaults chosen to provide the key benefit for
self-contained apps while still being conservative enough to have low
risk of introducing resolution failures.  App assemblies will all be
considered roots, framework assemblies will be removed if unreferenced
at assembly granularity, and at method granularity will have prejitting
suppressed for unmarked code.