### PR TITLE
Make TestDatabase public

### DIFF
--- a/linker/Tests/TestCases/TestDatabase.cs
+++ b/linker/Tests/TestCases/TestDatabase.cs
@@ -7,7 +7,7 @@ using Mono.Linker.Tests.TestCasesRunner;
 
 namespace Mono.Linker.Tests.TestCases
 {
-	static class TestDatabase
+	public static class TestDatabase
 	{
 		public static IEnumerable<TestCaseData> XmlTests()
 		{


### PR DESCRIPTION
We want to access TestDatabase so that we can run tests in test fixture classes that do not derive from `All`