### PR TITLE
Compile ExplicitStaticCtor with /optimize+

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases/Statics/ExplicitStaticCtor.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Statics/ExplicitStaticCtor.cs
@@ -1,9 +1,11 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Statics
 {
+	[SetupCompileArgument ("/optimize+")]
 	public class ExplicitStaticCtor
 	{
 		public static void Main ()


### PR DESCRIPTION
This eliminates a source of instability in the test where it could fail if compiled with a compiler that put a `nop` into the cctor