### PR TITLE
Fix include i18n assemblies not working

### DIFF
--- a/linker/Linker.Steps/LoadI18nAssemblies.cs
+++ b/linker/Linker.Steps/LoadI18nAssemblies.cs
@@ -27,7 +27,7 @@
 //
 
 using System;
-
+using System.Linq;
 using Mono.Cecil;
 
 namespace Mono.Linker.Steps {
@@ -46,7 +46,7 @@ namespace Mono.Linker.Steps {
 		protected override bool ConditionToProcess ()
 		{
 			return _assemblies != I18nAssemblies.None &&
-				Type.GetType ("System.MonoType") != null;
+				Context.GetAssemblies ().FirstOrDefault (a => a.Name.Name == "mscorlib")?.MainModule.GetType ("System.MonoType") != null;
 		}
 
 		protected override void Process()

--- a/linker/Tests/Mono.Linker.Tests.Cases/CoreLink/CanIncludeI18nAssemblies.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/CoreLink/CanIncludeI18nAssemblies.cs
@@ -1,0 +1,25 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.CoreLink {
+	[SetupLinkerCoreAction ("link")]
+	[Il8n ("all")]
+	
+	// i18n assemblies should only be included when processing mono class libs.  By forcing this test to use mcs,
+	// we can ensure the test will be ignored when the test runs against .net fw assemblies.
+	[SetupCSharpCompilerToUse ("mcs")]
+	
+	[KeptAssembly ("I18N.dll")]
+	[KeptAssembly ("I18N.CJK.dll")]
+	[KeptAssembly ("I18N.MidEast.dll")]
+	[KeptAssembly ("I18N.Other.dll")]
+	[KeptAssembly ("I18N.Rare.dll")]
+	[KeptAssembly ("I18N.West.dll")]
+	
+	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
+	public class CanIncludeI18nAssemblies {
+		public static void Main ()
+		{
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -99,6 +99,7 @@
     <Compile Include="Basic\UsedEventOnInterfaceIsRemovedWhenUsedFromClass.cs" />
     <Compile Include="Basic\UsedPropertyIsKept.cs" />
     <Compile Include="Basic\UsedStructIsKept.cs" />
+    <Compile Include="CoreLink\CanIncludeI18nAssemblies.cs" />
     <Compile Include="CoreLink\NoSecurityPlusOnlyKeepUsedRemovesAllSecurityAttributesFromCoreLibraries.cs" />
     <Compile Include="LinkXml\CanPreserveTypesUsingRegex.cs" />
     <Compile Include="LinkXml\CanPreserveAnExportedType.cs" />


### PR DESCRIPTION
When running the linker on .NET Framework and processing an assembly against mono class libraries, the LoadI18nAssemblies step would do nothing because it was checking to see if the linker was running on mono rather than if the class libraries being processed were mono class libs.

The test I wrote doesn't cover the scenario I hit.   It's just a basic test to ensure the option works.