### PR TITLE
Add a test to verify forwarder can be preserved via xml

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -258,6 +258,7 @@
     <Compile Include="TypeForwarding\Dependencies\ReferenceImplementationLibrary.cs" />
     <Compile Include="TypeForwarding\TypeForwarderOnlyAssembliesRemoved.cs" />
     <Compile Include="TypeForwarding\TypeForwarderOnlyAssembliesKept.cs" />
+    <Compile Include="TypeForwarding\TypeForwarderOnlyAssemblyCanBePreservedViaLinkXml.cs" />
     <Compile Include="VirtualMethods\ClassUsedFromConcreteTypeHasInterfaceMethodRemoved.cs" />
     <Compile Include="VirtualMethods\ClassUsedFromInterfaceHasInterfaceMethodKept.cs" />
     <Compile Include="VirtualMethods\StructUsedFromConcreteTypeHasInterfaceMethodRemoved.cs" />
@@ -375,6 +376,7 @@
     <Content Include="TestFramework\Dependencies\CanCompileTestCaseWithMcs.txt" />
     <Content Include="TestFramework\Dependencies\VerifyResourceInAssemblyAttributesBehavior.txt" />
     <Content Include="LinkXml\PreserveBackingFieldWhenPropertyIsKept.xml" />
+    <Content Include="TypeForwarding\TypeForwarderOnlyAssemblyCanBePreservedViaLinkXml.xml" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Mono.Linker.Tests.Cases.Expectations\Mono.Linker.Tests.Cases.Expectations.csproj">

--- a/linker/Tests/Mono.Linker.Tests.Cases/TypeForwarding/TypeForwarderOnlyAssemblyCanBePreservedViaLinkXml.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/TypeForwarding/TypeForwarderOnlyAssemblyCanBePreservedViaLinkXml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.TypeForwarding.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.TypeForwarding {
+	[KeepTypeForwarderOnlyAssemblies ("false")]
+	[SetupCompileBefore ("Forwarder.dll", new[] { "Dependencies/ReferenceImplementationLibrary.cs" }, defines: new[] { "INCLUDE_REFERENCE_IMPL" })]
+	// Add another assembly in that uses the forwarder just to make things a little more complex
+	[SetupCompileBefore ("Library.dll", new[] { "Dependencies/LibraryUsingForwarder.cs" }, references: new[] { "Forwarder.dll" })]
+
+	// After compiling the test case we then replace the reference impl with implementation + type forwarder
+	[SetupCompileAfter ("Implementation.dll", new[] { "Dependencies/ImplementationLibrary.cs" })]
+	[SetupCompileAfter ("Forwarder.dll", new[] { "Dependencies/ForwarderLibrary.cs" }, references: new[] { "Implementation.dll" })]
+
+	[KeptAssembly ("Forwarder.dll")]
+	[KeptMemberInAssembly ("Implementation.dll", typeof (ImplementationLibrary), "GetSomeValue()")]
+	[KeptMemberInAssembly ("Library.dll", typeof (LibraryUsingForwarder), "GetValueFromOtherAssembly()")]
+	
+	[KeptTypeInAssembly("Forwarder.dll", typeof (ImplementationLibrary))]
+	public class TypeForwarderOnlyAssemblyCanBePreservedViaLinkXml {
+		static void Main()
+		{
+			Console.WriteLine (new ImplementationLibrary ().GetSomeValue ());
+			Console.WriteLine (new LibraryUsingForwarder ().GetValueFromOtherAssembly ());
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/TypeForwarding/TypeForwarderOnlyAssemblyCanBePreservedViaLinkXml.xml
+++ b/linker/Tests/Mono.Linker.Tests.Cases/TypeForwarding/TypeForwarderOnlyAssemblyCanBePreservedViaLinkXml.xml
@@ -1,0 +1,4 @@
+﻿<linker>
+    <assembly fullname="Forwarder, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+    </assembly>
+</linker>


### PR DESCRIPTION
Add a test to verify that a forwarder only assembly that would normally be removed due to keep type forwarder only assemblies being false can be preserved using a link.xml file.  This worked correctly without any code changes.

* Allow [KeptTypeInAssembly] to assert exported types.

* Fix an issue in ResultChecker where we could mistakenly resolve an original assembly.  ReaderParameters stores the resolver that is used first, this led to the ExportedType.Resolve() trying to resolve the type in the original assembly.  Using a separate ReaderParameters for original and linked assemblies fixes this issue