### PR TITLE
Update the test which was testing not the behaviour we want.

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases/Advanced/PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithCopyAction.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Advanced/PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithCopyAction.cs
@@ -3,9 +3,9 @@ using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Advanced {
-	[IgnoreTestCase("Bug introduced with https://github.com/mono/linker/pull/348")]
-	[SetupLinkerCoreAction ("copy")]
+	[SetupLinkerCoreAction ("copyused")]
 	[RemovedAssembly ("System.Core.dll")]
+	[SkipPeVerify]
 	public class PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithCopyAction {
 		public static void Main ()
 		{


### PR DESCRIPTION
When copy mode is used for **any** reference we don't track if the reference is used
or not. We are using `PreserveDependency` with assembly as the way to include reference to assembly which was not added to normal assembly-ref table due to for example circular build issues.

For this we want PreserveDependency copy to behave same as assembly-ref copy. The users have `copyused` option to keep the reference only when used