### PR TITLE
Don't attempt to link duplicate managed assemblies

### DIFF
--- a/corebuild/integration/ILLink.Tasks/FindDuplicatesByMetadata.cs
+++ b/corebuild/integration/ILLink.Tasks/FindDuplicatesByMetadata.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace ILLink.Tasks
+{
+	public class FindDuplicatesByMetadata : Task
+	{
+		/// <summary>
+		///   Items to scan.
+		/// </summary>
+		[Required]
+		public ITaskItem [] Items { get; set; }
+
+		/// <summary>
+		///   Name of metadata to scan for.
+		/// </summary>
+		[Required]
+		public String MetadataName { get; set; }
+
+		/// <summary>
+		///   Duplicate items: the input items for which the
+		///   specified metadata was shared by multiple input
+		///   items.
+		/// </summary>
+		[Output]
+		public ITaskItem [] DuplicateItems { get; set; }
+
+		public override bool Execute ()
+		{
+			DuplicateItems = Items.GroupBy (i => i.GetMetadata(MetadataName))
+				.Where (g => g.Count () > 1)
+				.SelectMany (g => g)
+				.ToArray ();
+			return true;
+		}
+	}
+}

--- a/corebuild/integration/ILLink.Tasks/FindDuplicatesByMetadata.cs
+++ b/corebuild/integration/ILLink.Tasks/FindDuplicatesByMetadata.cs
@@ -37,7 +37,7 @@ namespace ILLink.Tasks
 
 		public override bool Execute ()
 		{
-			var duplicateGroups = Items.GroupBy (i => i.GetMetadata(MetadataName))
+			var duplicateGroups = Items.GroupBy (i => i.GetMetadata (MetadataName))
 				.Where (g => g.Count () > 1);
 			DuplicateItems = duplicateGroups.SelectMany (g => g).ToArray ();
 			DuplicateRepresentatives = duplicateGroups.Select (g => g.First ()).ToArray ();

--- a/corebuild/integration/ILLink.Tasks/FindDuplicatesByMetadata.cs
+++ b/corebuild/integration/ILLink.Tasks/FindDuplicatesByMetadata.cs
@@ -28,12 +28,19 @@ namespace ILLink.Tasks
 		[Output]
 		public ITaskItem [] DuplicateItems { get; set; }
 
+		/// <summary>
+		///   Duplicate representatives: includes one input
+		///   item from each set of duplicates.
+		/// </summary>
+		[Output]
+		public ITaskItem [] DuplicateRepresentatives { get; set; }
+
 		public override bool Execute ()
 		{
-			DuplicateItems = Items.GroupBy (i => i.GetMetadata(MetadataName))
-				.Where (g => g.Count () > 1)
-				.SelectMany (g => g)
-				.ToArray ();
+			var duplicateGroups = Items.GroupBy (i => i.GetMetadata(MetadataName))
+				.Where (g => g.Count () > 1);
+			DuplicateItems = duplicateGroups.SelectMany (g => g).ToArray ();
+			DuplicateRepresentatives = duplicateGroups.Select (g => g.First ()).ToArray ();
 			return true;
 		}
 	}

--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.csproj
@@ -106,6 +106,7 @@
     <Compile Include="CreateRootDescriptorFile.cs" />
     <Compile Include="CreateRuntimeRootDescriptorFile.cs" />
     <Compile Include="FilterByMetadata.cs" />
+    <Compile Include="FindDuplicatesByMetadata.cs" />
     <Compile Include="Utils.cs" />
     <Compile Include="Microsoft.NET.Build.Tasks/LockFileCache.cs" />
     <Compile Include="Microsoft.NET.Build.Tasks/BuildErrorException.cs" />

--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
@@ -502,7 +502,7 @@
           DependsOnTargets="_ComputeManagedResolvedAssembliesToPublish;_ComputeLinkedAssemblies;_FindNativeDeps;_HandlePublishFileConflicts"
           BeforeTargets="GeneratePublishDependencyFile"
           Condition=" '$(LinkDuringPublish)' == 'true' ">
-    <ComputeRemovedAssemblies InputAssemblies="@(_ManagedResolvedAssembliesToPublish)"
+    <ComputeRemovedAssemblies InputAssemblies="@(_ManagedAssembliesToLink)"
                               KeptAssemblies="@(_LinkedResolvedAssemblies)">
       <Output TaskParameter="RemovedAssemblies" ItemName="_RemovedManagedAssemblies" />
     </ComputeRemovedAssemblies>

--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
@@ -319,11 +319,11 @@
       <_ManagedAssembliesToLink Include="@(_ManagedResolvedAssembliesToPublish)" />
     </ItemGroup>
 
