### PR TITLE
Print out the test type name for easy link in IDE runners

### DIFF
--- a/linker/Tests/TestCasesRunner/TestRunner.cs
+++ b/linker/Tests/TestCasesRunner/TestRunner.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Mono.Cecil;
 using Mono.Linker.Tests.TestCases;
 using NUnit.Framework;
@@ -20,6 +21,8 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 				string ignoreReason;
 				if (metadataProvider.IsIgnored (out ignoreReason))
 					Assert.Ignore (ignoreReason);
+				
+				Console.WriteLine ($"Running : {testCase.ReconstructedFullTypeName}");
 
 				var sandbox = Sandbox (testCase, metadataProvider);
 				var compilationResult = Compile (sandbox, metadataProvider);


### PR DESCRIPTION
Because the tests are generated from a  [TestCaseSource], clicking on the test itself in the runner window will jump you to the method with  [TestCaseSource] method rather than the file we generated the test case from.

When the name of the test type appears in stdout, IDE based test runners such as ReSharper and Rider will make the type name a clickable link in the test output window.  This adds a handy way of jumping to the test case file.