### PR TITLE
Set crossgen defaults when linker is enabled

### DIFF
--- a/corebuild/integration/ILLink.Tasks/ComputeCrossgenedAssemblies.cs
+++ b/corebuild/integration/ILLink.Tasks/ComputeCrossgenedAssemblies.cs
@@ -4,7 +4,7 @@ using Microsoft.Build.Utilities;
 
 namespace ILLink.Tasks
 {
-	public class ComputeReadyToRunAssemblies : Task
+	public class ComputeCrossgenedAssemblies : Task
 	{
 		/// <summary>
 		///   Paths to assemblies.
@@ -13,16 +13,16 @@ namespace ILLink.Tasks
 		public ITaskItem[] Assemblies { get; set; }
 
 		/// <summary>
-		///   This will contain the output list of
-		///   ready-to-run assemblies. Metadata from the input
-		///   parameter Assemblies is preserved.
+		///   This will contain the output list of crossgen-ed
+		///   assemblies. Metadata from the input parameter
+		///   Assemblies is preserved.
 		/// </summary>
 		[Output]
-		public ITaskItem[] ReadyToRunAssemblies { get; set; }
+		public ITaskItem[] CrossgenedAssemblies { get; set; }
 
 		public override bool Execute()
 		{
-			ReadyToRunAssemblies = Assemblies
+			CrossgenedAssemblies = Assemblies
 				.Where(f => Utils.IsCrossgenedAssembly(f.ItemSpec))
 				.ToArray();
 			return true;

--- a/corebuild/integration/ILLink.Tasks/ILLink.CrossGen.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.CrossGen.targets
@@ -210,17 +210,17 @@
 
   </Target>
 
-  <UsingTask TaskName="ComputeReadyToRunAssemblies" AssemblyFile="$(LinkTaskDllPath)" />
+  <UsingTask TaskName="ComputeCrossgenedAssemblies" AssemblyFile="$(LinkTaskDllPath)" />
   <Target Name="_ComputeFilesToCrossGen"
           DependsOnTargets="_ComputeDefaultFilesToCrossGen">
 
-    <ComputeReadyToRunAssemblies Assemblies="@(FilesToCrossGen)">
-      <Output TaskParameter="ReadyToRunAssemblies" ItemName="_ReadyToRunFiles" />
-    </ComputeReadyToRunAssemblies>
+    <ComputeCrossgenedAssemblies Assemblies="@(FilesToCrossGen)">
+      <Output TaskParameter="CrossgenedAssemblies" ItemName="_CrossgenedFiles" />
+    </ComputeCrossgenedAssemblies>
 
     <!-- Don't try to run crossgen on assemblies that are already R2R. -->
     <ItemGroup>
-      <FilesToCrossGen Remove="@(_ReadyToRunFiles)" />
+      <FilesToCrossGen Remove="@(_CrossgenedFiles)" />
     </ItemGroup>
 
     <Message Text="files to crossgen: @(FilesToCrossGen)" />

--- a/corebuild/integration/ILLink.Tasks/ILLink.CrossGen.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.CrossGen.targets
@@ -208,8 +208,6 @@
       <FilesToCrossGen Include="@(_PlatformLibrariesForCrossGen)" />
     </ItemGroup>
 
-    <Error Text="System.Private.CoreLib should already be crossgen compiled."
-           Condition=" '%(FilesToCrossGen.Filename)' == 'System.Private.CoreLib' " />
   </Target>
 
   <UsingTask TaskName="ComputeReadyToRunAssemblies" AssemblyFile="$(LinkTaskDllPath)" />

--- a/corebuild/integration/ILLink.Tasks/ILLink.CrossGen.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.CrossGen.targets
@@ -28,8 +28,7 @@
     <ItemGroup>
       <_CrossGenResolvedAssembliesToPublishCandidates Include="@(ResolvedAssembliesToPublish->'$(IntermediateOptimizedDir)/%(Filename)%(Extension)')" />
       <_CrossGenResolvedAssembliesToPublish Include="@(_CrossGenResolvedAssembliesToPublishCandidates)" Condition="Exists('%(Identity)')" />
-      <!-- FilesToCrossGen doesn't contain System.Private.CoreLib, so
-           it will still be published. -->
+
       <ResolvedAssembliesToPublish Remove="@(FilesToCrossGen)" />
       <ResolvedAssembliesToPublish Include="@(_CrossGenResolvedAssembliesToPublish)" />
     </ItemGroup>

--- a/corebuild/integration/ILLink.Tasks/ILLink.CrossGen.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.CrossGen.targets
@@ -187,9 +187,9 @@
 
   <UsingTask TaskName="FilterByMetadata" AssemblyFile="$(LinkTaskDllPath)" />
   <!-- This computes the default set of files that we want to be
-       crossgen'd. Some of these may already be R2R images, and these
-       will not be crossgen'd again. The default is to crossgen the
-       app and platform libraries. Defaults will be used only if
+       crossgen'd. Some of these may already be crossgen images, and
+       these will not be crossgen'd again. The default is to crossgen
+       the app and platform libraries. Defaults will be used only if
        FilesToCrossGen hasn't been set elsewhere, allowing users and
        other props/targets to select what will be crossgen'd. -->
   <Target Name="_ComputeDefaultFilesToCrossGen"
@@ -217,7 +217,8 @@
       <Output TaskParameter="CrossgenedAssemblies" ItemName="_CrossgenedFiles" />
     </ComputeCrossgenedAssemblies>
 
-    <!-- Don't try to run crossgen on assemblies that are already R2R. -->
+    <!-- Don't try to run crossgen on assemblies that are already
+         crossgen'd. -->
     <ItemGroup>
       <FilesToCrossGen Remove="@(_CrossgenedFiles)" />
     </ItemGroup>

--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.csproj
@@ -101,7 +101,7 @@
     <Compile Include="LinkTask.cs" />
     <Compile Include="CompareSizes.cs" />
     <Compile Include="ComputeManagedAssemblies.cs" />
-    <Compile Include="ComputeReadyToRunAssemblies.cs" />
+    <Compile Include="ComputeCrossgenedAssemblies.cs" />
     <Compile Include="GetRuntimeLibraries.cs" />
     <Compile Include="CreateRootDescriptorFile.cs" />
     <Compile Include="CreateRuntimeRootDescriptorFile.cs" />

--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
@@ -232,17 +232,6 @@
       <Output TaskParameter="AssemblyPathsWithActions" ItemName="_ManagedAssembliesToLinkWithActions" />
     </SetAssemblyActions>
 
-    <!-- For System.Private.CoreLib, we set the action to skip if it
-         doesn't have an embedded root descriptor. This prevents it
-         from being analyzed, but it can still potentially be modified
-         and output by the linker if it needs to add the
-         BypassNGenAttribute. -->
-    <ItemGroup Condition=" '$(_SPCHasEmbeddedRootDescriptor)' != 'true' ">
-      <_ManagedAssembliesToLinkWithActions Condition=" '%(Filename)' == 'System.Private.CoreLib' ">
-        <action>skip</action>
-      </_ManagedAssembliesToLinkWithActions>
-    </ItemGroup>
-
     <ItemGroup>
       <_ManagedAssembliesToLink Remove="@(_ManagedAssembliesToLink)" />
       <_ManagedAssembliesToLink Include="@(_ManagedAssembliesToLinkWithActions)" />

--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
@@ -201,12 +201,12 @@
       <Output TaskParameter="FilteredItems" ItemName="_OriginalLinkedAssemblies" />
     </FilterByMetadata>
 
-    <ComputeReadyToRunAssemblies Assemblies="@(_OriginalLinkedAssemblies)">
-      <Output TaskParameter="ReadyToRunAssemblies" ItemName="_OriginalLinkedAssembliesThatWereCrossgend" />
-    </ComputeReadyToRunAssemblies>
+    <ComputeCrossgenedAssemblies Assemblies="@(_OriginalLinkedAssemblies)">
+      <Output TaskParameter="CrossgenedAssemblies" ItemName="_OriginalLinkedAssembliesThatWereCrossgened" />
+    </ComputeCrossgenedAssemblies>
 
     <ItemGroup>
-      <_LinkedAssembliesToCrossgen Include="@(_OriginalLinkedAssembliesThatWereCrossgend->'$(IntermediateLinkDir)/%(Filename)%(Extension)')" />
+      <_LinkedAssembliesToCrossgen Include="@(_OriginalLinkedAssembliesThatWereCrossgened->'$(IntermediateLinkDir)/%(Filename)%(Extension)')" />
       <FilesToCrossgen Include="@(_LinkedAssembliesToCrossgen)" />
     </ItemGroup>
 

--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
@@ -214,7 +214,7 @@
 
   <UsingTask TaskName="SetAssemblyActions" AssemblyFile="$(LinkTaskDllPath)" />
   <Target Name="_SetAssemblyActions"
-          DependsOnTargets="_ComputeManagedAssembliesToLink;_ComputePlatformLibraries;_CheckSystemPrivateCorelibEmbeddedRoots">
+          DependsOnTargets="_ComputeManagedAssembliesToLink;_ComputePlatformLibraries">
 
     <ItemGroup>
       <_PlatformAssembliesToLink Include="@(PlatformLibraries->'%(Filename)')" />
@@ -391,7 +391,7 @@
        be part of the build step or pack step, OR pack could be made
        to work on the publish output. -->
   <Target Name="_ComputeLinkerRootAssemblies"
-          DependsOnTargets="_ComputeManagedResolvedAssembliesToPublish;_ComputePlatformLibraries">
+          DependsOnTargets="_ComputeManagedResolvedAssembliesToPublish;_ComputePlatformLibraries;_CheckSystemPrivateCorelibEmbeddedRoots">
     <!-- If RootAllApplicationAssemblies is true, roots are everything
          minus the framework assemblies. This doesn't include the
          intermediate assembly, because we root it separately using an
@@ -412,6 +412,11 @@
     <ItemGroup Condition=" '$(RootAllApplicationAssemblies)' == 'false' ">
       <LinkerRootAssemblies Include="@(IntermediateAssembly)" />
     </ItemGroup>
+
+    <ItemGroup Condition=" '$(_SPCHasEmbeddedRootDescriptor)' != 'true' ">
+      <LinkerRootAssemblies Include="@(_ManagedResolvedAssembliesToPublish->'%(Filename)'" Condition=" '%(Filename)' == 'System.Private.CoreLib' " />
+    </ItemGroup>
+
   </Target>
 
   <UsingTask TaskName="CheckEmbeddedRootDescriptor" AssemblyFile="$(LinkTaskDllPath)" />

--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
@@ -186,33 +186,68 @@
       <_LinkedDebugSymbols Include="@(__LinkedDebugSymbols)"
                            Condition="Exists('%(Identity)') And '$(_DebugSymbolsProduced)' == 'true' " />
     </ItemGroup>
+
+  </Target>
+
+  <!-- Compute the default set of assemblies to crossgen after
+       linking. This will include any assemblies modified by the
+       linker that were crossgen'd before linking. -->
+  <Target Name="_ComputeLinkedAssembliesToCrossgen"
+          AfterTargets="_ComputeLinkedAssemblies"
+          Condition=" '$(CrossGenDuringPublish)' == 'true' ">
+    <FilterByMetadata Items="@(_ManagedResolvedAssembliesToPublish);@(IntermediateAssembly)"
+                      MetadataName="Filename"
+                      MetadataValues="@(_LinkedResolvedAssemblies->'%(Filename)');@(_LinkedIntermediateAssembly->'%(Filename)')">
+      <Output TaskParameter="FilteredItems" ItemName="_OriginalLinkedAssemblies" />
+    </FilterByMetadata>
+
+    <ComputeReadyToRunAssemblies Assemblies="@(_OriginalLinkedAssemblies)">
+      <Output TaskParameter="ReadyToRunAssemblies" ItemName="_OriginalLinkedAssembliesThatWereCrossgend" />
+    </ComputeReadyToRunAssemblies>
+
+    <ItemGroup>
+      <_LinkedAssembliesToCrossgen Include="@(_OriginalLinkedAssembliesThatWereCrossgend->'$(IntermediateLinkDir)/%(Filename)%(Extension)')" />
+      <FilesToCrossgen Include="@(_LinkedAssembliesToCrossgen)" />
+    </ItemGroup>
+
   </Target>
 
   <UsingTask TaskName="SetAssemblyActions" AssemblyFile="$(LinkTaskDllPath)" />
   <Target Name="_SetAssemblyActions"
-          DependsOnTargets="_ComputeManagedAssembliesToLink;_ComputePlatformLibraries">
+          DependsOnTargets="_ComputeManagedAssembliesToLink;_ComputePlatformLibraries;_CheckSystemPrivateCorelibEmbeddedRoots">
 
-      <ItemGroup>
-          <_PlatformAssembliesToLink Include="@(PlatformLibraries->'%(Filename)')" />
-          <_PlatformAssembliesToLink Include="System.Private.CoreLib" />
-          <_ApplicationAssembliesToLink Include="@(_ManagedAssembliesToLink->'%(Filename)')" />
-          <_ApplicationAssembliesToLink Remove="@(_PlatformAssembliesToLink)" />
-      </ItemGroup>
+    <ItemGroup>
+      <_PlatformAssembliesToLink Include="@(PlatformLibraries->'%(Filename)')" />
+      <_ApplicationAssembliesToLink Include="@(_ManagedAssembliesToLink->'%(Filename)')" />
+      <_ApplicationAssembliesToLink Remove="@(_PlatformAssembliesToLink)" />
+    </ItemGroup>
 
-      <SetAssemblyActions AssemblyPaths="@(_ManagedAssembliesToLink)"
-                          ApplicationAssemblyNames="@(_ApplicationAssembliesToLink)"
-                          PlatformAssemblyNames="@(_PlatformAssembliesToLink)"
-                          UsedApplicationAssemblyAction="$(UsedApplicationAssemblyAction)"
-                          UnusedApplicationAssemblyAction="$(UnusedApplicationAssemblyAction)"
-                          UsedPlatformAssemblyAction="$(UsedPlatformAssemblyAction)"
-                          UnusedPlatformAssemblyAction="$(UnusedPlatformAssemblyAction)">
-        <Output TaskParameter="AssemblyPathsWithActions" ItemName="_ManagedAssembliesToLinkWithActions" />
-      </SetAssemblyActions>
+    <SetAssemblyActions AssemblyPaths="@(_ManagedAssembliesToLink)"
+                        ApplicationAssemblyNames="@(_ApplicationAssembliesToLink)"
+                        PlatformAssemblyNames="@(_PlatformAssembliesToLink)"
+                        UsedApplicationAssemblyAction="$(UsedApplicationAssemblyAction)"
+                        UnusedApplicationAssemblyAction="$(UnusedApplicationAssemblyAction)"
+                        UsedPlatformAssemblyAction="$(UsedPlatformAssemblyAction)"
+                        UnusedPlatformAssemblyAction="$(UnusedPlatformAssemblyAction)">
+      <Output TaskParameter="AssemblyPathsWithActions" ItemName="_ManagedAssembliesToLinkWithActions" />
+    </SetAssemblyActions>
 
-      <ItemGroup>
-          <_ManagedAssembliesToLink Remove="@(_ManagedAssembliesToLink)" />
-          <_ManagedAssembliesToLink Include="@(_ManagedAssembliesToLinkWithActions)" />
-      </ItemGroup>
+    <!-- For System.Private.CoreLib, we set the action to skip if it
+         doesn't have an embedded root descriptor. This prevents it
+         from being analyzed, but it can still potentially be modified
+         and output by the linker if it needs to add the
+         BypassNGenAttribute. -->
+    <ItemGroup Condition=" '$(_SPCHasEmbeddedRootDescriptor)' != 'true' ">
+      <_ManagedAssembliesToLinkWithActions Condition=" '%(Filename)' == 'System.Private.CoreLib' ">
+        <action>skip</action>
+      </_ManagedAssembliesToLinkWithActions>
+    </ItemGroup>
+
+    <ItemGroup>
+      <_ManagedAssembliesToLink Remove="@(_ManagedAssembliesToLink)" />
+      <_ManagedAssembliesToLink Include="@(_ManagedAssembliesToLinkWithActions)" />
+    </ItemGroup>
+
   </Target>
 
   <!-- This calls the linker. Inputs are the managed assemblies to
@@ -367,7 +402,7 @@
        be part of the build step or pack step, OR pack could be made
        to work on the publish output. -->
   <Target Name="_ComputeLinkerRootAssemblies"
-          DependsOnTargets="_ComputeManagedResolvedAssembliesToPublish;_ComputePlatformLibraries;_CheckSystemPrivateCorelibEmbeddedRoots">
+          DependsOnTargets="_ComputeManagedResolvedAssembliesToPublish;_ComputePlatformLibraries">
     <!-- If RootAllApplicationAssemblies is true, roots are everything
          minus the framework assemblies. This doesn't include the
          intermediate assembly, because we root it separately using an
@@ -382,13 +417,11 @@
     <ItemGroup Condition=" '$(RootAllApplicationAssemblies)' == 'true' ">
       <_LinkerRootAssemblies Include="@(_ManagedResolvedAssembliesToPublish->'%(Filename)')" />
       <_LinkerRootAssemblies Remove="@(PlatformLibraries->'%(Filename)')" />
-      <_LinkerRootAssemblies Remove="System.Private.CoreLib" Condition=" '$(_SPCHasEmbeddedRootDescriptor)' == 'true' "/>
       <LinkerRootAssemblies Include="@(_LinkerRootAssemblies)" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(RootAllApplicationAssemblies)' == 'false' ">
       <LinkerRootAssemblies Include="@(IntermediateAssembly)" />
-      <LinkerRootAssemblies Include="System.Private.CoreLib" Condition=" '$(_SPCHasEmbeddedRootDescriptor)' == 'false' "/>
     </ItemGroup>
   </Target>
 
@@ -412,6 +445,11 @@
                          PackageNames="$(MicrosoftNETPlatformLibrary)">
       <Output TaskParameter="RuntimeLibraries" ItemName="PlatformLibraries" />
     </GetRuntimeLibraries>
+
+    <ItemGroup>
+      <PlatformLibraries Include="@(_ManagedAssembliesToLink)" Condition=" '%(Filename)' == 'System.Private.CoreLib' " />
+    </ItemGroup>
+
     <ItemGroup Condition=" '$(SelfContained)' != 'true' ">
       <!-- Portable publish: computed referenced-not-published set in _ComputeManagedAssembliesToLink -->
       <PlatformLibraries Include="@(_ReferencedLibraries)" />

--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
@@ -414,7 +414,7 @@
     </ItemGroup>
 
     <ItemGroup Condition=" '$(_SPCHasEmbeddedRootDescriptor)' != 'true' ">
-      <LinkerRootAssemblies Include="@(_ManagedResolvedAssembliesToPublish->'%(Filename)'" Condition=" '%(Filename)' == 'System.Private.CoreLib' " />
+      <LinkerRootAssemblies Include="@(_ManagedResolvedAssembliesToPublish->'%(Filename)')" Condition=" '%(Filename)' == 'System.Private.CoreLib' " />
     </ItemGroup>
 
   </Target>

--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
@@ -205,6 +205,11 @@
       <Output TaskParameter="CrossgenedAssemblies" ItemName="_OriginalLinkedAssembliesThatWereCrossgened" />
     </ComputeCrossgenedAssemblies>
 
+    <!-- Ideally, we would remember which assemblies were R2R and
+         which were fragile crossgen-ed, and do the same after
+         linking. Currently this makes no difference because
+         System.Private.CoreLib is the only fragile image, and it
+         can't be ready-to-run crossgen-ed. -->
     <ItemGroup>
       <_LinkedAssembliesToCrossgen Include="@(_OriginalLinkedAssembliesThatWereCrossgened->'$(IntermediateLinkDir)/%(Filename)%(Extension)')" />
       <FilesToCrossgen Include="@(_LinkedAssembliesToCrossgen)" />


### PR DESCRIPTION
This introduces behavior that will crossgen any assemblies modified by the linker that were crossgen'd before linking.

The defaults for SPC have been updated so that it will never be rooted via -a. If it has an embedded root descriptor, this is the same as before - the root descriptor will specify what to root from SPC. If it doesn't have one, then its action will be AddBypassNGenUsed as it is part of the platform.

@erozenfeld PTAL.