### PR TITLE
Add Annotations.TryGetPreserve

### DIFF
--- a/linker/Linker.Steps/MarkStep.cs
+++ b/linker/Linker.Steps/MarkStep.cs
@@ -1487,10 +1487,10 @@ namespace Mono.Linker.Steps {
 		{
 			ApplyPreserveMethods (type);
 
-			if (!Annotations.IsPreserved (type))
+			if (!Annotations.TryGetPreserve (type, out TypePreserve preserve))
 				return;
 
-			switch (Annotations.GetPreserve (type)) {
+			switch (preserve) {
 			case TypePreserve.All:
 				MarkFields (type, true);
 				MarkMethods (type);
@@ -1988,10 +1988,10 @@ namespace Mono.Linker.Steps {
 			if (resolvedInterfaceType.IsImport || resolvedInterfaceType.IsWindowsRuntime)
 				return true;
 
-			if (!Annotations.IsPreserved (type))
+			if (!Annotations.TryGetPreserve (type, out TypePreserve preserve))
 				return false;
 
-			return Annotations.GetPreserve (type) == TypePreserve.All;
+			return preserve == TypePreserve.All;
 		}
 
 		protected virtual void MarkInterfaceImplementation (InterfaceImplementation iface)

--- a/linker/Linker.Steps/ResolveFromXmlStep.cs
+++ b/linker/Linker.Steps/ResolveFromXmlStep.cs
@@ -253,7 +253,7 @@ namespace Mono.Linker.Steps {
 			}
 
 			if (Annotations.IsMarked (type)) { 
-				var existingLevel = Annotations.IsPreserved (type) ? Annotations.GetPreserve (type) : TypePreserve.Nothing; 
+				var existingLevel = Annotations.TryGetPreserve (type, out TypePreserve existingPreserve) ? existingPreserve : TypePreserve.Nothing; 
 				var duplicateLevel = preserve != TypePreserve.Nothing ? preserve : nav.HasChildren ? TypePreserve.Nothing : TypePreserve.All; 
 				Context.LogMessage ($"Duplicate preserve in {_xmlDocumentLocation} of {type.FullName} ({existingLevel}).  Duplicate uses ({duplicateLevel})"); 
 			} 

--- a/linker/Linker/Annotations.cs
+++ b/linker/Linker/Annotations.cs
@@ -205,6 +205,11 @@ namespace Mono.Linker {
 			throw new NotSupportedException ($"No type preserve information for `{type}`");
 		}
 
+		public bool TryGetPreserve (TypeDefinition type, out TypePreserve preserve)
+		{
+			return preserved_types.TryGetValue (type, out preserve);
+		}
+
 		public HashSet<string> GetResourcesToRemove (AssemblyDefinition assembly)
 		{
 			HashSet<string> resources;


### PR DESCRIPTION
I left the existing IsPreserved and GetPreserve methods because I think there are still situations where it is clearer to use those methods instead of TryGetPreserve