### PR TITLE
Don't change BeforeFieldInit on enums

### DIFF
--- a/linker/Linker.Steps/SweepStep.cs
+++ b/linker/Linker.Steps/SweepStep.cs
@@ -290,9 +290,8 @@ namespace Mono.Linker.Steps {
 			if (type.HasEvents)
 				SweepCustomAttributeCollection (type.Events);
 
-			if (type.HasFields && !type.IsBeforeFieldInit && !Annotations.HasPreservedStaticCtor (type))
+			if (type.HasFields && !type.IsBeforeFieldInit && !Annotations.HasPreservedStaticCtor (type) && !type.IsEnum)
 				type.IsBeforeFieldInit = true;
-
 		}
 
 		protected void SweepNestedTypes (TypeDefinition type)

--- a/linker/Tests/Mono.Linker.Tests.Cases/Basic/UsedEnumIsKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Basic/UsedEnumIsKept.cs
@@ -25,7 +25,6 @@ namespace Mono.Linker.Tests.Cases.Basic {
 		[Kept]
 		[KeptMember ("value__")]
 		[KeptBaseType (typeof(Enum))]
-		[AddedPseudoAttributeAttribute ((uint)TypeAttributes.BeforeFieldInit)]
 		enum Used {
 			[Kept]
 			One,


### PR DESCRIPTION
There's no size value to changing it as far as I'm aware and it forces all tests using an enum to add the `AddedPseudoAttribute` which is one of the less intuitive attributes to have to use so it's nice to keep these to only the niches where they are truly needed