### PR TITLE
Expectation attribute changes

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupLinkerActionAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupLinkerActionAttribute.cs
@@ -7,12 +7,8 @@ namespace Mono.Linker.Tests.Cases.Expectations.Metadata
 	{
 		public SetupLinkerActionAttribute (string action, string assembly)
 		{
-			switch (action) {
-			case "link": case "copy": case "skip":
-				break;
-			default:
-				throw new ArgumentOutOfRangeException (nameof (action));
-			}
+			if (string.IsNullOrEmpty (action))
+				throw new ArgumentNullException (nameof (action));
 		}
 	}
 }

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupLinkerArgumentAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupLinkerArgumentAttribute.cs
@@ -15,7 +15,11 @@ namespace Mono.Linker.Tests.Cases.Expectations.Metadata {
 			if (string.IsNullOrEmpty (flag))
 				throw new ArgumentNullException (nameof (flag));
 
-			if (flag[0] == '-' && flag.Length == 2)
-				throw new ArgumentException ($"Flag `{flag}` is short.  Avoid using this attribute with command line flags that are to short to communicate their meaning.  Support a more descriptive flag or create a new attribute for tests to use similar to {nameof(SetupLinkerCoreActionAttribute)}");}
+			if (flag[0] == '-' && flag.Length == 2) {
+				string errorMessage = "Flag `" + flag + "` is short.";
+				errorMessage += "  Avoid using this attribute with command line flags that are to short to communicate their meaning.  Support a more descriptive flag or create a new attribute for tests to use similar to " + nameof (SetupLinkerCoreActionAttribute);
+				throw new ArgumentException (errorMessage);
+			}
+		}
 	}
 }

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupLinkerCoreActionAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupLinkerCoreActionAttribute.cs
@@ -7,14 +7,8 @@ namespace Mono.Linker.Tests.Cases.Expectations.Metadata
 	{
 		public SetupLinkerCoreActionAttribute (string action)
 		{
-			switch (action) {
-			case "link":
-			case "copy":
-			case "skip":
-				break;
-			default:
-				throw new ArgumentOutOfRangeException (nameof (action));
-			}
+			if (string.IsNullOrEmpty (action))
+				throw new ArgumentNullException (nameof (action));
 		}
 	}
 }


### PR DESCRIPTION
* Simplify string usage in some attributes.  We have a new profile coming that doesn't have some string methods that are used when a switch is used.

* These attributes that were using a switch were technically out of date anyways.  They would have blocked usage of other AssemblyActions, so I don't see a harm in loosening up the error checking

* Adjust another attribute ctor, again, so that fewer members of String are used.