### PR TITLE
Enable link during portable publish

### DIFF
--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
@@ -281,6 +281,11 @@
       <_ManagedAssembliesToLink Include="@(IntermediateAssembly)" />
       <_ManagedAssembliesToLink Include="@(_ManagedResolvedAssembliesToPublish)" />
     </ItemGroup>
+    <ItemGroup Condition=" '$(SelfContained)' != 'true' ">
+      <!-- Portable publish: need to supply the linker with any needed reference assemblies as well -->
+      <_ReferencedLibraries Include="@(ReferencePath->'%(ResolvedPath)')" Exclude="@(_ManagedAssembliesToLink)" />
+      <_ManagedAssembliesToLink Include="@(_ReferencedLibraries)" />
+    </ItemGroup>
   </Target>
 
 
@@ -363,7 +368,7 @@
   </Target>
 
   <UsingTask TaskName="CheckEmbeddedRootDescriptor" AssemblyFile="$(LinkTaskDllPath)" />
-  <Target Name="_CheckSystemPrivateCorelibEmbeddedRoots"
+  <Target Name="_CheckSystemPrivateCorelibEmbeddedRoots" Condition=" '$(SelfContained)' == 'true' "
           DependsOnTargets="_ComputeManagedAssembliesToLink">
     <CheckEmbeddedRootDescriptor AssemblyPath="@(_ManagedAssembliesToLink->WithMetadataValue('Filename', 'System.Private.CoreLib'))">
       <Output TaskParameter="HasEmbeddedRootDescriptor" PropertyName="_SPCHasEmbeddedRootDescriptor" />
@@ -373,13 +378,20 @@
   <!-- Platform libraries are the managed runtime assets needed by the
        "platform", currently Microsoft.NETCore.App. -->
   <UsingTask TaskName="GetRuntimeLibraries" AssemblyFile="$(LinkTaskDllPath)" />
-  <Target Name="_ComputePlatformLibraries">
-    <GetRuntimeLibraries AssetsFilePath="$(ProjectAssetsFile)"
+  <Target Name="_ComputePlatformLibraries"
+          DependsOnTargets="_ComputeManagedAssembliesToLink">
+    <GetRuntimeLibraries Condition=" '$(SelfContained)' == 'true' "
+                         AssetsFilePath="$(ProjectAssetsFile)"
                          TargetFramework="$(TargetFrameworkMoniker)"
                          RuntimeIdentifier="$(RuntimeIdentifier)"
                          PackageNames="$(MicrosoftNETPlatformLibrary)">
       <Output TaskParameter="RuntimeLibraries" ItemName="PlatformLibraries" />
     </GetRuntimeLibraries>
+    <ItemGroup Condition=" '$(SelfContained)' != 'true' ">
+      <!-- Portable publish: computed referenced-not-published set in _ComputeManagedAssembliesToLink -->
+      <PlatformLibraries Include="@(_ReferencedLibraries)" />
+    </ItemGroup>
+    <!-- Message Text="Jobu: @(PlatformLibraries)" Importance="High" / -->
   </Target>
 
 

--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
@@ -285,9 +285,8 @@
     <!-- Portable publish: need to supply the linker with any needed
          reference assemblies as well.
 
-         We want to exclude assemblies that are going to be published
-         with the app. Sometimes assemblies have separate reference
-         and implementation assemblies. In these cases, prefer the
+         Sometimes assemblies have separate reference and
+         implementation assemblies. In these cases, prefer the
          implementation assembly, and prevent inclusion of the ref
          assembly by filtering on filename instead of the full
          path. -->

--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
@@ -99,7 +99,7 @@
       <ResolvedAssembliesToPublish Include="@(_NativeKeptDepsToPublish)" />
       <ResolvedAssembliesToPublish Include="@(_LinkedResolvedAssemblies)" />
     </ItemGroup>
-    
+
     <!-- Rewrite IntermediateAssembly, which is an input to
          ComputeFilesToPublish. -->
     <ItemGroup>
