### PR TITLE
Remove assembly dependencies imported via reflection logic

### DIFF
--- a/linker/Linker.Steps/MarkStep.cs
+++ b/linker/Linker.Steps/MarkStep.cs
@@ -1893,21 +1893,6 @@ namespace Mono.Linker.Steps {
 						break;
 				}
 
-				if (foundType == null && assemblyName != null) {
-					AssemblyDefinition newDependency;
-					try {
-						newDependency = _context.Resolve (assemblyName);
-					} catch {
-						newDependency = null;
-					}
-
-					if (newDependency == null) {
-						_context.Logger.LogMessage (MessageImportance.Low, $"Could not resolve assembly {assemblyName}");
-					} else {
-						foundType = newDependency.MainModule.GetType (typeName);
-					}
-				}
-
 				if (foundType == null)
 					continue;
 				

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -189,7 +189,12 @@
     <Compile Include="References\Individual\Dependencies\CanSkipUnresolved_Library.cs" />
     <Compile Include="References\Dependencies\UserAssembliesAreLinkedByDefault_Library1.cs" />
     <Compile Include="References\UserAssembliesAreLinkedByDefault.cs" />
+    <Compile Include="Reflection\AssemblyImportedViaReflectionWithDerivedType.cs" />
+    <Compile Include="Reflection\AssemblyImportedViaReflectionWithReference.cs" />
     <Compile Include="Reflection\ConstructorUsedViaReflection.cs" />
+    <Compile Include="Reflection\Dependencies\AssemblyDependencyWithReference.cs" />
+    <Compile Include="Reflection\Dependencies\AssemblyImportedViaReflectionWithDerivedType_Base.cs" />
+    <Compile Include="Reflection\Dependencies\AssemblyImportedViaReflectionWithDerivedType_Reflect.cs" />
     <Compile Include="Reflection\EventUsedViaReflection.cs" />
     <Compile Include="Reflection\FieldUsedViaReflection.cs" />
     <Compile Include="Reflection\MethodUsedViaReflectionWithDefaultBindingFlags.cs" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/Reflection/AssemblyImportedViaReflection.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Reflection/AssemblyImportedViaReflection.cs
