### PR TITLE
Improved sandboxing of prebuilt test assembly dependencies

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/ReferenceDependencyAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/ReferenceDependencyAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Metadata {
+	[AttributeUsage (AttributeTargets.Class, AllowMultiple = true)]
+	public class ReferenceDependencyAttribute : BaseMetadataAttribute {
+		public ReferenceDependencyAttribute (string value)
+		{
+			if (string.IsNullOrEmpty (value))
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (value));
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Assertions\RemovedTypeInAssemblyAttribute.cs" />
     <Compile Include="Assertions\SkipPeVerifyAttribute.cs" />
     <Compile Include="Metadata\BaseMetadataAttribute.cs" />
+    <Compile Include="Metadata\ReferenceDependencyAttribute.cs" />
     <Compile Include="Metadata\SetupCompileAfterAttribute.cs" />
     <Compile Include="Metadata\SetupCompileAssemblyNameAttribute.cs" />
     <Compile Include="Metadata\SetupCompileArgumentAttribute.cs" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdb.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdb.cs
@@ -4,9 +4,8 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Symbols {
-	[Reference ("LibraryWithMdb.dll")]
-	[SandboxDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll", "input/LibraryWithMdb.dll")]
-	[SandboxDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb", "input/LibraryWithMdb.dll.mdb")]
+	[Reference ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll")]
+	[ReferenceDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb")]
 	[SetupLinkerLinkSymbols ("false")]
 
 	[RemovedSymbols ("LibraryWithMdb.dll")]

--- a/linker/Tests/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdbAndSymbolLinkingEnabled.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdbAndSymbolLinkingEnabled.cs
@@ -4,9 +4,8 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Symbols {
-	[Reference ("LibraryWithMdb.dll")]
-	[SandboxDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll", "input/LibraryWithMdb.dll")]
-	[SandboxDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb", "input/LibraryWithMdb.dll.mdb")]
+	[Reference ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll")]
+	[ReferenceDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb")]
 	[SetupLinkerLinkSymbols ("true")]
 
 	[KeptSymbols ("LibraryWithMdb.dll")]

--- a/linker/Tests/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdbCopyAction.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdbCopyAction.cs
@@ -3,9 +3,8 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Symbols {
-	[Reference ("LibraryWithMdb.dll")]
-	[SandboxDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll", "input/LibraryWithMdb.dll")]
-	[SandboxDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb", "input/LibraryWithMdb.dll.mdb")]
+	[Reference ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll")]
+	[ReferenceDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb")]
 	[SetupLinkerLinkSymbols ("false")]
 	[SetupLinkerAction ("copy", "LibraryWithMdb")]
 

--- a/linker/Tests/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdbCopyActionAndSymbolLinkingEnabled.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdbCopyActionAndSymbolLinkingEnabled.cs
@@ -3,9 +3,8 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Symbols {
-	[Reference ("LibraryWithMdb.dll")]
-	[SandboxDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll", "input/LibraryWithMdb.dll")]
-	[SandboxDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb", "input/LibraryWithMdb.dll.mdb")]
+	[Reference ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll")]
+	[ReferenceDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb")]
 	[SetupLinkerLinkSymbols ("true")]
 	[SetupLinkerAction ("copy", "LibraryWithMdb")]
 

--- a/linker/Tests/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdbDeleteAction.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdbDeleteAction.cs
@@ -3,9 +3,8 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Symbols {
-	[Reference ("LibraryWithMdb.dll")]
-	[SandboxDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll", "input/LibraryWithMdb.dll")]
-	[SandboxDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb", "input/LibraryWithMdb.dll.mdb")]
+	[Reference ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll")]
+	[ReferenceDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb")]
 	[SetupLinkerLinkSymbols ("false")]
 
 	[RemovedAssembly ("LibraryWithMdb.dll")]

--- a/linker/Tests/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdbDeleteActionAndSymbolLinkingEnabled.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdbDeleteActionAndSymbolLinkingEnabled.cs
@@ -3,9 +3,8 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Symbols {
-	[Reference ("LibraryWithMdb.dll")]
-	[SandboxDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll", "input/LibraryWithMdb.dll")]
-	[SandboxDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb", "input/LibraryWithMdb.dll.mdb")]
+	[Reference ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll")]
+	[ReferenceDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb")]
 	[SetupLinkerLinkSymbols ("true")]
 
 	[RemovedAssembly ("LibraryWithMdb.dll")]

--- a/linker/Tests/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdb.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdb.cs
@@ -3,9 +3,8 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Symbols {
-	[Reference ("LibraryWithPdb.dll")]
-	[SandboxDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll", "input/LibraryWithPdb.dll")]
-	[SandboxDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb", "input/LibraryWithPdb.pdb")]
+	[Reference ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll")]
+	[ReferenceDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb")]
 	[SetupLinkerLinkSymbols ("false")]
 
 	[RemovedSymbols ("LibraryWithPdb.dll")]

--- a/linker/Tests/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbAndSymbolLinkingEnabled.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbAndSymbolLinkingEnabled.cs
@@ -4,9 +4,8 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Symbols {
-	[Reference ("LibraryWithPdb.dll")]
-	[SandboxDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll", "input/LibraryWithPdb.dll")]
-	[SandboxDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb", "input/LibraryWithPdb.pdb")]
+	[Reference ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll")]
+	[ReferenceDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb")]
 	[SetupLinkerLinkSymbols( "true")]
 
 #if WIN32

--- a/linker/Tests/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbCopyAction.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbCopyAction.cs
@@ -3,9 +3,8 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Symbols {
-	[Reference ("LibraryWithPdb.dll")]
-	[SandboxDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll", "input/LibraryWithPdb.dll")]
-	[SandboxDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb", "input/LibraryWithPdb.pdb")]
+	[Reference ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll")]
+	[ReferenceDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb")]
 	[SetupLinkerLinkSymbols ("false")]
 	[SetupLinkerAction ("copy", "LibraryWithPdb")]
 

--- a/linker/Tests/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbCopyActionAndSymbolLinkingEnabled.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbCopyActionAndSymbolLinkingEnabled.cs
@@ -3,9 +3,8 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Symbols {
-	[Reference ("LibraryWithPdb.dll")]
-	[SandboxDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll", "input/LibraryWithPdb.dll")]
-	[SandboxDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb", "input/LibraryWithPdb.pdb")]
+	[Reference ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll")]
+	[ReferenceDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb")]
 	[SetupLinkerLinkSymbols ("true")]
 	[SetupLinkerAction ("copy", "LibraryWithPdb")]
 

--- a/linker/Tests/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbDeleteAction.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbDeleteAction.cs
@@ -3,9 +3,8 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Symbols {
-	[Reference ("LibraryWithPdb.dll")]
-	[SandboxDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll", "input/LibraryWithPdb.dll")]
-	[SandboxDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb", "input/LibraryWithPdb.pdb")]
+	[Reference ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll")]
+	[ReferenceDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb")]
 	[SetupLinkerLinkSymbols ("false")]
 
 	[RemovedAssembly ("LibraryWithPdb.dll")]

--- a/linker/Tests/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbDeleteActionAndSymbolLinkingEnabled.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbDeleteActionAndSymbolLinkingEnabled.cs
@@ -3,9 +3,8 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Symbols {
-	[Reference ("LibraryWithPdb.dll")]
-	[SandboxDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll", "input/LibraryWithPdb.dll")]
-	[SandboxDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb", "input/LibraryWithPdb.pdb")]
+	[Reference ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll")]
+	[ReferenceDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb")]
 	[SetupLinkerLinkSymbols ("true")]
 
 	[RemovedAssembly ("LibraryWithPdb.dll")]

--- a/linker/Tests/Mono.Linker.Tests.Cases/Symbols/ReferencesWithMixedSymbolTypes.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Symbols/ReferencesWithMixedSymbolTypes.cs
@@ -6,13 +6,11 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 [assembly: KeptAttributeAttribute (typeof (System.Diagnostics.DebuggableAttribute))]
 
 namespace Mono.Linker.Tests.Cases.Symbols {
-	[Reference ("LibraryWithMdb.dll")]
-	[SandboxDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll", "input/LibraryWithMdb.dll")]
-	[SandboxDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb", "input/LibraryWithMdb.dll.mdb")]
+	[Reference ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll")]
+	[ReferenceDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb")]
 
-	[Reference ("LibraryWithPdb.dll")]
-	[SandboxDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll", "input/LibraryWithPdb.dll")]
-	[SandboxDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb", "input/LibraryWithPdb.pdb")]
+	[Reference ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll")]
+	[ReferenceDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb")]
 
 	[SetupCompileBefore ("LibraryWithCompilerDefaultSymbols.dll", new[] { "Dependencies/LibraryWithCompilerDefaultSymbols.cs" }, additionalArguments: "/debug:full")]
 	[SetupCompileBefore("LibraryWithPortablePdbSymbols.dll", new[] { "Dependencies/LibraryWithPortablePdbSymbols.cs" }, additionalArguments: "/debug:portable", compilerToUse: "csc")]

--- a/linker/Tests/Mono.Linker.Tests.Cases/Symbols/ReferencesWithMixedSymbolTypesAndSymbolLinkingEnabled.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Symbols/ReferencesWithMixedSymbolTypesAndSymbolLinkingEnabled.cs
@@ -6,13 +6,11 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 [assembly: KeptAttributeAttribute (typeof (System.Diagnostics.DebuggableAttribute))]
 
 namespace Mono.Linker.Tests.Cases.Symbols {
-	[Reference ("LibraryWithMdb.dll")]
-	[SandboxDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll", "input/LibraryWithMdb.dll")]
-	[SandboxDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb", "input/LibraryWithMdb.dll.mdb")]
+	[Reference ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll")]
+	[ReferenceDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb")]
 
-	[Reference ("LibraryWithPdb.dll")]
-	[SandboxDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll", "input/LibraryWithPdb.dll")]
-	[SandboxDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb", "input/LibraryWithPdb.pdb")]
+	[Reference ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll")]
+	[ReferenceDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb")]
 
 	[SetupCompileBefore ("LibraryWithCompilerDefaultSymbols.dll", new[] { "Dependencies/LibraryWithCompilerDefaultSymbols.cs" }, additionalArguments: "/debug:full")]
 	[SetupCompileBefore ("LibraryWithPortablePdbSymbols.dll", new[] { "Dependencies/LibraryWithPortablePdbSymbols.cs" }, additionalArguments: "/debug:portable", compilerToUse: "csc")]

--- a/linker/Tests/TestCasesRunner/TestCaseSandbox.cs
+++ b/linker/Tests/TestCasesRunner/TestCaseSandbox.cs
@@ -76,6 +76,15 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 				if (destination.Parent == InputDirectory)
 					dep.Source.Copy (ExpectationsDirectory.Combine (destination.RelativeTo (InputDirectory)));
 			}
+			
+			// Copy non class library dependencies to the sandbox
+			foreach (var fileName in metadataProvider.GetReferenceValues ()) {
+				if (!fileName.StartsWith ("System.", StringComparison.Ordinal) && !fileName.StartsWith ("Mono.", StringComparison.Ordinal) && !fileName.StartsWith ("Microsoft.", StringComparison.Ordinal))
+					CopyToInputAndExpectations (_testCase.SourceFile.Parent.Combine (fileName.ToNPath ()));
+			}
+			
+			foreach (var referenceDependency in metadataProvider.GetReferenceDependencies ())
+				CopyToInputAndExpectations (_testCase.SourceFile.Parent.Combine (referenceDependency.ToNPath()));
 
 			foreach (var res in metadataProvider.GetResources ()) {
 				res.Source.FileMustExist ().Copy (ResourcesDirectory.Combine (res.DestinationFileName));


### PR DESCRIPTION
This PR adds better support for referencing a pre-built assembly in a test.  Previously you had to do a round about mechanism such as

```
[Reference ("LibraryWithMdb.dll")]
[SandboxDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll", "input/LibraryWithMdb.dll")]
[SandboxDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb", "input/LibraryWithMdb.dll.mdb")]
```

This required knowledge of the temporary sandbox directory layout.

Now that same scenario looks like

```
[Reference ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll")]
[ReferenceDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb")]
```
