### PR TITLE
Add ability to assert references on test case assembly

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptReferenceAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptReferenceAttribute.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Assertions {
+	/// <summary>
+	/// Verifies that a reference exists in the test case assembly
+	/// </summary>
+	[AttributeUsage (AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+	public class KeptReferenceAttribute : KeptAttribute {
+		public KeptReferenceAttribute (string name)
+		{
+			if (string.IsNullOrEmpty (name))
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (name));
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
@@ -50,6 +50,7 @@
     <Compile Include="Assertions\KeptInitializerData.cs" />
     <Compile Include="Assertions\KeptMemberAttribute.cs" />
     <Compile Include="Assertions\KeptMemberInAssemblyAttribute.cs" />
+    <Compile Include="Assertions\KeptReferenceAttribute.cs" />
     <Compile Include="Assertions\KeptResourceAttribute.cs" />
     <Compile Include="Assertions\KeptResourceInAssemblyAttribute.cs" />
     <Compile Include="Assertions\KeptSecurityAttribute.cs" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/References/ReferencesAreRemovedWhenAllUsagesAreRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/References/ReferencesAreRemovedWhenAllUsagesAreRemoved.cs
@@ -9,6 +9,7 @@ namespace Mono.Linker.Tests.Cases.References {
 	[Il8n ("none")]
 	[Reference ("System.dll")]
 	[RemovedAssembly ("System.dll")]
+	[KeptReference ("mscorlib.dll")]
 	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168
 	[SkipPeVerify(SkipPeVerifyForToolchian.Pedump)]
 	// System.Core.dll is referenced by System.dll in the .NET FW class libraries. Our GetType reflection marking code


### PR DESCRIPTION
This attribute allows asserting the references that the test case has.

This is a niche attribute I need for the empty assembly thing I'm adding to our UnityLinker.  I'm adding it upstream because we don't do anything to directly assert a reference is removed today.

Given that most tests will never care about asserting references, I made it so that tests don't need to define [KeptAssembly] for all the references they expect to be kept until there is at least 1 of these attributes