### PR TITLE
Don't use ResolvedPath metadata on ReferencePath

### DIFF
--- a/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
+++ b/corebuild/integration/ILLink.Tasks/ILLink.Tasks.targets
@@ -343,14 +343,14 @@
          implementation assembly, and prevent inclusion of the ref
          assembly by filtering on filename instead of the full
          path. -->
-    <FilterByMetadata Items="@(ReferencePath->'%(ResolvedPath)')"
+    <FilterByMetadata Items="@(ReferencePath)"
                       MetadataName="Filename"
                       MetadataValues="@(_ManagedAssembliesToLink->'%(Filename)')"
                       Condition=" '$(SelfContained)' != 'true' ">
       <Output TaskParameter="FilteredItems" ItemName="_ReferencedLibrariesToExclude" />
     </FilterByMetadata>
     <ItemGroup Condition=" '$(SelfContained)' != 'true' ">
-      <_ReferencedLibraries Include="@(ReferencePath->'%(ResolvedPath)')" Exclude="@(_ReferencedLibrariesToExclude)" />
+      <_ReferencedLibraries Include="@(ReferencePath)" Exclude="@(_ReferencedLibrariesToExclude)" />
       <_ManagedAssembliesToLink Include="@(_ReferencedLibraries)" />
     </ItemGroup>
 


### PR DESCRIPTION
This fixes https://github.com/mono/linker/issues/286, introduced by https://github.com/dotnet/sdk/pull/1857, which removes some metadata from this ItemGroup.

I tested this on a simple project. @nguerrera, can you confirm whether the ReferencePath ItemGroup should contain the correct path to any resolved assemblies in general? If not, which item metadata could we use instead?