-    <!-- Remove all implementation dlls that have duplicates. This can
-         happen if a portable app has platform-specific managed
-         assemblies. The linker isn't currently able to analyze
-         multiple assemblies with the same identity, so we skip
-         these. -->
+    <!-- Remove duplicate implementation dlls. This can happen if a
+         portable app has platform-specific managed assemblies. The
+         linker isn't currently able to analyze multiple assemblies
+         with the same identity, so we skip these, keeping only one
+         representative assembly from each set of duplicates. -->
     <FindDuplicatesByMetadata Items="@(_ManagedAssembliesToLink)"
                               MetadataName="Filename">
       <Output TaskParameter="DuplicateItems" ItemName="_DuplicateManagedAssemblies" />

--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
@@ -426,8 +426,13 @@
     <ItemGroup Condition=" '$(RootAllApplicationAssemblies)' == 'true' ">
       <_LinkerRootAssemblies Include="@(_ManagedResolvedAssembliesToPublish->'%(Filename)')" />
       <_LinkerRootAssemblies Remove="@(PlatformLibraries->'%(Filename)')" />
-      <_LinkerRootAssemblies Remove="@(_DuplicateManagedAssembliesToSkip->'%(Filename)')" />
-      <LinkerRootAssemblies Include="@(_LinkerRootAssemblies)" />
+    </ItemGroup>
+    <RemoveDuplicates Inputs="@(_LinkerRootAssemblies)"
+                      Condition=" '$(RootAllApplicationAssemblies)' == 'true' ">
+      <Output TaskParameter="Filtered" ItemName="_UniqueLinkerRootAssemblies" />
+    </RemoveDuplicates>
+    <ItemGroup Condition=" '$(RootAllApplicationAssemblies)' == 'true' ">
+      <LinkerRootAssemblies Include="@(_UniqueLinkerRootAssemblies)" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(RootAllApplicationAssemblies)' == 'false' ">

--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
@@ -95,7 +95,7 @@
     <!-- Rewrite ResolvedAssembliesToPublish, which is an input to
          ComputeFilesToPublish. -->
     <ItemGroup>
-      <ResolvedAssembliesToPublish Remove="@(_ManagedResolvedAssembliesToPublish)" />
+      <ResolvedAssembliesToPublish Remove="@(_ManagedAssembliesToLink)" />
       <ResolvedAssembliesToPublish Remove="@(_NativeResolvedDepsToPublish)" />
       <ResolvedAssembliesToPublish Include="@(_NativeKeptDepsToPublish)" />
       <ResolvedAssembliesToPublish Include="@(_LinkedResolvedAssemblies)" />
@@ -299,7 +299,7 @@
       <_NativeDepsToAlwaysKeep Include="hostpolicy.dll;libhostpolicy.dylib;libhostpolicy.so" />
     </ItemGroup>
 
-    <FindNativeDeps ManagedAssemblyPaths="@(_ManagedLinkedAssemblies)"
+    <FindNativeDeps ManagedAssemblyPaths="@(_ManagedLinkedAssemblies);@(_DuplicateManagedAssemblies)"
                     NativeDepsPaths="@(_NativeResolvedDepsToPublish)"
                     NativeDepsToKeep="@(_NativeDepsToAlwaysKeep)">
       <Output TaskParameter="KeptNativeDepsPaths" ItemName="_NativeKeptDepsToPublish" />
@@ -310,11 +310,25 @@
   <!-- Computes the managed assemblies that are input to the
        linker. Includes managed assemblies from
        ResolvedAssembliesToPublish, and IntermediateAssembly. -->
+  <UsingTask TaskName="FindDuplicatesByMetadata" AssemblyFile="$(LinkTaskDllPath)" />
   <Target Name="_ComputeManagedAssembliesToLink"
           DependsOnTargets="_ComputeManagedResolvedAssembliesToPublish">
     <ItemGroup>
       <_ManagedAssembliesToLink Include="@(IntermediateAssembly)" />
       <_ManagedAssembliesToLink Include="@(_ManagedResolvedAssembliesToPublish)" />
+    </ItemGroup>
+
+    <!-- Remove all implementation dlls that have duplicates. This can
+         happen if a portable app has platform-specific managed
+         assemblies. The linker isn't currently able to analyze
+         multiple assemblies with the same identity, so we skip
+         these. -->
+    <FindDuplicatesByMetadata Items="@(_ManagedAssembliesToLink)"
+                              MetadataName="Filename">
+      <Output TaskParameter="DuplicateItems" ItemName="_DuplicateManagedAssemblies" />
+    </FindDuplicatesByMetadata>
+    <ItemGroup>
+      <_ManagedAssembliesToLink Remove="@(_DuplicateManagedAssemblies)" />
     </ItemGroup>
 
     <!-- Portable publish: need to supply the linker with any needed
