### PR TITLE
Tolerate assembly resolution errors

### DIFF
--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
@@ -222,7 +222,7 @@
          the future we will want to generate these depending on the
          scenario in which the linker is invoked. -->
     <PropertyGroup>
-      <ExtraLinkerArgs Condition=" '$(ExtraLinkerArgs)' == '' ">-t -l none -b true</ExtraLinkerArgs>
+      <ExtraLinkerArgs Condition=" '$(ExtraLinkerArgs)' == '' ">-t -l none -b true --skip-unresolved true</ExtraLinkerArgs>
     </PropertyGroup>
     <ILLink AssemblyPaths="@(_ManagedAssembliesToLink)"
             RootAssemblyNames="@(LinkerRootAssemblies)"

--- a/linker/Linker.Steps/MarkStep.cs
+++ b/linker/Linker.Steps/MarkStep.cs
@@ -150,13 +150,9 @@ namespace Mono.Linker.Steps {
 
 					if (!isForwarder)
 						continue;
-					TypeDefinition type = null;
-					try {
-						type = exported.Resolve ();
-					}
-					catch (AssemblyResolutionException) {
+					TypeDefinition type = exported.Resolve ();
+					if (type == null)
 						continue;
-					}
 					if (!Annotations.IsMarked (type))
 						continue;
 					Tracer.Push (type);

--- a/linker/Linker.Steps/ResolveFromAssemblyStep.cs
+++ b/linker/Linker.Steps/ResolveFromAssemblyStep.cs
@@ -117,12 +117,7 @@ namespace Mono.Linker.Steps
 
 					if (!isForwarder)
 						continue;
-					TypeDefinition resolvedExportedType = null;
-					try {
-						resolvedExportedType = exported.Resolve ();
-					} catch (AssemblyResolutionException) {
-						continue;
-					}
+					TypeDefinition resolvedExportedType = exported.Resolve ();
 
 					if (resolvedExportedType == null) {
 						//

--- a/linker/Linker.Steps/ResolveFromXmlStep.cs
+++ b/linker/Linker.Steps/ResolveFromXmlStep.cs
@@ -213,12 +213,7 @@ namespace Mono.Linker.Steps {
 		{
 			if (regex.Match (exportedType.FullName).Success) {
 				MarkingHelpers.MarkExportedType (exportedType, module);
-				TypeDefinition type = null;
-				try {
-					type = exportedType.Resolve ();
-				}
-				catch (AssemblyResolutionException) {
-				}
+				TypeDefinition type = exportedType.Resolve ();
 				if (type != null) {
 					ProcessType (type, nav);
 				}

--- a/linker/Linker.Steps/SweepStep.cs
+++ b/linker/Linker.Steps/SweepStep.cs
@@ -172,13 +172,9 @@ namespace Mono.Linker.Steps {
 			var references = assembly.MainModule.AssemblyReferences;
 			for (int i = 0; i < references.Count; i++) {
 				var reference = references [i];
-				AssemblyDefinition r = null;
-				try {
-					r = Context.Resolver.Resolve (reference);
-				}
-				catch (AssemblyResolutionException) {
+				AssemblyDefinition r = Context.Resolver.Resolve (reference);
+				if (r == null)
 					continue;
-				}
 				if (!AreSameReference (r.Name, target.Name))
 					continue;
 

--- a/linker/Linker/AssemblyResolver.cs
+++ b/linker/Linker/AssemblyResolver.cs
@@ -103,7 +103,8 @@ namespace Mono.Linker {
 			}
 
 			_assemblies.Clear ();
-			_unresolvedAssemblies.Clear ();
+			if (_unresolvedAssemblies != null)
+				_unresolvedAssemblies.Clear ();
 		}
 	}
 }

--- a/linker/Linker/Driver.cs
+++ b/linker/Linker/Driver.cs
@@ -343,7 +343,7 @@ namespace Mono.Linker {
 
 			Console.WriteLine ("   --about             About the {0}", _linker);
 			Console.WriteLine ("   --version           Print the version number of the {0}", _linker);
-			Console.WriteLine ("   --skip-unresolved   Ignore unresolved types and methods (true or false)");
+			Console.WriteLine ("   --skip-unresolved   Ignore unresolved types, methods, and assemblies (true or false)");
 			Console.WriteLine ("   --dependencies-file Specify the dependencies file path, if unset the default path is used: <output directory>/linker-dependencies.xml.gz");
 			Console.WriteLine ("   --dump-dependencies Dump dependencies for the linker analyzer tool");
 			Console.WriteLine ("   --reduced-tracing   Reduces dependency output related to assemblies that will not be modified");

--- a/linker/Linker/Driver.cs
+++ b/linker/Linker/Driver.cs
@@ -106,7 +106,9 @@ namespace Mono.Linker {
 							Usage ("Option is too short");
 
 						if (token == "--skip-unresolved") {
-							context.IgnoreUnresolved = bool.Parse (GetParam ());
+							bool ignoreUnresolved = bool.Parse (GetParam ());
+							context.IgnoreUnresolved = ignoreUnresolved;
+							context.Resolver.IgnoreUnresolved = ignoreUnresolved;
 							continue;
 						}
 

--- a/linker/Linker/LinkContext.cs
+++ b/linker/Linker/LinkContext.cs
@@ -104,10 +104,7 @@ namespace Mono.Linker {
 		public bool IgnoreUnresolved
 		{
 			get { return _ignoreUnresolved; }
-			set {
-				_ignoreUnresolved = value;
-				_resolver.IgnoreUnresolved = value;
-			}
+			set { _ignoreUnresolved = value; }
 		}
 
 		public bool EnableReducedTracing { get; set; }
@@ -161,6 +158,7 @@ namespace Mono.Linker {
 		{
 			_pipeline = pipeline;
 			_resolver = resolver;
+			_resolver.Context = this;
 			_actions = new Dictionary<string, AssemblyAction> ();
 			_parameters = new Dictionary<string, string> ();
 			_readerParameters = readerParameters;

--- a/linker/Linker/LinkContext.cs
+++ b/linker/Linker/LinkContext.cs
@@ -104,7 +104,10 @@ namespace Mono.Linker {
 		public bool IgnoreUnresolved
 		{
 			get { return _ignoreUnresolved; }
-			set { _ignoreUnresolved = value; }
+			set {
+				_ignoreUnresolved = value;
+				_resolver.IgnoreUnresolved = value;
+			}
 		}
 
 		public bool EnableReducedTracing { get; set; }
@@ -208,7 +211,7 @@ namespace Mono.Linker {
 			try {
 				AssemblyDefinition assembly = _resolver.Resolve (reference, _readerParameters);
 
-				if (SeenFirstTime (assembly)) {
+				if (assembly != null && SeenFirstTime (assembly)) {
 					SafeReadSymbols (assembly);
 					SetAction (assembly);
 				}
@@ -248,11 +251,9 @@ namespace Mono.Linker {
 		{
 			List<AssemblyDefinition> references = new List<AssemblyDefinition> ();
 			foreach (AssemblyNameReference reference in assembly.MainModule.AssemblyReferences) {
-				try {
-					references.Add (Resolve (reference));
-				}
-				catch (AssemblyResolutionException) {
-				}
+				AssemblyDefinition definition = Resolve (reference);
+				if (definition != null)
+					references.Add (definition);
 			}
 			return references;
 		}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/SkipUnresolvedAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/SkipUnresolvedAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Metadata {
+	public sealed class SkipUnresolvedAttribute : BaseMetadataAttribute {
+		public readonly bool Value;
+
+		public SkipUnresolvedAttribute (bool value)
+		{
+			Value = value;
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Metadata\NotATestCaseAttribute.cs" />
     <Compile Include="Metadata\ReferenceAttribute.cs" />
     <Compile Include="Metadata\SandboxDependencyAttribute.cs" />
+    <Compile Include="Metadata\SkipUnresolvedAttribute.cs" />
     <Compile Include="Assertions\KeptBaseTypeAttribute.cs" />
     <Compile Include="Assertions\KeptInterfaceAttribute.cs" />
     <Compile Include="Assertions\KeptAttributeAttribute.cs" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/TypeForwarding/MissingTargetReference.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/TypeForwarding/MissingTargetReference.cs
@@ -4,6 +4,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.TypeForwarding
 {
+	[SkipUnresolved (true)]
 	[Define ("IL_ASSEMBLY_AVAILABLE")]
 	[SetupCompileBefore ("TypeForwarderMissingReference.dll", new [] { "Dependencies/TypeForwarderMissingReference.il" })]
 	[SetupLinkerAction ("link", "TypeForwarderMissingReference.dll")]

--- a/linker/Tests/TestCasesRunner/LinkerArgumentBuilder.cs
+++ b/linker/Tests/TestCasesRunner/LinkerArgumentBuilder.cs
@@ -66,6 +66,14 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			Append (assembly);
 		}
 
+		public virtual void AddSkipUnresolved (bool skipUnresolved)
+		{
+			if (skipUnresolved) {
+				Append ("--skip-unresolved");
+				Append ("true");
+			}
+		}
+
 		public string [] ToArgs ()
 		{
 			return _arguments.ToArray ();
@@ -107,6 +115,8 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			
 			if (!string.IsNullOrEmpty (options.LinkSymbols))
 				AddLinkSymbols (options.LinkSymbols);
+
+			AddSkipUnresolved (options.SkipUnresolved);
 
 			// Unity uses different argument format and needs to be able to translate to their format.  In order to make that easier
 			// we keep the information in flag + values format for as long as we can so that this information doesn't have to be parsed out of a single string

--- a/linker/Tests/TestCasesRunner/TestCaseLinkerOptions.cs
+++ b/linker/Tests/TestCasesRunner/TestCaseLinkerOptions.cs
@@ -11,6 +11,7 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 		public bool IncludeBlacklistStep;
 		public string KeepTypeForwarderOnlyAssemblies;
 		public string LinkSymbols;
+		public bool SkipUnresolved;
 
 		public List<KeyValuePair<string, string[]>> AdditionalArguments = new List<KeyValuePair<string, string[]>> ();
 	}

--- a/linker/Tests/TestCasesRunner/TestCaseMetadaProvider.cs
+++ b/linker/Tests/TestCasesRunner/TestCaseMetadaProvider.cs
@@ -31,7 +31,8 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 				IncludeBlacklistStep = GetOptionAttributeValue (nameof (IncludeBlacklistStepAttribute), false),
 				KeepTypeForwarderOnlyAssemblies = GetOptionAttributeValue (nameof (KeepTypeForwarderOnlyAssembliesAttribute), string.Empty),
 				LinkSymbols = GetOptionAttributeValue (nameof (SetupLinkerLinkSymbolsAttribute), string.Empty),
-				CoreAssembliesAction = GetOptionAttributeValue<string> (nameof (SetupLinkerCoreActionAttribute), null)
+				CoreAssembliesAction = GetOptionAttributeValue<string> (nameof (SetupLinkerCoreActionAttribute), null),
+				SkipUnresolved = GetOptionAttributeValue (nameof (SkipUnresolvedAttribute), false)
 			};
 
 			foreach (var assemblyAction in _testCaseTypeDefinition.CustomAttributes.Where (attr => attr.AttributeType.Name == nameof (SetupLinkerActionAttribute)))


### PR DESCRIPTION
Previously, we swallowed AssemblyResolutionException in a few places
in various steps. We need an option to be generally more tolerant of
AssemblyResolutionExceptions, because there can be cases during
portable publish in which referenced assemblies are not present during
publish because they're part of the shared framework.

Instead of handling AssemblyResolutionException in every place in the
linker that tries to resolve methods/types/etc, this change adds an
option that enables the resolver to return null when an assembly is
not found. The null result is also cached to avoid multiple lookups.

Only a few places in the linker need to be modified to handle null
results, and the existing places where we used to catch
AssemblyResolutionException now only need to deal with a null result
instead. The downside of this approach is that these places cannot
distinguish between types not found in an existing assembly, and
assemblies that were not found.

The new behavior is grouped under the option --skip-unresolved, which
already handles unresolved types and methods in some cases. When this
option is enabled, a warning is logged, and no exception is thrown.

@erozenfeld, please review