### PR TITLE
Add --strip-security option to remove security attributes

### DIFF
--- a/linker/Linker.Steps/RemoveSecurityStep.cs
+++ b/linker/Linker.Steps/RemoveSecurityStep.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Linq;
+using Mono.Cecil;
+
+namespace Mono.Linker.Steps {
+	public class RemoveSecurityStep : BaseStep {
+		protected override void ProcessAssembly (AssemblyDefinition assembly)
+		{
+			if (Annotations.GetAction (assembly) == AssemblyAction.Link) {
+				ClearSecurityDeclarations (assembly);
+				RemoveCustomAttributesThatAreForSecurity (assembly);
+
+				foreach (var type in assembly.MainModule.Types)
+					ProcessType (type);
+			}
+		}
+
+		static void ProcessType (TypeDefinition type)
+		{
+			RemoveCustomAttributesThatAreForSecurity (type);
+			ClearSecurityDeclarations (type);
+			type.HasSecurity = false;
+
+			foreach (var field in type.Fields)
+				RemoveCustomAttributesThatAreForSecurity (field);
+
+			foreach (var method in type.Methods) {
+				ClearSecurityDeclarations (method);
+				RemoveCustomAttributesThatAreForSecurity (method);
+				method.HasSecurity = false;
+			}
+
+			foreach (var nested in type.NestedTypes)
+				ProcessType (nested);
+		}
+
+		static void ClearSecurityDeclarations (ISecurityDeclarationProvider provider)
+		{
+			provider.SecurityDeclarations.Clear ();
+		}
+
+		/// <summary>
+		/// We have to remove some security attributes, otherwise pe verify will complain that a type has HasSecurity = false
+		/// </summary>
+		/// <param name="provider"></param>
+		static void RemoveCustomAttributesThatAreForSecurity (ICustomAttributeProvider provider)
+		{
+			if (!provider.HasCustomAttributes)
+				return;
+
+			var attrsToRemove = provider.CustomAttributes.Where (IsCustomAttributeForSecurity).ToArray ();
+			foreach (var remove in attrsToRemove)
+				provider.CustomAttributes.Remove (remove);
+		}
+
+		static bool IsCustomAttributeForSecurity (CustomAttribute attr)
+		{
+			switch (attr.AttributeType.FullName) {
+			case "System.Security.SecurityCriticalAttribute":
+			case "System.Security.SecuritySafeCriticalAttribute":
+			case "System.Security.SuppressUnmanagedCodeSecurityAttribute":
+				return true;
+			}
+
+			return false;
+		}
+	}
+}

--- a/linker/Linker/Driver.cs
+++ b/linker/Linker/Driver.cs
@@ -122,6 +122,12 @@ namespace Mono.Linker {
 							context.KeepUsedAttributeTypesOnly = bool.Parse (GetParam ());
 							continue;
 						}
