### PR TITLE
Update FixedBuffer tests

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/FixedLengthArrayAttributesArePreserved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/FixedLengthArrayAttributesArePreserved.cs
@@ -1,11 +1,7 @@
 using System.Runtime.CompilerServices;
 using System.Security;
-using System.Security.Permissions;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
-
-[assembly: KeptSecurity (typeof (SecurityPermissionAttribute))]
-[module: KeptAttributeAttribute (typeof (UnverifiableCodeAttribute))]
 
 namespace Mono.Linker.Tests.Cases.Attributes {
 	/// <summary>

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/FixedLengthArrayAttributesArePreserved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/FixedLengthArrayAttributesArePreserved.cs
@@ -1,9 +1,6 @@
 using System.Runtime.CompilerServices;
-using System.Security.Permissions;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
-
-[assembly: KeptSecurity (typeof (SecurityPermissionAttribute))]
 
 namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
 	[SetupLinkerArgument ("--used-attrs-only", "true")]


### PR DESCRIPTION
My PR to add these tests and another PR changed the security attribute behavior.  when the tests ran for both PR's neither had both changes.

It wasn't until both changes landed in master that the tests broke.