### PR TITLE
IsImport and IsWindowsRuntime set to false when COM attrs removed

### DIFF
--- a/linker/Linker/Annotations.cs
+++ b/linker/Linker/Annotations.cs
@@ -191,7 +191,7 @@ namespace Mono.Linker {
 			if (preserved_types.TryGetValue (type, out preserve))
 				return preserve;
 
-			throw new NotSupportedException ();
+			throw new NotSupportedException ($"No type preserve information for `{type}`");
 		}
 
 		public HashSet<string> GetResourcesToRemove (AssemblyDefinition assembly)

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/RemovedPseudoAttributeAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/RemovedPseudoAttributeAttribute.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 
 namespace Mono.Linker.Tests.Cases.Expectations.Assertions {
-	[AttributeUsage (AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Delegate | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Event, AllowMultiple = true, Inherited = false)]
+	[AttributeUsage (AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Delegate | AttributeTargets.Interface | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Event, AllowMultiple = true, Inherited = false)]
 	public class RemovedPseudoAttributeAttribute : BaseExpectedLinkedBehaviorAttribute {
 		public RemovedPseudoAttributeAttribute (uint value) {
 		}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/ComAttributesAreRemovedWhenFeatureExcluded.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/ComAttributesAreRemovedWhenFeatureExcluded.cs
@@ -18,6 +18,7 @@ namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
 		}
 		
 		[Kept]
+		[RemovedPseudoAttribute (0x00001000u)]
 		[ComImport]
 		[Guid ("D7BB1889-3AB7-4681-A115-60CA9158FECA")]
 		[InterfaceType (ComInterfaceType.InterfaceIsIUnknown)]


### PR DESCRIPTION
Once all the COM attributes are removed we need to set IsImport and IsWindowsRuntime to false since the type is no longer really a com or windows runtime type.