@@ -114,7 +114,7 @@
       <_DebugSymbolsIntermediatePath Include="@(_LinkedDebugSymbols)" Condition=" '$(_DebugSymbolsProduced)' == 'true' " />
     </ItemGroup>
   </Target>
-  
+
   <!-- The SDK has a target called ComputeRefAssembliesToPublish that
        runs after ComputeFilesToPublish and rewrites
        ResolvedFileToPublish to include any reference assemblies that
@@ -207,7 +207,7 @@
           <_ManagedAssembliesToLink Include="@(_ManagedAssembliesToLinkWithActions)" />
       </ItemGroup>
   </Target>
-    
+
   <!-- This calls the linker. Inputs are the managed assemblies to
        link, and root specifications. The semaphore enables msbuild to
        skip linking during an incremental build, when the semaphore is
@@ -281,12 +281,27 @@
       <_ManagedAssembliesToLink Include="@(IntermediateAssembly)" />
       <_ManagedAssembliesToLink Include="@(_ManagedResolvedAssembliesToPublish)" />
     </ItemGroup>
+
+    <!-- Portable publish: need to supply the linker with any needed
+         reference assemblies as well.
+
+         We want to exclude assemblies that are going to be published
+         with the app. Sometimes assemblies have separate reference
+         and implementation assemblies. In these cases, prefer the
+         implementation assembly, and prevent inclusion of the ref
+         assembly by filtering on filename instead of the full
+         path. -->
+    <FilterByMetadata Items="@(ReferencePath->'%(ResolvedPath)')"
+                      MetadataName="Filename"
+                      MetadataValues="@(_ManagedAssembliesToLink->'%(Filename)')"
+                      Condition=" '$(SelfContained)' != 'true' ">
+      <Output TaskParameter="FilteredItems" ItemName="_ReferencedLibrariesToExclude" />
+    </FilterByMetadata>
     <ItemGroup Condition=" '$(SelfContained)' != 'true' ">
-      <!-- Portable publish: need to supply the linker with any needed
-           reference assemblies as well -->
-      <_ReferencedLibraries Include="@(ReferencePath->'%(ResolvedPath)')" Exclude="@(_ManagedAssembliesToLink)" />
+      <_ReferencedLibraries Include="@(ReferencePath->'%(ResolvedPath)')" Exclude="@(_ReferencedLibrariesToExclude)" />
       <_ManagedAssembliesToLink Include="@(_ReferencedLibraries)" />
     </ItemGroup>
+
   </Target>
 
 
@@ -313,7 +328,7 @@
          output and the generated deps.json file. Excluding it from
          _ManagedResolvedAssembliesToPublish will prevent it from
          getting filtered out of the publish output later.
-         
+
          In the future we may want to detect ngen assemblies and
          filter them more robustly. -->
     <!-- TODO: Which .ni files do we expect to be in
@@ -345,12 +360,13 @@
        to work on the publish output. -->
   <Target Name="_ComputeLinkerRootAssemblies"
           DependsOnTargets="_ComputeManagedResolvedAssembliesToPublish;_ComputePlatformLibraries;_CheckSystemPrivateCorelibEmbeddedRoots">
-    <!-- If RootAllApplicationAssemblies is true, roots are everything minus the framework
-         assemblies. This doesn't include the intermediate assembly,
-         because we root it separately using an xml file,
-         which lets us explicitly root everything.
+    <!-- If RootAllApplicationAssemblies is true, roots are everything
+         minus the framework assemblies. This doesn't include the
+         intermediate assembly, because we root it separately using an
+         xml file, which lets us explicitly root everything.
 
-         If RootAllApplicationAssemblies is false, only intermediate assembly's Main method is rooted.
+         If RootAllApplicationAssemblies is false, only intermediate
+         assembly's Main method is rooted.
 
          System.Private.CoreLib is rooted unless it has an embedded
          xml descriptor file. -->
