### PR TITLE
Mark Types Used Via Reflection

### DIFF
--- a/linker/Linker.Steps/MarkStep.cs
+++ b/linker/Linker.Steps/MarkStep.cs
@@ -1636,6 +1636,7 @@ namespace Mono.Linker.Steps {
 			MarkSomethingUsedViaReflection ("GetProperty", MarkPropertyUsedViaReflection, body.Instructions);
 			MarkSomethingUsedViaReflection ("GetField", MarkFieldUsedViaReflection, body.Instructions);
 			MarkSomethingUsedViaReflection ("GetEvent", MarkEventUsedViaReflection, body.Instructions);
+			MarkTypeUsedViaReflection (body.Instructions);
 		}
 
 		protected virtual void MarkInstruction (Instruction instruction)
@@ -1684,22 +1685,30 @@ namespace Mono.Linker.Steps {
 			MarkType (iface.InterfaceType);
 		}
 
+		bool CheckReflectionMethod (Instruction instruction, string reflectionMethod)
+		{
+			if (instruction.OpCode != OpCodes.Call && instruction.OpCode != OpCodes.Callvirt)
+				return false;
+
+			var methodBeingCalled = instruction.Operand as MethodReference;
+			if (methodBeingCalled == null || methodBeingCalled.DeclaringType.Name != "Type" || methodBeingCalled.DeclaringType.Namespace != "System")
+				return false;
+
+			if (methodBeingCalled.Name != reflectionMethod)
+				return false;
+
+			return true;
+		}
 
 		void MarkSomethingUsedViaReflection (string reflectionMethod, Action<Collection<Instruction>, string, TypeDefinition, BindingFlags> markMethod, Collection<Instruction> instructions)
 		{
 			for (var i = 0; i < instructions.Count; i++) {
 				var instruction = instructions [i];
-				if (instruction.OpCode != OpCodes.Call && instruction.OpCode != OpCodes.Callvirt)
+
+				if (!CheckReflectionMethod (instruction, reflectionMethod))
 					continue;
 
-				var methodBeingCalled = instruction.Operand as MethodReference;
-				if (methodBeingCalled == null || methodBeingCalled.DeclaringType.Name != "Type" || methodBeingCalled.DeclaringType.Namespace != "System")
-					continue;
-
-				if (methodBeingCalled.Name != reflectionMethod)
-					continue;
-
-				_context.Tracer.Push ($"Reflection-{methodBeingCalled}");
+				_context.Tracer.Push ($"Reflection-{instruction.Operand as MethodReference}");
 				var nameOfThingUsedViaReflection = OperandOfNearestInstructionBefore<string> (i, OpCodes.Ldstr, instructions);
 				var bindingFlags = (BindingFlags) OperandOfNearestInstructionBefore<sbyte> (i, OpCodes.Ldc_I4_S, instructions);
 
@@ -1710,6 +1719,47 @@ namespace Mono.Linker.Steps {
 					var typeDefinition = declaringTypeOfThingInvokedViaReflection?.Resolve ();
 					if (typeDefinition != null)
 						markMethod (instructions, nameOfThingUsedViaReflection, typeDefinition, bindingFlags);
+				}
+				_context.Tracer.Pop ();
+			}
+		}
+
+		void MarkTypeUsedViaReflection (Collection<Instruction> instructions)
+		{
+			for (var i = 0; i < instructions.Count; i++) {
+				var instruction = instructions [i];
+
+				if (!CheckReflectionMethod (instruction, "GetType"))
+					continue;
+
+				_context.Tracer.Push ($"Reflection-{instruction.Operand as MethodReference}");
+				var typeAssemblyQualifiedName = OperandOfNearestInstructionBefore<string> (i, OpCodes.Ldstr, instructions);
+
+				//We're not going to support preserving generic types yet
+				if (typeAssemblyQualifiedName == null || typeAssemblyQualifiedName.Contains ("`"))
+					continue;
+
+				//Filter the assembly qualified name down to the basic type by removing pointer, reference, and array markers on the type
+				//We must also convert nested types from + to / to match cecil's formatting
+				typeAssemblyQualifiedName = typeAssemblyQualifiedName
+					.Replace ("+", "/")
+					.Replace ("*", string.Empty)
+					.Replace ("&", string.Empty);
+				typeAssemblyQualifiedName = Regex.Replace (typeAssemblyQualifiedName, @"\[(.*?)\]", string.Empty);
+
+				var tokens = typeAssemblyQualifiedName.Split (',');
+				var typeName = tokens [0].Trim ();
+				string assemblyName = null;
+				if (tokens.Length > 1)
+					assemblyName = tokens [1].Trim ();
+
+				foreach (var assemblyDefinition in _context.GetAssemblies ()) {
+					if (assemblyName != null && assemblyDefinition.Name.Name != assemblyName)
+						continue;
+
+					var type = assemblyDefinition.MainModule.GetType (typeName);
+					if (type != null)
+						MarkType (type);
 				}
 				_context.Tracer.Pop ();
 			}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/NoSecurity/CoreLibrarySecurityAttributeTypesAreRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/NoSecurity/CoreLibrarySecurityAttributeTypesAreRemoved.cs
@@ -28,6 +28,11 @@ namespace Mono.Linker.Tests.Cases.Attributes.NoSecurity {
 	// Fails with `Runtime critical type System.Reflection.CustomAttributeData not found` which is a known short coming
 	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
 	[SkipPeVerify ("System.dll")]
+
+	// System.Core.dll is referenced by System.dll in the .NET FW class libraries. Our GetType reflection marking code
+	// detects a GetType("SHA256CryptoServiceProvider") in System.dll, which then causes a type in System.Core.dll to be marked.
+	// PeVerify fails on the original GAC copy of System.Core.dll so it's expected that it will also fail on the stripped version we output
+	[SkipPeVerify ("System.Core.dll")]
 	public class CoreLibrarySecurityAttributeTypesAreRemoved {
 		public static void Main ()
 		{

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/CanLinkCoreLibrariesWithOnlyKeepUsedAttributes.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/CanLinkCoreLibrariesWithOnlyKeepUsedAttributes.cs
@@ -7,7 +7,10 @@ namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
 	[SetupLinkerCoreAction ("link")]
 	[SetupLinkerArgument ("--used-attrs-only", "true")]
 	[Reference ("System.dll")]
-
+	// System.Core.dll is referenced by System.dll in the .NET FW class libraries. Our GetType reflection marking code
+	// detects a GetType("SHA256CryptoServiceProvider") in System.dll, which then causes a type in System.Core.dll to be marked.
+	// PeVerify fails on the original GAC copy of System.Core.dll so it's expected that it will also fail on the stripped version we output
+	[SkipPeVerify ("System.Core.dll")]
 	// Fails with `Runtime critical type System.Reflection.CustomAttributeData not found`
 	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
 	class CanLinkCoreLibrariesWithOnlyKeepUsedAttributes {

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeTypeOnMethodIsRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeTypeOnMethodIsRemoved.cs
@@ -4,6 +4,10 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
 	[SetupLinkerArgument ("--used-attrs-only", "true")]
+	// System.Core.dll is referenced by System.dll in the .NET FW class libraries. Our GetType reflection marking code
+	// detects a GetType("SHA256CryptoServiceProvider") in System.dll, which then causes a type in System.Core.dll to be marked.
+	// PeVerify fails on the original GAC copy of System.Core.dll so it's expected that it will also fail on the stripped version we output
+	[SkipPeVerify ("System.Core.dll")]
 	class UnusedAttributeTypeOnMethodIsRemoved {
 		static void Main ()
 		{

--- a/linker/Tests/Mono.Linker.Tests.Cases/CoreLink/LinkingOfCoreLibrariesRemovesUnusedTypes.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/CoreLink/LinkingOfCoreLibrariesRemovesUnusedTypes.cs
@@ -23,6 +23,10 @@ namespace Mono.Linker.Tests.Cases.CoreLink {
 	//  All sorts of stuff is flagged as invalid even in the original System.dll and System.Configuration.dll for mono class libraries
 	[SkipPeVerify("System.dll")]
 	[SkipPeVerify("System.Configuration.dll")]
+	// System.Core.dll is referenced by System.dll in the .NET FW class libraries. Our GetType reflection marking code
+	// detects a GetType("SHA256CryptoServiceProvider") in System.dll, which then causes a type in System.Core.dll to be marked.
+	// PeVerify fails on the original GAC copy of System.Core.dll so it's expected that it will also fail on the stripped version we output
+	[SkipPeVerify ("System.Core.dll")]
 	class LinkingOfCoreLibrariesRemovesUnusedTypes {
 		public static void Main ()
 		{

--- a/linker/Tests/Mono.Linker.Tests.Cases/CoreLink/NoSecurityPlusOnlyKeepUsedRemovesAllSecurityAttributesFromCoreLibraries.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/CoreLink/NoSecurityPlusOnlyKeepUsedRemovesAllSecurityAttributesFromCoreLibraries.cs
@@ -27,6 +27,10 @@ namespace Mono.Linker.Tests.Cases.CoreLink {
 	// Fails with `Runtime critical type System.Reflection.CustomAttributeData not found` which is a known short coming
 	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
 	[SkipPeVerify ("System.dll")]
+	// System.Core.dll is referenced by System.dll in the .NET FW class libraries. Our GetType reflection marking code
+	// detects a GetType("SHA256CryptoServiceProvider") in System.dll, which then causes a type in System.Core.dll to be marked.
+	// PeVerify fails on the original GAC copy of System.Core.dll so it's expected that it will also fail on the stripped version we output
+	[SkipPeVerify ("System.Core.dll")]
 	public class NoSecurityPlusOnlyKeepUsedRemovesAllSecurityAttributesFromCoreLibraries {
 		public static void Main ()
 		{

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -120,6 +120,7 @@
     <Compile Include="Reflection\MightKeepExtraThings.cs" />
     <Compile Include="Reflection\MethodUsedViaReflection.cs" />
     <Compile Include="Reflection\PropertyUsedViaReflection.cs" />
+    <Compile Include="Reflection\TypeUsedViaReflection.cs" />
     <Compile Include="Reflection\UsedViaReflectionIntegrationTest.cs" />
     <Compile Include="Resources\EmbeddedLinkXmlFileInReferencedAssemblyIsNotProcessedIfNameDoesNotMatchAnAssembly.cs" />
     <Compile Include="Resources\Dependencies\EmbeddedLinkXmlFileInReferencedAssemblyIsNotProcessedIfNameDoesNotMatchAnAssembly_Lib1.cs" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/References/ReferencesAreRemovedWhenAllUsagesAreRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/References/ReferencesAreRemovedWhenAllUsagesAreRemoved.cs
@@ -11,6 +11,10 @@ namespace Mono.Linker.Tests.Cases.References {
 	[RemovedAssembly ("System.dll")]
 	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168
 	[SkipPeVerify(SkipPeVerifyForToolchian.Pedump)]
+	// System.Core.dll is referenced by System.dll in the .NET FW class libraries. Our GetType reflection marking code
+	// detects a GetType("SHA256CryptoServiceProvider") in System.dll, which then causes a type in System.Core.dll to be marked.
+	// PeVerify fails on the original GAC copy of System.Core.dll so it's expected that it will also fail on the stripped version we output
+	[SkipPeVerify ("System.Core.dll")]
 	class ReferencesAreRemovedWhenAllUsagesAreRemoved {
 		public static void Main ()
 		{

--- a/linker/Tests/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflection.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflection.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Diagnostics;
+using System.Reflection;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Reflection {
+	public class TypeUsedViaReflection {
+		public static void Main ()
+		{
+			TestGetTypeKeptViaReflectionFullString ();
+			TestGetTypeKeptViaReflectionTypeAsmName ();
+			TestGetTypeKeptViaReflectionType ();
+			TestGetTypeKeptViaReflectionPointer ();
+			TestGetTypeKeptViaReflectionReference ();
+			TestGetTypeKeptViaReflectionArray ();
+			TestGetTypeKeptViaReflectionArrayOfArray ();
+			TestGetTypeKeptViaReflectionMultiDimentionalArray ();
+			TestGetTypeKeptViaReflectionMultiDimentionalArrayFullString ();
+			TestGetTypeKeptViaReflectionMultiDimentionalArrayAsmName ();
+		}
+
+		[Kept]
+		public class TypeKeptViaReflectionFull { }
+
+		[Kept]
+		public static void TestGetTypeKeptViaReflectionFullString ()
+		{
+			var reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+TypeKeptViaReflectionFull, test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null";
+			var typeKept = Type.GetType (reflectionTypeKeptString, false);
+		}
+
+		[Kept]
+		public class TypeKeptViaReflectionTypeAsmName { }
+
+		[Kept]
+		public static void TestGetTypeKeptViaReflectionTypeAsmName ()
+		{
+			var reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+TypeKeptViaReflectionTypeAsmName, test";
+			var typeKept = Type.GetType (reflectionTypeKeptString, false);
+		}
+
+		[Kept]
+		public class TypeKeptViaReflectionType { }
+
+		[Kept]
+		public static void TestGetTypeKeptViaReflectionType ()
+		{
+			var reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+TypeKeptViaReflectionType";
+			var typeKept = Type.GetType (reflectionTypeKeptString, false);
+		}
+
+		[Kept]
+		public class TypeKeptViaReflectionPointer { }
+
+		[Kept]
+		public static void TestGetTypeKeptViaReflectionPointer ()
+		{
+			var reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+TypeKeptViaReflectionPointer*";
+			var typeKept = Type.GetType (reflectionTypeKeptString, false);
+		}
+
+		[Kept]
+		public class TypeKeptViaReflectionReference { }
+
+		[Kept]
+		public static void TestGetTypeKeptViaReflectionReference ()
+		{
+			var reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+TypeKeptViaReflectionReference&";
+			var typeKept = Type.GetType (reflectionTypeKeptString, false);
+		}
+
+		[Kept]
+		public class TypeKeptViaReflectionArray { }
+
+		[Kept]
+		public static void TestGetTypeKeptViaReflectionArray ()
+		{
+			var reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+TypeKeptViaReflectionArray[]";
+			var typeKept = Type.GetType (reflectionTypeKeptString, false);
+		}
+
+		[Kept]
+		public class TypeKeptViaReflectionArrayOfArray{ }
+
+		[Kept]
+		public static void TestGetTypeKeptViaReflectionArrayOfArray ()
+		{
+			var reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+TypeKeptViaReflectionArrayOfArray[][]";
+			var typeKept = Type.GetType (reflectionTypeKeptString, false);
+		}
+
+
+		[Kept]
+		public class TypeKeptViaReflectionMultiDimentionalArray{ }
+
+		[Kept]
+		public static void TestGetTypeKeptViaReflectionMultiDimentionalArray ()
+		{
+			var reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+TypeKeptViaReflectionMultiDimentionalArray[,]";
+			var typeKept = Type.GetType (reflectionTypeKeptString, false);
+		}
+
+		[Kept]
+		public class TypeKeptViaReflectionMultiDimentionalArrayFullString { }
+
+		[Kept]
+		public static void TestGetTypeKeptViaReflectionMultiDimentionalArrayFullString ()
+		{
+			var reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+TypeKeptViaReflectionMultiDimentionalArrayFullString[,], test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null";
+			var typeKept = Type.GetType (reflectionTypeKeptString, false);
+		}
+
+		[Kept]
+		public class TypeKeptViaReflectionMultiDimentionalArrayAsmName { }
+
+		[Kept]
+		public static void TestGetTypeKeptViaReflectionMultiDimentionalArrayAsmName ()
+		{
+			var reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+TypeKeptViaReflectionMultiDimentionalArrayAsmName[,], test";
+			var typeKept = Type.GetType (reflectionTypeKeptString, false);
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflection.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflection.cs
@@ -7,116 +7,127 @@ namespace Mono.Linker.Tests.Cases.Reflection {
 	public class TypeUsedViaReflection {
 		public static void Main ()
 		{
-			TestGetTypeKeptViaReflectionFullString ();
-			TestGetTypeKeptViaReflectionTypeAsmName ();
-			TestGetTypeKeptViaReflectionType ();
-			TestGetTypeKeptViaReflectionPointer ();
-			TestGetTypeKeptViaReflectionReference ();
-			TestGetTypeKeptViaReflectionArray ();
-			TestGetTypeKeptViaReflectionArrayOfArray ();
-			TestGetTypeKeptViaReflectionMultiDimentionalArray ();
-			TestGetTypeKeptViaReflectionMultiDimentionalArrayFullString ();
-			TestGetTypeKeptViaReflectionMultiDimentionalArrayAsmName ();
+			TestFullString ();
+			TestFullStringConst();
+			TestTypeAsmName ();
+			TestType ();
+			TestPointer ();
+			TestReference ();
+			TestArray ();
+			TestArrayOfArray ();
+			TestMultiDimentionalArray ();
+			TestMultiDimentionalArrayFullString ();
+			TestMultiDimentionalArrayAsmName ();
 		}
 
 		[Kept]
-		public class TypeKeptViaReflectionFull { }
+		public class Full { }
 
 		[Kept]
-		public static void TestGetTypeKeptViaReflectionFullString ()
+		public static void TestFullString ()
 		{
-			var reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+TypeKeptViaReflectionFull, test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null";
+			var reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+Full, test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null";
 			var typeKept = Type.GetType (reflectionTypeKeptString, false);
 		}
 
 		[Kept]
-		public class TypeKeptViaReflectionTypeAsmName { }
+		public class FullConst { }
 
 		[Kept]
-		public static void TestGetTypeKeptViaReflectionTypeAsmName ()
+		public static void TestFullStringConst()
 		{
-			var reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+TypeKeptViaReflectionTypeAsmName, test";
+			const string reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+FullConst, test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null";
+			var typeKept = Type.GetType(reflectionTypeKeptString, false);
+		}
+
+		[Kept]
+		public class TypeAsmName { }
+
+		[Kept]
+		public static void TestTypeAsmName ()
+		{
+			var reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+TypeAsmName, test";
 			var typeKept = Type.GetType (reflectionTypeKeptString, false);
 		}
 
 		[Kept]
-		public class TypeKeptViaReflectionType { }
+		public class AType { }
 
 		[Kept]
-		public static void TestGetTypeKeptViaReflectionType ()
+		public static void TestType ()
 		{
-			var reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+TypeKeptViaReflectionType";
+			var reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+AType";
 			var typeKept = Type.GetType (reflectionTypeKeptString, false);
 		}
 
 		[Kept]
-		public class TypeKeptViaReflectionPointer { }
+		public class Pointer { }
 
 		[Kept]
-		public static void TestGetTypeKeptViaReflectionPointer ()
+		public static void TestPointer ()
 		{
-			var reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+TypeKeptViaReflectionPointer*";
+			var reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+Pointer*";
 			var typeKept = Type.GetType (reflectionTypeKeptString, false);
 		}
 
 		[Kept]
-		public class TypeKeptViaReflectionReference { }
+		public class Reference { }
 
 		[Kept]
-		public static void TestGetTypeKeptViaReflectionReference ()
+		public static void TestReference ()
 		{
-			var reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+TypeKeptViaReflectionReference&";
+			var reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+Reference&";
 			var typeKept = Type.GetType (reflectionTypeKeptString, false);
 		}
 
 		[Kept]
-		public class TypeKeptViaReflectionArray { }
+		public class Array { }
 
 		[Kept]
-		public static void TestGetTypeKeptViaReflectionArray ()
+		public static void TestArray ()
 		{
-			var reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+TypeKeptViaReflectionArray[]";
+			var reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+Array[]";
 			var typeKept = Type.GetType (reflectionTypeKeptString, false);
 		}
 
 		[Kept]
-		public class TypeKeptViaReflectionArrayOfArray{ }
+		public class ArrayOfArray{ }
 
 		[Kept]
-		public static void TestGetTypeKeptViaReflectionArrayOfArray ()
+		public static void TestArrayOfArray ()
 		{
-			var reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+TypeKeptViaReflectionArrayOfArray[][]";
+			var reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+ArrayOfArray[][]";
 			var typeKept = Type.GetType (reflectionTypeKeptString, false);
 		}
 
 
 		[Kept]
-		public class TypeKeptViaReflectionMultiDimentionalArray{ }
+		public class MultiDimentionalArray{ }
 
 		[Kept]
-		public static void TestGetTypeKeptViaReflectionMultiDimentionalArray ()
+		public static void TestMultiDimentionalArray ()
 		{
-			var reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+TypeKeptViaReflectionMultiDimentionalArray[,]";
+			var reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+MultiDimentionalArray[,]";
 			var typeKept = Type.GetType (reflectionTypeKeptString, false);
 		}
 
 		[Kept]
-		public class TypeKeptViaReflectionMultiDimentionalArrayFullString { }
+		public class MultiDimentionalArrayFullString { }
 
 		[Kept]
-		public static void TestGetTypeKeptViaReflectionMultiDimentionalArrayFullString ()
+		public static void TestMultiDimentionalArrayFullString ()
 		{
-			var reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+TypeKeptViaReflectionMultiDimentionalArrayFullString[,], test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null";
+			var reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+MultiDimentionalArrayFullString[,], test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null";
 			var typeKept = Type.GetType (reflectionTypeKeptString, false);
 		}
 
 		[Kept]
-		public class TypeKeptViaReflectionMultiDimentionalArrayAsmName { }
+		public class MultiDimentionalArrayAsmName { }
 
 		[Kept]
-		public static void TestGetTypeKeptViaReflectionMultiDimentionalArrayAsmName ()
+		public static void TestMultiDimentionalArrayAsmName ()
 		{
-			var reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+TypeKeptViaReflectionMultiDimentionalArrayAsmName[,], test";
+			var reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+MultiDimentionalArrayAsmName[,], test";
 			var typeKept = Type.GetType (reflectionTypeKeptString, false);
 		}
 	}


### PR DESCRIPTION
These changes mark types that are kept via reflection Type.GetType()