+						
+						if (token == "--strip-security") {
+							if (bool.Parse (GetParam ()))
+								p.AddStepBefore (typeof (MarkStep), new RemoveSecurityStep ());
+							continue;
+						}
 
 						switch (token [2]) {
 						case 'v':
@@ -340,6 +346,7 @@ namespace Mono.Linker {
 			Console.WriteLine ("   --dump-dependencies Dump dependencies for the linker analyzer tool");
 			Console.WriteLine ("   --reduced-tracing   Reduces dependency output related to assemblies that will not be modified");
 			Console.WriteLine ("   --used-attrs-only   Attributes on types, methods, etc will be removed if the attribute type is not used");
+			Console.WriteLine ("   --strip-security    In linked assemblies, attributes on assemblies, types, and methods related to security will be removed");
 			Console.WriteLine ("   -out                Specify the output directory, default to `output'");
 			Console.WriteLine ("   -c                  Action on the core assemblies, skip, copy, copyused, addbypassngen, addbypassngenused or link, default to skip");
 			Console.WriteLine ("   -u                  Action on the user assemblies, skip, copy, copyused, addbypassngen, addbypassngenused or link, default to link");

--- a/linker/Mono.Linker.csproj
+++ b/linker/Mono.Linker.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Linker.Steps\CleanStep.cs" />
     <Compile Include="Linker.Steps\RegenerateGuidStep.cs" />
     <Compile Include="Linker.Steps\LoadI18nAssemblies.cs" />
+    <Compile Include="Linker.Steps\RemoveSecurityStep.cs" />
     <Compile Include="Linker\IXApiVisitor.cs" />
     <Compile Include="Linker\I18nAssemblies.cs" />
     <Compile Include="Linker.Steps\IStep.cs" />

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/RemovedPseudoAttributeAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/RemovedPseudoAttributeAttribute.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Assertions {
+	[AttributeUsage (AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Delegate | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Event, AllowMultiple = true, Inherited = false)]
+	public class RemovedPseudoAttributeAttribute : BaseExpectedLinkedBehaviorAttribute {
+		public RemovedPseudoAttributeAttribute (uint value) {
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Assertions\KeptTypeInAssemblyAttribute.cs" />
     <Compile Include="Assertions\RemovedAssemblyAttribute.cs" />
     <Compile Include="Assertions\RemovedMemberInAssemblyAttribute.cs" />
+    <Compile Include="Assertions\RemovedPseudoAttributeAttribute.cs" />
     <Compile Include="Assertions\RemovedResourceInAssemblyAttribute.cs" />
     <Compile Include="Assertions\RemovedSymbolsAttribute.cs" />
     <Compile Include="Assertions\RemovedTypeInAssemblyAttribute.cs" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/NoSecurity/CoreLibrarySecurityAttributeTypesAreRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/NoSecurity/CoreLibrarySecurityAttributeTypesAreRemoved.cs
@@ -1,0 +1,38 @@
+﻿using System.Diagnostics;
+using System.Security;
+using System.Security.Permissions;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Attributes.NoSecurity {
+	[SetupLinkerCoreAction ("link")]
+	[SetupLinkerArgument ("--strip-security", "true")]
+	[Reference ("System.dll")]
+	// Attributes from System.Security.Permissions
+	[RemovedTypeInAssembly ("mscorlib.dll", typeof (SecurityPermissionAttribute))]
+	[RemovedTypeInAssembly ("mscorlib.dll", typeof (PermissionSetAttribute))]
+	[RemovedTypeInAssembly ("mscorlib.dll", typeof (ReflectionPermissionAttribute))]
+	[RemovedTypeInAssembly ("mscorlib.dll", typeof (RegistryPermissionAttribute))]
+	[RemovedTypeInAssembly ("mscorlib.dll", typeof (StrongNameIdentityPermissionAttribute))]
+	[RemovedTypeInAssembly ("mscorlib.dll", typeof (CodeAccessSecurityAttribute))]
+	[RemovedTypeInAssembly ("mscorlib.dll", typeof (EnvironmentPermissionAttribute))]
+	[RemovedTypeInAssembly ("mscorlib.dll", typeof (FileIOPermissionAttribute))]
+	[RemovedTypeInAssembly ("mscorlib.dll", typeof (HostProtectionAttribute))]
+	
+	// "Special" attributes from System.Security namespace that we seem to need to remove in order to set HasSecurity = false and not have
+	// pe verify complain
+	[RemovedTypeInAssembly ("mscorlib.dll", typeof (SecurityCriticalAttribute))]
+	[RemovedTypeInAssembly ("mscorlib.dll", typeof (SecuritySafeCriticalAttribute))]
+	[RemovedTypeInAssembly ("mscorlib.dll", typeof (SuppressUnmanagedCodeSecurityAttribute))]
+	
+	// Fails with `Runtime critical type System.Reflection.CustomAttributeData not found` which is a known short coming
+	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
+	[SkipPeVerify ("System.dll")]
+	public class CoreLibrarySecurityAttributeTypesAreRemoved {
+		public static void Main ()
+		{
+			// Use something that has security attributes to make this test more meaningful
+			var process = new Process ();
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/NoSecurity/SecurityAttributesOnUsedMethodAreRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/NoSecurity/SecurityAttributesOnUsedMethodAreRemoved.cs
@@ -1,0 +1,24 @@
+﻿using System.Security.Permissions;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Attributes.NoSecurity {
+	[SetupLinkerArgument ("--strip-security", "true")]
+	public class SecurityAttributesOnUsedMethodAreRemoved {
+		static void Main ()
+		{
+			new Foo ().Method ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		class Foo {
+			[SecurityPermission (SecurityAction.LinkDemand)]
+			[Kept]
+			[RemovedPseudoAttribute (16384)]
+			public void Method ()
+			{
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/NoSecurity/SecurityAttributesOnUsedTypeAreRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/NoSecurity/SecurityAttributesOnUsedTypeAreRemoved.cs
@@ -1,0 +1,20 @@
+﻿using System.Security.Permissions;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Attributes.NoSecurity {
+	[SetupLinkerArgument ("--strip-security", "true")]
+	public class SecurityAttributesOnUsedTypeAreRemoved {
+		static void Main ()
+		{
+			new Foo ();
+		}
+
+		[SecurityPermission (SecurityAction.LinkDemand)]
+		[Kept]
+		[KeptMember (".ctor()")]
+		[RemovedPseudoAttribute (262144u)]
+		class Foo {
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/CoreLink/NoSecurityPlusOnlyKeepUsedRemovesAllSecurityAttributesFromCoreLibraries.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/CoreLink/NoSecurityPlusOnlyKeepUsedRemovesAllSecurityAttributesFromCoreLibraries.cs
@@ -1,0 +1,37 @@
+﻿using System.Diagnostics;
+using System.Security;
+using System.Security.Permissions;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.CoreLink {
+	[SetupLinkerCoreAction ("link")]
+	[SetupLinkerArgument ("--strip-security", "true")]
+	[SetupLinkerArgument ("--used-attrs-only", "true")]
+	[Reference ("System.dll")]
+	[RemovedTypeInAssembly ("mscorlib.dll", typeof (SecurityPermissionAttribute))]
+	[RemovedTypeInAssembly ("mscorlib.dll", typeof (PermissionSetAttribute))]
+	[RemovedTypeInAssembly ("mscorlib.dll", typeof (ReflectionPermissionAttribute))]
+	[RemovedTypeInAssembly ("mscorlib.dll", typeof (RegistryPermissionAttribute))]
+	[RemovedTypeInAssembly ("mscorlib.dll", typeof (StrongNameIdentityPermissionAttribute))]
+	[RemovedTypeInAssembly ("mscorlib.dll", typeof (CodeAccessSecurityAttribute))]
+	[RemovedTypeInAssembly ("mscorlib.dll", typeof (EnvironmentPermissionAttribute))]
+	[RemovedTypeInAssembly ("mscorlib.dll", typeof (FileIOPermissionAttribute))]
+	[RemovedTypeInAssembly ("mscorlib.dll", typeof (HostProtectionAttribute))]
+	[RemovedTypeInAssembly ("mscorlib.dll", typeof (SecurityCriticalAttribute))]
+	[RemovedTypeInAssembly ("mscorlib.dll", typeof (SecuritySafeCriticalAttribute))]
+	[RemovedTypeInAssembly ("mscorlib.dll", typeof (SuppressUnmanagedCodeSecurityAttribute))]
+	[RemovedTypeInAssembly ("mscorlib.dll", typeof (SecurityRulesAttribute))]
+	[RemovedTypeInAssembly ("mscorlib.dll", typeof (AllowPartiallyTrustedCallersAttribute))]
+	[RemovedTypeInAssembly ("mscorlib.dll", typeof (UnverifiableCodeAttribute))]
+	// Fails with `Runtime critical type System.Reflection.CustomAttributeData not found` which is a known short coming
+	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
+	[SkipPeVerify ("System.dll")]
+	public class NoSecurityPlusOnlyKeepUsedRemovesAllSecurityAttributesFromCoreLibraries {
+		public static void Main ()
+		{
+			// Use something that has security attributes to make this test more meaningful
+			var process = new Process ();
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -51,6 +51,9 @@
     <Compile Include="Attributes\AttributeOnUsedMethodIsKept.cs" />
     <Compile Include="Attributes\AttributeOnUsedPropertyIsKept.cs" />
     <None Include="Attributes\OnlyKeepUsed\Dependencies\UnusedAttributeWithTypeForwarderIsRemoved_Forwarder.cs" />
+    <Compile Include="Attributes\NoSecurity\SecurityAttributesOnUsedMethodAreRemoved.cs" />
+    <Compile Include="Attributes\NoSecurity\SecurityAttributesOnUsedTypeAreRemoved.cs" />
+    <Compile Include="Attributes\NoSecurity\CoreLibrarySecurityAttributeTypesAreRemoved.cs" />
     <Compile Include="Attributes\OnlyKeepUsed\Dependencies\UnusedAttributeWithTypeForwarderIsRemoved_Lib.cs" />
     <Compile Include="Attributes\OnlyKeepUsed\AttributeDefinedAndUsedInOtherAssemblyIsKept.cs" />
     <Compile Include="Attributes\OnlyKeepUsed\AttributeUsedByAttributeIsKept.cs" />
@@ -94,6 +97,7 @@
     <Compile Include="Basic\UsedEventOnInterfaceIsRemovedWhenUsedFromClass.cs" />
     <Compile Include="Basic\UsedPropertyIsKept.cs" />
     <Compile Include="Basic\UsedStructIsKept.cs" />
+    <Compile Include="CoreLink\NoSecurityPlusOnlyKeepUsedRemovesAllSecurityAttributesFromCoreLibraries.cs" />
     <Compile Include="LinkXml\CanPreserveTypesUsingRegex.cs" />
     <Compile Include="LinkXml\CanPreserveAnExportedType.cs" />
     <None Include="LinkXml\Dependencies\CanPreserveAnExportedType_Forwarder.cs" />


### PR DESCRIPTION
Add an option that will remove SecurityDeclarations from Types and Methods along with a few security attributes.

When this new option is used with `--strip-security`  all attributes from System.Security and System.Security.Permissions that are not used will be linked away.