### PR TITLE
Add ClearInitLocals and ClearInitLocalsAssemblies optional ILLink task parameters.

### DIFF
--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
@@ -224,15 +224,14 @@
          scenario in which the linker is invoked. -->
     <PropertyGroup>
       <ExtraLinkerArgs Condition=" '$(ExtraLinkerArgs)' == '' ">-t -l none -b true --skip-unresolved true --verbose</ExtraLinkerArgs>
-      <!-- version of ILLink.CustomSteps is passed as a workaround for msbuild issue #3016 -->
-      <ExtraLinkerArgs Condition=" '$(ClearInitLocals)' == 'true' ">$(ExtraLinkerArgs) -s ILLink.CustomSteps.ClearInitLocalsStep,ILLink.CustomSteps,Version=0.0.0.0:OutputStep</ExtraLinkerArgs>
-      <ExtraLinkerArgs Condition=" '$(ClearInitLocals)' == 'true' and '$(ClearInitLocalsAssemblies)' != ''">$(ExtraLinkerArgs) -m ClearInitLocalsAssemblies $(ClearInitLocalsAssemblies)</ExtraLinkerArgs>
     </PropertyGroup>
     <ILLink AssemblyPaths="@(_ManagedAssembliesToLink)"
             RootAssemblyNames="@(LinkerRootAssemblies)"
             RootDescriptorFiles="@(LinkerRootDescriptors)"
             OutputDirectory="$(IntermediateLinkDir)"
             DumpDependencies="$(LinkerDumpDependencies)"
+            ClearInitLocals="$(ClearInitLocals)"
+            ClearInitLocalsAssemblies="$(ClearInitLocalsAssemblies)"
             ExtraArgs="$(ExtraLinkerArgs)" />
 
     <Touch Files="$(_LinkSemaphore)" AlwaysCreate="true">

--- a/corebuild/integration/ILLink.Tasks/LinkTask.cs
+++ b/corebuild/integration/ILLink.Tasks/LinkTask.cs
@@ -47,6 +47,17 @@ namespace ILLink.Tasks
 		public ITaskItem [] RootDescriptorFiles { get; set; }
 
 		/// <summary>
+		///   Boolean specifying whether to clear initlocals flag on methods.
+		/// </summary>
+		public bool ClearInitLocals { get; set; }
+
+		/// <summary>
+		///   A comma-separated list of assemblies whose methods
+		///   should have initlocals flag cleared if ClearInitLocals is true.
+		/// </summary>
+		public string ClearInitLocalsAssemblies { get; set; }
+
+		/// <summary>
 		///   Extra arguments to pass to illink, delimited by spaces.
 		/// </summary>
 		public string ExtraArgs { get; set; }
@@ -103,6 +114,17 @@ namespace ILLink.Tasks
 			if (OutputDirectory != null) {
 				args.Add ("-out");
 				args.Add (OutputDirectory.ItemSpec);
+			}
+
+			if (ClearInitLocals) {
+				args.Add ("-s");
+				// Version of ILLink.CustomSteps is passed as a workaround for msbuild issue #3016
+				args.Add ("ILLink.CustomSteps.ClearInitLocalsStep,ILLink.CustomSteps,Version=0.0.0.0:OutputStep");
+				if ((ClearInitLocalsAssemblies != null) && (ClearInitLocalsAssemblies.Length > 0)) {
+					args.Add ("-m");
+					args.Add ("ClearInitLocalsAssemblies");
+					args.Add (ClearInitLocalsAssemblies);
+				}
 			}
 
 			if (ExtraArgs != null) {


### PR DESCRIPTION
This change allows ClearInitLocals and ClearInitLocalsAssemblies to be specified
directly on ILLink task, which is useful when the task  used outside of publishing (e.g., in corefx).
