### PR TITLE
Refactoring of VirtualMethods test suite

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptInterfaceAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptInterfaceAttribute.cs
@@ -2,7 +2,7 @@
 
 namespace Mono.Linker.Tests.Cases.Expectations.Assertions
 {
-	[AttributeUsage (AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
+	[AttributeUsage (AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface, AllowMultiple = true, Inherited = false)]
 	public class KeptInterfaceAttribute : KeptAttribute
 	{
 

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/UnusedAbstractMethodRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/UnusedAbstractMethodRemoved.cs
@@ -1,0 +1,24 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses {
+	public class UnusedAbstractMethodRemoved {
+		public static void Main ()
+		{
+			var tmp = new B ();
+		}
+
+		[KeptMember (".ctor()")]
+		abstract class Base {
+			public abstract void Call ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof (Base))]
+		class B : Base {
+			public override void Call ()
+			{
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/UnusedVirtualMethodRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/UnusedVirtualMethodRemoved.cs
@@ -1,0 +1,26 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses {
+	public class UnusedVirtualMethodRemoved {
+		public static void Main ()
+		{
+			var tmp = new B ();
+		}
+
+		[KeptMember (".ctor()")]
+		abstract class Base {
+			public virtual void Call ()
+			{
+			}
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof (Base))]
+		class B : Base {
+			public override void Call ()
+			{
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/UsedOverrideOfAbstractMethodIsKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/UsedOverrideOfAbstractMethodIsKept.cs
@@ -1,0 +1,27 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses {
+	public class UsedOverrideOfAbstractMethodIsKept {
+		public static void Main ()
+		{
+			var tmp = new B ();
+			tmp.Call ();
+		}
+
+		[KeptMember (".ctor()")]
+		abstract class Base {
+			[Kept]
+			public abstract void Call ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof (Base))]
+		class B : Base {
+			[Kept]
+			public override void Call ()
+			{
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/UsedOverrideOfVirtualMethodIsKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/UsedOverrideOfVirtualMethodIsKept.cs
@@ -1,0 +1,29 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses {
+	public class UsedOverrideOfVirtualMethodIsKept {
+		public static void Main ()
+		{
+			var tmp = new B ();
+			tmp.Call ();
+		}
+
+		[KeptMember (".ctor()")]
+		abstract class Base {
+			[Kept]
+			public virtual void Call ()
+			{
+			}
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof (Base))]
+		class B : Base {
+			[Kept]
+			public override void Call ()
+			{
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/ClassImplementingInterfaceMethodsNested.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/ClassImplementingInterfaceMethodsNested.cs
@@ -1,0 +1,38 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType {
+	public class ClassImplementingInterfaceMethodsNested {
+		public static void Main ()
+		{
+			IFoo i = new A ();
+			i.Foo ();
+		}
+
+		[Kept]
+		interface IFoo {
+			[Kept]
+			void Foo ();
+		}
+		
+		[Kept]
+		[KeptInterface (typeof (IFoo))]
+		interface IBar : IFoo {
+			void Bar ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptInterface (typeof (IBar))]
+		[KeptInterface (typeof (IFoo))]
+		class A : IBar {
+			[Kept]
+			public void Foo ()
+			{
+			}
+
+			public void Bar ()
+			{
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/ClassImplemtingInterfaceMethodsThroughBaseClass2.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/ClassImplemtingInterfaceMethodsThroughBaseClass2.cs
@@ -1,19 +1,22 @@
 ﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
-namespace Mono.Linker.Tests.Cases.VirtualMethods {
-	class ClassImplemtingInterfaceMethodsThroughBaseClass3 {
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType {
+	class ClassImplemtingInterfaceMethodsThroughBaseClass2 {
 		public static void Main ()
 		{
-			new B ().Foo ();
+			new B ();
+			IFoo i = null;
+			i.Foo ();
 		}
 
 		interface IFoo {
+			[Kept]
 			void Foo ();
 		}
 
 		[KeptMember (".ctor()")]
 		class B {
-			[Kept]
+			[Kept] // FIXME: Should be removed
 			public void Foo ()
 			{
 			}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/ClassImplemtingInterfaceMethodsThroughBaseClass3.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/ClassImplemtingInterfaceMethodsThroughBaseClass3.cs
@@ -1,13 +1,12 @@
 ﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
-namespace Mono.Linker.Tests.Cases.VirtualMethods {
-	class ClassImplemtingInterfaceMethodsThroughBaseClass4 {
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType {
+	class ClassImplemtingInterfaceMethodsThroughBaseClass3 {
 		public static void Main ()
 		{
-			new A ().Foo ();
+			new B ().Foo ();
 		}
 
-		[Kept]
 		interface IFoo {
 			void Foo ();
 		}
@@ -20,9 +19,6 @@ namespace Mono.Linker.Tests.Cases.VirtualMethods {
 			}
 		}
 
-		[KeptMember (".ctor()")]
-		[KeptBaseType (typeof (B))]
-		[KeptInterface (typeof (IFoo))] // FIXME: Why is it not removed
 		class A : B, IFoo {
 			//my IFoo.Foo() is actually implemented by B which doesn't know about it.
 		}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/ClassImplemtingInterfaceMethodsThroughBaseClass4.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/ClassImplemtingInterfaceMethodsThroughBaseClass4.cs
@@ -1,10 +1,10 @@
 ﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
-namespace Mono.Linker.Tests.Cases.VirtualMethods {
-	class ClassImplemtingInterfaceMethodsThroughBaseClass5 {
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType {
+	class ClassImplemtingInterfaceMethodsThroughBaseClass4 {
 		public static void Main ()
 		{
-			new A ();
+			new A ().Foo ();
 		}
 
 		[Kept]
@@ -14,6 +14,7 @@ namespace Mono.Linker.Tests.Cases.VirtualMethods {
 
 		[KeptMember (".ctor()")]
 		class B {
+			[Kept]
 			public void Foo ()
 			{
 			}
@@ -21,7 +22,7 @@ namespace Mono.Linker.Tests.Cases.VirtualMethods {
 
 		[KeptMember (".ctor()")]
 		[KeptBaseType (typeof (B))]
-		[KeptInterface (typeof (IFoo))]
+		[KeptInterface (typeof (IFoo))] // FIXME: Why is it not removed
 		class A : B, IFoo {
 			//my IFoo.Foo() is actually implemented by B which doesn't know about it.
 		}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/ClassImplemtingInterfaceMethodsThroughBaseClass5.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/ClassImplemtingInterfaceMethodsThroughBaseClass5.cs
@@ -1,27 +1,27 @@
 ﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
-namespace Mono.Linker.Tests.Cases.VirtualMethods {
-	class ClassImplemtingInterfaceMethodsThroughBaseClass2 {
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType {
+	class ClassImplemtingInterfaceMethodsThroughBaseClass5 {
 		public static void Main ()
 		{
-			new B ();
-			IFoo i = null;
-			i.Foo ();
+			new A ();
 		}
 
+		[Kept]
 		interface IFoo {
-			[Kept]
 			void Foo ();
 		}
 
 		[KeptMember (".ctor()")]
 		class B {
-			[Kept] // FIXME: Should be removed
 			public void Foo ()
 			{
 			}
 		}
 
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof (B))]
+		[KeptInterface (typeof (IFoo))]
 		class A : B, IFoo {
 			//my IFoo.Foo() is actually implemented by B which doesn't know about it.
 		}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/ClassImplemtingInterfaceMethodsThroughBaseClass6.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/ClassImplemtingInterfaceMethodsThroughBaseClass6.cs
@@ -1,6 +1,6 @@
 ﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
-namespace Mono.Linker.Tests.Cases.VirtualMethods {
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType {
 	class ClassImplemtingInterfaceMethodsThroughBaseClass6 {
 		public static void Main ()
 		{

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/ClassUsedFromConcreteTypeHasInterfaceMethodRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/ClassUsedFromConcreteTypeHasInterfaceMethodRemoved.cs
@@ -1,17 +1,18 @@
 ﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
-namespace Mono.Linker.Tests.Cases.VirtualMethods
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType
 {
-	class StructUsedFromInterfaceHasInterfaceMethodKept {
+	class ClassUsedFromConcreteTypeHasInterfaceMethodRemoved {
 		public static void Main ()
 		{
-			IFoo a = new A ();
+			A a = new A ();
 			a.Foo ();
 		}
 
 		[Kept]
+		[KeptMember (".ctor()")]
 		[KeptInterface (typeof (IFoo))]
-		struct A : IFoo {
+		class A : IFoo {
 			[Kept]
 			public void Foo ()
 			{
@@ -20,7 +21,6 @@ namespace Mono.Linker.Tests.Cases.VirtualMethods
 
 		[Kept]
 		public interface IFoo {
-			[Kept]
 			void Foo ();
 		}
 	}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/ClassUsedFromInterfaceHasInterfaceMethodKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/ClassUsedFromInterfaceHasInterfaceMethodKept.cs
@@ -1,17 +1,18 @@
 ﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
-namespace Mono.Linker.Tests.Cases.VirtualMethods
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType
 {
-	class StructUsedFromConcreteTypeHasInterfaceMethodRemoved {
+	class ClassUsedFromInterfaceHasInterfaceMethodKept {
 		public static void Main ()
 		{
-			A a = new A ();
+			IFoo a = new A ();
 			a.Foo ();
 		}
 
 		[Kept]
+		[KeptMember (".ctor()")]
 		[KeptInterface (typeof (IFoo))]
-		struct A : IFoo {
+		class A : IFoo {
 			[Kept]
 			public void Foo ()
 			{
@@ -20,6 +21,7 @@ namespace Mono.Linker.Tests.Cases.VirtualMethods
 
 		[Kept]
 		public interface IFoo {
+			[Kept]
 			void Foo ();
 		}
 	}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/TypeGetsMarkedThatImplementsAlreadyMarkedInterfaceMethod.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/TypeGetsMarkedThatImplementsAlreadyMarkedInterfaceMethod.cs
@@ -1,6 +1,6 @@
 ﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
-namespace Mono.Linker.Tests.Cases.VirtualMethods {
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType {
 	class TypeGetsMarkedThatImplementsAlreadyMarkedInterfaceMethod {
 		public static void Main ()
 		{

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnValueType/StructImplementingInterfaceMethodsNested.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnValueType/StructImplementingInterfaceMethodsNested.cs
@@ -1,0 +1,37 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnValueType {
+	public class StructImplementingInterfaceMethodsNested {
+		public static void Main ()
+		{
+			IFoo i = new A ();
+			i.Foo ();
+		}
+
+		[Kept]
+		interface IFoo {
+			[Kept]
+			void Foo ();
+		}
+		
+		[Kept]
+		[KeptInterface (typeof (IFoo))]
+		interface IBar : IFoo {
+			void Bar ();
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IBar))]
+		[KeptInterface (typeof (IFoo))]
+		struct A : IBar {
+			[Kept]
+			public void Foo ()
+			{
+			}
+
+			public void Bar ()
+			{
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnValueType/StructUsedFromConcreteTypeHasInterfaceMethodRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnValueType/StructUsedFromConcreteTypeHasInterfaceMethodRemoved.cs
@@ -1,11 +1,11 @@
 ﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
-namespace Mono.Linker.Tests.Cases.VirtualMethods
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnValueType
 {
-	class ClassUsedFromInterfaceHasInterfaceMethodKept {
+	class StructUsedFromConcreteTypeHasInterfaceMethodRemoved {
 		public static void Main ()
 		{
-			IFoo a = new A ();
+			A a = new A ();
 			a.Foo ();
 		}
 
@@ -20,7 +20,6 @@ namespace Mono.Linker.Tests.Cases.VirtualMethods
 
 		[Kept]
 		public interface IFoo {
-			[Kept]
 			void Foo ();
 		}
 	}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnValueType/StructUsedFromInterfaceHasInterfaceMethodKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnValueType/StructUsedFromInterfaceHasInterfaceMethodKept.cs
@@ -1,11 +1,11 @@
 ﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
-namespace Mono.Linker.Tests.Cases.VirtualMethods
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnValueType
 {
-	class ClassUsedFromConcreteTypeHasInterfaceMethodRemoved {
+	class StructUsedFromInterfaceHasInterfaceMethodKept {
 		public static void Main ()
 		{
-			A a = new A ();
+			IFoo a = new A ();
 			a.Foo ();
 		}
 
@@ -20,6 +20,7 @@ namespace Mono.Linker.Tests.Cases.VirtualMethods
 
 		[Kept]
 		public interface IFoo {
+			[Kept]
 			void Foo ();
 		}
 	}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.VirtualMethods/HarderToDetectUnusedVirtualMethodGetsRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.VirtualMethods/HarderToDetectUnusedVirtualMethodGetsRemoved.cs
@@ -1,6 +1,6 @@
 ﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
-namespace Mono.Linker.Tests.Cases.VirtualMethods {
+namespace Mono.Linker.Tests.Cases.Inheritance.VirtualMethods {
 	class HarderToDetectUnusedVirtualMethodGetsRemoved {
 		public static void Main ()
 		{

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.VirtualMethods/UnusedTypeWithOverrideOfVirtualMethodIsRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.VirtualMethods/UnusedTypeWithOverrideOfVirtualMethodIsRemoved.cs
@@ -1,7 +1,7 @@
 ﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
-namespace Mono.Linker.Tests.Cases.VirtualMethods {
-	class UnusedVirtualMethodRemoved {
+namespace Mono.Linker.Tests.Cases.Inheritance.VirtualMethods {
+	class UnusedTypeWithOverrideOfVirtualMethodIsRemoved {
 		public static void Main ()
 		{
 			new Base ().Call ();

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.VirtualMethods/UnusedVirtualMethodRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.VirtualMethods/UnusedVirtualMethodRemoved.cs
@@ -1,0 +1,26 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.VirtualMethods {
+	public class UnusedVirtualMethodRemoved {
+		public static void Main ()
+		{
+			var tmp = new B ();
+		}
+
+		[KeptMember (".ctor()")]
+		class Base {
+			public virtual void Call ()
+			{
+			}
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof (Base))]
+		class B : Base {
+			public override void Call ()
+			{
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.VirtualMethods/UsedOverrideOfVirtualMethodIsKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.VirtualMethods/UsedOverrideOfVirtualMethodIsKept.cs
@@ -1,0 +1,29 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.VirtualMethods {
+	public class UsedOverrideOfVirtualMethodIsKept {
+		public static void Main ()
+		{
+			var tmp = new B ();
+			tmp.Call ();
+		}
+
+		[KeptMember (".ctor()")]
+		class Base {
+			[Kept]
+			public virtual void Call ()
+			{
+			}
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof (Base))]
+		class B : Base {
+			[Kept]
+			public override void Call ()
+			{
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.VirtualMethods/UsedTypeWithOverrideOfVirtualMethodHasOverrideKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.VirtualMethods/UsedTypeWithOverrideOfVirtualMethodHasOverrideKept.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
-namespace Mono.Linker.Tests.Cases.VirtualMethods {
-	public class UsedVirtualMethodNotRemoved {
+namespace Mono.Linker.Tests.Cases.Inheritance.VirtualMethods {
+	public class UsedTypeWithOverrideOfVirtualMethodHasOverrideKept {
 		public static void Main ()
 		{
 			new B ();

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.VirtualMethods/VirtualMethodGetsPerservedIfBaseMethodGetsInvoked.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.VirtualMethods/VirtualMethodGetsPerservedIfBaseMethodGetsInvoked.cs
@@ -1,6 +1,6 @@
 ﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
-namespace Mono.Linker.Tests.Cases.VirtualMethods {
+namespace Mono.Linker.Tests.Cases.Inheritance.VirtualMethods {
 	class VirtualMethodGetsPerservedIfBaseMethodGetsInvoked {
 		public static void Main ()
 		{

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.VirtualMethods/VirtualMethodGetsStrippedIfImplementingMethodGetsInvokedDirectly.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.VirtualMethods/VirtualMethodGetsStrippedIfImplementingMethodGetsInvokedDirectly.cs
@@ -1,6 +1,6 @@
 ﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
-namespace Mono.Linker.Tests.Cases.VirtualMethods {
+namespace Mono.Linker.Tests.Cases.Inheritance.VirtualMethods {
 	class VirtualMethodGetsStrippedIfImplementingMethodGetsInvokedDirectly {
 		public static void Main ()
 		{

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -172,6 +172,29 @@
     <Compile Include="Basic\UsedStructIsKept.cs" />
     <Compile Include="CoreLink\CanIncludeI18nAssemblies.cs" />
     <Compile Include="CoreLink\NoSecurityPlusOnlyKeepUsedRemovesAllSecurityAttributesFromCoreLibraries.cs" />
+    <Compile Include="Inheritance.AbstractClasses\UnusedAbstractMethodRemoved.cs" />
+    <Compile Include="Inheritance.AbstractClasses\UnusedVirtualMethodRemoved.cs" />
+    <Compile Include="Inheritance.AbstractClasses\UsedOverrideOfAbstractMethodIsKept.cs" />
+    <Compile Include="Inheritance.AbstractClasses\UsedOverrideOfVirtualMethodIsKept.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\ClassImplementingInterfaceMethodsNested.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\ClassImplemtingInterfaceMethodsThroughBaseClass2.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\ClassImplemtingInterfaceMethodsThroughBaseClass3.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\ClassImplemtingInterfaceMethodsThroughBaseClass4.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\ClassImplemtingInterfaceMethodsThroughBaseClass5.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\ClassImplemtingInterfaceMethodsThroughBaseClass6.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\ClassUsedFromConcreteTypeHasInterfaceMethodRemoved.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\ClassUsedFromInterfaceHasInterfaceMethodKept.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\TypeGetsMarkedThatImplementsAlreadyMarkedInterfaceMethod.cs" />
+    <Compile Include="Inheritance.Interfaces\OnValueType\StructImplementingInterfaceMethodsNested.cs" />
+    <Compile Include="Inheritance.Interfaces\OnValueType\StructUsedFromConcreteTypeHasInterfaceMethodRemoved.cs" />
+    <Compile Include="Inheritance.Interfaces\OnValueType\StructUsedFromInterfaceHasInterfaceMethodKept.cs" />
+    <Compile Include="Inheritance.VirtualMethods\HarderToDetectUnusedVirtualMethodGetsRemoved.cs" />
+    <Compile Include="Inheritance.VirtualMethods\UnusedTypeWithOverrideOfVirtualMethodIsRemoved.cs" />
+    <Compile Include="Inheritance.VirtualMethods\UnusedVirtualMethodRemoved.cs" />
+    <Compile Include="Inheritance.VirtualMethods\UsedOverrideOfVirtualMethodIsKept.cs" />
+    <Compile Include="Inheritance.VirtualMethods\UsedTypeWithOverrideOfVirtualMethodHasOverrideKept.cs" />
+    <Compile Include="Inheritance.VirtualMethods\VirtualMethodGetsPerservedIfBaseMethodGetsInvoked.cs" />
+    <Compile Include="Inheritance.VirtualMethods\VirtualMethodGetsStrippedIfImplementingMethodGetsInvokedDirectly.cs" />
     <Compile Include="Libraries\CanLinkPublicApisOfLibrary.cs" />
     <Compile Include="Libraries\DefaultLibraryLinkBehavior.cs" />
     <Compile Include="Libraries\Dependencies\UserAssemblyActionWorks_Lib.cs" />
@@ -290,10 +313,6 @@
     <Compile Include="TypeForwarding\TypeForwarderOnlyAssembliesRemoved.cs" />
     <Compile Include="TypeForwarding\TypeForwarderOnlyAssembliesKept.cs" />
     <Compile Include="TypeForwarding\TypeForwarderOnlyAssemblyCanBePreservedViaLinkXml.cs" />
-    <Compile Include="VirtualMethods\ClassUsedFromConcreteTypeHasInterfaceMethodRemoved.cs" />
-    <Compile Include="VirtualMethods\ClassUsedFromInterfaceHasInterfaceMethodKept.cs" />
-    <Compile Include="VirtualMethods\StructUsedFromConcreteTypeHasInterfaceMethodRemoved.cs" />
-    <Compile Include="VirtualMethods\StructUsedFromInterfaceHasInterfaceMethodKept.cs" />
     <Compile Include="CoreLink\CopyOfCoreLibrariesKeepsUnusedTypes.cs" />
     <Compile Include="CoreLink\LinkingOfCoreLibrariesRemovesUnusedMethods.cs" />
     <Compile Include="CoreLink\LinkingOfCoreLibrariesRemovesUnusedTypes.cs" />
@@ -340,24 +359,13 @@
     <Compile Include="LinkXml\UnusedTypeWithPreserveNothingAndPreserveMembers.cs" />
     <Compile Include="LinkXml\UnusedTypeWithPreserveNothingHasMembersRemoved.cs" />
     <Compile Include="References\ReferencesAreRemovedWhenAllUsagesAreRemoved.cs" />
-    <Compile Include="VirtualMethods\ClassImplemtingInterfaceMethodsThroughBaseClass2.cs" />
-    <Compile Include="VirtualMethods\ClassImplemtingInterfaceMethodsThroughBaseClass3.cs" />
-    <Compile Include="VirtualMethods\ClassImplemtingInterfaceMethodsThroughBaseClass4.cs" />
-    <Compile Include="VirtualMethods\ClassImplemtingInterfaceMethodsThroughBaseClass5.cs" />
-    <Compile Include="VirtualMethods\ClassImplemtingInterfaceMethodsThroughBaseClass6.cs" />
-    <Compile Include="VirtualMethods\HarderToDetectUnusedVirtualMethodGetsRemoved.cs" />
     <Compile Include="Basic\UnusedClassGetsRemoved.cs" />
     <Compile Include="Basic\UnusedNestedClassGetsRemoved.cs" />
     <Compile Include="Statics\UnusedStaticMethodGetsRemoved.cs" />
-    <Compile Include="VirtualMethods\UnusedVirtualMethodRemoved.cs" />
-    <Compile Include="VirtualMethods\UsedVirtualMethodNotRemoved.cs" />
     <Compile Include="Generics\UsedOverloadedGenericMethodInGenericClassIsNotStripped.cs" />
     <Compile Include="Generics\UsedOverloadedGenericMethodInstanceInGenericClassIsNotStripped.cs" />
     <Compile Include="Generics\UsedOverloadedGenericMethodWithNoParametersIsNotStripped.cs" />
     <Compile Include="Statics\UnusedStaticConstructorGetsRemoved.cs" />
-    <Compile Include="VirtualMethods\TypeGetsMarkedThatImplementsAlreadyMarkedInterfaceMethod.cs" />
-    <Compile Include="VirtualMethods\VirtualMethodGetsPerservedIfBaseMethodGetsInvoked.cs" />
-    <Compile Include="VirtualMethods\VirtualMethodGetsStrippedIfImplementingMethodGetsInvokedDirectly.cs" />
     <Compile Include="TypeForwarding\MissingTargetReference.cs" />
     <None Include="TypeForwarding\Dependencies\TypeForwarderMissingReference.il" />
     <Compile Include="Basic\UsedInterfaceIsKept.cs" />
@@ -437,6 +445,7 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Attributes.StructLayout\" />
+    <Folder Include="Inheritance.Complex" />
     <Folder Include="Reflection\Dependencies\" />
     <Folder Include="Advanced\Dependencies\" />
   </ItemGroup>

--- a/linker/Tests/TestCases/TestDatabase.cs
+++ b/linker/Tests/TestCases/TestDatabase.cs
@@ -21,11 +21,6 @@ namespace Mono.Linker.Tests.TestCases
 			return NUnitCasesByPrefix("Basic.");
 		}
 
-		public static IEnumerable<TestCaseData> VirtualMethodsTests()
-		{
-			return NUnitCasesByPrefix("VirtualMethods.");
-		}
-
 		public static IEnumerable<TestCaseData> AttributeTests()
 		{
 			return NUnitCasesByPrefix("Attributes.");
@@ -94,6 +89,26 @@ namespace Mono.Linker.Tests.TestCases
 		public static IEnumerable<TestCaseData> AdvancedTests ()
 		{
 			return NUnitCasesByPrefix ("Advanced.");
+		}
+		
+		public static IEnumerable<TestCaseData> InheritanceInterfaceTests ()
+		{
+			return NUnitCasesByPrefix ("Inheritance.Interfaces.");
+		}
+		
+		public static IEnumerable<TestCaseData> InheritanceAbstractClassTests ()
+		{
+			return NUnitCasesByPrefix ("Inheritance.AbstractClasses.");
+		}
+		
+		public static IEnumerable<TestCaseData> InheritanceVirtualMethodsTests ()
+		{
+			return NUnitCasesByPrefix ("Inheritance.VirtualMethods.");
+		}
+		
+		public static IEnumerable<TestCaseData> InheritanceComplexTests ()
+		{
+			return NUnitCasesByPrefix ("Inheritance.Complex.");
 		}
 
 		public static TestCaseCollector CreateCollector ()

--- a/linker/Tests/TestCases/TestSuites.cs
+++ b/linker/Tests/TestCases/TestSuites.cs
@@ -18,12 +18,6 @@ namespace Mono.Linker.Tests.TestCases
 			Run (testCase);
 		}
 
-		[TestCaseSource (typeof (TestDatabase), nameof (TestDatabase.VirtualMethodsTests))]
-		public void VirtualMethodTests (TestCase testCase)
-		{
-			Run (testCase);
-		}
-
 		[TestCaseSource (typeof (TestDatabase), nameof (TestDatabase.XmlTests))]
 		public void XmlTests (TestCase testCase)
 		{
@@ -104,6 +98,30 @@ namespace Mono.Linker.Tests.TestCases
 		
 		[TestCaseSource (typeof (TestDatabase), nameof (TestDatabase.LibrariesTests))]
 		public void LibrariesTests (TestCase testCase)
+		{
+			Run (testCase);
+		}
+		
+		[TestCaseSource (typeof (TestDatabase), nameof (TestDatabase.InheritanceInterfaceTests))]
+		public void InheritanceInterfaceTests (TestCase testCase)
+		{
+			Run (testCase);
+		}
+		
+		[TestCaseSource (typeof (TestDatabase), nameof (TestDatabase.InheritanceAbstractClassTests))]
+		public void InheritanceAbstractClassTests (TestCase testCase)
+		{
+			Run (testCase);
+		}
+		
+		[TestCaseSource (typeof (TestDatabase), nameof (TestDatabase.InheritanceVirtualMethodsTests))]
+		public void InheritanceVirtualMethodsTests (TestCase testCase)
+		{
+			Run (testCase);
+		}
+		
+		[TestCaseSource (typeof (TestDatabase), nameof (TestDatabase.InheritanceComplexTests))]
+		public void InheritanceComplexTests (TestCase testCase)
 		{
 			Run (testCase);
 		}


### PR DESCRIPTION
* Fixed two tests that should have been using a class instead of a struct

* Broke up VirtualMethods test folder into 4 folders to better make room for new tests that will be coming

* Added some simple tests for abstract classes.

* Allow [KeptInterface] on interfaces

* Add new interface tests, mainly to make use of [KeptInterface] on an interface