### PR TITLE
Fix a regression introduced in f9c0d99, putting back the try/catch.

### DIFF
--- a/linker/Linker/LinkContext.cs
+++ b/linker/Linker/LinkContext.cs
@@ -233,16 +233,18 @@ namespace Mono.Linker {
 
 			if (_symbolReaderProvider == null)
 				throw new ArgumentNullException (nameof (_symbolReaderProvider));
-			
-			var symbolReader = _symbolReaderProvider.GetSymbolReader (
-				assembly.MainModule,
-				assembly.MainModule.FileName);
 
-			if (symbolReader == null)
-				return;
+			try {
+				var symbolReader = _symbolReaderProvider.GetSymbolReader (
+					assembly.MainModule,
+					assembly.MainModule.FileName);
 
-			_annotations.AddSymbolReader (assembly, symbolReader);
-			assembly.MainModule.ReadSymbols (symbolReader);
+				if (symbolReader == null)
+					return;
+
+				_annotations.AddSymbolReader (assembly, symbolReader);
+				assembly.MainModule.ReadSymbols (symbolReader);
+			} catch { }
 		}
 
 		public virtual ICollection<AssemblyDefinition> ResolveReferences (AssemblyDefinition assembly)


### PR DESCRIPTION
`LinkContext.SafeReadSymbols` used to have a try / catch block around the actual symbol reading.

This got removed in [f9c0d99](https://github.com/mono/linker/commit/f9c0d99fd8630c508f2c801552282b8218ff9d3c) and is now breaking the monthly Xamarin.Android integration.