### PR TITLE
Sweep all, not just the first, referenced assemblies of the same name

### DIFF
--- a/linker/Linker.Steps/SweepStep.cs
+++ b/linker/Linker.Steps/SweepStep.cs
@@ -179,7 +179,8 @@ namespace Mono.Linker.Steps {
 					continue;
 
 				ReferenceRemoved (assembly, reference);
-				references.RemoveAt (i);
+				// removal from `references` requires an adjustment to `i`
+				references.RemoveAt (i--);
 				// Removing the reference does not mean it will be saved back to disk!
 				// That depends on the AssemblyAction set for the `assembly`
 				switch (Annotations.GetAction (assembly)) {
@@ -208,8 +209,6 @@ namespace Mono.Linker.Steps {
 					}
 					break;
 				}
-				// earlier removal from `references` requires an adjustment
-				i--;
 			}
 		}
 

--- a/linker/Linker.Steps/SweepStep.cs
+++ b/linker/Linker.Steps/SweepStep.cs
@@ -178,7 +178,7 @@ namespace Mono.Linker.Steps {
 				if (!AreSameReference (r.Name, target.Name))
 					continue;
 
-				ReferenceRemoved (assembly, references [i]);
+				ReferenceRemoved (assembly, reference);
 				references.RemoveAt (i);
 				// Removing the reference does not mean it will be saved back to disk!
 				// That depends on the AssemblyAction set for the `assembly`
@@ -208,7 +208,8 @@ namespace Mono.Linker.Steps {
 					}
 					break;
 				}
-				return;
+				// earlier removal from `references` requires an adjustment
+				i--;
 			}
 		}
 


### PR DESCRIPTION
It's uncommon but, with facades..., an assembly binary can end up with
references to more than one version of an assembly, e.g.

> System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
> System.Runtime, Version=4.0.20.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a

The existing logic would `return` after processing the first reference,
which means the 2nd reference would remain in the assembly (even if it
was never marked).

This is incorrect and cause issues (for XI) where unreferenced metadata
prevent the caching of some build artifacts - which means further builds
take longer than they should.