### PR TITLE
Harden TypeNameParsing to avoid crashes

### DIFF
--- a/linker/Linker/TypeNameParser.cs
+++ b/linker/Linker/TypeNameParser.cs
@@ -19,6 +19,14 @@ namespace Mono.Linker {
 			while (value.IndexOf ('[') > 0) {
 				var openidx = value.IndexOf ('[');
 				var closeidx = value.IndexOf (']');
+				
+				// No matching close ] or out of order
+				if (closeidx < 0 || closeidx < openidx) {
+					typeName = null;
+					assemblyName = null;
+					return false;
+				}
+
 				value = value.Remove (openidx, closeidx + 1 - openidx);
 			}
 
@@ -27,6 +35,12 @@ namespace Mono.Linker {
 			assemblyName = null;
 			if (tokens.Length > 1)
 				assemblyName = tokens [1].Trim ();
+
+			if (string.IsNullOrWhiteSpace (typeName)) {
+				typeName = null;
+				assemblyName = null;
+				return false;
+			}
 
 			return true;
 		}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -145,6 +145,11 @@
     <Compile Include="Reflection\MethodUsedViaReflection.cs" />
     <Compile Include="Reflection\PropertyUsedViaReflection.cs" />
     <Compile Include="Reflection\TypeUsedViaReflection.cs" />
+    <Compile Include="Reflection\TypeUsedViaReflectionAssemblyDoesntExist.cs" />
+    <Compile Include="Reflection\TypeUsedViaReflectionLdstrIncomplete.cs" />
+    <Compile Include="Reflection\TypeUsedViaReflectionLdstrValidButChanged.cs" />
+    <Compile Include="Reflection\TypeUsedViaReflectionTypeDoesntExist.cs" />
+    <Compile Include="Reflection\TypeUsedViaReflectionTypeNameIsSymbol.cs" />
     <Compile Include="Reflection\UsedViaReflectionIntegrationTest.cs" />
     <Compile Include="Resources\EmbeddedLinkXmlFileInReferencedAssemblyIsNotProcessedIfNameDoesNotMatchAnAssembly.cs" />
     <Compile Include="Resources\Dependencies\EmbeddedLinkXmlFileInReferencedAssemblyIsNotProcessedIfNameDoesNotMatchAnAssembly_Lib1.cs" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflectionAssemblyDoesntExist.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflectionAssemblyDoesntExist.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Mono.Linker.Tests.Cases.Reflection {
+	public class TypeUsedViaReflectionAssemblyDoesntExist {
+		public static void Main ()
+		{
+			var typeName = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflectionAssemblyDoesntExist+DoesntExist, test";
+			var typeKept = Type.GetType (typeName, false);
+		}
+
+		public class Full { }
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflectionLdstrIncomplete.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflectionLdstrIncomplete.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Reflection {
+	/// <summary>
+	/// This case we can't detect and need to gracefully do nothing
+	/// </summary>
+	public class TypeUsedViaReflectionLdstrIncomplete {
+		public static void Main ()
+		{
+			var typePart = GetTypePart ();
+			var asemmblyPart = ",test";
+			var typeKept = Type.GetType (string.Concat (typePart, asemmblyPart), false);
+		}
+
+		public class Full { }
+
+		[Kept]
+		static string GetTypePart ()
+		{
+			return "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflectionLdstrIncomplete+Full";
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflectionLdstrValidButChanged.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflectionLdstrValidButChanged.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Reflection {
+	/// <summary>
+	/// We don't know if `typeName` will be changed or not.  If we error on the side of caution and preserve something
+	/// that we found, I don't think that's a big deal
+	/// </summary>
+	public class TypeUsedViaReflectionLdstrValidButChanged {
+		public static void Main ()
+		{
+			var replace = "Mono.Linker";
+			var with = "Blah.Blah";
+			var typeName = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflectionLdstrValidButChanged+Full, test";
+			var typeKept = Type.GetType (typeName.Replace (replace, with), false);
+		}
+
+		[Kept]
+		public class Full { }
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflectionTypeDoesntExist.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflectionTypeDoesntExist.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Mono.Linker.Tests.Cases.Reflection {
+	public class TypeUsedViaReflectionTypeDoesntExist {
+		public static void Main ()
+		{
+			var typeName = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflectionTypeDoesntExist+Full, DoesntExist";
+			var typeKept = Type.GetType (typeName, false);
+		}
+
+		public class Full { }
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflectionTypeNameIsSymbol.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflectionTypeNameIsSymbol.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Mono.Linker.Tests.Cases.Reflection {
+	public class TypeUsedViaReflectionTypeNameIsSymbol {
+		public static void Main ()
+		{
+			var typeName = "+, test";
+			var typeKept = Type.GetType (typeName, false);
+		}
+
+		public class Full { }
+	}
+}

--- a/linker/Tests/Tests/TypeNameParserTests.cs
+++ b/linker/Tests/Tests/TypeNameParserTests.cs
@@ -90,6 +90,28 @@ namespace Mono.Linker.Tests {
 			Assert.That (assemblyName, Is.Null);
 		}
 
+		[Test]
+		public void MissingTypeName ()
+		{
+			Assert.That (TypeNameParser.TryParseTypeAssemblyQualifiedName (", System", out string typeName, out string assemblyName), Is.False);
+			Assert.That (typeName, Is.Null);
+			Assert.That (assemblyName, Is.Null);
+		}
+
+		
+		[TestCase ("A[]][")]
+		[TestCase ("A][")]
+		[TestCase ("A[")]
+		[TestCase (",    ,    ")]
+		[TestCase (", , , ")]
+		[TestCase (", , , , ")]
+		public void InvalidValues (string name)
+		{
+			Assert.That (TypeNameParser.TryParseTypeAssemblyQualifiedName (name, out string typeName, out string assemblyName), Is.False);
+			Assert.That (typeName, Is.Null);
+			Assert.That (assemblyName, Is.Null);
+		}
+
 		class SampleNestedType {
 		}
 


### PR DESCRIPTION
* Fix crash processing class libs due to type name portion of found ldstr being empty.  Ex: `, System`

* Fix crash that could have happened when closing `]` was missing.  Ex : `A]`

* Fix infinite loop that could have happened when `[]` were out of order.  Ex: `A][`

* Add tests for some other odd scenarios to make sure they behave as expected