### PR TITLE
More complex preserve dependency tests.

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases/Advanced/Dependencies/PreserveDependencyMethodInNonReferencedAssemblyBase2.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Advanced/Dependencies/PreserveDependencyMethodInNonReferencedAssemblyBase2.cs
@@ -1,0 +1,8 @@
+﻿namespace Mono.Linker.Tests.Cases.Advanced.Dependencies {
+	public class PreserveDependencyMethodInNonReferencedAssemblyBase2 : PreserveDependencyMethodInNonReferencedAssemblyBase {
+		public override string Method ()
+		{
+			return "Base2";
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Advanced/Dependencies/PreserveDependencyMethodInNonReferencedAssemblyChainedLibrary.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Advanced/Dependencies/PreserveDependencyMethodInNonReferencedAssemblyChainedLibrary.cs
@@ -1,0 +1,16 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace Mono.Linker.Tests.Cases.Advanced.Dependencies {
+	public class PreserveDependencyMethodInNonReferencedAssemblyChainedLibrary : PreserveDependencyMethodInNonReferencedAssemblyBase {
+		public override string Method ()
+		{
+			Dependency ();
+			return "Dependency";
+		}
+		
+		[PreserveDependency (".ctor()", "Mono.Linker.Tests.Cases.Advanced.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyBase2", "base2")]
+		public static void Dependency ()
+		{
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Advanced/Dependencies/PreserveDependencyMethodInNonReferencedAssemblyChainedReferenceLibrary.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Advanced/Dependencies/PreserveDependencyMethodInNonReferencedAssemblyChainedReferenceLibrary.cs
@@ -1,0 +1,9 @@
+﻿namespace Mono.Linker.Tests.Cases.Advanced.Dependencies {
+	public class PreserveDependencyMethodInNonReferencedAssemblyChainedReferenceLibrary : PreserveDependencyMethodInNonReferencedAssemblyBase {
+		public override string Method ()
+		{
+			PreserveDependencyMethodInNonReferencedAssemblyChainedLibrary.Dependency ();
+			return "Dependency";
+		} 
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Advanced/PreserveDependencyMethodInNonReferencedAssemblyChained.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Advanced/PreserveDependencyMethodInNonReferencedAssemblyChained.cs
@@ -1,0 +1,42 @@
+﻿using System.Runtime.CompilerServices;
+using Mono.Linker.Tests.Cases.Advanced.Dependencies;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Advanced {
+	[IgnoreTestCase ("Currently failing")]
+	[SetupCompileBefore ("base.dll", new [] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyBase.cs" })]
+	[SetupCompileBefore ("base2.dll", new [] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyBase2.cs" }, references: new [] { "base.dll" }, addAsReference: false)]
+	[SetupCompileBefore ("library.dll", new [] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyChainedLibrary.cs" }, references: new [] { "base.dll" }, addAsReference: false)]
+	[KeptAssembly ("base.dll")]
+	[KeptAssembly ("base2.dll")]
+	[KeptAssembly ("library.dll")]
+	[KeptMemberInAssembly ("base.dll", typeof (PreserveDependencyMethodInNonReferencedAssemblyBase), "Method()")]
+	[KeptMemberInAssembly ("base2.dll", "Mono.Linker.Tests.Cases.Advanced.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyBase2", "Method()")]
+	[KeptMemberInAssembly ("library.dll", "Mono.Linker.Tests.Cases.Advanced.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyChainedLibrary", "Method()")]
+	public class PreserveDependencyMethodInNonReferencedAssemblyChained {
+		public static void Main ()
+		{
+			var obj = new Foo ();
+			var val = obj.Method ();
+			Dependency ();
+		}
+
+		[Kept]
+		[PreserveDependency (".ctor()", "Mono.Linker.Tests.Cases.Advanced.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyChainedLibrary", "library")]
+		static void Dependency ()
+		{
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof (PreserveDependencyMethodInNonReferencedAssemblyBase))]
+		class Foo : PreserveDependencyMethodInNonReferencedAssemblyBase {
+			[Kept]
+			public override string Method ()
+			{
+				return "Foo";
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Advanced/PreserveDependencyMethodInNonReferencedAssemblyChainedReference.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Advanced/PreserveDependencyMethodInNonReferencedAssemblyChainedReference.cs
@@ -1,0 +1,45 @@
+﻿using System.Runtime.CompilerServices;
+using Mono.Linker.Tests.Cases.Advanced.Dependencies;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Advanced {
+	[IgnoreTestCase ("Currently failing")]
+	[SetupCompileBefore ("base.dll", new [] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyBase.cs" })]
+	[SetupCompileBefore ("base2.dll", new [] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyBase2.cs" }, references: new [] { "base.dll" }, addAsReference: false)]
+	[SetupCompileBefore ("reference.dll", new [] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyChainedLibrary.cs" }, references: new [] { "base.dll" }, addAsReference: false)]
+	[SetupCompileBefore ("library.dll", new [] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyChainedReferenceLibrary.cs" }, references: new [] { "base.dll", "reference.dll" }, addAsReference: false)]
+	[KeptAssembly ("base.dll")]
+	[KeptAssembly ("base2.dll")]
+	[KeptAssembly ("library.dll")]
+	[KeptAssembly ("reference.dll")]
+	[KeptMemberInAssembly ("base.dll", typeof (PreserveDependencyMethodInNonReferencedAssemblyBase), "Method()")]
+	[KeptMemberInAssembly ("base2.dll", "Mono.Linker.Tests.Cases.Advanced.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyBase2", "Method()")]
+	[KeptMemberInAssembly ("library.dll", "Mono.Linker.Tests.Cases.Advanced.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyChainedReferenceLibrary", "Method()")]
+	[KeptMemberInAssembly ("reference.dll", "Mono.Linker.Tests.Cases.Advanced.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyChainedLibrary", "Method()")]
+	public class PreserveDependencyMethodInNonReferencedAssemblyChainedReference {
+		public static void Main ()
+		{
+			var obj = new Foo ();
+			var val = obj.Method ();
+			Dependency ();
+		}
+		
+		[Kept]
+		[PreserveDependency (".ctor()", "Mono.Linker.Tests.Cases.Advanced.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyChainedReferenceLibrary", "library")]
+		static void Dependency ()
+		{
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof (PreserveDependencyMethodInNonReferencedAssemblyBase))]
+		class Foo : PreserveDependencyMethodInNonReferencedAssemblyBase {
+			[Kept]
+			public override string Method ()
+			{
+				return "Foo";
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -37,6 +37,11 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Advanced\Dependencies\PreserveDependencyMethodInNonReferencedAssemblyBase2.cs" />
+    <Compile Include="Advanced\Dependencies\PreserveDependencyMethodInNonReferencedAssemblyChainedLibrary.cs" />
+    <Compile Include="Advanced\Dependencies\PreserveDependencyMethodInNonReferencedAssemblyChainedReferenceLibrary.cs" />
+    <Compile Include="Advanced\PreserveDependencyMethodInNonReferencedAssemblyChained.cs" />
+    <Compile Include="Advanced\PreserveDependencyMethodInNonReferencedAssemblyChainedReference.cs" />
     <Compile Include="Advanced\PreserveDependencyMethodInNonReferencedAssemblyWithEmbeddedXml.cs" />
     <Compile Include="Advanced\PreserveDependencyOnUnusedMethodInNonReferencedAssembly.cs" />
     <Compile Include="Advanced\PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithCopyAction.cs" />


### PR DESCRIPTION
Add two new tests where an assembly is included from [PreserveDependency] and then that assembly either directly or via  reference has a [PreserveDependency] that brings in another new assembly.

Tests are currently failing so they have been ignored