### PR TITLE
Keep com attributes when only keep used and feature not excluded

### DIFF
--- a/linker/Linker.Steps/MarkStep.cs
+++ b/linker/Linker.Steps/MarkStep.cs
@@ -460,6 +460,9 @@ namespace Mono.Linker.Steps {
 				case "System.ThreadStaticAttribute":
 				case "System.ContextStaticAttribute":
 					return true;
+				case "System.Runtime.InteropServices.InterfaceTypeAttribute":
+				case "System.Runtime.InteropServices.GuidAttribute":
+					return !_context.IsFeatureExcluded ("com");
 				}
 				
 				if (!Annotations.IsMarked (attr_type.Resolve ()))

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/ComAttributesArePreserved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/ComAttributesArePreserved.cs
@@ -1,0 +1,31 @@
+﻿using System.Runtime.InteropServices;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
+	/// <summary>
+	/// COM related attributes are reauired at runtime
+	/// </summary>
+	[SetupLinkerArgument ("--used-attrs-only", "true")]
+	public class ComAttributesArePreserved {
+		public static void Main ()
+		{
+			var tmp = ReturnValueUsedToMarkType ();
+		}
+
+		[Kept]
+		static A ReturnValueUsedToMarkType ()
+		{
+			return null;
+		}
+		
+		[Kept]
+		[KeptAttributeAttribute (typeof (GuidAttribute))]
+		[KeptAttributeAttribute (typeof (InterfaceTypeAttribute))]
+		[ComImport]
+		[Guid ("D7BB1889-3AB7-4681-A115-60CA9158FECA")]
+		[InterfaceType (ComInterfaceType.InterfaceIsIUnknown)]
+		interface A {
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/ComAttributesAreRemovedWhenFeatureExcluded.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/ComAttributesAreRemovedWhenFeatureExcluded.cs
@@ -1,0 +1,27 @@
+﻿using System.Runtime.InteropServices;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
+	[SetupLinkerArgument ("--used-attrs-only", "true")]
+	[SetupLinkerArgument ("--exclude-feature", "com")]
+	public class ComAttributesAreRemovedWhenFeatureExcluded {
+		public static void Main ()
+		{
+			var tmp = ReturnValueUsedToMarkType ();
+		}
+		
+		[Kept]
+		static A ReturnValueUsedToMarkType ()
+		{
+			return null;
+		}
+		
+		[Kept]
+		[ComImport]
+		[Guid ("D7BB1889-3AB7-4681-A115-60CA9158FECA")]
+		[InterfaceType (ComInterfaceType.InterfaceIsIUnknown)]
+		interface A {
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -112,6 +112,8 @@
     <Compile Include="Attributes\NoSecurity\SecurityAttributesOnUsedMethodAreRemoved.cs" />
     <Compile Include="Attributes\NoSecurity\SecurityAttributesOnUsedTypeAreRemoved.cs" />
     <Compile Include="Attributes\NoSecurity\CoreLibrarySecurityAttributeTypesAreRemoved.cs" />
+    <Compile Include="Attributes\OnlyKeepUsed\ComAttributesArePreserved.cs" />
+    <Compile Include="Attributes\OnlyKeepUsed\ComAttributesAreRemovedWhenFeatureExcluded.cs" />
     <Compile Include="Attributes\OnlyKeepUsed\ContextStaticIsPreservedOnField.cs" />
     <Compile Include="Attributes\OnlyKeepUsed\Dependencies\UnusedAttributeWithTypeForwarderIsRemoved_Lib.cs" />
     <Compile Include="Attributes\OnlyKeepUsed\AttributeDefinedAndUsedInOtherAssemblyIsKept.cs" />


### PR DESCRIPTION
These com related attributes are needed at runtime.  When the only keep used attributes option is enabled, we need to mark these as long as com is not an excluded feature