### PR TITLE
Preserve attributes for fixed length arrays

### DIFF
--- a/linker/Linker.Steps/MarkStep.cs
+++ b/linker/Linker.Steps/MarkStep.cs
@@ -453,6 +453,9 @@ namespace Mono.Linker.Steps {
 				case "System.ThreadStaticAttribute":
 				case "System.ContextStaticAttribute":
 					return true;
+				// Attributes related to `fixed` keyword used to declare fixed length arrays
+				case "System.Runtime.CompilerServices.FixedBufferAttribute":
+					return true;
 				case "System.Runtime.InteropServices.InterfaceTypeAttribute":
 				case "System.Runtime.InteropServices.GuidAttribute":
 					return !_context.IsFeatureExcluded ("com");

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptAttributeOnFixedBufferTypeAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptAttributeOnFixedBufferTypeAttribute.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Assertions {
+	[AttributeUsage (AttributeTargets.Field, Inherited = false, AllowMultiple = true)]
+	public class KeptAttributeOnFixedBufferTypeAttribute : KeptAttribute {
+		public KeptAttributeOnFixedBufferTypeAttribute (string attributeName)
+		{
+			if (string.IsNullOrEmpty (attributeName))
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (attributeName));
+		}
+
+		public KeptAttributeOnFixedBufferTypeAttribute (Type type)
+		{
+			if (type == null)
+				throw new ArgumentNullException (nameof (type));
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptFixedBufferAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptFixedBufferAttribute.cs
@@ -1,0 +1,7 @@
+using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Assertions {
+	[AttributeUsage (AttributeTargets.Field, Inherited = false, AllowMultiple = false)]
+	public class KeptFixedBufferAttribute : KeptAttribute {
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
@@ -44,10 +44,12 @@
     <Compile Include="Assertions\KeptAttribute.cs" />
     <Compile Include="Assertions\BaseExpectedLinkedBehaviorAttribute.cs" />
     <Compile Include="Assertions\KeptAttributeInAssemblyAttribute.cs" />
+    <Compile Include="Assertions\KeptAttributeOnFixedBufferTypeAttribute.cs" />
     <Compile Include="Assertions\KeptBackingFieldAttribute.cs" />
     <Compile Include="Assertions\KeptDelegateCacheFieldAttribute.cs" />
     <Compile Include="Assertions\KeptEventAddMethodAttribute.cs" />
     <Compile Include="Assertions\KeptEventRemoveMethodAttribute.cs" />
+    <Compile Include="Assertions\KeptFixedBufferAttribute.cs" />
     <Compile Include="Assertions\KeptInitializerData.cs" />
     <Compile Include="Assertions\KeptMemberAttribute.cs" />
     <Compile Include="Assertions\KeptMemberInAssemblyAttribute.cs" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/FixedLengthArrayAttributesArePreserved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/FixedLengthArrayAttributesArePreserved.cs
@@ -1,0 +1,45 @@
+using System.Runtime.CompilerServices;
+using System.Security;
+using System.Security.Permissions;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+[assembly: KeptSecurity (typeof (SecurityPermissionAttribute))]
+[module: KeptAttributeAttribute (typeof (UnverifiableCodeAttribute))]
+
+namespace Mono.Linker.Tests.Cases.Attributes {
+	/// <summary>
+	/// The purpose of this test is mainly to provide coverage on the `KeptAttributeOnFixedBufferType` attribute
+	/// </summary>
+	[SetupCompileArgument ("/unsafe")]
+	// Can't verify because the test contains unsafe code
+	[SkipPeVerify]
+	public class FixedLengthArrayAttributesArePreserved {
+		public static void Main ()
+		{
+			Helper ();
+		}
+
+		[Kept]
+		static unsafe void Helper ()
+		{
+			var tmp = new WithFixedArrayField ();
+			var v = tmp.Values;
+			AMethodToUseTheReturnValue (v);
+		}
+
+		[Kept]
+		static unsafe void AMethodToUseTheReturnValue (int* ptr)
+		{
+		}
+		
+		[Kept]
+		public unsafe struct WithFixedArrayField {
+			[Kept]
+			[KeptFixedBuffer]
+			[KeptAttributeOnFixedBufferType (typeof (UnsafeValueTypeAttribute))]
+			[KeptAttributeAttribute (typeof (FixedBufferAttribute))]
+			public fixed int Values [10];
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/FixedLengthArrayAttributesArePreserved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/FixedLengthArrayAttributesArePreserved.cs
@@ -1,0 +1,41 @@
+using System.Runtime.CompilerServices;
+using System.Security.Permissions;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+[assembly: KeptSecurity (typeof (SecurityPermissionAttribute))]
+
+namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
+	[SetupLinkerArgument ("--used-attrs-only", "true")]
+	[SetupCompileArgument ("/unsafe")]
+
+	// Can't verify because the test contains unsafe code
+	[SkipPeVerify]
+	public class FixedLengthArrayAttributesArePreserved {
+		public static void Main ()
+		{
+			Helper ();
+		}
+
+		[Kept]
+		static unsafe void Helper ()
+		{
+			var tmp = new WithFixedArrayField ();
+			var v = tmp.Values;
+			AMethodToUseTheReturnValue (v);
+		}
+
+		[Kept]
+		static unsafe void AMethodToUseTheReturnValue (int* ptr)
+		{
+		}
+		
+		[Kept]
+		public unsafe struct WithFixedArrayField {
+			[Kept]
+			[KeptFixedBuffer]
+			[KeptAttributeAttribute (typeof (FixedBufferAttribute))]
+			public fixed int Values [10];
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -20,6 +20,7 @@
     <DefineConstants>DEBUG;TRACE;INCLUDE_EXPECTATIONS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>0</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -28,6 +29,7 @@
     <DefineConstants>TRACE;INCLUDE_EXPECTATIONS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>0</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -92,6 +94,7 @@
     <Compile Include="Attributes\Dependencies\TypeDefinedInReference.cs" />
     <Compile Include="Attributes\Dependencies\TypeDefinedInReference2.cs" />
     <Compile Include="Attributes\Dependencies\TypeDefinedInReferenceWithReference.cs" />
+    <Compile Include="Attributes\FixedLengthArrayAttributesArePreserved.cs" />
     <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeArrayOnAttributeCtorOnType.cs" />
     <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeOnAttributeCtorOnAssembly.cs" />
     <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeOnAttributeCtorOnAssemblyOtherTypesInAttributeAssemblyUsed.cs" />
@@ -120,6 +123,7 @@
     <Compile Include="Attributes\OnlyKeepUsed\AttributeDefinedAndUsedInOtherAssemblyIsKept.cs" />
     <Compile Include="Attributes\OnlyKeepUsed\AttributeUsedByAttributeIsKept.cs" />
     <Compile Include="Attributes\OnlyKeepUsed\CoreLibraryUsedAssemblyAttributesAreKept.cs" />
+    <Compile Include="Attributes\OnlyKeepUsed\FixedLengthArrayAttributesArePreserved.cs" />
     <Compile Include="Attributes\OnlyKeepUsed\ThreadStaticIsPreservedOnField.cs" />
     <Compile Include="Attributes\OnlyKeepUsed\CoreLibraryUnusedAssemblyAttributesAreRemoved.cs" />
     <Compile Include="Attributes\OnlyKeepUsed\UnusedAttributeOnReturnTypeIsRemoved.cs" />


### PR DESCRIPTION
A couple compiler generated attributes should be kept for the runtime when only keep used attributes is enabled