### PR TITLE
Expose call to IStep.Process

### DIFF
--- a/linker/Linker/Pipeline.cs
+++ b/linker/Linker/Pipeline.cs
@@ -123,11 +123,16 @@ namespace Mono.Linker {
 		{
 			while (_steps.Count > 0) {
 				IStep step = _steps [0];
-				context.Tracer.Push (step);
-				step.Process (context);
-				context.Tracer.Pop ();
+				ProcessStep (context, step);
 				_steps.Remove (step);
 			}
+		}
+		
+		protected virtual void ProcessStep (LinkContext context, IStep step)
+		{
+			context.Tracer.Push (step);
+			step.Process (context);
+			context.Tracer.Pop ();
 		}
 
 		public IStep [] GetSteps ()


### PR DESCRIPTION
I'm hooking some profiling code into our linker and the call to IStep.Process() is a nice call to profile.  Exposing a protected member on Pipeline to make this call let's us derive and wrap the call.