### PR TITLE
Add [KeptAllTypesAndMembersInAssembly]

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptAllTypesAndMembersInAssemblyAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptAllTypesAndMembersInAssemblyAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Assertions {
+	[AttributeUsage (AttributeTargets.Class | AttributeTargets.Delegate, AllowMultiple = true, Inherited = false)]
+	public class KeptAllTypesAndMembersInAssemblyAttribute : BaseInAssemblyAttribute {
+		public KeptAllTypesAndMembersInAssemblyAttribute (string assemblyFileName)
+		{
+			if (string.IsNullOrEmpty (assemblyFileName))
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (assemblyFileName));
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
@@ -39,6 +39,7 @@
   <ItemGroup>
     <Compile Include="Assertions\BaseInAssemblyAttribute.cs" />
     <Compile Include="Assertions\IgnoreTestCaseAttribute.cs" />
+    <Compile Include="Assertions\KeptAllTypesAndMembersInAssemblyAttribute.cs" />
     <Compile Include="Assertions\KeptAssemblyAttribute.cs" />
     <Compile Include="Assertions\KeptAttribute.cs" />
     <Compile Include="Assertions\BaseExpectedLinkedBehaviorAttribute.cs" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/CoreLink/CopyOfCoreLibrariesKeepsUnusedTypes.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/CoreLink/CopyOfCoreLibrariesKeepsUnusedTypes.cs
@@ -7,9 +7,7 @@ namespace Mono.Linker.Tests.Cases.CoreLink
 	[SetupLinkerCoreAction ("copy")]
 
 	[KeptAssembly ("mscorlib.dll")]
-	// These types are normally removed when the core libraries are linked
-	[KeptTypeInAssembly ("mscorlib.dll", typeof (ConsoleKeyInfo))]
-	[KeptTypeInAssembly ("mscorlib.dll", typeof (System.Collections.ObjectModel.KeyedCollection<,>))]
+	[KeptAllTypesAndMembersInAssembly ("mscorlib.dll")]
 
 	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168
 	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]


### PR DESCRIPTION
I need this functionality for something else in our UnityLinker tests so I thought I would add it upstream.

I found an existing testing that could make use of it