@@ -5,7 +5,8 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Reflection
 {
-	[SetupCompileBefore ("library.dll", new [] { "Dependencies/AssemblyDependency.cs" })]
+	[IgnoreTestCase ("Requires support for using a type in an unreferences assembly via reflection")]
+	[SetupCompileBefore ("library.dll", new [] { "Dependencies/AssemblyDependency.cs" }, addAsReference: false)]
 	[KeptAssembly ("library.dll")]
 	[KeptTypeInAssembly ("library.dll", "Mono.Linker.Tests.Cases.Reflection.Dependencies.AssemblyDependency")]
 	public class AssemblyImportedViaReflection

--- a/linker/Tests/Mono.Linker.Tests.Cases/Reflection/AssemblyImportedViaReflectionWithDerivedType.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Reflection/AssemblyImportedViaReflectionWithDerivedType.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Reflection.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.Reflection
+{
+	[IgnoreTestCase ("Requires support for using a type in an unreferences assembly via reflection")]
+	[SetupCompileBefore ("base.dll", new [] { "Dependencies/AssemblyImportedViaReflectionWithDerivedType_Base.cs" })]
+	[SetupCompileBefore ("reflection.dll", new [] { "Dependencies/AssemblyImportedViaReflectionWithDerivedType_Reflect.cs" }, references: new [] {"base.dll"}, addAsReference: false)]
+	[KeptAssembly ("base.dll")]
+	[KeptAssembly ("reflection.dll")]
+	[KeptMemberInAssembly ("base.dll", typeof (AssemblyImportedViaReflectionWithDerivedType_Base), "Method()")]
+	[KeptMemberInAssembly ("reflection.dll", "Mono.Linker.Tests.Cases.Reflection.Dependencies.AssemblyImportedViaReflectionWithDerivedType_Reflect", "Method()")]
+	public class AssemblyImportedViaReflectionWithDerivedType
+	{
+		public static void Main ()
+		{
+			// Cause a the new assembly to be included via reflection usage
+			const string newAssemblyType = "Mono.Linker.Tests.Cases.Reflection.Dependencies.AssemblyImportedViaReflectionWithDerivedType_Reflect, reflection, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null";
+			var res = Type.GetType (newAssemblyType, true);
+			
+			// Foo and the reflection assembly both have a class the inherits from the base type.
+			// by using `Method` here and marking the reflection type above, we've introduced a requirement that `Method` be marked on the type in the reflection assembly as well 
+			var obj = new Foo ();
+			var val = obj.Method ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof (AssemblyImportedViaReflectionWithDerivedType_Base))]
+		class Foo : AssemblyImportedViaReflectionWithDerivedType_Base {
+			[Kept]
+			public override string Method ()
+			{
+				return "Foo";
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Reflection/AssemblyImportedViaReflectionWithReference.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Reflection/AssemblyImportedViaReflectionWithReference.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Reflection
+{
+	[IgnoreTestCase ("Requires support for using a type in an unreferences assembly via reflection")]
+	[SetupCompileBefore ("reference.dll", new [] { "Dependencies/AssemblyDependency.cs" }, addAsReference: false)]
+	[SetupCompileBefore ("library.dll", new [] { "Dependencies/AssemblyDependencyWithReference.cs" }, references: new []{"reference.dll"}, addAsReference: false)]
+	[KeptAssembly ("reference.dll")]
+	[KeptAssembly ("library.dll")]
+	[KeptTypeInAssembly ("library.dll", "Mono.Linker.Tests.Cases.Reflection.Dependencies.AssemblyDependencyWithReference")]
+	[KeptTypeInAssembly ("reference.dll", "Mono.Linker.Tests.Cases.Reflection.Dependencies.AssemblyDependency")]
+	public class AssemblyImportedViaReflectionWithReference
+	{
+		public static void Main ()
+		{
+			const string newAssemblyType = "Mono.Linker.Tests.Cases.Reflection.Dependencies.AssemblyDependencyWithReference, library, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null";
+			var res = Type.GetType (newAssemblyType, true);
+			return;
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Reflection/Dependencies/AssemblyDependencyWithReference.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Reflection/Dependencies/AssemblyDependencyWithReference.cs
@@ -1,0 +1,4 @@
+﻿namespace Mono.Linker.Tests.Cases.Reflection.Dependencies {
+	public class AssemblyDependencyWithReference : AssemblyDependency {
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Reflection/Dependencies/AssemblyImportedViaReflectionWithDerivedType_Base.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Reflection/Dependencies/AssemblyImportedViaReflectionWithDerivedType_Base.cs
@@ -1,0 +1,5 @@
+﻿namespace Mono.Linker.Tests.Cases.Reflection.Dependencies {
+	public abstract class AssemblyImportedViaReflectionWithDerivedType_Base {
+		public abstract string Method ();
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Reflection/Dependencies/AssemblyImportedViaReflectionWithDerivedType_Reflect.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Reflection/Dependencies/AssemblyImportedViaReflectionWithDerivedType_Reflect.cs
@@ -1,0 +1,8 @@
+﻿namespace Mono.Linker.Tests.Cases.Reflection.Dependencies {
+	public class AssemblyImportedViaReflectionWithDerivedType_Reflect : AssemblyImportedViaReflectionWithDerivedType_Base {
+		public override string Method ()
+		{
+			return "Reflect";
+		}
+	}
+}


### PR DESCRIPTION
* Remove the logic added to the MarkStep by https://github.com/mono/linker/pull/340.  It had unexpected side effects and more design flaws than initially realized

* Two new tests have been added (but ignored) highlighting some of the additional challenges.