### PR TITLE
Cache collection of all test cases.  Remove OtherTests

### DIFF
--- a/linker/Tests/TestCases/TestDatabase.cs
+++ b/linker/Tests/TestCases/TestDatabase.cs
@@ -9,6 +9,8 @@ namespace Mono.Linker.Tests.TestCases
 {
 	public static class TestDatabase
 	{
+		private static TestCase[] _cachedAllCases;
+		
 		public static IEnumerable<TestCaseData> XmlTests()
 		{
 			return NUnitCasesByPrefix("LinkXml.");
@@ -79,29 +81,6 @@ namespace Mono.Linker.Tests.TestCases
 			return NUnitCasesByPrefix ("Symbols.");
 		}
 
-		public static IEnumerable<TestCaseData> OtherTests()
-		{
-			var allGroupedTestNames = new HashSet<string>(
-				XmlTests()
-					.Concat(BasicTests())
-					.Concat(XmlTests())
-					.Concat(VirtualMethodsTests())
-					.Concat(AttributeTests())
-					.Concat(GenericsTests())
-					.Concat(CoreLinkTests())
-					.Concat(StaticsTests())
-					.Concat(InteropTests())
-					.Concat(ReferencesTests ())
-					.Concat(ResourcesTests ())
-					.Concat(TypeForwardingTests ())
-					.Concat(TestFrameworkTests ())
-					.Concat(ReflectionTests ())
-					.Concat(SymbolsTests ())
-					.Select(c => ((TestCase)c.Arguments[0]).ReconstructedFullTypeName));
-
-			return AllCases().Where(c => !allGroupedTestNames.Contains(c.ReconstructedFullTypeName)).Select(c => CreateNUnitTestCase(c, c.DisplayName));
-		}
-
 		public static TestCaseCollector CreateCollector ()
 		{
 			string rootSourceDirectory;
@@ -112,10 +91,13 @@ namespace Mono.Linker.Tests.TestCases
 
 		static IEnumerable<TestCase> AllCases ()
 		{
-			return CreateCollector ()
-				.Collect ()
-				.OrderBy (c => c.DisplayName)
-				.ToArray ();
+			if (_cachedAllCases == null)
+				_cachedAllCases = CreateCollector ()
+					.Collect ()
+					.OrderBy (c => c.DisplayName)
+					.ToArray ();
+
+			return _cachedAllCases;
 		}
 
 		static IEnumerable<TestCaseData> NUnitCasesByPrefix(string testNamePrefix)

--- a/linker/Tests/TestCases/TestSuites.cs
+++ b/linker/Tests/TestCases/TestSuites.cs
@@ -90,12 +90,6 @@ namespace Mono.Linker.Tests.TestCases
 			Run (testCase);
 		}
 
-		[TestCaseSource (typeof (TestDatabase), nameof (TestDatabase.OtherTests))]
-		public void OtherTests (TestCase testCase)
-		{
-			Run (testCase);
-		}
-
 		protected virtual void Run (TestCase testCase)
 		{
 			var runner = new TestRunner (new ObjectFactory ());


### PR DESCRIPTION
* Caching all of the TestCases on the first call helps improve nunit test generation time.  AllCases() is called for all of the [TestCaseSource] generation methods.  The call to TestCaseCollector.Collect is a decent amount of work, chancing the result gives a noticable reduction in the delay before tests start running in an IDE based runner

* Remove "OtherTests"  the original idea of this was to catch tests that were not sorted into an existing group.  Code reviews & convention seem to be doing a good enough job of avoiding this.  Given the minimal value OtherTests provides and the fact that it is a relatively routine source of conflicts and boiler plate plumbing, let's remove it.