### PR TITLE
Move [PreserveDependency] tests into their own folder

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -37,16 +37,6 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Advanced\Dependencies\PreserveDependencyMethodInNonReferencedAssemblyBase2.cs" />
-    <Compile Include="Advanced\Dependencies\PreserveDependencyMethodInNonReferencedAssemblyChainedLibrary.cs" />
-    <Compile Include="Advanced\Dependencies\PreserveDependencyMethodInNonReferencedAssemblyChainedReferenceLibrary.cs" />
-    <Compile Include="Advanced\Dependencies\PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithCopyUsedAction_Lib.cs" />
-    <Compile Include="Advanced\PreserveDependencyMethodInNonReferencedAssemblyChained.cs" />
-    <Compile Include="Advanced\PreserveDependencyMethodInNonReferencedAssemblyChainedReference.cs" />
-    <Compile Include="Advanced\PreserveDependencyMethodInNonReferencedAssemblyWithEmbeddedXml.cs" />
-    <Compile Include="Advanced\PreserveDependencyOnUnusedMethodInNonReferencedAssembly.cs" />
-    <Compile Include="Advanced\PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithCopyUsedAction.cs" />
-    <Compile Include="Advanced\PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithEmbeddedXml.cs" />
     <Compile Include="Attributes.Debugger\DebuggerDisplayAttributeOnAssemblyUsingTarget.cs" />
     <Compile Include="Attributes.Debugger\DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly.cs" />
     <Compile Include="Attributes.Debugger\DebuggerDisplayAttributeOnAssemblyUsingTargetOnUnusedType.cs" />
@@ -202,6 +192,23 @@
     <Compile Include="LinkXml\UnusedGenericTypeWithPreserveAllHasAllMembersPreserved.cs" />
     <Compile Include="LinkXml\UnusedTypePreservedByLinkXmlWithCommentIsKept.cs" />
     <Compile Include="LinkXml\UnusedTypeWithNoDefinedPreserveHasAllMembersPreserved.cs" />
+    <Compile Include="PreserveDependencies\Dependencies\PreserveDependencyMethodInAssemblyLibrary.cs" />
+    <Compile Include="PreserveDependencies\Dependencies\PreserveDependencyMethodInNonReferencedAssemblyBase.cs" />
+    <Compile Include="PreserveDependencies\Dependencies\PreserveDependencyMethodInNonReferencedAssemblyBase2.cs" />
+    <Compile Include="PreserveDependencies\Dependencies\PreserveDependencyMethodInNonReferencedAssemblyChainedLibrary.cs" />
+    <Compile Include="PreserveDependencies\Dependencies\PreserveDependencyMethodInNonReferencedAssemblyChainedReferenceLibrary.cs" />
+    <Compile Include="PreserveDependencies\Dependencies\PreserveDependencyMethodInNonReferencedAssemblyLibrary.cs" />
+    <Compile Include="PreserveDependencies\Dependencies\PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithCopyUsedAction_Lib.cs" />
+    <Compile Include="PreserveDependencies\PreserveDependencyField.cs" />
+    <Compile Include="PreserveDependencies\PreserveDependencyMethod.cs" />
+    <Compile Include="PreserveDependencies\PreserveDependencyMethodInAssembly.cs" />
+    <Compile Include="PreserveDependencies\PreserveDependencyMethodInNonReferencedAssembly.cs" />
+    <Compile Include="PreserveDependencies\PreserveDependencyMethodInNonReferencedAssemblyChained.cs" />
+    <Compile Include="PreserveDependencies\PreserveDependencyMethodInNonReferencedAssemblyChainedReference.cs" />
+    <Compile Include="PreserveDependencies\PreserveDependencyMethodInNonReferencedAssemblyWithEmbeddedXml.cs" />
+    <Compile Include="PreserveDependencies\PreserveDependencyOnUnusedMethodInNonReferencedAssembly.cs" />
+    <Compile Include="PreserveDependencies\PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithCopyUsedAction.cs" />
+    <Compile Include="PreserveDependencies\PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithEmbeddedXml.cs" />
     <Compile Include="References\Individual\CanSkipUnresolved.cs" />
     <Compile Include="References\Individual\Dependencies\CanSkipUnresolved_Library.cs" />
     <Compile Include="References\Dependencies\UserAssembliesAreLinkedByDefault_Library1.cs" />
