### PR TITLE
Register all context assemblies actions.

### DIFF
--- a/linker/Linker.Steps/LoadReferencesStep.cs
+++ b/linker/Linker.Steps/LoadReferencesStep.cs
@@ -49,6 +49,8 @@ namespace Mono.Linker.Steps {
 
 			_references.Add (assembly.Name, assembly);
 
+			Context.RegisterAssembly (assembly);
+
 			foreach (AssemblyDefinition referenceDefinition in Context.ResolveReferences (assembly)) {
 				try {
 					ProcessReferences (referenceDefinition);

--- a/linker/Linker/LinkContext.cs
+++ b/linker/Linker/LinkContext.cs
@@ -212,15 +212,21 @@ namespace Mono.Linker {
 			try {
 				AssemblyDefinition assembly = _resolver.Resolve (reference, _readerParameters);
 
-				if (assembly != null && SeenFirstTime (assembly)) {
-					SafeReadSymbols (assembly);
-					SetAction (assembly);
-				}
+				if (assembly != null)
+					RegisterAssembly (assembly);
 
 				return assembly;
 			}
 			catch (Exception e) {
 				throw new AssemblyResolutionException (reference, e);
+			}
+		}
+
+		public void RegisterAssembly (AssemblyDefinition assembly)
+		{
+			if (SeenFirstTime (assembly)) {
+				SafeReadSymbols (assembly);
+				SetAction (assembly);
 			}
 		}
 


### PR DESCRIPTION
This was exposed in XA where we populate the resolver manually and the
a244cc740cd4413f58b4403fa128987046e9d9e7 change exposed this because
BlackList step requires any context assembly to have action set