### PR TITLE
Fix LockFileCache when SDK and ILLink  task are using different NuGet dlls

### DIFF
--- a/corebuild/integration/ILLink.Tasks/Microsoft.NET.Build.Tasks/LockFileCache.cs
+++ b/corebuild/integration/ILLink.Tasks/Microsoft.NET.Build.Tasks/LockFileCache.cs
@@ -12,6 +12,7 @@ namespace Microsoft.NET.Build.Tasks
 	internal class LockFileCache
 	{
 		private IBuildEngine4 _buildEngine;
+		private static string s_taskObjectPrefix = null;
 
 		public LockFileCache(IBuildEngine4 buildEngine)
 		{
@@ -45,7 +46,11 @@ namespace Microsoft.NET.Build.Tasks
 
 		private static string GetTaskObjectKey(string lockFilePath)
 		{
-			return $"{nameof(LockFileCache)}:{lockFilePath}";
+			if (s_taskObjectPrefix == null)
+			{
+				s_taskObjectPrefix = typeof(LockFile).AssemblyQualifiedName;
+			}
+			return $"{s_taskObjectPrefix}:{lockFilePath}";
 		}
 
 		private LockFile LoadLockFile(string path)


### PR DESCRIPTION
Avoid this by using a versioned prefix for the cache key. Of course we will no longer share the read if we happen to be on the same version, but this is safer.

Fixes #308 