### PR TITLE
Mark [ThreadStatic] and [ContextStatic] attributes

### DIFF
--- a/linker/Linker.Steps/MarkStep.cs
+++ b/linker/Linker.Steps/MarkStep.cs
@@ -308,8 +308,18 @@ namespace Mono.Linker.Steps {
 
 		protected virtual bool ShouldMarkCustomAttribute (CustomAttribute ca)
 		{
-			if (_context.KeepUsedAttributeTypesOnly && !Annotations.IsMarked (ca.AttributeType.Resolve ()))
-				return false;
+			if (_context.KeepUsedAttributeTypesOnly) {
+				switch (ca.AttributeType.FullName) {
+				// [ThreadStatic] and [ContextStatic] are required by the runtime
+				case "System.ThreadStaticAttribute":
+				case "System.ContextStaticAttribute":
+					return true;
+				}
+				
+				if (!Annotations.IsMarked (ca.AttributeType.Resolve ()))
+					return false;
+			}
+
 			return true;
 		}
 

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/ContextStaticIsPreservedOnField.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/ContextStaticIsPreservedOnField.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
+	/// <summary>
+	/// [ContextStatic] is required by the mono runtime
+	/// </summary>
+	[SetupLinkerArgument ("--used-attrs-only", "true")]
+	public class ContextStaticIsPreservedOnField {
+		[ContextStatic]
+		[Kept]
+		[KeptAttributeAttribute (typeof (ContextStaticAttribute))]
+		public static int UsedField;
+		
+		public static void Main ()
+		{
+			UsedField = 0;
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/ThreadStaticIsPreservedOnField.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/ThreadStaticIsPreservedOnField.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
+	/// <summary>
+	/// [ThreadStatic] is required by the mono runtime
+	/// </summary>
+	[SetupLinkerArgument ("--used-attrs-only", "true")]
+	public class ThreadStaticIsPreservedOnField {
+		[ThreadStatic]
+		[Kept]
+		[KeptAttributeAttribute (typeof (ThreadStaticAttribute))]
+		public static int UsedField;
+		
+		public static void Main ()
+		{
+			UsedField = 0;
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -54,9 +54,11 @@
     <Compile Include="Attributes\NoSecurity\SecurityAttributesOnUsedMethodAreRemoved.cs" />
     <Compile Include="Attributes\NoSecurity\SecurityAttributesOnUsedTypeAreRemoved.cs" />
     <Compile Include="Attributes\NoSecurity\CoreLibrarySecurityAttributeTypesAreRemoved.cs" />
+    <Compile Include="Attributes\OnlyKeepUsed\ContextStaticIsPreservedOnField.cs" />
     <Compile Include="Attributes\OnlyKeepUsed\Dependencies\UnusedAttributeWithTypeForwarderIsRemoved_Lib.cs" />
     <Compile Include="Attributes\OnlyKeepUsed\AttributeDefinedAndUsedInOtherAssemblyIsKept.cs" />
     <Compile Include="Attributes\OnlyKeepUsed\AttributeUsedByAttributeIsKept.cs" />
+    <Compile Include="Attributes\OnlyKeepUsed\ThreadStaticIsPreservedOnField.cs" />
     <Compile Include="Attributes\OnlyKeepUsed\UnusedAttributeTypeOnModuleIsRemoved.cs" />
     <Compile Include="Attributes\OnlyKeepUsed\UnusedAttributeWithTypeForwarderIsRemoved.cs" />
     <Compile Include="Attributes\OnlyKeepUsed\CanLinkCoreLibrariesWithOnlyKeepUsedAttributes.cs" />


### PR DESCRIPTION
These attributes are needed by the mono runtime, so they should be kept even if no managed usages of these attributes are marked