### PR TITLE
Fix disable before field init not working

### DIFF
--- a/linker/Linker/Driver.cs
+++ b/linker/Linker/Driver.cs
@@ -163,7 +163,7 @@ namespace Mono.Linker {
 							continue;
 
 						case "--disable-opt":
-							var opt = GetParam ();
+							var opt = GetParam ().ToLower ();
 							if (!disabled_optimizations.Contains (opt))
 								disabled_optimizations.Add (opt);
 

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -272,6 +272,7 @@
     <Compile Include="Resources\EmbeddedLinkXmlFileIsProcessed.cs" />
     <Compile Include="Resources\EmbeddedLinkXmlFileIsProcessedAndKept.cs" />
     <Compile Include="Resources\NonLinkerEmbeddedResourceHasNoImpact.cs" />
+    <Compile Include="Statics\DisableBeforeFieldInit\UnusedStaticFieldInitializer.cs" />
     <Compile Include="Symbols\Dependencies\LibraryWithEmbeddedPdbSymbols.cs" />
     <Compile Include="Symbols\Dependencies\LibraryWithPortablePdbSymbols.cs" />
     <Compile Include="Symbols\ReferenceWithEmbeddedPdb.cs" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/Statics/DisableBeforeFieldInit/UnusedStaticFieldInitializer.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Statics/DisableBeforeFieldInit/UnusedStaticFieldInitializer.cs
@@ -1,0 +1,26 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Statics.DisableBeforeFieldInit
+{
+	[SetupLinkerArgument ("--disable-opt", "BeforeFieldInit")]
+	public class UnusedStaticFieldInitializer
+	{
+		public static void Main ()
+		{
+			C.Foo ();
+		}
+
+		[KeptMember (".cctor()")]
+		static class C
+		{
+			[Kept]
+			public static object o = new object ();
+
+			[Kept]
+			public static void Foo ()
+			{
+			}
+		}
+	}
+}


### PR DESCRIPTION
* Disabling the option didn't restore the old before 

* ToLower() on the disable opt values so that all lower and/or enum value name works as you would expect

* Refactor static constructor marking in MarkStep.  Centralized logic and fixed if statements not working correctly when the optimization was disabled

* Fixed typo in method name

* Added new test to verify disabling works (test will fail without my changes to the MarkStep and Driver)