### PR TITLE
Ensure linker dependencies are properly written and closed.

### DIFF
--- a/linker/Linker/Driver.cs
+++ b/linker/Linker/Driver.cs
@@ -246,7 +246,13 @@ namespace Mono.Linker {
 					p.AddStepAfter (typeof (SweepStep), new AddBypassNGenStep ());
 				}
 
-				p.Process (context);
+				try {
+					p.Process (context);
+				}
+				finally {
+					if (dumpDependencies)
+						context.Tracer.Finish ();
+				}
 			}
 		}
 

--- a/linker/Linker/Tracer.cs
+++ b/linker/Linker/Tracer.cs
@@ -58,6 +58,7 @@ namespace Mono.Linker
 
 			if (string.IsNullOrEmpty (Path.GetDirectoryName (DependenciesFileName)) && !string.IsNullOrEmpty (context.OutputDirectory)) {
 				DependenciesFileName = Path.Combine (context.OutputDirectory, DependenciesFileName);
+				Directory.CreateDirectory (context.OutputDirectory);
 			}
 
 			var depsFile = File.OpenWrite (DependenciesFileName);


### PR DESCRIPTION
Add a finally clause that ensures that dependencies file is
written and resources are disposed if there is an unhandled exception.