### PR TITLE
Improved test framework support for dlls

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupCompileAsLibraryAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupCompileAsLibraryAttribute.cs
@@ -1,0 +1,7 @@
+﻿using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Metadata {
+	[AttributeUsage (AttributeTargets.Class, AllowMultiple = false)]
+	public class SetupCompileAsLibraryAttribute : BaseMetadataAttribute {
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupLinkerLinkPublicAndFamilyAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupLinkerLinkPublicAndFamilyAttribute.cs
@@ -1,0 +1,7 @@
+﻿using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Metadata {
+	[AttributeUsage (AttributeTargets.Class, AllowMultiple = false)]
+	public class SetupLinkerLinkPublicAndFamilyAttribute : BaseMetadataAttribute {
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Metadata\BaseMetadataAttribute.cs" />
     <Compile Include="Metadata\ReferenceDependencyAttribute.cs" />
     <Compile Include="Metadata\SetupCompileAfterAttribute.cs" />
+    <Compile Include="Metadata\SetupCompileAsLibraryAttribute.cs" />
     <Compile Include="Metadata\SetupCompileAssemblyNameAttribute.cs" />
     <Compile Include="Metadata\SetupCompileArgumentAttribute.cs" />
     <Compile Include="Metadata\SetupCompileBeforeAttribute.cs" />
@@ -74,6 +75,7 @@
     <Compile Include="Metadata\ReferenceAttribute.cs" />
     <Compile Include="Metadata\SandboxDependencyAttribute.cs" />
     <Compile Include="Metadata\SetupLinkerKeepDebugMembersAttribute.cs" />
+    <Compile Include="Metadata\SetupLinkerLinkPublicAndFamilyAttribute.cs" />
     <Compile Include="Metadata\SkipUnresolvedAttribute.cs" />
     <Compile Include="Metadata\StripResourcesAttribute.cs" />
     <Compile Include="Assertions\KeptBaseTypeAttribute.cs" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/Libraries/CanLinkPublicApisOfLibrary.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Libraries/CanLinkPublicApisOfLibrary.cs
@@ -1,0 +1,26 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Libraries {
+	[SetupLinkerLinkPublicAndFamily]
+	[SetupCompileAsLibrary]
+	[Kept]
+	[KeptMember (".ctor()")]
+	public class CanLinkPublicApisOfLibrary {
+		// Kept because by default libraries their action set to copy
+		[Kept]
+		public static void Main ()
+		{
+			// Main is needed for the test collector to find and treat as a test
+		}
+
+		[Kept]
+		public void UnusedPublicMethod ()
+		{
+		}
+
+		private void UnusedPrivateMethod ()
+		{
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Libraries/DefaultLibraryLinkBehavior.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Libraries/DefaultLibraryLinkBehavior.cs
@@ -1,0 +1,26 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Libraries {
+	[SetupCompileAsLibrary]
+	[Kept]
+	[KeptMember (".ctor()")]
+	public class DefaultLibraryLinkBehavior {
+		// Kept because by default libraries their action set to copy
+		[Kept]
+		public static void Main ()
+		{
+			// Main is needed for the test collector to find and treat as a test
+		}
+
+		[Kept]
+		public void UnusedPublicMethod ()
+		{
+		}
+
+		[Kept]
+		private void UnusedPrivateMethod ()
+		{
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -159,6 +159,8 @@
     <Compile Include="Basic\UsedStructIsKept.cs" />
     <Compile Include="CoreLink\CanIncludeI18nAssemblies.cs" />
     <Compile Include="CoreLink\NoSecurityPlusOnlyKeepUsedRemovesAllSecurityAttributesFromCoreLibraries.cs" />
+    <Compile Include="Libraries\CanLinkPublicApisOfLibrary.cs" />
+    <Compile Include="Libraries\DefaultLibraryLinkBehavior.cs" />
     <Compile Include="LinkXml\CanPreserveTypesUsingRegex.cs" />
     <Compile Include="LinkXml\CanPreserveAnExportedType.cs" />
     <None Include="LinkXml\Dependencies\CanPreserveAnExportedType_Forwarder.cs" />

--- a/linker/Tests/TestCases/TestDatabase.cs
+++ b/linker/Tests/TestCases/TestDatabase.cs
@@ -85,6 +85,11 @@ namespace Mono.Linker.Tests.TestCases
 		{
 			return NUnitCasesByPrefix ("Symbols.");
 		}
+		
+		public static IEnumerable<TestCaseData> LibrariesTests ()
+		{
+			return NUnitCasesByPrefix ("Libraries.");
+		}
 
 		public static IEnumerable<TestCaseData> AdvancedTests ()
 		{

--- a/linker/Tests/TestCases/TestSuites.cs
+++ b/linker/Tests/TestCases/TestSuites.cs
@@ -101,6 +101,12 @@ namespace Mono.Linker.Tests.TestCases
 		{
 			Run (testCase);
 		}
+		
+		[TestCaseSource (typeof (TestDatabase), nameof (TestDatabase.LibrariesTests))]
+		public void LibrariesTests (TestCase testCase)
+		{
+			Run (testCase);
+		}
 
 		protected virtual void Run (TestCase testCase)
 		{

--- a/linker/Tests/TestCasesRunner/AssemblyChecker.cs
+++ b/linker/Tests/TestCasesRunner/AssemblyChecker.cs
@@ -81,7 +81,7 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			//
 			bool expectedKept =
 				original.HasAttributeDerivedFrom (nameof (KeptAttribute)) ||
-				(linked != null && linkedModule.Assembly.EntryPoint.DeclaringType == linked) ||
+				(linked != null && linkedModule.Assembly.EntryPoint?.DeclaringType == linked) ||
 				original.AllMembers ().Any (l => l.HasAttribute (nameof (KeptAttribute)));
 
 			if (!expectedKept) {

--- a/linker/Tests/TestCasesRunner/LinkerArgumentBuilder.cs
+++ b/linker/Tests/TestCasesRunner/LinkerArgumentBuilder.cs
@@ -4,6 +4,12 @@ using Mono.Linker.Tests.Extensions;
 namespace Mono.Linker.Tests.TestCasesRunner {
 	public class LinkerArgumentBuilder {
 		private readonly List<string> _arguments = new List<string> ();
+		private readonly TestCaseMetadaProvider _metadaProvider;
+
+		public LinkerArgumentBuilder (TestCaseMetadaProvider metadaProvider)
+		{
+			_metadaProvider = metadaProvider;
+		}
 
 		public virtual void AddSearchDirectory (NPath directory)
 		{
@@ -32,6 +38,12 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 		public virtual void LinkFromAssembly (string fileName)
 		{
 			Append ("-a");
+			Append (fileName);
+		}
+		
+		public virtual void LinkFromPublicAndFamily (string fileName)
+		{
+			Append ("-r");
 			Append (fileName);
 		}
 
@@ -105,6 +117,14 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 				foreach (var val in values)
 					Append (val);
 			}
+		}
+		
+		public virtual void ProcessTestInputAssembly (NPath inputAssemblyPath)
+		{
+			if (_metadaProvider.LinkPublicAndFamily ())
+				LinkFromPublicAndFamily (inputAssemblyPath.ToString ());
+			else
+				LinkFromAssembly (inputAssemblyPath.ToString ());
 		}
 
 		public virtual void ProcessOptions (TestCaseLinkerOptions options)

--- a/linker/Tests/TestCasesRunner/ObjectFactory.cs
+++ b/linker/Tests/TestCasesRunner/ObjectFactory.cs
@@ -23,9 +23,9 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			return new TestCaseMetadaProvider (testCase, fullTestCaseAssemblyDefinition);
 		}
 
-		public virtual LinkerArgumentBuilder CreateLinkerArgumentBuilder ()
+		public virtual LinkerArgumentBuilder CreateLinkerArgumentBuilder (TestCaseMetadaProvider metadataProvider)
 		{
-			return new LinkerArgumentBuilder ();
+			return new LinkerArgumentBuilder (metadataProvider);
 		}
 	}
 }

--- a/linker/Tests/TestCasesRunner/TestCaseMetadaProvider.cs
+++ b/linker/Tests/TestCasesRunner/TestCaseMetadaProvider.cs
@@ -140,9 +140,18 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 				yield return (string) attr.ConstructorArguments.First ().Value;
 		}
 
+		public virtual bool LinkPublicAndFamily()
+		{
+			return _testCaseTypeDefinition.CustomAttributes
+				.FirstOrDefault (attr => attr.AttributeType.Name == nameof (SetupLinkerLinkPublicAndFamilyAttribute)) != null;
+		}
+
 		public virtual string GetAssemblyName ()
 		{
-			return GetOptionAttributeValue (nameof (SetupCompileAssemblyNameAttribute), "test.exe");
+			var asLibraryAttribute = _testCaseTypeDefinition.CustomAttributes
+				.FirstOrDefault (attr => attr.AttributeType.Name == nameof (SetupCompileAsLibraryAttribute));
+			var defaultName = asLibraryAttribute == null ? "test.exe" : "test.dll";
+			return GetOptionAttributeValue (nameof (SetupCompileAssemblyNameAttribute), defaultName);
 		}
 
 		public virtual string GetCSharpCompilerToUse ()

--- a/linker/Tests/TestCasesRunner/TestRunner.cs
+++ b/linker/Tests/TestCasesRunner/TestRunner.cs
@@ -86,7 +86,7 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 		private LinkedTestCaseResult Link (TestCase testCase, TestCaseSandbox sandbox, ManagedCompilationResult compilationResult, TestCaseMetadaProvider metadataProvider)
 		{
 			var linker = _factory.CreateLinker ();
-			var builder = _factory.CreateLinkerArgumentBuilder ();
+			var builder = _factory.CreateLinkerArgumentBuilder (metadataProvider);
 			var caseDefinedOptions = metadataProvider.GetLinkerOptions ();
 
 			builder.AddOutputDirectory (sandbox.OutputDirectory);
@@ -101,8 +101,7 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 
 			AddAdditionalLinkOptions (builder, metadataProvider);
 
-			// TODO: Should be overridable
-			builder.LinkFromAssembly (compilationResult.InputAssemblyPath.ToString ());
+			builder.ProcessTestInputAssembly (compilationResult.InputAssemblyPath);
 
 			linker.Link (builder.ToArgs ());
 


### PR DESCRIPTION
* Added [SetupCompileAsLibrary] to easily compile a test as a dll

* Added [SetupLinkerLinkPublicAndFamily] to allow for tests to use the -r argument instead of -a for the input test assembly

* Fixed a NullReferenceException in AssemblyChecker that would be thrown if the test assembly didn't have an EntryPoint