### PR TITLE
Move resolving of embedded link xml files before TypeMapStep

### DIFF
--- a/linker/Linker.Steps/BlacklistStep.cs
+++ b/linker/Linker.Steps/BlacklistStep.cs
@@ -47,7 +47,7 @@ namespace Mono.Linker.Steps {
 
 				try {
 					Context.LogMessage ("Processing resource linker descriptor: {0}", name);
-					Context.Pipeline.AddStepAfter (typeof (TypeMapStep), GetResolveStep (name));
+					AddToPipeline (GetResolveStep (name));
 				} catch (XmlException ex) {
 					/* This could happen if some broken XML file is included. */
 					Context.LogMessage ("Error processing {0}: {1}", name, ex);
@@ -64,7 +64,7 @@ namespace Mono.Linker.Steps {
 					try {
 						Context.LogMessage ("Processing embedded resource linker descriptor: {0}", rsc.Name);
 
-						Context.Pipeline.AddStepAfter (typeof (TypeMapStep), GetExternalResolveStep (rsc, asm));
+						AddToPipeline (GetExternalResolveStep (rsc, asm));
 					} catch (XmlException ex) {
 						/* This could happen if some broken XML file is embedded. */
 						Context.LogMessage ("Error processing {0}: {1}", rsc.Name, ex);
@@ -106,6 +106,11 @@ namespace Mono.Linker.Steps {
 					return assembly;
 
 			return null;
+		}
+
+		protected virtual void AddToPipeline (IStep resolveStep)
+		{
+			Context.Pipeline.AddStepAfter (typeof (BlacklistStep), resolveStep);
 		}
 
 		protected virtual IStep GetExternalResolveStep (EmbeddedResource resource, AssemblyDefinition assembly)

--- a/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/Dependencies/EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod/Base.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/Dependencies/EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod/Base.cs
@@ -1,0 +1,7 @@
+﻿namespace Mono.Linker.Tests.Cases.LinkXml.Dependencies.EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod {
+	public class Base {
+		public virtual void VirtualMethodFromBase ()
+		{
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/Dependencies/EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod/Library1.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/Dependencies/EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod/Library1.cs
@@ -1,0 +1,17 @@
+﻿namespace Mono.Linker.Tests.Cases.LinkXml.Dependencies.EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod {
+	public class Library1 : Base {
+		public override void VirtualMethodFromBase ()
+		{
+		}
+	}
+	
+	/// <summary>
+	/// This is here to confirm that derived types in the same assembly as the embedded resource are correctly taken into
+	/// consideration
+	/// </summary>
+	public class Library1Secondary : Base {
+		public override void VirtualMethodFromBase ()
+		{
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/Dependencies/EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod/Library1.xml
+++ b/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/Dependencies/EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod/Library1.xml
@@ -1,0 +1,10 @@
+﻿<linker>
+    <assembly fullname="Library1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+        <type fullname="Mono.Linker.Tests.Cases.LinkXml.Dependencies.EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod.Library1Secondary" preserve="nothing">
+        </type>
+    </assembly>
+    <assembly fullname="Library2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+        <type fullname="Mono.Linker.Tests.Cases.LinkXml.Dependencies.EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod.Library2" preserve="nothing">
+        </type>
+    </assembly>
+</linker>

--- a/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/Dependencies/EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod/Library2.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/Dependencies/EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod/Library2.cs
@@ -1,0 +1,7 @@
+﻿namespace Mono.Linker.Tests.Cases.LinkXml.Dependencies.EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod {
+	public class Library2 : Base {
+		public override void VirtualMethodFromBase ()
+		{
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod.cs
@@ -1,0 +1,31 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.LinkXml.Dependencies.EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod;
+
+namespace Mono.Linker.Tests.Cases.LinkXml {
+	[SetupCompileBefore ("Base.dll",
+		new []{"Dependencies/EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod/Base.cs"})]
+	[SetupCompileBefore ("Library1.dll",
+		new [] { "Dependencies/EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod/Library1.cs"},
+		new [] { "Base.dll"},
+		resources: new [] { "Dependencies/EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod/Library1.xml"})]
+	[SetupCompileBefore("Library2.dll",
+		new [] {"Dependencies/EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod/Library2.cs"},
+		new [] {"Base.dll"},
+		addAsReference: false)]
+	[IncludeBlacklistStep (true)]
+	
+	[KeptMemberInAssembly ("Library1.dll", typeof (Library1), "VirtualMethodFromBase()")]
+	[KeptMemberInAssembly ("Library1.dll", typeof (Library1Secondary), "VirtualMethodFromBase()")]
+	
+	// Library1's embedded link xml will preserve the Library2 type.  Because Library2 shares a base class with Library1
+	// Library2's override should be kept as well
+	[KeptMemberInAssembly ("Library2.dll", "Mono.Linker.Tests.Cases.LinkXml.Dependencies.EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod.Library2", "VirtualMethodFromBase()")]
+	public class EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod {
+		public static void Main ()
+		{
+			var tmp = new Library1 ();
+			tmp.VirtualMethodFromBase ();
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -105,6 +105,10 @@
     <None Include="LinkXml\Dependencies\CanPreserveAnExportedType_Forwarder.cs" />
     <Compile Include="LinkXml\CanPreserveExportedTypesUsingRegex.cs" />
     <Compile Include="LinkXml\Dependencies\CanPreserveAnExportedType_Library.cs" />
+    <Compile Include="LinkXml\Dependencies\EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod\Base.cs" />
+    <Compile Include="LinkXml\Dependencies\EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod\Library1.cs" />
+    <Compile Include="LinkXml\Dependencies\EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod\Library2.cs" />
+    <Compile Include="LinkXml\EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod.cs" />
     <Compile Include="LinkXml\UnusedAssemblyWithNoDefinedPreserveHasAllTypesPreserved.cs" />
     <Compile Include="LinkXml\UnusedEventPreservedByLinkXmlIsKept.cs" />
     <Compile Include="LinkXml\UnusedTypePreservedByLinkXmlWithCommentIsKept.cs" />
@@ -266,6 +270,7 @@
     <Content Include="LinkXml\CanPreserveTypesUsingRegex.xml" />
     <Content Include="LinkXml\CanPreserveAnExportedType.xml" />
     <Content Include="LinkXml\CanPreserveExportedTypesUsingRegex.xml" />
+    <Content Include="LinkXml\Dependencies\EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod\Library1.xml" />
     <Content Include="LinkXml\TypeWithPreserveFieldsHasBackingFieldsOfPropertiesRemoved.xml" />
     <Content Include="LinkXml\UnusedAssemblyWithNoDefinedPreserveHasAllTypesPreserved.xml" />
     <Content Include="LinkXml\UnusedEventPreservedByLinkXmlIsKept.xml" />


### PR DESCRIPTION
All resolving should happen before TypeMapStep just in case an embedded link xml file were to cause an additional assembly to be included