@@ -374,22 +381,14 @@
     <Compile Include="Symbols\ReferencesWithMixedSymbolTypesAndSymbolLinkingEnabled.cs" />
     <Compile Include="Symbols\ReferenceWithMdb.cs" />
     <Compile Include="Symbols\ReferenceWithMdbAndSymbolLinkingEnabled.cs" />
-    <Compile Include="Advanced\PreserveDependencyMethod.cs" />
     <Compile Include="Attributes.StructLayout\SequentialClass.cs" />
     <Compile Include="Attributes.StructLayout\AutoClass.cs" />
     <Compile Include="Attributes.StructLayout\UnusedTypeWithSequentialLayoutIsRemoved.cs" />
     <Compile Include="Attributes.StructLayout\ExplicitClass.cs" />
     <Compile Include="Reflection\AssemblyImportedViaReflection.cs" />
     <Compile Include="Reflection\Dependencies\AssemblyDependency.cs" />
-    <Compile Include="Advanced\PreserveDependencyMethodInAssembly.cs" />
-    <Compile Include="Advanced\Dependencies\PreserveDependencyMethodInAssemblyLibrary.cs" />
-    <Compile Include="Advanced\Dependencies\PreserveDependencyMethodInNonReferencedAssemblyBase.cs" />
-    <Compile Include="Advanced\Dependencies\PreserveDependencyMethodInNonReferencedAssemblyLibrary.cs" />
-    <Compile Include="Advanced\PreserveDependencyMethodInNonReferencedAssembly.cs" />
-    <Compile Include="Advanced\PreserveDependencyField.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="Advanced\Dependencies\PreserveDependencyMethodInNonReferencedAssemblyLibrary.xml" />
     <Content Include="Attributes\OnlyKeepUsed\Dependencies\AssemblyWithUnusedAttributeOnReturnParameterDefinition.il" />
     <Content Include="Attributes\OnlyKeepUsed\UnusedAttributePreservedViaLinkXmlIsKept.xml" />
     <Content Include="LinkXml\CanPreserveTypesUsingRegex.xml" />
@@ -419,6 +418,7 @@
     <Content Include="LinkXml\UnusedTypeWithPreserveMethodsHasFieldsRemoved.xml" />
     <Content Include="LinkXml\UnusedTypeWithPreserveNothingAndPreserveMembers.xml" />
     <Content Include="LinkXml\UnusedTypeWithPreserveNothingHasMembersRemoved.xml" />
+    <Content Include="PreserveDependencies\Dependencies\PreserveDependencyMethodInNonReferencedAssemblyLibrary.xml" />
     <Content Include="Resources\Dependencies\EmbeddedLinkXmlFileInReferencedAssemblyIsNotProcessedIfNameDoesNotMatchAnAssembly_Lib1_NotMatchingName.xml" />
     <Content Include="Resources\Dependencies\EmbeddedLinkXmlFileInReferencedAssemblyIsNotProcessedIfActionIsCopy_Lib1.xml" />
     <Content Include="Resources\Dependencies\EmbeddedLinkXmlFileInReferencedAssemblyIsProcessedIfActionIsLink_Lib1.xml" />
@@ -447,7 +447,6 @@
   <ItemGroup>
     <Folder Include="Attributes.StructLayout\" />
     <Folder Include="Reflection\Dependencies\" />