@@ -408,6 +422,7 @@
     <ItemGroup Condition=" '$(RootAllApplicationAssemblies)' == 'true' ">
       <_LinkerRootAssemblies Include="@(_ManagedResolvedAssembliesToPublish->'%(Filename)')" />
       <_LinkerRootAssemblies Remove="@(PlatformLibraries->'%(Filename)')" />
+      <_LinkerRootAssemblies Remove="@(_DuplicateManagedAssemblies->'%(Filename)')" />
       <LinkerRootAssemblies Include="@(_LinkerRootAssemblies)" />
     </ItemGroup>
 

--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
@@ -172,6 +172,7 @@
           DependsOnTargets="_ComputeManagedResolvedAssembliesToPublish;ILLink">
     <ItemGroup>
       <__LinkedResolvedAssemblies Include="@(_ManagedResolvedAssembliesToPublish->'$(IntermediateLinkDir)/%(Filename)%(Extension)')" />
+      <__LinkedResolvedAssemblies Remove="@(_DuplicateManagedAssembliesToSkip->'$(IntermediateLinkDir)/%(Filename)%(Extension)')" />
       <_LinkedResolvedAssemblies Include="@(__LinkedResolvedAssemblies)" Condition="Exists('%(Identity)')" />
     </ItemGroup>
 

--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
@@ -299,7 +299,7 @@
       <_NativeDepsToAlwaysKeep Include="hostpolicy.dll;libhostpolicy.dylib;libhostpolicy.so" />
     </ItemGroup>
 
-    <FindNativeDeps ManagedAssemblyPaths="@(_ManagedLinkedAssemblies);@(_DuplicateManagedAssemblies)"
+    <FindNativeDeps ManagedAssemblyPaths="@(_ManagedLinkedAssemblies);@(_DuplicateManagedAssembliesToSkip)"
                     NativeDepsPaths="@(_NativeResolvedDepsToPublish)"
                     NativeDepsToKeep="@(_NativeDepsToAlwaysKeep)">
       <Output TaskParameter="KeptNativeDepsPaths" ItemName="_NativeKeptDepsToPublish" />
@@ -326,9 +326,12 @@
     <FindDuplicatesByMetadata Items="@(_ManagedAssembliesToLink)"
                               MetadataName="Filename">
       <Output TaskParameter="DuplicateItems" ItemName="_DuplicateManagedAssemblies" />
+      <Output TaskParameter="DuplicateRepresentatives" ItemName="_DuplicateManagedAssembliesToLink" />
     </FindDuplicatesByMetadata>
     <ItemGroup>
-      <_ManagedAssembliesToLink Remove="@(_DuplicateManagedAssemblies)" />
+      <_DuplicateManagedAssembliesToSkip Include="@(_DuplicateManagedAssemblies)" />
+      <_DuplicateManagedAssembliesToSkip Remove="@(_DuplicateManagedAssembliesToLink)" />
+      <_ManagedAssembliesToLink Remove="@(_DuplicateManagedAssembliesToSkip)" />
     </ItemGroup>
 
     <!-- Portable publish: need to supply the linker with any needed
@@ -422,7 +425,7 @@
     <ItemGroup Condition=" '$(RootAllApplicationAssemblies)' == 'true' ">
       <_LinkerRootAssemblies Include="@(_ManagedResolvedAssembliesToPublish->'%(Filename)')" />
       <_LinkerRootAssemblies Remove="@(PlatformLibraries->'%(Filename)')" />
-      <_LinkerRootAssemblies Remove="@(_DuplicateManagedAssemblies->'%(Filename)')" />
+      <_LinkerRootAssemblies Remove="@(_DuplicateManagedAssembliesToSkip->'%(Filename)')" />
       <LinkerRootAssemblies Include="@(_LinkerRootAssemblies)" />
     </ItemGroup>
 


### PR DESCRIPTION
Portable apps can have platform-specific managed assemblies, but the
linker isn't able to handle multiple assemblies with the same
identity. We detect such duplicates, and prevent them from being
linked at all. This will prevent analysis of some code paths, but
seems to be fairly rare.

I've observed the following cases:
- System.Data.SqlClient
- System.Text.Encoding.CodePages

Both were pulled in by the ASP.NET metapackage. Some of these
duplicate assemblies may have native dependencies, so the native
trimming logic does scan them.

@erozenfeld, @ericstj please review.