### PR TITLE
Expose option to log internal exceptions

### DIFF
--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
@@ -223,7 +223,7 @@
          the future we will want to generate these depending on the
          scenario in which the linker is invoked. -->
     <PropertyGroup>
-      <ExtraLinkerArgs Condition=" '$(ExtraLinkerArgs)' == '' ">-t -l none -b true --skip-unresolved true</ExtraLinkerArgs>
+      <ExtraLinkerArgs Condition=" '$(ExtraLinkerArgs)' == '' ">-t -l none -b true --skip-unresolved true --log-warnings</ExtraLinkerArgs>
       <!-- version of ILLink.CustomSteps is passed as a workaround for msbuild issue #3016 -->
       <ExtraLinkerArgs Condition=" '$(ClearInitLocals)' == 'true' ">$(ExtraLinkerArgs) -s ILLink.CustomSteps.ClearInitLocalsStep,ILLink.CustomSteps,Version=0.0.0.0:OutputStep</ExtraLinkerArgs>
       <ExtraLinkerArgs Condition=" '$(ClearInitLocals)' == 'true' and '$(ClearInitLocalsAssemblies)' != ''">$(ExtraLinkerArgs) -m ClearInitLocalsAssemblies $(ClearInitLocalsAssemblies)</ExtraLinkerArgs>

--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
@@ -223,7 +223,7 @@
          the future we will want to generate these depending on the
          scenario in which the linker is invoked. -->
     <PropertyGroup>
-      <ExtraLinkerArgs Condition=" '$(ExtraLinkerArgs)' == '' ">-t -l none -b true --skip-unresolved true --log-warnings</ExtraLinkerArgs>
+      <ExtraLinkerArgs Condition=" '$(ExtraLinkerArgs)' == '' ">-t -l none -b true --skip-unresolved true --log-messages</ExtraLinkerArgs>
       <!-- version of ILLink.CustomSteps is passed as a workaround for msbuild issue #3016 -->
       <ExtraLinkerArgs Condition=" '$(ClearInitLocals)' == 'true' ">$(ExtraLinkerArgs) -s ILLink.CustomSteps.ClearInitLocalsStep,ILLink.CustomSteps,Version=0.0.0.0:OutputStep</ExtraLinkerArgs>
       <ExtraLinkerArgs Condition=" '$(ClearInitLocals)' == 'true' and '$(ClearInitLocalsAssemblies)' != ''">$(ExtraLinkerArgs) -m ClearInitLocalsAssemblies $(ClearInitLocalsAssemblies)</ExtraLinkerArgs>

--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
@@ -223,7 +223,7 @@
          the future we will want to generate these depending on the
          scenario in which the linker is invoked. -->
     <PropertyGroup>
-      <ExtraLinkerArgs Condition=" '$(ExtraLinkerArgs)' == '' ">-t -l none -b true --skip-unresolved true --log-messages</ExtraLinkerArgs>
+      <ExtraLinkerArgs Condition=" '$(ExtraLinkerArgs)' == '' ">-t -l none -b true --skip-unresolved true --verbose</ExtraLinkerArgs>
       <!-- version of ILLink.CustomSteps is passed as a workaround for msbuild issue #3016 -->
       <ExtraLinkerArgs Condition=" '$(ClearInitLocals)' == 'true' ">$(ExtraLinkerArgs) -s ILLink.CustomSteps.ClearInitLocalsStep,ILLink.CustomSteps,Version=0.0.0.0:OutputStep</ExtraLinkerArgs>
       <ExtraLinkerArgs Condition=" '$(ClearInitLocals)' == 'true' and '$(ClearInitLocalsAssemblies)' != ''">$(ExtraLinkerArgs) -m ClearInitLocalsAssemblies $(ClearInitLocalsAssemblies)</ExtraLinkerArgs>

--- a/linker/Linker/Driver.cs
+++ b/linker/Linker/Driver.cs
@@ -133,6 +133,11 @@ namespace Mono.Linker {
 							continue;
 						}
 
