### PR TITLE
Add a preserve test that uses generics

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/UnusedGenericTypeWithPreserveAllHasAllMembersPreserved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/UnusedGenericTypeWithPreserveAllHasAllMembersPreserved.cs
@@ -1,0 +1,85 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.LinkXml {
+	public class UnusedGenericTypeWithPreserveAllHasAllMembersPreserved {
+		public static void Main ()
+		{
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		class Unused<T1, T2, T3> {
+			[Kept]
+			public int Field1;
+
+			[Kept]
+			private int Field2;
+
+			[Kept]
+			internal int Field3;
+
+			[Kept]
+			public static int Field4;
+
+			[Kept]
+			private static int Field5;
+
+			[Kept]
+			internal static int Field6;
+
+			[Kept]
+			[KeptBackingField]
+			public string Property1 { [Kept] get; [Kept] set;}
+
+			[Kept]
+			[KeptBackingField]
+			private string Property2 { [Kept] get; [Kept] set; }
+
+			[Kept]
+			[KeptBackingField]
+			internal string Property3 { [Kept] get; [Kept] set; }
+
+			[Kept]
+			[KeptBackingField]
+			public static string Property4 { [Kept] get; [Kept] set; }
+
+			[Kept]
+			[KeptBackingField]
+			private static string Property5 { [Kept] get; [Kept] set; }
+
+			[Kept]
+			[KeptBackingField]
+			internal static string Property6 { [Kept] get; [Kept] set; }
+
+			[Kept]
+			public void Method1 ()
+			{
+			}
+
+			[Kept]
+			private void Method2 ()
+			{
+			}
+
+			[Kept]
+			internal void Method3 ()
+			{
+			}
+
+			[Kept]
+			public static void Method4 ()
+			{
+			}
+
+			[Kept]
+			private static void Method5 ()
+			{
+			}
+
+			[Kept]
+			internal static void Method6 ()
+			{
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/UnusedGenericTypeWithPreserveAllHasAllMembersPreserved.xml
+++ b/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/UnusedGenericTypeWithPreserveAllHasAllMembersPreserved.xml
@@ -1,0 +1,5 @@
+﻿<linker>
+    <assembly fullname="test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+        <type fullname="Mono.Linker.Tests.Cases.LinkXml.UnusedGenericTypeWithPreserveAllHasAllMembersPreserved/Unused`3" preserve="all" />
+    </assembly>
+</linker>   

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -111,6 +111,7 @@
     <Compile Include="LinkXml\EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod.cs" />
     <Compile Include="LinkXml\UnusedAssemblyWithNoDefinedPreserveHasAllTypesPreserved.cs" />
     <Compile Include="LinkXml\UnusedEventPreservedByLinkXmlIsKept.cs" />
+    <Compile Include="LinkXml\UnusedGenericTypeWithPreserveAllHasAllMembersPreserved.cs" />
     <Compile Include="LinkXml\UnusedTypePreservedByLinkXmlWithCommentIsKept.cs" />
     <Compile Include="LinkXml\UnusedTypeWithNoDefinedPreserveHasAllMembersPreserved.cs" />
     <Compile Include="References\Individual\CanSkipUnresolved.cs" />
@@ -275,6 +276,7 @@
     <Content Include="LinkXml\UnusedAssemblyWithNoDefinedPreserveHasAllTypesPreserved.xml" />
     <Content Include="LinkXml\UnusedEventPreservedByLinkXmlIsKept.xml" />
     <Content Include="LinkXml\UnusedFieldPreservedByLinkXmlIsKept.xml" />
+    <Content Include="LinkXml\UnusedGenericTypeWithPreserveAllHasAllMembersPreserved.xml" />
     <Content Include="LinkXml\UnusedMethodPreservedByLinkXmlIsKept.xml" />
     <Content Include="LinkXml\UnusedNestedTypePreservedByLinkXmlIsKept.xml" />
     <Content Include="LinkXml\UnusedPropertyPreservedByLinkXmlIsKept.xml" />


### PR DESCRIPTION
We didn't have any link xml tests that used generics.  I thought it would be helpful to have one if for no other reason than to act as documentation on how to format the preservation for a generic type