### PR TITLE
Root Internal methods when resolving from assembly.

### DIFF
--- a/linker/Linker.Steps/ResolveFromAssemblyStep.cs
+++ b/linker/Linker.Steps/ResolveFromAssemblyStep.cs
@@ -225,18 +225,24 @@ namespace Mono.Linker.Steps
 		static void MarkMethod (LinkContext context, MethodDefinition method, MethodAction action, RootVisibility rootVisibility)
 		{
 			bool markMethod;
-			switch (rootVisibility) {
-			default:
+
+			if (method.IsInternalCall)
 				markMethod = true;
-				break;
+			else {
 
-			case RootVisibility.PublicAndFamily:
-				markMethod = method.IsPublic || method.IsFamily || method.IsFamilyOrAssembly;
-				break;
+				switch (rootVisibility) {
+					default:
+						markMethod = true;
+						break;
 
-			case RootVisibility.PublicAndFamilyAndAssembly:
-				markMethod = method.IsPublic || method.IsFamily || method.IsFamilyOrAssembly || method.IsAssembly || method.IsFamilyAndAssembly;
-				break;
+					case RootVisibility.PublicAndFamily:
+						markMethod = method.IsPublic || method.IsFamily || method.IsFamilyOrAssembly;
+						break;
+
+					case RootVisibility.PublicAndFamilyAndAssembly:
+						markMethod = method.IsPublic || method.IsFamily || method.IsFamilyOrAssembly || method.IsAssembly || method.IsFamilyAndAssembly;
+						break;
+				}
 			}
 
 			if (markMethod) {


### PR DESCRIPTION
Internal methods should be rooted regardless of their visibility.
