### PR TITLE
Add ClearInitLocalsAssemblies parameter for ClearInitLocalsStep.

### DIFF
--- a/corebuild/integration/ILLink.CustomSteps/ClearInitLocals.cs
+++ b/corebuild/integration/ILLink.CustomSteps/ClearInitLocals.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 using Mono.Linker;
 using Mono.Linker.Steps;
@@ -8,17 +9,41 @@ namespace ILLink.CustomSteps
 {
 	public class ClearInitLocalsStep : BaseStep
 	{
-		protected override void ProcessAssembly(AssemblyDefinition assembly)
+		HashSet<string> _assemblies;
+
+		protected override void Process ()
 		{
+			string parameterName = "ClearInitLocalsAssemblies";
+
+			if (Context.HasParameter (parameterName)) {
+				string parameter = Context.GetParameter (parameterName);
+				_assemblies = new HashSet<string> (parameter.Split(','), StringComparer.OrdinalIgnoreCase);
+			}
+		}
+
+		protected override void ProcessAssembly (AssemblyDefinition assembly)
+		{
+			if ((_assemblies != null) && (!_assemblies.Contains (assembly.Name.Name))) {
+				return;
+			}
+
+			bool changed = false;
+
 			foreach (ModuleDefinition module in assembly.Modules) {
 				foreach (TypeDefinition type in module.Types) {
 					foreach (MethodDefinition method in type.Methods) {
 						if (method.Body != null) {
-							method.Body.InitLocals = false;
+							if (method.Body.InitLocals) {
+								method.Body.InitLocals = false;
+								changed = true;
+							}
 						}
 					}
 				}
 			}
+
+			if (changed && (Annotations.GetAction (assembly) == AssemblyAction.Copy))
+					Annotations.SetAction (assembly, AssemblyAction.Save);
 		}
 	}
 }

--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
@@ -26,6 +26,7 @@
     <RootAllApplicationAssemblies Condition=" '$(RootAllApplicationAssemblies)' != 'true' ">false</RootAllApplicationAssemblies>
     <LinkerTrimNativeDeps Condition=" '$(LinkerTrimNativeDeps)' == '' ">true</LinkerTrimNativeDeps>
     <LinkerTrimNativeDeps Condition=" '$(LinkerTrimNativeDeps)' != 'true' ">false</LinkerTrimNativeDeps>
+    <ClearInitLocals Condition=" '$(ClearInitLocals)' == '' ">false</ClearInitLocals>
   </PropertyGroup>
 
   <!-- This depends on LinkDuringPublish, so it needs to be imported
@@ -223,6 +224,9 @@
          scenario in which the linker is invoked. -->
     <PropertyGroup>
       <ExtraLinkerArgs Condition=" '$(ExtraLinkerArgs)' == '' ">-t -l none -b true --skip-unresolved true</ExtraLinkerArgs>
+      <!-- version of ILLink.CustomSteps is passed as a workaround for msbuild issue #3016 -->
+      <ExtraLinkerArgs Condition=" '$(ClearInitLocals)' == 'true' ">$(ExtraLinkerArgs) -s ILLink.CustomSteps.ClearInitLocalsStep,ILLink.CustomSteps,Version=0.0.0.0:OutputStep</ExtraLinkerArgs>
+      <ExtraLinkerArgs Condition=" '$(ClearInitLocals)' == 'true' and '$(ClearInitLocalsAssemblies)' != ''">$(ExtraLinkerArgs) -m ClearInitLocalsAssemblies $(ClearInitLocalsAssemblies)</ExtraLinkerArgs>
     </PropertyGroup>
     <ILLink AssemblyPaths="@(_ManagedAssembliesToLink)"
             RootAssemblyNames="@(LinkerRootAssemblies)"


### PR DESCRIPTION
Modified ClearInitLocalsStep to accept ClearInitLocalsAssemblies
custom parameter that can be specified via -m. The parameter
is a comma-separated list of assembly simple names that the the
step should be applied to. If the parameter is not specified ClearInitLocals
runs on all assemblies.