@@ -437,7 +453,7 @@
     <ItemGroup>
       <_RemovedNativeDeps Include="@(_NativeResolvedDepsToPublish)" />
       <_RemovedNativeDeps Remove="@(_NativeKeptDepsToPublish)" />
-      
+
       <_PublishConflictPackageFiles Include="@(_RemovedManagedAssemblies)" />
       <_PublishConflictPackageFiles Include="@(_RemovedNativeDeps)" />
     </ItemGroup>

--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
@@ -282,7 +282,8 @@
       <_ManagedAssembliesToLink Include="@(_ManagedResolvedAssembliesToPublish)" />
     </ItemGroup>
     <ItemGroup Condition=" '$(SelfContained)' != 'true' ">
-      <!-- Portable publish: need to supply the linker with any needed reference assemblies as well -->
+      <!-- Portable publish: need to supply the linker with any needed
+           reference assemblies as well -->
       <_ReferencedLibraries Include="@(ReferencePath->'%(ResolvedPath)')" Exclude="@(_ManagedAssembliesToLink)" />
       <_ManagedAssembliesToLink Include="@(_ReferencedLibraries)" />
     </ItemGroup>
@@ -391,7 +392,6 @@
       <!-- Portable publish: computed referenced-not-published set in _ComputeManagedAssembliesToLink -->
       <PlatformLibraries Include="@(_ReferencedLibraries)" />
     </ItemGroup>
-    <!-- Message Text="Jobu: @(PlatformLibraries)" Importance="High" / -->
   </Target>
 
 

--- a/corebuild/integration/test/CommandRunner.cs
+++ b/corebuild/integration/test/CommandRunner.cs
@@ -67,7 +67,7 @@ namespace ILLink.Tests
 				RedirectStandardOutput = true,
 				RedirectStandardError = true,
 			};
-                        outputHelper.WriteLine($"from caller working directory {Environment.CurrentDirectory}");
+			outputHelper.WriteLine($"caller working directory: {Environment.CurrentDirectory}");
 			if (!String.IsNullOrEmpty(args)) {
 				psi.Arguments = args;
 				outputHelper.WriteLine($"{command} {args}");

--- a/corebuild/integration/test/CommandRunner.cs
+++ b/corebuild/integration/test/CommandRunner.cs
@@ -67,6 +67,7 @@ namespace ILLink.Tests
 				RedirectStandardOutput = true,
 				RedirectStandardError = true,
 			};
