### PR TITLE
Add test when assembly preserve all

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/AssemblyWithPreserveAll.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/AssemblyWithPreserveAll.cs
@@ -1,0 +1,31 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.LinkXml {
+	[KeptMember (".ctor()")]
+	public class AssemblyWithPreserveAll {
+		public static void Main ()
+		{
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		class UnusedType {
+			[Kept]
+			public int UnusedField;
+
+			[Kept]
+			[KeptBackingField]
+			public int UnusedProperty { [Kept] get; [Kept] set; }
+			
+			[Kept]
+			public void UnusedMethod ()
+			{
+			}
+
+			[Kept]
+			[KeptMember (".ctor()")]
+			class UnusedNestedType {
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/AssemblyWithPreserveAll.xml
+++ b/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/AssemblyWithPreserveAll.xml
@@ -1,0 +1,4 @@
+<linker>
+    <assembly fullname="test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null" preserve="all">
+    </assembly>
+</linker>

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -222,6 +222,7 @@
     <Compile Include="Libraries\DefaultLibraryLinkBehavior.cs" />
     <Compile Include="Libraries\Dependencies\UserAssemblyActionWorks_Lib.cs" />
     <Compile Include="Libraries\UserAssemblyActionWorks.cs" />
+    <Compile Include="LinkXml\AssemblyWithPreserveAll.cs" />
     <Compile Include="LinkXml\CanPreserveTypesUsingRegex.cs" />
     <Compile Include="LinkXml\CanPreserveAnExportedType.cs" />
     <None Include="LinkXml\Dependencies\CanPreserveAnExportedType_Forwarder.cs" />
@@ -439,6 +440,7 @@
   <ItemGroup>
     <Content Include="Attributes\OnlyKeepUsed\Dependencies\AssemblyWithUnusedAttributeOnReturnParameterDefinition.il" />
     <Content Include="Attributes\OnlyKeepUsed\UnusedAttributePreservedViaLinkXmlIsKept.xml" />
+    <Content Include="LinkXml\AssemblyWithPreserveAll.xml" />
     <Content Include="LinkXml\CanPreserveTypesUsingRegex.xml" />
     <Content Include="LinkXml\CanPreserveAnExportedType.xml" />
     <Content Include="LinkXml\CanPreserveExportedTypesUsingRegex.xml" />


### PR DESCRIPTION
There wasn't a test for a link xml with an assembly that has preserve=all.  We document this behavior so I thought it would be good to have a test that explicitly tests this case.