+						if (token == "--log-warnings") {
+							context.LogInternalExceptions = true;
+							continue;
+						}
+
 						switch (token [2]) {
 						case 'v':
 							Version ();
@@ -346,6 +351,7 @@ namespace Mono.Linker {
 			Console.WriteLine ("   --about             About the {0}", _linker);
 			Console.WriteLine ("   --version           Print the version number of the {0}", _linker);
 			Console.WriteLine ("   --skip-unresolved   Ignore unresolved types, methods, and assemblies (true or false)");
+			Console.WriteLine ("   --log-warnings      Log warnings for internal exceptions");
 			Console.WriteLine ("   --dependencies-file Specify the dependencies file path, if unset the default path is used: <output directory>/linker-dependencies.xml.gz");
 			Console.WriteLine ("   --dump-dependencies Dump dependencies for the linker analyzer tool");
 			Console.WriteLine ("   --reduced-tracing   Reduces dependency output related to assemblies that will not be modified");

--- a/linker/Linker/Driver.cs
+++ b/linker/Linker/Driver.cs
@@ -112,8 +112,12 @@ namespace Mono.Linker {
 							continue;
 						}
 
-						if (token == "--dependencies-file")
-						{
+                                                if (token == "--log-messages") {
+                                                    context.LogMessages = true;
+                                                    continue;
+                                                }
+
+						if (token == "--dependencies-file") {
 							context.Tracer.DependenciesFileName = GetParam ();
 							continue;
 						}
@@ -130,11 +134,6 @@ namespace Mono.Linker {
 
 						if (token == "--used-attrs-only") {
 							context.KeepUsedAttributeTypesOnly = bool.Parse (GetParam ());
-							continue;
-						}
-
-						if (token == "--log-warnings") {
-							context.LogInternalExceptions = true;
 							continue;
 						}
 
@@ -351,7 +350,7 @@ namespace Mono.Linker {
 			Console.WriteLine ("   --about             About the {0}", _linker);
 			Console.WriteLine ("   --version           Print the version number of the {0}", _linker);
 			Console.WriteLine ("   --skip-unresolved   Ignore unresolved types, methods, and assemblies (true or false)");
-			Console.WriteLine ("   --log-warnings      Log warnings for internal exceptions");
+			Console.WriteLine ("   --log-messages      Log messages indicating progress and warnings");
 			Console.WriteLine ("   --dependencies-file Specify the dependencies file path, if unset the default path is used: <output directory>/linker-dependencies.xml.gz");
 			Console.WriteLine ("   --dump-dependencies Dump dependencies for the linker analyzer tool");
 			Console.WriteLine ("   --reduced-tracing   Reduces dependency output related to assemblies that will not be modified");

--- a/linker/Linker/Driver.cs
+++ b/linker/Linker/Driver.cs
@@ -112,10 +112,10 @@ namespace Mono.Linker {
 							continue;
 						}
 
-                                                if (token == "--log-messages") {
-                                                    context.LogMessages = true;
-                                                    continue;
-                                                }
+						if (token == "--verbose") {
+							context.LogMessages = true;
+							continue;
+						}
 
 						if (token == "--dependencies-file") {
 							context.Tracer.DependenciesFileName = GetParam ();
@@ -350,7 +350,7 @@ namespace Mono.Linker {
 			Console.WriteLine ("   --about             About the {0}", _linker);
 			Console.WriteLine ("   --version           Print the version number of the {0}", _linker);
 			Console.WriteLine ("   --skip-unresolved   Ignore unresolved types, methods, and assemblies (true or false)");
-			Console.WriteLine ("   --log-messages      Log messages indicating progress and warnings");
+			Console.WriteLine ("   --verbose           Log messages indicating progress and warnings");
 			Console.WriteLine ("   --dependencies-file Specify the dependencies file path, if unset the default path is used: <output directory>/linker-dependencies.xml.gz");
 			Console.WriteLine ("   --dump-dependencies Dump dependencies for the linker analyzer tool");
 			Console.WriteLine ("   --reduced-tracing   Reduces dependency output related to assemblies that will not be modified");

--- a/linker/Linker/LinkContext.cs
+++ b/linker/Linker/LinkContext.cs
@@ -133,7 +133,7 @@ namespace Mono.Linker {
 			set { _symbolWriterProvider = value; }
 		}
 
-		public bool LogInternalExceptions { get; set; } = false;
+		public bool LogMessages { get; set; } = false;
 
 		public ILogger Logger { get; set; } = new ConsoleLogger ();
 
@@ -342,7 +342,7 @@ namespace Mono.Linker {
 
 		public void LogMessage (MessageImportance importance, string message, params object [] values)
 		{
-			if (LogInternalExceptions && Logger != null)
+			if (LogMessages && Logger != null)
 				Logger.LogMessage (importance, message, values);
 		}
 	}


### PR DESCRIPTION
Also enable it for ILLink.Tasks, which will result in resolution
errors being logged as warnings during publish.

@erozenfeld PTAL.