### PR TITLE
Adjustments to how linker arguments are built

### DIFF
--- a/linker/Tests/TestCasesRunner/TestRunner.cs
+++ b/linker/Tests/TestCasesRunner/TestRunner.cs
@@ -87,6 +87,16 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 		{
 			var linker = _factory.CreateLinker ();
 			var builder = _factory.CreateLinkerArgumentBuilder (metadataProvider);
+
+			AddLinkOptions (sandbox, compilationResult, builder, metadataProvider);
+
+			linker.Link (builder.ToArgs ());
+
+			return new LinkedTestCaseResult (testCase, compilationResult.InputAssemblyPath, sandbox.OutputDirectory.Combine (compilationResult.InputAssemblyPath.FileName), compilationResult.ExpectationsAssemblyPath);
+		}
+
+		protected virtual void AddLinkOptions (TestCaseSandbox sandbox, ManagedCompilationResult compilationResult, LinkerArgumentBuilder builder, TestCaseMetadaProvider metadataProvider)
+		{
 			var caseDefinedOptions = metadataProvider.GetLinkerOptions ();
 
 			builder.AddOutputDirectory (sandbox.OutputDirectory);
@@ -99,17 +109,7 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 
 			builder.ProcessOptions (caseDefinedOptions);
 
-			AddAdditionalLinkOptions (builder, metadataProvider);
-
 			builder.ProcessTestInputAssembly (compilationResult.InputAssemblyPath);
-
-			linker.Link (builder.ToArgs ());
-
-			return new LinkedTestCaseResult (testCase, compilationResult.InputAssemblyPath, sandbox.OutputDirectory.Combine (compilationResult.InputAssemblyPath.FileName), compilationResult.ExpectationsAssemblyPath);
-		}
-
-		protected virtual void AddAdditionalLinkOptions (LinkerArgumentBuilder builder, TestCaseMetadaProvider metadataProvider)
-		{
 		}
 
 		private T GetResultOfTaskThatMakesNUnitAssertions<T> (Task<T> task)


### PR DESCRIPTION
My original motivation was to pass the sandbox to `AddAdditionalLinkOptions`.  Once I did that, I realized I might as well push all of the argument building down into `AddAdditionalLinkOptions`

I then renamed `AddAdditionalLinkOptions` to `AddLinkOptions` to more accurately reflect it's role