-    <Folder Include="Advanced\Dependencies\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/Dependencies/PreserveDependencyMethodInAssemblyLibrary.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/Dependencies/PreserveDependencyMethodInAssemblyLibrary.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-namespace Mono.Linker.Tests.Cases.Advanced.Dependencies {
+namespace Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies {
 	public class PreserveDependencyMethodInAssemblyLibrary {
 		public PreserveDependencyMethodInAssemblyLibrary ()
 		{

--- a/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/Dependencies/PreserveDependencyMethodInNonReferencedAssemblyBase.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/Dependencies/PreserveDependencyMethodInNonReferencedAssemblyBase.cs
@@ -1,4 +1,4 @@
-﻿namespace Mono.Linker.Tests.Cases.Advanced.Dependencies {
+﻿namespace Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies {
 	public abstract class PreserveDependencyMethodInNonReferencedAssemblyBase {
 		public abstract string Method ();
 	}

--- a/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/Dependencies/PreserveDependencyMethodInNonReferencedAssemblyBase2.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/Dependencies/PreserveDependencyMethodInNonReferencedAssemblyBase2.cs
@@ -1,4 +1,4 @@
-﻿namespace Mono.Linker.Tests.Cases.Advanced.Dependencies {
+﻿namespace Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies {
 	public class PreserveDependencyMethodInNonReferencedAssemblyBase2 : PreserveDependencyMethodInNonReferencedAssemblyBase {
 		public override string Method ()
 		{

--- a/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/Dependencies/PreserveDependencyMethodInNonReferencedAssemblyChainedLibrary.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/Dependencies/PreserveDependencyMethodInNonReferencedAssemblyChainedLibrary.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.CompilerServices;
 
-namespace Mono.Linker.Tests.Cases.Advanced.Dependencies {
+namespace Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies {
 	public class PreserveDependencyMethodInNonReferencedAssemblyChainedLibrary : PreserveDependencyMethodInNonReferencedAssemblyBase {
 		public override string Method ()
 		{

--- a/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/Dependencies/PreserveDependencyMethodInNonReferencedAssemblyChainedReferenceLibrary.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/Dependencies/PreserveDependencyMethodInNonReferencedAssemblyChainedReferenceLibrary.cs
@@ -1,4 +1,4 @@
-﻿namespace Mono.Linker.Tests.Cases.Advanced.Dependencies {
+﻿namespace Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies {
 	public class PreserveDependencyMethodInNonReferencedAssemblyChainedReferenceLibrary : PreserveDependencyMethodInNonReferencedAssemblyBase {
 		public override string Method ()
 		{

--- a/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/Dependencies/PreserveDependencyMethodInNonReferencedAssemblyLibrary.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/Dependencies/PreserveDependencyMethodInNonReferencedAssemblyLibrary.cs
@@ -1,4 +1,4 @@
-﻿namespace Mono.Linker.Tests.Cases.Advanced.Dependencies {
+﻿namespace Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies {
 	public class PreserveDependencyMethodInNonReferencedAssemblyLibrary : PreserveDependencyMethodInNonReferencedAssemblyBase {
 		public override string Method ()
 		{

--- a/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/Dependencies/PreserveDependencyMethodInNonReferencedAssemblyLibrary.xml
+++ b/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/Dependencies/PreserveDependencyMethodInNonReferencedAssemblyLibrary.xml
@@ -1,5 +1,5 @@
 ﻿<linker>
     <assembly fullname="PreserveDependencyMethodInNonReferencedAssemblyLibrary, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-        <type fullname="Mono.Linker.Tests.Cases.Advanced.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyLibrary" preserve="all" />
+        <type fullname="Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyLibrary" preserve="all" />
     </assembly>
 </linker>

--- a/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/Dependencies/PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithCopyUsedAction_Lib.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/Dependencies/PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithCopyUsedAction_Lib.cs
@@ -1,4 +1,4 @@
-namespace Mono.Linker.Tests.Cases.Advanced.Dependencies {
+namespace Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies {
 	public class PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithCopyUsedAction_Lib {
 		public static void MethodPreservedViaDependencyAttribute ()
 		{

--- a/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyField.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyField.cs
@@ -1,7 +1,7 @@
 ﻿using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
-namespace Mono.Linker.Tests.Cases.Advanced {
+namespace Mono.Linker.Tests.Cases.PreserveDependencies {
 	public class PreserveDependencyField {
 		public static void Main ()
 		{

--- a/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethod.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethod.cs
@@ -1,7 +1,7 @@
 ﻿using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
-namespace Mono.Linker.Tests.Cases.Advanced {
+namespace Mono.Linker.Tests.Cases.PreserveDependencies {
 	class PreserveDependencyMethod {
 		public static void Main ()
 		{
@@ -23,12 +23,12 @@ namespace Mono.Linker.Tests.Cases.Advanced {
 			}
 
 			[Kept]
-			[PreserveDependency ("Dependency1()", "Mono.Linker.Tests.Cases.Advanced.C")]
-			[PreserveDependency ("Dependency2`1    (   T[]  ,   System.Int32  )  ", "Mono.Linker.Tests.Cases.Advanced.C")]
-			[PreserveDependency ("field", "Mono.Linker.Tests.Cases.Advanced.C")]
-			[PreserveDependency ("NextOne (Mono.Linker.Tests.Cases.Advanced.PreserveDependencyMethod+Nested&)", "Mono.Linker.Tests.Cases.Advanced.PreserveDependencyMethod+Nested")]
-			[PreserveDependency ("Property", "Mono.Linker.Tests.Cases.Advanced.C")]
-			[PreserveDependency ("get_Property()", "Mono.Linker.Tests.Cases.Advanced.C")]
+			[PreserveDependency ("Dependency1()", "Mono.Linker.Tests.Cases.PreserveDependencies.C")]
+			[PreserveDependency ("Dependency2`1    (   T[]  ,   System.Int32  )  ", "Mono.Linker.Tests.Cases.PreserveDependencies.C")]
+			[PreserveDependency ("field", "Mono.Linker.Tests.Cases.PreserveDependencies.C")]
+			[PreserveDependency ("NextOne (Mono.Linker.Tests.Cases.PreserveDependencies.PreserveDependencyMethod+Nested&)", "Mono.Linker.Tests.Cases.PreserveDependencies.PreserveDependencyMethod+Nested")]
+			[PreserveDependency ("Property", "Mono.Linker.Tests.Cases.PreserveDependencies.C")]
+			[PreserveDependency ("get_Property()", "Mono.Linker.Tests.Cases.PreserveDependencies.C")]
 			public static void Method ()
 			{
 			}

--- a/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethodInAssembly.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethodInAssembly.cs
@@ -2,9 +2,9 @@
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
-namespace Mono.Linker.Tests.Cases.Advanced
+namespace Mono.Linker.Tests.Cases.PreserveDependencies
 {
-	[KeptMemberInAssembly ("library.dll", "Mono.Linker.Tests.Cases.Advanced.Dependencies.PreserveDependencyMethodInAssemblyLibrary", ".ctor()")]
+	[KeptMemberInAssembly ("library.dll", "Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies.PreserveDependencyMethodInAssemblyLibrary", ".ctor()")]
 	[SetupCompileBefore ("library.dll", new [] { "Dependencies/PreserveDependencyMethodInAssemblyLibrary.cs" })]
 	public class PreserveDependencyMethodInAssembly
 	{
@@ -14,7 +14,7 @@ namespace Mono.Linker.Tests.Cases.Advanced
 		}
 
 		[Kept]
-		[PreserveDependency (".ctor()", "Mono.Linker.Tests.Cases.Advanced.Dependencies.PreserveDependencyMethodInAssemblyLibrary", "library")]
+		[PreserveDependency (".ctor()", "Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies.PreserveDependencyMethodInAssemblyLibrary", "library")]
 		static void Dependency ()
 		{
 		}

--- a/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethodInNonReferencedAssembly.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethodInNonReferencedAssembly.cs
@@ -1,15 +1,15 @@
 ﻿using System.Runtime.CompilerServices;
-using Mono.Linker.Tests.Cases.Advanced.Dependencies;
+using Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
-namespace Mono.Linker.Tests.Cases.Advanced {
+namespace Mono.Linker.Tests.Cases.PreserveDependencies {
 	[SetupCompileBefore ("base.dll", new [] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyBase.cs" })]
 	[SetupCompileBefore ("library.dll", new [] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyLibrary.cs" }, references: new [] { "base.dll" }, addAsReference: false)]
 	[KeptAssembly ("base.dll")]
 	[KeptAssembly ("library.dll")]
 	[KeptMemberInAssembly ("base.dll", typeof (PreserveDependencyMethodInNonReferencedAssemblyBase), "Method()")]
-	[KeptMemberInAssembly ("library.dll", "Mono.Linker.Tests.Cases.Advanced.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyLibrary", "Method()")]
+	[KeptMemberInAssembly ("library.dll", "Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyLibrary", "Method()")]
 	public class PreserveDependencyMethodInNonReferencedAssembly {
 		public static void Main ()
 		{
@@ -19,7 +19,7 @@ namespace Mono.Linker.Tests.Cases.Advanced {
 		}
 
 		[Kept]
-		[PreserveDependency (".ctor()", "Mono.Linker.Tests.Cases.Advanced.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyLibrary", "library")]
+		[PreserveDependency (".ctor()", "Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyLibrary", "library")]
 		static void Dependency ()
 		{
 		}

--- a/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethodInNonReferencedAssemblyChained.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethodInNonReferencedAssemblyChained.cs
@@ -1,9 +1,9 @@
 ﻿using System.Runtime.CompilerServices;
-using Mono.Linker.Tests.Cases.Advanced.Dependencies;
+using Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
-namespace Mono.Linker.Tests.Cases.Advanced {
+namespace Mono.Linker.Tests.Cases.PreserveDependencies {
 	[IgnoreTestCase ("Currently failing")]
 	[SetupCompileBefore ("base.dll", new [] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyBase.cs" })]
 	[SetupCompileBefore ("base2.dll", new [] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyBase2.cs" }, references: new [] { "base.dll" }, addAsReference: false)]
@@ -12,8 +12,8 @@ namespace Mono.Linker.Tests.Cases.Advanced {
 	[KeptAssembly ("base2.dll")]
 	[KeptAssembly ("library.dll")]
 	[KeptMemberInAssembly ("base.dll", typeof (PreserveDependencyMethodInNonReferencedAssemblyBase), "Method()")]
-	[KeptMemberInAssembly ("base2.dll", "Mono.Linker.Tests.Cases.Advanced.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyBase2", "Method()")]
-	[KeptMemberInAssembly ("library.dll", "Mono.Linker.Tests.Cases.Advanced.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyChainedLibrary", "Method()")]
+	[KeptMemberInAssembly ("base2.dll", "Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyBase2", "Method()")]
+	[KeptMemberInAssembly ("library.dll", "Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyChainedLibrary", "Method()")]
 	public class PreserveDependencyMethodInNonReferencedAssemblyChained {
 		public static void Main ()
 		{
@@ -23,7 +23,7 @@ namespace Mono.Linker.Tests.Cases.Advanced {
 		}
 
 		[Kept]
-		[PreserveDependency (".ctor()", "Mono.Linker.Tests.Cases.Advanced.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyChainedLibrary", "library")]
+		[PreserveDependency (".ctor()", "Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyChainedLibrary", "library")]
 		static void Dependency ()
 		{
 		}

--- a/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethodInNonReferencedAssemblyChainedReference.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethodInNonReferencedAssemblyChainedReference.cs
@@ -1,9 +1,9 @@
 ﻿using System.Runtime.CompilerServices;
-using Mono.Linker.Tests.Cases.Advanced.Dependencies;
+using Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
-namespace Mono.Linker.Tests.Cases.Advanced {
+namespace Mono.Linker.Tests.Cases.PreserveDependencies {
 	[IgnoreTestCase ("Currently failing")]
 	[SetupCompileBefore ("base.dll", new [] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyBase.cs" })]
 	[SetupCompileBefore ("base2.dll", new [] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyBase2.cs" }, references: new [] { "base.dll" }, addAsReference: false)]
@@ -14,9 +14,9 @@ namespace Mono.Linker.Tests.Cases.Advanced {
 	[KeptAssembly ("library.dll")]
 	[KeptAssembly ("reference.dll")]
 	[KeptMemberInAssembly ("base.dll", typeof (PreserveDependencyMethodInNonReferencedAssemblyBase), "Method()")]
-	[KeptMemberInAssembly ("base2.dll", "Mono.Linker.Tests.Cases.Advanced.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyBase2", "Method()")]
-	[KeptMemberInAssembly ("library.dll", "Mono.Linker.Tests.Cases.Advanced.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyChainedReferenceLibrary", "Method()")]
-	[KeptMemberInAssembly ("reference.dll", "Mono.Linker.Tests.Cases.Advanced.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyChainedLibrary", "Method()")]
+	[KeptMemberInAssembly ("base2.dll", "Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyBase2", "Method()")]
+	[KeptMemberInAssembly ("library.dll", "Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyChainedReferenceLibrary", "Method()")]
+	[KeptMemberInAssembly ("reference.dll", "Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyChainedLibrary", "Method()")]
 	public class PreserveDependencyMethodInNonReferencedAssemblyChainedReference {
 		public static void Main ()
 		{
@@ -26,7 +26,7 @@ namespace Mono.Linker.Tests.Cases.Advanced {
 		}
 		
 		[Kept]
-		[PreserveDependency (".ctor()", "Mono.Linker.Tests.Cases.Advanced.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyChainedReferenceLibrary", "library")]
+		[PreserveDependency (".ctor()", "Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyChainedReferenceLibrary", "library")]
 		static void Dependency ()
 		{
 		}

--- a/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethodInNonReferencedAssemblyWithEmbeddedXml.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethodInNonReferencedAssemblyWithEmbeddedXml.cs
@@ -1,11 +1,11 @@
 ﻿using System.Runtime.CompilerServices;
-using Mono.Linker.Tests.Cases.Advanced.Dependencies;
+using Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
-namespace Mono.Linker.Tests.Cases.Advanced {
+namespace Mono.Linker.Tests.Cases.PreserveDependencies {
 	/// <summary>
-	/// This test is here to ensure that link xml embedded in an assembly used by a [PreserveDependency] is not processed if the dependency is not used
+	/// This is an acceptable bug with the currently implementation.  Embeddeded link xml files will not be processed
 	/// </summary>
 	[IncludeBlacklistStep (true)]
 	[SetupCompileBefore ("base.dll", new [] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyBase.cs" })]
@@ -16,15 +16,17 @@ namespace Mono.Linker.Tests.Cases.Advanced {
 		resources: new [] {"Dependencies/PreserveDependencyMethodInNonReferencedAssemblyLibrary.xml"},
 		addAsReference: false)]
 	[KeptAssembly ("base.dll")]
-	[RemovedAssembly ("PreserveDependencyMethodInNonReferencedAssemblyLibrary.dll")]
-	public class PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithEmbeddedXml {
+	[RemovedMemberInAssembly ("PreserveDependencyMethodInNonReferencedAssemblyLibrary.dll", "Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyLibrary", "UnusedMethod()")]
+	public class PreserveDependencyMethodInNonReferencedAssemblyWithEmbeddedXml {
 		public static void Main ()
 		{
 			var obj = new Foo ();
 			var val = obj.Method ();
+			Dependency ();
 		}
 
-		[PreserveDependency (".ctor()", "Mono.Linker.Tests.Cases.Advanced.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyLibrary", "PreserveDependencyMethodInNonReferencedAssemblyLibrary")]
+		[Kept]
+		[PreserveDependency (".ctor()", "Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyLibrary", "PreserveDependencyMethodInNonReferencedAssemblyLibrary")]
 		static void Dependency ()
 		{
 		}

--- a/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyOnUnusedMethodInNonReferencedAssembly.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyOnUnusedMethodInNonReferencedAssembly.cs
@@ -1,9 +1,9 @@
 ﻿using System.Runtime.CompilerServices;
-using Mono.Linker.Tests.Cases.Advanced.Dependencies;
+using Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
-namespace Mono.Linker.Tests.Cases.Advanced {
+namespace Mono.Linker.Tests.Cases.PreserveDependencies {
 	[SetupCompileBefore ("base.dll", new [] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyBase.cs" })]
 	[SetupCompileBefore ("library.dll", new [] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyLibrary.cs" }, references: new [] { "base.dll" }, addAsReference: false)]
 	[KeptAssembly ("base.dll")]
@@ -16,7 +16,7 @@ namespace Mono.Linker.Tests.Cases.Advanced {
 			var val = obj.Method ();
 		}
 
-		[PreserveDependency (".ctor()", "Mono.Linker.Tests.Cases.Advanced.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyLibrary", "library")]
+		[PreserveDependency (".ctor()", "Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyLibrary", "library")]
 		static void Dependency ()
 		{
 		}

--- a/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithCopyUsedAction.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithCopyUsedAction.cs
@@ -2,7 +2,7 @@
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
-namespace Mono.Linker.Tests.Cases.Advanced {
+namespace Mono.Linker.Tests.Cases.PreserveDependencies {
 	[SetupLinkerUserAction ("copyused")]
 	[SetupCompileBefore ("library.dll", new [] {"Dependencies/PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithCopyUsedAction_Lib.cs"}, addAsReference: false)]
 	[RemovedAssembly ("library.dll")]
@@ -11,7 +11,7 @@ namespace Mono.Linker.Tests.Cases.Advanced {
 		{
 		}
 
-		[PreserveDependency ("MethodPreservedViaDependencyAttribute()", "Mono.Linker.Tests.Cases.Advanced.Dependencies.PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithCopyUsedAction_Lib", "library")]
+		[PreserveDependency ("MethodPreservedViaDependencyAttribute()", "Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies.PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithCopyUsedAction_Lib", "library")]
 		static void Dependency ()
 		{
 		}

--- a/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithEmbeddedXml.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithEmbeddedXml.cs
@@ -1,11 +1,11 @@
 ﻿using System.Runtime.CompilerServices;
-using Mono.Linker.Tests.Cases.Advanced.Dependencies;
+using Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
-namespace Mono.Linker.Tests.Cases.Advanced {
+namespace Mono.Linker.Tests.Cases.PreserveDependencies {
 	/// <summary>
-	/// This is an acceptable bug with the currently implementation.  Embeddeded link xml files will not be processed
+	/// This test is here to ensure that link xml embedded in an assembly used by a [PreserveDependency] is not processed if the dependency is not used
 	/// </summary>
 	[IncludeBlacklistStep (true)]
 	[SetupCompileBefore ("base.dll", new [] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyBase.cs" })]
@@ -16,17 +16,15 @@ namespace Mono.Linker.Tests.Cases.Advanced {
 		resources: new [] {"Dependencies/PreserveDependencyMethodInNonReferencedAssemblyLibrary.xml"},
 		addAsReference: false)]
 	[KeptAssembly ("base.dll")]
-	[RemovedMemberInAssembly ("PreserveDependencyMethodInNonReferencedAssemblyLibrary.dll", "Mono.Linker.Tests.Cases.Advanced.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyLibrary", "UnusedMethod()")]
-	public class PreserveDependencyMethodInNonReferencedAssemblyWithEmbeddedXml {
+	[RemovedAssembly ("PreserveDependencyMethodInNonReferencedAssemblyLibrary.dll")]
+	public class PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithEmbeddedXml {
 		public static void Main ()
 		{
 			var obj = new Foo ();
 			var val = obj.Method ();
-			Dependency ();
 		}
 
-		[Kept]
-		[PreserveDependency (".ctor()", "Mono.Linker.Tests.Cases.Advanced.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyLibrary", "PreserveDependencyMethodInNonReferencedAssemblyLibrary")]
+		[PreserveDependency (".ctor()", "Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyLibrary", "PreserveDependencyMethodInNonReferencedAssemblyLibrary")]
 		static void Dependency ()
 		{
 		}

--- a/linker/Tests/TestCases/TestDatabase.cs
+++ b/linker/Tests/TestCases/TestDatabase.cs
@@ -86,6 +86,11 @@ namespace Mono.Linker.Tests.TestCases
 			return NUnitCasesByPrefix ("Symbols.");
 		}
 		
+		public static IEnumerable<TestCaseData> PreserveDependenciesTests ()
+		{
+			return NUnitCasesByPrefix ("PreserveDependencies.");
+		}
+		
 		public static IEnumerable<TestCaseData> LibrariesTests ()
 		{
 			return NUnitCasesByPrefix ("Libraries.");

--- a/linker/Tests/TestCases/TestSuites.cs
+++ b/linker/Tests/TestCases/TestSuites.cs
@@ -96,6 +96,12 @@ namespace Mono.Linker.Tests.TestCases
 			Run (testCase);
 		}
 		
+		[TestCaseSource (typeof (TestDatabase), nameof (TestDatabase.PreserveDependenciesTests))]
+		public void PreserveDependenciesTests (TestCase testCase)
+		{
+			Run (testCase);
+		}
+		
 		[TestCaseSource (typeof (TestDatabase), nameof (TestDatabase.SymbolsTests))]
 		public void SymbolsTests (TestCase testCase)
 		{


### PR DESCRIPTION
This is a growing feature and I think it's worthy of it's own directory to keep it's tests organized.