### PR TITLE
Make removal of processed resources optional.

### DIFF
--- a/linker/Linker.Steps/ResolveFromXmlStep.cs
+++ b/linker/Linker.Steps/ResolveFromXmlStep.cs
@@ -93,7 +93,7 @@ namespace Mono.Linker.Steps {
 			try {
 				ProcessAssemblies (Context, nav.SelectChildren ("assembly", _ns));
 
-				if (!string.IsNullOrEmpty (_resourceName))
+				if (!string.IsNullOrEmpty (_resourceName) && Context.StripResources)
 					Context.Annotations.AddResourceToRemove (_resourceAssembly, _resourceName);
 			} catch (Exception ex) when (!(ex is XmlResolutionException)) {
 				throw new XmlResolutionException (string.Format ("Failed to process XML description: {0}", _xmlDocumentLocation), ex);

--- a/linker/Linker/Driver.cs
+++ b/linker/Linker/Driver.cs
@@ -143,6 +143,11 @@ namespace Mono.Linker {
 							continue;
 						}
 
+						if (token == "--strip-resources") {
+							context.StripResources = bool.Parse (GetParam ());
+							continue;
+						}
+
 						switch (token [2]) {
 						case 'v':
 							Version ();
@@ -316,6 +321,7 @@ namespace Mono.Linker {
 			return assemblies;
 		}
 
+
 		AssemblyAction ParseAssemblyAction (string s)
 		{
 			var assemblyAction = (AssemblyAction)Enum.Parse(typeof(AssemblyAction), s, true);
@@ -362,6 +368,7 @@ namespace Mono.Linker {
 			Console.WriteLine ("   --reduced-tracing   Reduces dependency output related to assemblies that will not be modified");
 			Console.WriteLine ("   --used-attrs-only   Attributes on types, methods, etc will be removed if the attribute type is not used");
 			Console.WriteLine ("   --strip-security    In linked assemblies, attributes on assemblies, types, and methods related to security will be removed");
+			Console.WriteLine ("   --strip-resources   Remove link xml resources that were processed (true or false), default to true");
 			Console.WriteLine ("   -out                Specify the output directory, default to `output'");
 			Console.WriteLine ("   -c                  Action on the core assemblies, skip, copy, copyused, addbypassngen, addbypassngenused or link, default to skip");
 			Console.WriteLine ("   -u                  Action on the user assemblies, skip, copy, copyused, addbypassngen, addbypassngenused or link, default to link");

--- a/linker/Linker/LinkContext.cs
+++ b/linker/Linker/LinkContext.cs
@@ -111,6 +111,8 @@ namespace Mono.Linker {
 
 		public bool KeepUsedAttributeTypesOnly { get; set; }
 
+		public bool StripResources { get; set; }
+
 		public System.Collections.IDictionary Actions {
 			get { return _actions; }
 		}
@@ -171,6 +173,7 @@ namespace Mono.Linker {
 			_annotations = factory.CreateAnnotationStore (this);
 			MarkingHelpers = factory.CreateMarkingHelpers (this);
 			Tracer = factory.CreateTracer (this);
+			StripResources = true;
 		}
 
 		public TypeDefinition GetType (string fullName)

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/StripResourcesAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/StripResourcesAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Metadata {
+	public sealed class StripResourcesAttribute : BaseMetadataAttribute {
+		public readonly bool Value;
+
+		public StripResourcesAttribute (bool value)
+		{
+			Value = value;
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Metadata\ReferenceAttribute.cs" />
     <Compile Include="Metadata\SandboxDependencyAttribute.cs" />
     <Compile Include="Metadata\SkipUnresolvedAttribute.cs" />
+    <Compile Include="Metadata\StripResourcesAttribute.cs" />
     <Compile Include="Assertions\KeptBaseTypeAttribute.cs" />
     <Compile Include="Assertions\KeptInterfaceAttribute.cs" />
     <Compile Include="Assertions\KeptAttributeAttribute.cs" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -123,6 +123,7 @@
     <Compile Include="Resources\EmbeddedLinkXmlFileIsNotProcessedWhenBlacklistStepIsDisabled.cs" />
     <Compile Include="Resources\EmbeddedLinkXmlFileIsNotProcessedWhenCoreLinkActionIsSkip.cs" />
     <Compile Include="Resources\EmbeddedLinkXmlFileIsProcessed.cs" />
+    <Compile Include="Resources\EmbeddedLinkXmlFileIsProcessedAndKept.cs" />
     <Compile Include="Resources\NonLinkerEmbeddedResourceHasNoImpact.cs" />
     <Compile Include="Symbols\Dependencies\LibraryWithEmbeddedPdbSymbols.cs" />
     <Compile Include="Symbols\Dependencies\LibraryWithPortablePdbSymbols.cs" />
@@ -274,6 +275,7 @@
     <Content Include="Resources\Dependencies\EmbeddedLinkXmlFileIsNotProcessedWhenBlacklistStepIsDisabled.xml" />
     <Content Include="Resources\Dependencies\EmbeddedLinkXmlFileIsNotProcessedWhenCoreLinkActionIsSkip.xml" />
     <Content Include="Resources\Dependencies\EmbeddedLinkXmlFileIsProcessed.xml" />
+    <Content Include="Resources\Dependencies\EmbeddedLinkXmlFileIsProcessedAndKept.xml" />
     <Content Include="Resources\Dependencies\NonLinkerEmbeddedResourceHasNoImpact.xml" />
     <Content Include="TestFramework\Dependencies\CanCompileTestCaseWithCsc.txt" />
     <Content Include="TestFramework\Dependencies\CanCompileTestCaseWithMcs.txt" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/Resources/Dependencies/EmbeddedLinkXmlFileIsProcessedAndKept.xml
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Resources/Dependencies/EmbeddedLinkXmlFileIsProcessedAndKept.xml
@@ -1,0 +1,5 @@
+﻿<linker>
+  <assembly fullname="test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+    <type fullname="Mono.Linker.Tests.Cases.Resources.EmbeddedLinkXmlFileIsProcessedAndKept/Unused" />
+  </assembly>
+</linker>

--- a/linker/Tests/Mono.Linker.Tests.Cases/Resources/EmbeddedLinkXmlFileIsProcessedAndKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Resources/EmbeddedLinkXmlFileIsProcessedAndKept.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Resources
+{
+	[SetupLinkerCoreAction ("link")]
+	[IncludeBlacklistStep (true)]
+	[StripResources (false)]
+
+	// We need to rename the resource so that it matches the name of an assembly being processed.  This is a requriement of the black list step
+	[SetupCompileResource ("Dependencies/EmbeddedLinkXmlFileIsProcessedAndKept.xml", "test.xml")]
+	[SkipPeVerify]
+	[KeptResource ("test.xml")]
+	public class EmbeddedLinkXmlFileIsProcessedAndKept {
+		public static void Main ()
+		{
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		public class Unused {
+		}
+	}
+}

--- a/linker/Tests/TestCasesRunner/LinkerArgumentBuilder.cs
+++ b/linker/Tests/TestCasesRunner/LinkerArgumentBuilder.cs
@@ -74,6 +74,14 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			}
 		}
 
+		public virtual void AddStripResources (bool stripResources)
+		{
+			if (!stripResources) {
+				Append ("--strip-resources");
+				Append ("false");
+			}
+		}
+
 		public string [] ToArgs ()
 		{
 			return _arguments.ToArray ();
@@ -117,6 +125,8 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 				AddLinkSymbols (options.LinkSymbols);
 
 			AddSkipUnresolved (options.SkipUnresolved);
+
+			AddStripResources (options.StripResources);
 
 			// Unity uses different argument format and needs to be able to translate to their format.  In order to make that easier
 			// we keep the information in flag + values format for as long as we can so that this information doesn't have to be parsed out of a single string

--- a/linker/Tests/TestCasesRunner/TestCaseLinkerOptions.cs
+++ b/linker/Tests/TestCasesRunner/TestCaseLinkerOptions.cs
@@ -12,6 +12,7 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 		public string KeepTypeForwarderOnlyAssemblies;
 		public string LinkSymbols;
 		public bool SkipUnresolved;
+		public bool StripResources;
 
 		public List<KeyValuePair<string, string[]>> AdditionalArguments = new List<KeyValuePair<string, string[]>> ();
 	}

--- a/linker/Tests/TestCasesRunner/TestCaseMetadaProvider.cs
+++ b/linker/Tests/TestCasesRunner/TestCaseMetadaProvider.cs
@@ -32,7 +32,8 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 				KeepTypeForwarderOnlyAssemblies = GetOptionAttributeValue (nameof (KeepTypeForwarderOnlyAssembliesAttribute), string.Empty),
 				LinkSymbols = GetOptionAttributeValue (nameof (SetupLinkerLinkSymbolsAttribute), string.Empty),
 				CoreAssembliesAction = GetOptionAttributeValue<string> (nameof (SetupLinkerCoreActionAttribute), null),
-				SkipUnresolved = GetOptionAttributeValue (nameof (SkipUnresolvedAttribute), false)
+				SkipUnresolved = GetOptionAttributeValue (nameof (SkipUnresolvedAttribute), false),
+				StripResources = GetOptionAttributeValue (nameof (StripResourcesAttribute), true)
 			};
 
 			foreach (var assemblyAction in _testCaseTypeDefinition.CustomAttributes.Where (attr => attr.AttributeType.Name == nameof (SetupLinkerActionAttribute)))


### PR DESCRIPTION
We have a scenario when the linker is invoked on an assembly
more than once so we need to preserve the embedded xml resources.