### PR TITLE
Fixes and tests for debugger attribute support in the linker

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupLinkerKeepDebugMembersAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupLinkerKeepDebugMembersAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Metadata {
+	[AttributeUsage (AttributeTargets.Class)]
+	public class SetupLinkerKeepDebugMembersAttribute : BaseMetadataAttribute{
+		public SetupLinkerKeepDebugMembersAttribute (string value)
+		{
+			if (string.IsNullOrEmpty (value))
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (value));
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Metadata\NotATestCaseAttribute.cs" />
     <Compile Include="Metadata\ReferenceAttribute.cs" />
     <Compile Include="Metadata\SandboxDependencyAttribute.cs" />
+    <Compile Include="Metadata\SetupLinkerKeepDebugMembersAttribute.cs" />
     <Compile Include="Metadata\SkipUnresolvedAttribute.cs" />
     <Compile Include="Metadata\StripResourcesAttribute.cs" />
     <Compile Include="Assertions\KeptBaseTypeAttribute.cs" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerDisplayAttributeOnAssemblyUsingTarget.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerDisplayAttributeOnAssemblyUsingTarget.cs
@@ -1,0 +1,33 @@
+﻿using System.Diagnostics;
+using Mono.Linker.Tests.Cases.Attributes.Debugger;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+[assembly: KeptAttributeAttribute (typeof (DebuggerDisplayAttribute))]
+[assembly: DebuggerDisplay ("{Property}", Target = typeof (DebuggerDisplayAttributeOnAssemblyUsingTarget.Foo))]
+
+namespace Mono.Linker.Tests.Cases.Attributes.Debugger {
+	[SetupLinkerCoreAction ("link")]
+	[SetupLinkerKeepDebugMembers ("false")]
+	
+	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168
+	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
+	
+	[KeptMemberInAssembly ("mscorlib.dll", typeof (DebuggerDisplayAttribute), ".ctor(System.String)")]
+	[KeptMemberInAssembly ("mscorlib.dll", typeof (DebuggerDisplayAttribute), "set_Target(System.Type)")]
+	public class DebuggerDisplayAttributeOnAssemblyUsingTarget {
+		public static void Main ()
+		{
+			var foo = new Foo ();
+			foo.Property = 1;
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		public class Foo {
+			[Kept]
+			[KeptBackingField]
+			public int Property { get; [Kept] set; }
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerDisplayAttributeOnAssemblyUsingTargetOnUnusedType.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerDisplayAttributeOnAssemblyUsingTargetOnUnusedType.cs
@@ -1,0 +1,25 @@
+﻿using System.Diagnostics;
+using Mono.Linker.Tests.Cases.Attributes.Debugger;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+[assembly: DebuggerDisplay ("{Property}", Target = typeof (DebuggerDisplayAttributeOnAssemblyUsingTargetOnUnusedType.Foo))]
+
+namespace Mono.Linker.Tests.Cases.Attributes.Debugger {
+	[SetupLinkerCoreAction ("link")]
+	[SetupLinkerKeepDebugMembers ("false")]
+
+	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168
+	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
+	
+	[KeptMemberInAssembly ("mscorlib.dll", typeof (DebuggerDisplayAttribute), ".ctor(System.String)")]
+	public class DebuggerDisplayAttributeOnAssemblyUsingTargetOnUnusedType {
+		public static void Main ()
+		{
+		}
+
+		public class Foo {
+			public int Property { get; set; }
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly.cs
@@ -1,0 +1,30 @@
+﻿using System.Diagnostics;
+using Mono.Linker.Tests.Cases.Attributes.Debugger.Dependencies;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+[assembly: KeptAttributeAttribute (typeof (DebuggerDisplayAttribute))]
+[assembly: DebuggerDisplay ("{Property}", TargetTypeName = "Mono.Linker.Tests.Cases.Attributes.Debugger.Dependencies.DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly, library")]
+
+namespace Mono.Linker.Tests.Cases.Attributes.Debugger {
+	[IgnoreTestCase ("Need to fix.  Currently we only check the assembly the attribute is in")]
+	[SetupLinkerCoreAction ("link")]
+	[SetupLinkerKeepDebugMembers ("false")]
+	[SetupCompileBefore ("library.dll", new [] { "Dependencies/DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly_Lib.cs" })]
+	
+	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168
+	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
+	
+	[KeptMemberInAssembly ("mscorlib.dll", typeof (DebuggerDisplayAttribute), ".ctor(System.String)")]
+	[KeptMemberInAssembly ("mscorlib.dll", typeof (DebuggerDisplayAttribute), "set_Target(System.Type)")]
+	
+	[RemovedMemberInAssembly ("library.dll", typeof (DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly_Lib), "get_Property()")]
+	[KeptMemberInAssembly ("library.dll", typeof (DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly_Lib), "set_Property(System.Int32)")]
+	public class DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly {
+		public static void Main ()
+		{
+			var foo = new DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly_Lib ();
+			foo.Property = 1;
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerDisplayAttributeOnType.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerDisplayAttributeOnType.cs
@@ -1,0 +1,39 @@
+﻿using System.Diagnostics;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Attributes.Debugger {
+	[SetupLinkerCoreAction ("link")]
+	[SetupLinkerKeepDebugMembers ("false")]
+
+	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168
+	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
+
+	[KeptMemberInAssembly ("mscorlib.dll", typeof (DebuggerDisplayAttribute), ".ctor(System.String)")]
+	public class DebuggerDisplayAttributeOnType {
+		public static void Main ()
+		{
+			var foo = new Foo ();
+			var bar = new Bar();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptAttributeAttribute (typeof (DebuggerDisplayAttribute))]
+		[DebuggerDisplay ("{Property}")]
+		class Foo {
+			public int Property { get; set; }
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptAttributeAttribute (typeof (DebuggerDisplayAttribute))]
+		[DebuggerDisplay ("{Method()}")]
+		class Bar {
+			public int Method ()
+			{
+				return 1;
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerDisplayAttributeOnTypeThatIsNotUsed.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerDisplayAttributeOnTypeThatIsNotUsed.cs
@@ -1,0 +1,21 @@
+﻿using System.Diagnostics;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Attributes.Debugger {
+	[SetupLinkerCoreAction ("link")]
+	[SetupLinkerKeepDebugMembers ("false")]
+
+	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168
+	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
+	public class DebuggerDisplayAttributeOnTypeThatIsNotUsed {
+		public static void Main ()
+		{
+		}
+
+		[DebuggerDisplay ("{Property}")]
+		class Foo {
+			public int Property { get; set; }
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerTypeProxyAttributeOnAssemblyUsingTarget.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerTypeProxyAttributeOnAssemblyUsingTarget.cs
@@ -1,0 +1,43 @@
+﻿using System.Diagnostics;
+using Mono.Linker.Tests.Cases.Attributes.Debugger;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+[assembly: KeptAttributeAttribute(typeof(DebuggerTypeProxyAttribute))]
+[assembly: DebuggerTypeProxy (typeof(DebuggerTypeProxyAttributeOnAssemblyUsingTarget.Foo.FooDebugView), Target = typeof (DebuggerTypeProxyAttributeOnAssemblyUsingTarget.Foo))]
+
+namespace Mono.Linker.Tests.Cases.Attributes.Debugger {
+	[SetupLinkerCoreAction ("link")]
+	[SetupLinkerKeepDebugMembers ("false")]
+	
+	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168
+	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
+	
+	[KeptMemberInAssembly ("mscorlib.dll", typeof (DebuggerTypeProxyAttribute), ".ctor(System.Type)")]
+	public class DebuggerTypeProxyAttributeOnAssemblyUsingTarget {
+		public static void Main ()
+		{
+			var foo = new Foo ();
+			foo.Property = 1;
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		public class Foo {
+			[Kept]
+			[KeptBackingField]
+			public int Property { get; [Kept] set; }
+
+			[Kept]
+			internal class FooDebugView
+			{
+				private Foo _foo;
+
+				public FooDebugView(Foo foo)
+				{
+					_foo = foo;
+				}
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerTypeProxyAttributeOnType.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerTypeProxyAttributeOnType.cs
@@ -1,0 +1,33 @@
+﻿using System.Diagnostics;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Attributes.Debugger {
+	[SetupLinkerCoreAction ("link")]
+	[SetupLinkerKeepDebugMembers ("false")]
+	
+	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168
+	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
+	
+	[KeptMemberInAssembly ("mscorlib.dll", typeof (DebuggerTypeProxyAttribute), ".ctor(System.Type)")]
+	public class DebuggerTypeProxyAttributeOnType {
+		public static void Main ()
+		{
+			var foo = new Foo ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptAttributeAttribute (typeof (DebuggerTypeProxyAttribute))]
+		[DebuggerTypeProxy (typeof (FooDebugView))]
+		class Foo {
+		}
+		
+		[Kept]
+		class FooDebugView {
+			public FooDebugView (Foo foo)
+			{
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes.Debugger/Dependencies/DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly_Lib.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes.Debugger/Dependencies/DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly_Lib.cs
@@ -1,0 +1,5 @@
+﻿namespace Mono.Linker.Tests.Cases.Attributes.Debugger.Dependencies {
+	public class DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly_Lib {
+		public int Property { get; set; }
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnAssemblyUsingTarget.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnAssemblyUsingTarget.cs
@@ -1,0 +1,33 @@
+﻿using System.Diagnostics;
+using Mono.Linker.Tests.Cases.Attributes.Debugger.KeepDebugMembers;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+[assembly: KeptAttributeAttribute (typeof (DebuggerDisplayAttribute))]
+[assembly: DebuggerDisplay ("{Property}", Target = typeof (DebuggerDisplayAttributeOnAssemblyUsingTarget.Foo))]
+
+namespace Mono.Linker.Tests.Cases.Attributes.Debugger.KeepDebugMembers {
+	[SetupLinkerCoreAction ("link")]
+	[SetupLinkerKeepDebugMembers ("true")]
+	
+	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168
+	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
+	
+	[KeptMemberInAssembly ("mscorlib.dll", typeof (DebuggerDisplayAttribute), ".ctor(System.String)")]
+	[KeptMemberInAssembly ("mscorlib.dll", typeof (DebuggerDisplayAttribute), "set_Target(System.Type)")]
+	public class DebuggerDisplayAttributeOnAssemblyUsingTarget {
+		public static void Main ()
+		{
+			var foo = new Foo ();
+			foo.Property = 1;
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		public class Foo {
+			[Kept]
+			[KeptBackingField]
+			public int Property { [Kept] get; [Kept] set; }
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnAssemblyUsingTargetOnUnusedType.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnAssemblyUsingTargetOnUnusedType.cs
@@ -1,0 +1,25 @@
+﻿using System.Diagnostics;
+using Mono.Linker.Tests.Cases.Attributes.Debugger.KeepDebugMembers;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+[assembly: DebuggerDisplay ("{Property}", Target = typeof (DebuggerDisplayAttributeOnAssemblyUsingTargetOnUnusedType.Foo))]
+
+namespace Mono.Linker.Tests.Cases.Attributes.Debugger.KeepDebugMembers {
+	[SetupLinkerCoreAction ("link")]
+	[SetupLinkerKeepDebugMembers ("true")]
+
+	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168
+	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
+
+	[KeptMemberInAssembly ("mscorlib.dll", typeof (DebuggerDisplayAttribute), ".ctor(System.String)")]
+	public class DebuggerDisplayAttributeOnAssemblyUsingTargetOnUnusedType {
+		public static void Main ()
+		{
+		}
+
+		public class Foo {
+			public int Property { get; set; }
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly.cs
@@ -1,0 +1,31 @@
+﻿
+using System.Diagnostics;
+using Mono.Linker.Tests.Cases.Attributes.Debugger.Dependencies;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+[assembly: KeptAttributeAttribute(typeof (DebuggerDisplayAttribute))]
+[assembly: DebuggerDisplay ("{Property}", TargetTypeName = "Mono.Linker.Tests.Cases.Attributes.Debugger.Dependencies.DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly, library")]
+
+namespace Mono.Linker.Tests.Cases.Attributes.Debugger.KeepDebugMembers {
+	[IgnoreTestCase ("Need to fix.  Currently we only check the assembly the attribute is in")]
+	[SetupLinkerCoreAction ("link")]
+	[SetupLinkerKeepDebugMembers ("true")]
+	[SetupCompileBefore ("library.dll", new [] { "../Dependencies/DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly_Lib.cs" })]
+	
+	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168
+	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
+	
+	[KeptMemberInAssembly ("mscorlib.dll", typeof (DebuggerDisplayAttribute), ".ctor(System.String)")]
+	[KeptMemberInAssembly ("mscorlib.dll", typeof (DebuggerDisplayAttribute), "set_Target(System.Type)")]
+	
+	[KeptMemberInAssembly ("library.dll", typeof (DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly_Lib), "get_Property()")]
+	[KeptMemberInAssembly ("library.dll", typeof (DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly_Lib), "set_Property(System.Int32)")]
+	public class DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly {
+		public static void Main ()
+		{
+			var foo = new DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly_Lib ();
+			foo.Property = 1;
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnType.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnType.cs
@@ -1,0 +1,42 @@
+﻿using System.Diagnostics;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Attributes.Debugger.KeepDebugMembers {
+	[SetupLinkerCoreAction ("link")]
+	[SetupLinkerKeepDebugMembers ("true")]
+	
+	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168
+	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
+	
+	[KeptMemberInAssembly ("mscorlib.dll", typeof (DebuggerDisplayAttribute), ".ctor(System.String)")]
+	public class DebuggerDisplayAttributeOnType {
+		public static void Main ()
+		{
+			var foo = new Foo ();
+			var bar = new Bar();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptAttributeAttribute (typeof (DebuggerDisplayAttribute))]
+		[DebuggerDisplay ("{Property}")]
+		class Foo {
+			[Kept]
+			[KeptBackingField]
+			public int Property { [Kept] get; [Kept] set; }
+		}
+		
+		[Kept]
+		[KeptMember(".ctor()")]
+		[KeptAttributeAttribute (typeof (DebuggerDisplayAttribute))]
+		[DebuggerDisplay ("{Method()}")]
+		class Bar {
+			[Kept]
+			public int Method ()
+			{
+				return 1;
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnTypeThatIsNotUsed.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnTypeThatIsNotUsed.cs
@@ -1,0 +1,21 @@
+﻿using System.Diagnostics;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Attributes.Debugger.KeepDebugMembers {
+	[SetupLinkerCoreAction ("link")]
+	[SetupLinkerKeepDebugMembers ("true")]
+	
+	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168
+	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
+	public class DebuggerDisplayAttributeOnTypeThatIsNotUsed {
+		public static void Main ()
+		{
+		}
+
+		[DebuggerDisplay ("{Property}")]
+		class Foo {
+			public int Property { get; set; }
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerTypeProxyAttributeOnAssemblyUsingTarget.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerTypeProxyAttributeOnAssemblyUsingTarget.cs
@@ -1,0 +1,46 @@
+﻿using System.Diagnostics;
+using Mono.Linker.Tests.Cases.Attributes.Debugger.KeepDebugMembers;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+[assembly: KeptAttributeAttribute (typeof (DebuggerTypeProxyAttribute))]
+[assembly: DebuggerTypeProxy (typeof(DebuggerTypeProxyAttributeOnAssemblyUsingTarget.Foo.FooDebugView), Target = typeof (DebuggerTypeProxyAttributeOnAssemblyUsingTarget.Foo))]
+
+namespace Mono.Linker.Tests.Cases.Attributes.Debugger.KeepDebugMembers {
+	[SetupLinkerCoreAction ("link")]
+	[SetupLinkerKeepDebugMembers ("true")]
+	
+	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168
+	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
+	
+	[KeptMemberInAssembly ("mscorlib.dll", typeof (DebuggerTypeProxyAttribute), ".ctor(System.Type)")]
+	[KeptMemberInAssembly ("mscorlib.dll", typeof (DebuggerTypeProxyAttribute), "set_Target(System.Type)")]
+	public class DebuggerTypeProxyAttributeOnAssemblyUsingTarget {
+		public static void Main ()
+		{
+			var foo = new Foo ();
+			foo.Property = 1;
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		public class Foo {
+			[Kept]
+			[KeptBackingField]
+			public int Property { get; [Kept] set; }
+
+			[Kept]
+			internal class FooDebugView
+			{
+				[Kept]
+				private Foo _foo;
+
+				[Kept]
+				public FooDebugView(Foo foo)
+				{
+					_foo = foo;
+				}
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerTypeProxyAttributeOnType.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerTypeProxyAttributeOnType.cs
@@ -1,0 +1,34 @@
+﻿using System.Diagnostics;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Attributes.Debugger.KeepDebugMembers {
+	[SetupLinkerCoreAction ("link")]
+	[SetupLinkerKeepDebugMembers ("true")]
+	
+	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168
+	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
+	
+	[KeptMemberInAssembly ("mscorlib.dll", typeof (DebuggerTypeProxyAttribute), ".ctor(System.Type)")]
+	public class DebuggerTypeProxyAttributeOnType {
+		public static void Main ()
+		{
+			var foo = new Foo ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptAttributeAttribute (typeof (DebuggerTypeProxyAttribute))]
+		[DebuggerTypeProxy (typeof (FooDebugView))]
+		class Foo {
+		}
+		
+		[Kept]
+		class FooDebugView {
+			[Kept]
+			public FooDebugView (Foo foo)
+			{
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -37,6 +37,21 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Attributes.Debugger\DebuggerDisplayAttributeOnAssemblyUsingTarget.cs" />
+    <Compile Include="Attributes.Debugger\DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly.cs" />
+    <Compile Include="Attributes.Debugger\DebuggerDisplayAttributeOnAssemblyUsingTargetOnUnusedType.cs" />
+    <Compile Include="Attributes.Debugger\DebuggerDisplayAttributeOnType.cs" />
+    <Compile Include="Attributes.Debugger\DebuggerDisplayAttributeOnTypeThatIsNotUsed.cs" />
+    <Compile Include="Attributes.Debugger\DebuggerTypeProxyAttributeOnAssemblyUsingTarget.cs" />
+    <Compile Include="Attributes.Debugger\DebuggerTypeProxyAttributeOnType.cs" />
+    <Compile Include="Attributes.Debugger\Dependencies\DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly_Lib.cs" />
+    <Compile Include="Attributes.Debugger\KeepDebugMembers\DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly.cs" />
+    <Compile Include="Attributes.Debugger\KeepDebugMembers\DebuggerTypeProxyAttributeOnAssemblyUsingTarget.cs" />
+    <Compile Include="Attributes.Debugger\KeepDebugMembers\DebuggerDisplayAttributeOnAssemblyUsingTarget.cs" />
+    <Compile Include="Attributes.Debugger\KeepDebugMembers\DebuggerDisplayAttributeOnAssemblyUsingTargetOnUnusedType.cs" />
+    <Compile Include="Attributes.Debugger\KeepDebugMembers\DebuggerTypeProxyAttributeOnType.cs" />
+    <Compile Include="Attributes.Debugger\KeepDebugMembers\DebuggerDisplayAttributeOnType.cs" />
+    <Compile Include="Attributes.Debugger\KeepDebugMembers\DebuggerDisplayAttributeOnTypeThatIsNotUsed.cs" />
     <Compile Include="Attributes\AssemblyAttributeIsRemovedIfOnlyTypesUsedInAssembly.cs" />
     <Compile Include="Attributes\AssemblyAttributeKeptInComplexCase.cs" />
     <Compile Include="Attributes\AttributeOnAssemblyIsKept.cs" />

--- a/linker/Tests/TestCases/TestDatabase.cs
+++ b/linker/Tests/TestCases/TestDatabase.cs
@@ -28,6 +28,11 @@ namespace Mono.Linker.Tests.TestCases
 		{
 			return NUnitCasesByPrefix("Attributes.");
 		}
+		
+		public static IEnumerable<TestCaseData> AttributeDebuggerTests ()
+		{
+			return NUnitCasesByPrefix ("Attributes.Debugger.");
+		}
 
 		public static IEnumerable<TestCaseData> GenericsTests()
 		{

--- a/linker/Tests/TestCases/TestSuites.cs
+++ b/linker/Tests/TestCases/TestSuites.cs
@@ -29,6 +29,12 @@ namespace Mono.Linker.Tests.TestCases
 		{
 			Run (testCase);
 		}
+		
+		[TestCaseSource (typeof (TestDatabase), nameof (TestDatabase.AttributeDebuggerTests))]
+		public void AttributesDebuggerTests (TestCase testCase)
+		{
+			Run (testCase);
+		}
 
 		[TestCaseSource (typeof (TestDatabase), nameof (TestDatabase.GenericsTests))]
 		public void GenericsTests (TestCase testCase)

--- a/linker/Tests/TestCasesRunner/LinkerArgumentBuilder.cs
+++ b/linker/Tests/TestCasesRunner/LinkerArgumentBuilder.cs
@@ -58,6 +58,12 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			Append ("-b");
 			Append (value);
 		}
+		
+		public virtual void AddKeepDebugMembers (string value)
+		{
+			Append ("-v");
+			Append (value);
+		}
 
 		public virtual void AddAssemblyAction (string action, string assembly)
 		{
@@ -123,6 +129,9 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			
 			if (!string.IsNullOrEmpty (options.LinkSymbols))
 				AddLinkSymbols (options.LinkSymbols);
+			
+			if (!string.IsNullOrEmpty (options.KeepDebugMembers))
+				AddKeepDebugMembers (options.KeepDebugMembers);
 
 			AddSkipUnresolved (options.SkipUnresolved);
 

--- a/linker/Tests/TestCasesRunner/TestCaseLinkerOptions.cs
+++ b/linker/Tests/TestCasesRunner/TestCaseLinkerOptions.cs
@@ -10,6 +10,7 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 		public string Il8n;
 		public bool IncludeBlacklistStep;
 		public string KeepTypeForwarderOnlyAssemblies;
+		public string KeepDebugMembers;
 		public string LinkSymbols;
 		public bool SkipUnresolved;
 		public bool StripResources;

--- a/linker/Tests/TestCasesRunner/TestCaseMetadaProvider.cs
+++ b/linker/Tests/TestCasesRunner/TestCaseMetadaProvider.cs
@@ -30,6 +30,7 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 				Il8n = GetOptionAttributeValue (nameof (Il8nAttribute), "none"),
 				IncludeBlacklistStep = GetOptionAttributeValue (nameof (IncludeBlacklistStepAttribute), false),
 				KeepTypeForwarderOnlyAssemblies = GetOptionAttributeValue (nameof (KeepTypeForwarderOnlyAssembliesAttribute), string.Empty),
+				KeepDebugMembers = GetOptionAttributeValue (nameof (SetupLinkerKeepDebugMembersAttribute), string.Empty),
 				LinkSymbols = GetOptionAttributeValue (nameof (SetupLinkerLinkSymbolsAttribute), string.Empty),
 				CoreAssembliesAction = GetOptionAttributeValue<string> (nameof (SetupLinkerCoreActionAttribute), null),
 				SkipUnresolved = GetOptionAttributeValue (nameof (SkipUnresolvedAttribute), false),


### PR DESCRIPTION
* Adding a test suite for debugger attributes.
* Fixing issue with debugger display attribute Target property being
stripped from assembly-level DebuggerDisplayAttribute instances.
* Updated handling of debugger display attribute types so that neither
the attribute nor the target type are marked if the target is null or
itself not marked.