+                        outputHelper.WriteLine($"from caller working directory {Environment.CurrentDirectory}");
 			if (!String.IsNullOrEmpty(args)) {
 				psi.Arguments = args;
 				outputHelper.WriteLine($"{command} {args}");
@@ -74,7 +75,7 @@ namespace ILLink.Tests
 				outputHelper.WriteLine($"{command}");
 			}
 			if (!String.IsNullOrEmpty(workingDir)) {
-				outputHelper.WriteLine("$working directory: {workingDir}");
+				outputHelper.WriteLine($"working directory: {workingDir}");
 				psi.WorkingDirectory = workingDir;
 			}
 			if (!String.IsNullOrEmpty(additionalPath)) {

--- a/corebuild/integration/test/IntegrationTestBase.cs
+++ b/corebuild/integration/test/IntegrationTestBase.cs
@@ -68,7 +68,7 @@ namespace ILLink.Tests
 		{
 			string demoRoot = Path.GetDirectoryName(csproj);
 
-			string publishArgs = $"publish -r {rid} -c {config} /v:n /p:ShowLinkerSizeComparison=true";
+			string publishArgs = $"publish -c {context.Configuration} /v:n /p:ShowLinkerSizeComparison=true";
 			if (selfContained) {
 				publishArgs += $" -r {context.RuntimeIdentifier}";
 			}

--- a/corebuild/integration/test/IntegrationTestBase.cs
+++ b/corebuild/integration/test/IntegrationTestBase.cs
@@ -60,14 +60,18 @@ namespace ILLink.Tests
 		///   that the project already contains a reference to the
 		///   linker task package.
 		///   Optionally takes a list of root descriptor files.
+		///   Returns the path to the built app, either the renamed
+		///   host for self-contained publish, or the dll containing
+		///   the entry point.
 		/// </summary>
-		public void BuildAndLink(string csproj, List<string> rootFiles = null, Dictionary<string, string> extraPublishArgs = null)
+		public string BuildAndLink(string csproj, List<string> rootFiles = null, Dictionary<string, string> extraPublishArgs = null, bool selfContained = false)
 		{
-			string rid = context.RuntimeIdentifier;
-			string config = context.Configuration;
 			string demoRoot = Path.GetDirectoryName(csproj);
 
 			string publishArgs = $"publish -r {rid} -c {config} /v:n /p:ShowLinkerSizeComparison=true";
+			if (selfContained) {
+				publishArgs += $" -r {context.RuntimeIdentifier}";
+			}
 			string rootFilesStr;
 			if (rootFiles != null && rootFiles.Any()) {
 				rootFilesStr = String.Join(";", rootFiles);
@@ -83,28 +87,45 @@ namespace ILLink.Tests
 			if (ret != 0) {
 				output.WriteLine("publish failed, returning " + ret);
 				Assert.True(false);
-				return;
 			}
-		}
 
-		public int RunApp(string csproj, out string processOutput, int timeout = Int32.MaxValue, string terminatingOutput = null)
-		{
-			string demoRoot = Path.GetDirectoryName(csproj);
 			// detect the target framework for which the app was published
 			string tfmDir = Path.Combine(demoRoot, "bin", context.Configuration);
 			string tfm = Directory.GetDirectories(tfmDir).Select(p => Path.GetFileName(p)).Single();
-			string executablePath = Path.Combine(tfmDir, tfm,
-				context.RuntimeIdentifier, "publish",
-				Path.GetFileNameWithoutExtension(csproj)
-			);
-			if (context.RuntimeIdentifier.Contains("win")) {
-				executablePath += ".exe";
+			string builtApp = Path.Combine(tfmDir, tfm);
+			if (selfContained) {
+				builtApp = Path.Combine(builtApp, context.RuntimeIdentifier);
 			}
-			Assert.True(File.Exists(executablePath));
+			builtApp = Path.Combine(builtApp, "publish",
+				Path.GetFileNameWithoutExtension(csproj));
+			if (selfContained) {
+				if (context.RuntimeIdentifier.Contains("win")) {
+					builtApp += ".exe";
+				}
+			} else {
+				builtApp += ".dll";
+			}
+			Assert.True(File.Exists(builtApp));
+			return builtApp;
+		}
 
-			int ret = RunCommand(executablePath, null,
-				Directory.GetParent(executablePath).FullName,
-				null, out processOutput, timeout, terminatingOutput);
+		public int RunApp(string target, out string processOutput, int timeout = Int32.MaxValue,
+			string terminatingOutput = null, bool selfContained = false)
+		{
+			Assert.True(File.Exists(target));
+			int ret;
+			if (selfContained) {
+				ret = RunCommand(
+					target, null,
+					Directory.GetParent(target).FullName,
+					null, out processOutput, timeout, terminatingOutput);
+			} else {
+				ret = RunCommand(
+					Path.GetFullPath(context.DotnetToolPath),
+					Path.GetFullPath(target),
+					Directory.GetParent(target).FullName,
+					null, out processOutput, timeout, terminatingOutput);
+			}
 			return ret;
 		}
 

--- a/corebuild/integration/test/MusicStoreTest.cs
+++ b/corebuild/integration/test/MusicStoreTest.cs
@@ -10,8 +10,6 @@ namespace ILLink.Tests
 {
 	public class MusicStoreTest : IntegrationTestBase
 	{
-		public MusicStoreTest(ITestOutputHelper output) : base(output) {}
-
 		private static List<string> rootFiles = new List<string> { "MusicStoreReflection.xml" };
 
 		private static string gitRepo = "http://github.com/aspnet/JitBench";
@@ -34,40 +32,138 @@ namespace ILLink.Tests
 		// The version of Microsoft.AspNetCore.All to publish with.
 		private static string aspNetVersion = "2.1.0-preview1-27654";
 
-		[Fact]
-		public void RunMusicStore()
+		private static Dictionary<string, string> extraPublishArgs;
+		private static Dictionary<string, string> ExtraPublishArgs
 		{
-			string csproj = SetupProject();
+			get {
+				if (extraPublishArgs != null) {
+					return extraPublishArgs;
+				}
+				extraPublishArgs = new Dictionary<string, string>();
+				extraPublishArgs.Add("JITBENCH_FRAMEWORK_VERSION", runtimeVersion);
+				extraPublishArgs.Add("JITBENCH_ASPNET_VERSION", aspNetVersion);
+				return extraPublishArgs;
+			}
+		}
 
-			// Copy root files into the project directory
-			string demoRoot= Path.GetDirectoryName(csproj);
-			CopyRootFiles(demoRoot);
+		private static string csproj;
 
-			// This is necessary because JitBench comes with a
-			// NuGet.Config that has a <clear /> line, preventing
-			// NuGet.Config sources defined in outer directories from
-			// applying.
-			string nugetConfig = Path.Combine("JitBench", "NuGet.config");
-			AddLocalNugetFeedAfterClear(nugetConfig);
+		public MusicStoreTest(ITestOutputHelper output) : base(output) {
+			csproj = SetupProject();
 
-			AddLinkerReference(csproj);
+			// MusicStore targets .NET Core 2.1, so it must be built
+			// using an SDK that can target 2.1. We obtain that SDK
+			// here.
+			context.DotnetToolPath = ObtainSDK(context.TestBin, repoName);
+		}
 
-			Dictionary<string, string> extraPublishArgs = new Dictionary<string, string>();
-			extraPublishArgs.Add("JITBENCH_FRAMEWORK_VERSION", runtimeVersion);
-			extraPublishArgs.Add("JITBENCH_ASPNET_VERSION", aspNetVersion);
-			BuildAndLink(csproj, rootFiles, extraPublishArgs);
+		[Fact]
+		public void RunMusicStoreStandalone()
+		{
+			string executablePath = BuildAndLink(csproj, rootFiles, ExtraPublishArgs, selfContained: true);
+			CheckOutput(executablePath, selfContained: true);
+		}
 
-			int ret = RunApp(csproj, out string commandOutput);
+		[Fact]
+		public void RunMusicStorePortable()
+		{
+			string target = BuildAndLink(csproj, rootFiles, ExtraPublishArgs, selfContained: false);
+			CheckOutput(target, selfContained: false);
+		}
+
+		void CheckOutput(string target, bool selfContained = false)
+		{
+			int ret = RunApp(target, out string commandOutput, selfContained: selfContained);
+
 			Assert.True(commandOutput.Contains("Starting request to http://localhost:5000"));
 			Assert.True(commandOutput.Contains("Response: OK"));
 			Assert.True(commandOutput.Contains("Running 100 requests"));
 			Assert.True(ret == 0);
 		}
 
+		// returns path to .csproj project file
+		string SetupProject()
+		{
+			int ret;
+			string demoRoot = Path.Combine(repoName, Path.Combine("src", "MusicStore"));
+			string csproj = Path.Combine(demoRoot, "MusicStore.csproj");
+
+			if (File.Exists(csproj)) {
+				output.WriteLine($"using existing project {csproj}");
+				return csproj;
+			}
+
+			if (Directory.Exists(repoName)) {
+				Directory.Delete(repoName, true);
+			}
+
+			ret = RunCommand("git", $"clone {gitRepo} {repoName}");
+			if (ret != 0) {
+				output.WriteLine("git failed");
+				Assert.True(false);
+			}
+
+			if (!Directory.Exists(demoRoot)) {
+				output.WriteLine($"{demoRoot} does not exist");
+				Assert.True(false);
+			}
+
+			ret = RunCommand("git", $"checkout {gitRevision}", demoRoot);
+			if (ret != 0) {
+				output.WriteLine($"problem checking out revision {gitRevision}");
+				Assert.True(false);
+			}
+
+			// Copy root files into the project directory
+			CopyRootFiles(demoRoot);
+
+			// This is necessary because JitBench comes with a
+			// NuGet.Config that has a <clear /> line, preventing
+			// NuGet.Config sources defined in outer directories from
+			// applying.
+			string nugetConfig = Path.Combine(repoName, "NuGet.config");
+			AddLocalNugetFeedAfterClear(nugetConfig);
+
+			AddLinkerReference(csproj);
+
+			AddGlobalJson(repoName);
+
+			return csproj;
+		}
+
+		void AddGlobalJson(string repoDir)
+		{
+			string globalJson = Path.Combine(repoDir, "global.json");
+			string globalJsonContents = "{ \"sdk\": { \"version\": \"" + sdkVersion + "\" } }\n";
+			File.WriteAllText(globalJson, globalJsonContents);
+		}
+
+
+		string GetDotnetToolPath(string dotnetDir)
+		{
+			string dotnetToolName = Directory.GetFiles(dotnetDir)
+				.Select(p => Path.GetFileName(p))
+				.Where(p => p.Contains("dotnet"))
+				.Single();
+			string dotnetToolPath = Path.Combine(dotnetDir, dotnetToolName);
+
+			if (!File.Exists(dotnetToolPath)) {
+				output.WriteLine("repo-local dotnet tool does not exist.");
+				Assert.True(false);
+			}
+
+			return dotnetToolPath;
+		}
+
 		string ObtainSDK(string rootDir, string repoDir)
 		{
 			int ret;
 			string dotnetDirName = ".dotnet";
+			string dotnetDir = Path.Combine(rootDir, dotnetDirName);
+			if (Directory.Exists(dotnetDir)) {
+				return GetDotnetToolPath(dotnetDir);
+			}
+
 			string dotnetInstall = Path.Combine(Path.GetFullPath(repoDir), "dotnet-install");
 			if (context.RuntimeIdentifier.Contains("win")) {
 				dotnetInstall += ".ps1";
@@ -103,57 +199,7 @@ namespace ILLink.Tests
 				}
 			}
 
-			string dotnetDir = Path.Combine(rootDir, dotnetDirName);
-			string dotnetToolName = Directory.GetFiles(dotnetDir)
-				.Select(p => Path.GetFileName(p))
-				.Where(p => p.Contains("dotnet"))
-				.Single();
-			string dotnetToolPath = Path.Combine(dotnetDir, dotnetToolName);
-			if (!File.Exists(dotnetToolPath)) {
-				output.WriteLine("repo-local dotnet tool does not exist.");
-				Assert.True(false);
-			}
-
-			string globalJson = Path.Combine(repoDir, "global.json");
-			string globalJsonContents = "{ \"sdk\": { \"version\": \"" + sdkVersion + "\" } }\n";
-			File.WriteAllText(globalJson, globalJsonContents);
-
-			return dotnetToolPath;
-		}
-
-		// returns path to .csproj project file
-		string SetupProject()
-		{
-			int ret;
-			if (Directory.Exists(repoName)) {
-				Directory.Delete(repoName, true);
-			}
-
-			ret = RunCommand("git", $"clone {gitRepo}");
-			if (ret != 0) {
-				output.WriteLine("git failed");
-				Assert.True(false);
-			}
-
-			string demoRoot = Path.Combine("JitBench", Path.Combine("src", "MusicStore"));
-			if (!Directory.Exists(demoRoot)) {
-				output.WriteLine($"{demoRoot} does not exist");
-				Assert.True(false);
-			}
-
-			ret = RunCommand("git", $"checkout {gitRevision}", demoRoot);
-			if (ret != 0) {
-				output.WriteLine($"problem checking out revision {gitRevision}");
-				Assert.True(false);
-			}
-
-			// MusicStore targets .NET Core 2.1, so it must be built
-			// using an SDK that can target 2.1. We obtain that SDK
-			// here.
-			context.DotnetToolPath = ObtainSDK(context.TestBin, repoName);
-
-			string csproj = Path.Combine(demoRoot, "MusicStore.csproj");
-			return csproj;
+			return GetDotnetToolPath(dotnetDir);
 		}
 
 		static void CopyRootFiles(string demoRoot)

--- a/corebuild/integration/test/MusicStoreTest.cs
+++ b/corebuild/integration/test/MusicStoreTest.cs
@@ -32,17 +32,17 @@ namespace ILLink.Tests
 		// The version of Microsoft.AspNetCore.All to publish with.
 		private static string aspNetVersion = "2.1.0-preview1-27654";
 
-		private static Dictionary<string, string> extraPublishArgs;
-		private static Dictionary<string, string> ExtraPublishArgs
+		private static Dictionary<string, string> versionPublishArgs;
+		private static Dictionary<string, string> VersionPublishArgs
 		{
 			get {
-				if (extraPublishArgs != null) {
-					return extraPublishArgs;
+				if (versionPublishArgs != null) {
+					return versionPublishArgs;
 				}
-				extraPublishArgs = new Dictionary<string, string>();
-				extraPublishArgs.Add("JITBENCH_FRAMEWORK_VERSION", runtimeVersion);
-				extraPublishArgs.Add("JITBENCH_ASPNET_VERSION", aspNetVersion);
-				return extraPublishArgs;
+				versionPublishArgs = new Dictionary<string, string>();
+				versionPublishArgs.Add("JITBENCH_FRAMEWORK_VERSION", runtimeVersion);
+				versionPublishArgs.Add("JITBENCH_ASPNET_VERSION", aspNetVersion);
+				return versionPublishArgs;
 			}
 		}
 
@@ -60,14 +60,16 @@ namespace ILLink.Tests
 		[Fact]
 		public void RunMusicStoreStandalone()
 		{
-			string executablePath = BuildAndLink(csproj, rootFiles, ExtraPublishArgs, selfContained: true);
+			string executablePath = BuildAndLink(csproj, rootFiles, VersionPublishArgs, selfContained: true);
 			CheckOutput(executablePath, selfContained: true);
 		}
 
 		[Fact]
 		public void RunMusicStorePortable()
 		{
-			string target = BuildAndLink(csproj, rootFiles, ExtraPublishArgs, selfContained: false);
+			Dictionary<string, string> extraPublishArgs = new Dictionary<string, string>(VersionPublishArgs);
+			extraPublishArgs.Add("PublishWithAspNetCoreTargetManifest", "false");
+			string target = BuildAndLink(csproj, null, extraPublishArgs, selfContained: false);
 			CheckOutput(target, selfContained: false);
 		}
 

--- a/corebuild/integration/test/WebApiTest.cs
+++ b/corebuild/integration/test/WebApiTest.cs
@@ -64,10 +64,10 @@ namespace ILLink.Tests
 		[Fact]
 		public void RunWebApi()
 		{
-			BuildAndLink(csproj);
+			string target = BuildAndLink(csproj);
 
 			string terminatingOutput = "Now listening on: http://localhost:5000";
-			int ret = RunApp(csproj, out string commandOutput, 60000, terminatingOutput);
+			int ret = RunApp(target, out string commandOutput, 60000, terminatingOutput);
 			Assert.True(commandOutput.Contains("Application started. Press Ctrl+C to shut down."));
 			Assert.True(commandOutput.Contains(terminatingOutput));
 		}

--- a/corebuild/integration/test/WebApiTest.cs
+++ b/corebuild/integration/test/WebApiTest.cs
@@ -62,12 +62,23 @@ namespace ILLink.Tests
 		}
 
 		[Fact]
-		public void RunWebApi()
+		public void RunWebApiStandalone()
 		{
-			string target = BuildAndLink(csproj);
+			string executablePath = BuildAndLink(csproj, selfContained: true);
+			CheckOutput(executablePath, selfContained: true);
+		}
 
+		[Fact]
+		public void RunWebApiPortable()
+		{
+			string target = BuildAndLink(csproj, selfContained: false);
+			CheckOutput(target, selfContained: false);
+		}
+
+		void CheckOutput(string target, bool selfContained = false)
+		{
 			string terminatingOutput = "Now listening on: http://localhost:5000";
-			int ret = RunApp(target, out string commandOutput, 60000, terminatingOutput);
+			int ret = RunApp(target, out string commandOutput, 60000, terminatingOutput, selfContained: selfContained);
 			Assert.True(commandOutput.Contains("Application started. Press Ctrl+C to shut down."));
 			Assert.True(commandOutput.Contains(terminatingOutput));
 		}

--- a/corebuild/integration/test/WebApiTest.cs
+++ b/corebuild/integration/test/WebApiTest.cs
@@ -8,11 +8,21 @@ namespace ILLink.Tests
 {
 	public class WebApiTest : IntegrationTestBase
 	{
-		public WebApiTest(ITestOutputHelper output) : base(output) {}
+		private string csproj;
+
+		public WebApiTest(ITestOutputHelper output) : base(output) {
+			csproj = SetupProject();
+		}
 
 		public string SetupProject()
 		{
 			string projectRoot = "webapi";
+			string csproj = Path.Combine(projectRoot, $"{projectRoot}.csproj");
+
+			if (File.Exists(csproj)) {
+				output.WriteLine($"using existing project {csproj}");
+				return csproj;
+			}
 
 			if (Directory.Exists(projectRoot)) {
 				Directory.Delete(projectRoot, true);
@@ -25,7 +35,10 @@ namespace ILLink.Tests
 				Assert.True(false);
 			}
 
-			string csproj = Path.Combine(projectRoot, $"{projectRoot}.csproj");
+			PreventPublishFiltering(csproj);
+
+			AddLinkerReference(csproj);
+
 			return csproj;
 		}
 
@@ -51,12 +64,6 @@ namespace ILLink.Tests
 		[Fact]
 		public void RunWebApi()
 		{
-			string csproj = SetupProject();
-
-			PreventPublishFiltering(csproj);
-
-			AddLinkerReference(csproj);
-
 			BuildAndLink(csproj);
 
 			string terminatingOutput = "Now listening on: http://localhost:5000";


### PR DESCRIPTION
This enables the linker to run during a portable publish.

During portable publish, the framework is shared. The set of assemblies to be excluded from publish is determined by a platform manifest that's part of the NETCore.App package. The portable publish set can include references to parts of the framework that are filtered by this mechanism, and aren't exposed as reference assemblies (for example, platform-specific assemblies that we don't want developers to compile against directly). With [tolerate resolution errors](https://github.com/mono/linker/pull/260), the linker can tolerate such missing references.

However, we still want to pass ReferencePath to the linker to prevent a large number of resolution warnings for parts of the framework that don't get published. This doesn't cover everything (as noted above), but limits the number of warnings. These reference assemblies are made part of the linker "platform", with a default action of skip during portable publish. This way the ref assemblies are used to prevent resolution errors, but they aren't part of the linker output.

Portable publish also depends on [find more native dependencies](https://github.com/mono/linker/pull/261).

In addition to the mentioned changes, this includes integration tests that exercise portable publish on helloworld, webapi, and musicstore.

@erozenfeld, @ericstj PTAL.
/cc @richlander @petermarcu


