### PR TITLE
Make native dependency logic find more cases

### DIFF
--- a/corebuild/integration/ILLink.Tasks/FindNativeDeps.cs
+++ b/corebuild/integration/ILLink.Tasks/FindNativeDeps.cs
@@ -21,7 +21,7 @@ namespace ILLink.Tasks
 
 		/// <summary>
 		///   The set of native dependencies to keep even if they
-		///   aren't found to be referenced by a managed assembly..
+		///   aren't found to be referenced by a managed assembly.
 		/// </summary>
 		public ITaskItem [] NativeDepsToKeep { get; set; }
 
@@ -45,11 +45,12 @@ namespace ILLink.Tasks
 		public override bool Execute ()
 		{
 			var allNativeNames = new HashSet<string> ();
-			foreach (var nativeDep in NativeDepsPaths) {
-				var fileName = Path.GetFileName (nativeDep.ItemSpec);
-				allNativeNames.Add (fileName);
-			}
+			foreach (var nativeDep in NativeDepsPaths)
+				allNativeNames.Add (Path.GetFileName (nativeDep.ItemSpec));
 			var keptNativeNames = new HashSet<string> ();
+			foreach (var nativeDep in NativeDepsToKeep)
+				keptNativeNames.Add (Path.GetFileName (nativeDep.ItemSpec));
+
 			var managedAssemblies = ManagedAssemblyPaths.Select (i => i.ItemSpec).ToArray ();
 			foreach (string managedAssembly in managedAssemblies) {
 				using (var peReader = new PEReader(new FileStream (managedAssembly, FileMode.Open, FileAccess.Read, FileShare.Read))) {


### PR DESCRIPTION
Previously, the native dependency logic looked for the first native
dependency whose filename (without extension) matched each reference
in managed metadata.

With this change, it will find all such native dependencies, including
different files with the same name (relevant when the publish output
contains cross-arch libraries for the same platform) or native
libraries with different extensions but the same filename (relevant
when the publish output contains cross-platform libraries).

This is one prerequisite for running the linker during portable
publish, because in portable publish we often output a
runtime-specific native library for each supported platform. The case
I found was libuv, which was being published as libuv.dll for
different windows OSs, libuv.dylib for macOS, and libuv.so for unix.

@erozenfeld, @ericstj, please review.