### PR TITLE
Use string type check instead of #if for native reader checking

### DIFF
--- a/linker/Linker.Steps/OutputStep.cs
+++ b/linker/Linker.Steps/OutputStep.cs
@@ -162,11 +162,9 @@ namespace Mono.Linker.Steps {
 			if (!assembly.MainModule.HasSymbols)
 				return parameters;
 
-#if NATIVE_READER_SUPPORT
-			// NativePdb's can't be written on non-windows platforms
-			if (Environment.OSVersion.Platform != PlatformID.Win32NT && assembly.MainModule.SymbolReader is Mono.Cecil.Pdb.NativePdbReader)
+			// Use a string check to avoid a hard dependency on Mono.Cecil.Pdb
+			if (Environment.OSVersion.Platform != PlatformID.Win32NT && assembly.MainModule.SymbolReader.GetType ().FullName == "Mono.Cecil.Pdb.NativePdbReader")
 				return parameters;
-#endif
 
 			if (Context.SymbolWriterProvider != null)
 				parameters.SymbolWriterProvider = Context.SymbolWriterProvider;

--- a/linker/Mono.Linker.csproj
+++ b/linker/Mono.Linker.csproj
@@ -33,7 +33,7 @@
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE;NATIVE_READER_SUPPORT</DefineConstants>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -41,7 +41,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>True</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;NATIVE_READER_SUPPORT</DefineConstants>
+    <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>


### PR DESCRIPTION
This is an alternative approach to 
https://github.com/mono/linker/commit/f7f6081202417d43d5b8c3dadd2b7ccd48c2f4cf#diff-78e7cd35fdf21ba1a7924c0def208816

This commit led to a regression in our UnityLinker because we use a different compilation pipeline in certain cases and they did not define NATIVE_READER_SUPPORT.

I think the #if was always going to be fragile and error prone.  I believe this string type check will provide the same flexibility as the commit above desired without requiring special defines to be defined