### PR TITLE
Add tests cover using statement difference between mcs and csc.

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptReferencesInAssemblyAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptReferencesInAssemblyAttribute.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Assertions {
+	[AttributeUsage (AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+	public class KeptReferencesInAssemblyAttribute : BaseInAssemblyAttribute {
+		public KeptReferencesInAssemblyAttribute (string assemblyFileName, string [] expectedReferenceAssemblyNames)
+		{
+			if (string.IsNullOrEmpty (assemblyFileName))
+				throw new ArgumentNullException (nameof (assemblyFileName));
+
+			if (expectedReferenceAssemblyNames == null)
+				throw new ArgumentNullException (nameof (expectedReferenceAssemblyNames));
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Assertions\KeptMemberAttribute.cs" />
     <Compile Include="Assertions\KeptMemberInAssemblyAttribute.cs" />
     <Compile Include="Assertions\KeptReferenceAttribute.cs" />
+    <Compile Include="Assertions\KeptReferencesInAssemblyAttribute.cs" />
     <Compile Include="Assertions\KeptResourceAttribute.cs" />
     <Compile Include="Assertions\KeptResourceInAssemblyAttribute.cs" />
     <Compile Include="Assertions\KeptSecurityAttribute.cs" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -297,6 +297,10 @@
     <Compile Include="PreserveDependencies\PreserveDependencyOnUnusedMethodInNonReferencedAssembly.cs" />
     <Compile Include="PreserveDependencies\PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithCopyUsedAction.cs" />
     <Compile Include="PreserveDependencies\PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithEmbeddedXml.cs" />
+    <Compile Include="References\AssemblyOnlyUsedByUsingWithCsc.cs" />
+    <Compile Include="References\AssemblyOnlyUsedByUsingWithMcs.cs" />
+    <Compile Include="References\Dependencies\AssemblyOnlyUsedByUsing_Copied.cs" />
+    <Compile Include="References\Dependencies\AssemblyOnlyUsedByUsing_Lib.cs" />
     <Compile Include="References\Individual\CanSkipUnresolved.cs" />
     <Compile Include="References\Individual\Dependencies\CanSkipUnresolved_Library.cs" />
     <Compile Include="References\Dependencies\UserAssembliesAreLinkedByDefault_Library1.cs" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/References/AssemblyOnlyUsedByUsingWithCsc.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/References/AssemblyOnlyUsedByUsingWithCsc.cs
@@ -1,0 +1,29 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.References.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.References {
+	/// <summary>
+	/// We can't detect the using usage in the assembly.  As a result, nothing in `library` is going to be marked and that assembly will be deleted.
+	/// Because of that, `copied` needs to have it's reference to `library` removed even though we specified an assembly action of `copy`
+	/// </summary>
+	[SetupLinkerAction ("copy", "copied")]
+	[SetupCompileBefore ("library.dll", new [] {"Dependencies/AssemblyOnlyUsedByUsing_Lib.cs"})]
+	
+	// When csc is used, `copied.dll` will have a reference to `library.dll`
+	[SetupCompileBefore ("copied.dll", new [] {"Dependencies/AssemblyOnlyUsedByUsing_Copied.cs"}, new [] {"library.dll"}, compilerToUse: "csc")]
+
+	// Here to assert that the test is setup correctly to copy the copied assembly.  This is an important aspect of the bug
+	[KeptMemberInAssembly ("copied.dll", typeof (AssemblyOnlyUsedByUsing_Copied), "Unused()")]
+	
+	// We library should be gone.  The `using` statement leaves no traces in the IL so nothing in `library` will be marked
+	[RemovedAssembly ("library.dll")]
+	[KeptReferencesInAssembly ("copied.dll", new [] {"mscorlib"})]
+	public class AssemblyOnlyUsedByUsingWithCsc {
+		public static void Main ()
+		{
+			// Use something to keep the reference at compile time
+			AssemblyOnlyUsedByUsing_Copied.UsedToKeepReference ();
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/References/AssemblyOnlyUsedByUsingWithMcs.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/References/AssemblyOnlyUsedByUsingWithMcs.cs
@@ -1,0 +1,24 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.References.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.References {
+	[SetupLinkerAction ("copy", "copied")]
+	[SetupCompileBefore ("library.dll", new [] {"Dependencies/AssemblyOnlyUsedByUsing_Lib.cs"})]
+	
+	// When mcs is used, `copied.dll` will not have a reference to `library.dll`
+	[SetupCompileBefore ("copied.dll", new [] {"Dependencies/AssemblyOnlyUsedByUsing_Copied.cs"}, new [] {"library.dll"}, compilerToUse: "mcs")]
+
+	// Here to assert that the test is setup correctly to copy the copied assembly.  This is an important aspect of the bug
+	[KeptMemberInAssembly ("copied.dll", typeof (AssemblyOnlyUsedByUsing_Copied), "Unused()")]
+
+	[RemovedAssembly ("library.dll")]
+	[KeptReferencesInAssembly ("copied.dll", new [] {"mscorlib"})]
+	public class AssemblyOnlyUsedByUsingWithMcs {
+		public static void Main ()
+		{
+			// Use something to keep the reference at compile time
+			AssemblyOnlyUsedByUsing_Copied.UsedToKeepReference ();
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/References/Dependencies/AssemblyOnlyUsedByUsing_Copied.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/References/Dependencies/AssemblyOnlyUsedByUsing_Copied.cs
@@ -1,0 +1,16 @@
+
+// This is what triggers the behavior difference between Roslyn and mcs.  Roslyn will keep the reference
+// to this assembly because of this whereas mcs will not
+using ImportantForBug = Mono.Linker.Tests.Cases.References.Dependencies.AssemblyOnlyUsedByUsing_Lib;
+
+namespace Mono.Linker.Tests.Cases.References.Dependencies {
+	public class AssemblyOnlyUsedByUsing_Copied {
+		public static void UsedToKeepReference ()
+		{
+		}
+
+		private static void Unused ()
+		{
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/References/Dependencies/AssemblyOnlyUsedByUsing_Lib.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/References/Dependencies/AssemblyOnlyUsedByUsing_Lib.cs
@@ -1,0 +1,4 @@
+namespace Mono.Linker.Tests.Cases.References.Dependencies {
+	public class AssemblyOnlyUsedByUsing_Lib {
+	}
+}

--- a/linker/Tests/TestCasesRunner/ResultChecker.cs
+++ b/linker/Tests/TestCasesRunner/ResultChecker.cs
@@ -244,6 +244,9 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 							case nameof (RemovedResourceInAssemblyAttribute):
 								VerifyRemovedResourceInAssembly (checkAttrInAssembly);
 								break;
+							case nameof (KeptReferencesInAssemblyAttribute):
+								VerifyKeptReferencesInAssembly (checkAttrInAssembly);
+								break;
 							default:
 								UnhandledOtherAssemblyAssertion (expectedTypeName, checkAttrInAssembly, linkedType);
 								break;
@@ -504,6 +507,13 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			}
 
 			return false;
+		}
+
+		void VerifyKeptReferencesInAssembly (CustomAttribute inAssemblyAttribute)
+		{
+			var assembly = ResolveLinkedAssembly (inAssemblyAttribute.ConstructorArguments [0].Value.ToString ());
+			var expectedReferenceNames = ((CustomAttributeArgument []) inAssemblyAttribute.ConstructorArguments [1].Value).Select (attr => (string) attr.Value);
+			Assert.That (assembly.MainModule.AssemblyReferences.Select (asm => asm.Name), Is.EquivalentTo (expectedReferenceNames));
 		}
 
 		void VerifyKeptResourceInAssembly (CustomAttribute inAssemblyAttribute)


### PR DESCRIPTION
@marek-safar I could use your opinion on whether or not you think this is a bug in the linker.

This PR contains just tests to reproduce what I think is a bug.  I did not implement a fix yet.  I wanted to confirm whether or not you think it is a bug before I spend time on a fix.

`AssemblyOnlyUsedByUsingWithCsc` is the test that currently fails and I think it should pass.

What it does is
* Compile an assembly called `library.dll`

* Compile an assembly called `copied.dll` that makes use of `library.dll` with only the following code

```
// This is what triggers the behavior difference between Roslyn and mcs.  Roslyn will keep the reference
// to this assembly because of this whereas mcs will not
using ImportantForBug = Mono.Linker.Tests.Cases.References.Dependencies.AssemblyOnlyUsedByUsing_Lib;
```

And `copied.dll` is setup to have `AssemblyAction.Copy`

And most importantly, compile `copied.dll` with `csc`

Note that `csc` will include a reference to `library.dll` in `copied.dll` where as `mcs` will not.

`AssemblyOnlyUsedByUsingWithCsc` fails because I have an assert expecting that `library.dll` survives stripping.  I think this is a valid assertion given that `copied.dll` references `library.dll` and `copied.dll` had `AssemblyAction.Copy`.

It seems to me that there is a bug in that references of an assembly with AssemblyAction.Copy should always exist after stripping, even if they've been stripped down to empty assemblies.  Would you agree?  What are your thoughts?

Note that I added the test `AssemblyOnlyUsedByUsingWithMcs` just to show what happens with `mcs`.  This test passes.

