### PR TITLE
Optimizes marking of static constructor for beforefieldinit types.

### DIFF
--- a/linker/Linker.Steps/MarkStep.cs
+++ b/linker/Linker.Steps/MarkStep.cs
@@ -465,6 +465,11 @@ namespace Mono.Linker.Steps {
 			return true;
 		}
 
+		protected virtual bool ShoulMarkTypeConstructor (TypeDefinition type)
+		{
+			return !type.IsBeforeFieldInit;
+		}
+
 		protected virtual bool ShouldMarkTopLevelCustomAttribute (AttributeProviderPair app, MethodDefinition resolvedConstructor)
 		{
 			var ca = app.Attribute;
@@ -913,10 +918,10 @@ namespace Mono.Linker.Steps {
 
 			if (type.HasMethods) {
 				MarkMethodsIf (type.Methods, IsVirtualAndHasPreservedParent);
-				if (!type.IsBeforeFieldInit) {
-					if (MarkMethodIf (type.Methods, IsStaticConstructor))
-						Annotations.SetPreservedStaticCtor (type);
-				}
+
+				if (ShoulMarkTypeConstructor (type) && MarkMethodIf (type.Methods, IsStaticConstructor))
+					Annotations.SetPreservedStaticCtor (type);
+
 				MarkMethodsIf (type.Methods, HasSerializationAttribute);
 			}
 

--- a/linker/Linker.Steps/MarkStep.cs
+++ b/linker/Linker.Steps/MarkStep.cs
@@ -467,7 +467,7 @@ namespace Mono.Linker.Steps {
 
 		protected virtual bool ShoulMarkTypeConstructor (TypeDefinition type)
 		{
-			return !type.IsBeforeFieldInit;
+			return !type.IsBeforeFieldInit && _context.IsOptimizationEnabled (CodeOptimizations.BeforeFieldInit);
 		}
 
 		protected virtual bool ShouldMarkTopLevelCustomAttribute (AttributeProviderPair app, MethodDefinition resolvedConstructor)
@@ -819,7 +819,7 @@ namespace Mono.Linker.Steps {
 			DoAdditionalFieldProcessing (field);
 
 			var parent = reference.DeclaringType.Resolve ();
-			if (parent.IsBeforeFieldInit && !Annotations.HasPreservedStaticCtor (parent)) {
+			if (parent.IsBeforeFieldInit && !Annotations.HasPreservedStaticCtor (parent) && _context.IsOptimizationEnabled (CodeOptimizations.BeforeFieldInit)) {
 				if (MarkMethodIf (parent.Methods, IsStaticConstructor))
 					Annotations.SetPreservedStaticCtor (parent);
 			}

--- a/linker/Linker/Annotations.cs
+++ b/linker/Linker/Annotations.cs
@@ -52,6 +52,7 @@ namespace Mono.Linker {
 		protected readonly Dictionary<object, Dictionary<IMetadataTokenProvider, object>> custom_annotations = new Dictionary<object, Dictionary<IMetadataTokenProvider, object>> ();
 		protected readonly Dictionary<AssemblyDefinition, HashSet<string>> resources_to_remove = new Dictionary<AssemblyDefinition, HashSet<string>> ();
 		protected readonly HashSet<CustomAttribute> marked_attributes = new HashSet<CustomAttribute> ();
+		readonly HashSet<TypeDefinition> marked_types_with_cctor = new HashSet<TypeDefinition> ();
 
 		public AnnotationStore (LinkContext context) => this.context = context;
 
@@ -327,5 +328,16 @@ namespace Mono.Linker {
 			custom_annotations.Add (key, slots);
 			return slots;
 		}
+
+		public bool HasPreservedStaticCtor (TypeDefinition type)
+		{
+			return marked_types_with_cctor.Contains (type);
+		}
+
+		public bool SetPreservedStaticCtor (TypeDefinition type)
+		{
+			return marked_types_with_cctor.Add (type);
+		}
+
 	}
 }

--- a/linker/Linker/LinkContext.cs
+++ b/linker/Linker/LinkContext.cs
@@ -145,6 +145,8 @@ namespace Mono.Linker {
 
 		public string[] ExcludedFeatures { get; set; }
 
+		public CodeOptimizations DisabledOptimizations { get; set; }
+
 		public LinkContext (Pipeline pipeline)
 			: this (pipeline, new AssemblyResolver ())
 		{
@@ -358,6 +360,11 @@ namespace Mono.Linker {
 		public bool IsFeatureExcluded (string featureName)
 		{
 			return ExcludedFeatures != null && Array.IndexOf (ExcludedFeatures, featureName) >= 0;
+		}
+
+		public bool IsOptimizationEnabled (CodeOptimizations optimization)
+		{
+			return (DisabledOptimizations & optimization) == 0;
 		}
 
 		public void LogMessage (string message, params object[] values)

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -397,6 +397,10 @@
     <Compile Include="Attributes.StructLayout\ExplicitClass.cs" />
     <Compile Include="Reflection\AssemblyImportedViaReflection.cs" />
     <Compile Include="Reflection\Dependencies\AssemblyDependency.cs" />
+    <Compile Include="Statics\ExplicitStaticCtor.cs" />
+    <Compile Include="Statics\UnusedStaticFieldInitializer.cs" />
+    <Compile Include="Statics\StaticFieldInitializer.cs" />
+    <Compile Include="Statics\MixedStaticFieldInitializerAndCtor.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Attributes\OnlyKeepUsed\Dependencies\AssemblyWithUnusedAttributeOnReturnParameterDefinition.il" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/Statics/ExplicitStaticCtor.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Statics/ExplicitStaticCtor.cs
@@ -1,0 +1,25 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Statics
+{
+	public class ExplicitStaticCtor
+	{
+		public static void Main ()
+		{
+			C.Foo ();
+		}
+
+		static class C
+		{
+			[Kept]
+			static C ()
+			{
+			}
+
+			[Kept]
+			public static void Foo ()
+			{
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Statics/MixedStaticFieldInitializerAndCtor.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Statics/MixedStaticFieldInitializerAndCtor.cs
@@ -1,0 +1,28 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Statics
+{
+	public class MixedStaticFieldInitializerAndCtor
+	{
+		public static void Main ()
+		{
+			C.Foo ();
+		}
+
+		static class C
+		{
+			[Kept]
+			public static object o = new object ();
+
+			[Kept]
+			static C ()
+			{
+			}
+
+			[Kept]
+			public static void Foo ()
+			{
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Statics/StaticFieldInitializer.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Statics/StaticFieldInitializer.cs
@@ -1,0 +1,25 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Statics
+{
+	public class StaticFieldInitializer
+	{
+		public static void Main ()
+		{
+			C.Foo ();
+		}
+
+		[KeptMember(".cctor()")]
+		static class C
+		{
+			[Kept]
+			public static object o = new object ();
+
+			[Kept]
+			public static object Foo ()
+			{
+				return o;
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Statics/UnusedStaticFieldInitializer.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Statics/UnusedStaticFieldInitializer.cs
@@ -1,0 +1,22 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Statics
+{
+	public class UnusedStaticFieldInitializer
+	{
+		public static void Main ()
+		{
+			C.Foo ();
+		}
+
+		static class C
+		{
+			public static object o = new object ();
+
+			[Kept]
+			public static void Foo ()
+			{
+			}
+		}
+	}
+}


### PR DESCRIPTION
When the type is marked with beforefieldinit the static constructor
was generated from static field initializers only. Therefore we
can mark it after any of the static field is marked.