### PR TITLE
Add support for more InAssembly test attributes

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptInterfaceOnTypeInAssemblyAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptInterfaceOnTypeInAssemblyAttribute.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Assertions {
+	[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+	public class KeptInterfaceOnTypeInAssemblyAttribute : BaseInAssemblyAttribute {
+		public KeptInterfaceOnTypeInAssemblyAttribute (string assemblyFileName, Type type, string interfaceAssemblyFileName, Type interfaceType)
+		{
+			if (type == null)
+				throw new ArgumentNullException (nameof (type));
+			if (string.IsNullOrEmpty (assemblyFileName))
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (assemblyFileName));
+			
+			if (string.IsNullOrEmpty (interfaceAssemblyFileName))
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (interfaceAssemblyFileName));
+			if (interfaceType == null)
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (interfaceType));
+		}
+
+		public KeptInterfaceOnTypeInAssemblyAttribute (string assemblyFileName, string typeName, string interfaceAssemblyFileName, string interfaceTypeName)
+		{
+			if (string.IsNullOrEmpty (assemblyFileName))
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (assemblyFileName));
+			if (string.IsNullOrEmpty (typeName))
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (typeName));
+			
+			if (string.IsNullOrEmpty (interfaceAssemblyFileName))
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (interfaceAssemblyFileName));
+			if (string.IsNullOrEmpty (interfaceTypeName))
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (interfaceTypeName));
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/RemovedInterfaceOnTypeInAssemblyAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/RemovedInterfaceOnTypeInAssemblyAttribute.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Assertions {
+	[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+	public class RemovedInterfaceOnTypeInAssemblyAttribute : BaseInAssemblyAttribute {
+		public RemovedInterfaceOnTypeInAssemblyAttribute (string assemblyFileName, Type type, string interfaceAssemblyFileName, Type interfaceType)
+		{
+			if (type == null)
+				throw new ArgumentNullException (nameof (type));
+			if (string.IsNullOrEmpty (assemblyFileName))
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (assemblyFileName));
+			
+			if (string.IsNullOrEmpty (interfaceAssemblyFileName))
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (interfaceAssemblyFileName));
+			if (interfaceType == null)
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (interfaceType));
+		}
+
+		public RemovedInterfaceOnTypeInAssemblyAttribute (string assemblyFileName, string typeName, string interfaceAssemblyFileName, string interfaceTypeName)
+		{
+			if (string.IsNullOrEmpty (assemblyFileName))
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (assemblyFileName));
+			if (string.IsNullOrEmpty (typeName))
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (typeName));
+			
+			if (string.IsNullOrEmpty (interfaceAssemblyFileName))
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (interfaceAssemblyFileName));
+			if (string.IsNullOrEmpty (interfaceTypeName))
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (interfaceTypeName));
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Assertions\KeptEventRemoveMethodAttribute.cs" />
     <Compile Include="Assertions\KeptFixedBufferAttribute.cs" />
     <Compile Include="Assertions\KeptInitializerData.cs" />
+    <Compile Include="Assertions\KeptInterfaceOnTypeInAssemblyAttribute.cs" />
     <Compile Include="Assertions\KeptMemberAttribute.cs" />
     <Compile Include="Assertions\KeptMemberInAssemblyAttribute.cs" />
     <Compile Include="Assertions\KeptReferenceAttribute.cs" />
@@ -61,6 +62,7 @@
     <Compile Include="Assertions\KeptTypeInAssemblyAttribute.cs" />
     <Compile Include="Assertions\RemovedAssemblyAttribute.cs" />
     <Compile Include="Assertions\RemovedAttributeInAssembly.cs" />
+    <Compile Include="Assertions\RemovedInterfaceOnTypeInAssemblyAttribute.cs" />
     <Compile Include="Assertions\RemovedMemberInAssemblyAttribute.cs" />
     <Compile Include="Assertions\RemovedPseudoAttributeAttribute.cs" />
     <Compile Include="Assertions\RemovedResourceInAssemblyAttribute.cs" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -340,6 +340,7 @@
     <Compile Include="TestFramework\CanCompileTestCaseWithCsc.cs" />
     <Compile Include="TestFramework\CanCompileTestCaseWithMsc.cs" />
     <Compile Include="TestFramework\CanSandboxDependenciesUsingType.cs" />
+    <Compile Include="TestFramework\CanVerifyInterfacesOnTypesInAssembly.cs" />
     <Compile Include="TestFramework\Dependencies\CanCompileReferencesUsingTypes_LibSource1.cs" />
     <Compile Include="TestFramework\Dependencies\CanCompileReferencesUsingTypes_LibSource2.cs" />
     <Compile Include="TestFramework\Dependencies\CanCompileReferencesWithResources_Lib1.cs" />
@@ -347,6 +348,7 @@
     <Compile Include="TestFramework\Dependencies\CanCompileTestCaseWithMcs_Lib.cs" />
     <Compile Include="TestFramework\Dependencies\CanSandboxDependenciesUsingType_Source1.cs" />
     <Compile Include="TestFramework\Dependencies\CanSandboxDependenciesUsingType_Source2.cs" />
+    <Compile Include="TestFramework\Dependencies\CanVerifyInterfacesOnTypesInAssembly_Lib.cs" />
     <Compile Include="TestFramework\Dependencies\VerifyAttributesInAssemblyWorks_Base.cs" />
     <Compile Include="TestFramework\Dependencies\VerifyAttributesInAssemblyWorks_Lib.cs" />
     <Compile Include="TestFramework\VerifyAttributesInAssemblyWorks.cs" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/TestFramework/CanVerifyInterfacesOnTypesInAssembly.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/TestFramework/CanVerifyInterfacesOnTypesInAssembly.cs
@@ -1,0 +1,16 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.TestFramework.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.TestFramework {
+	[SetupCompileBefore ("library.dll", new [] {"Dependencies/CanVerifyInterfacesOnTypesInAssembly_Lib.cs"})]
+	[KeptInterfaceOnTypeInAssembly ("library", typeof (CanVerifyInterfacesOnTypesInAssembly_Lib.A), "library", typeof (CanVerifyInterfacesOnTypesInAssembly_Lib.IFoo))]
+	[RemovedInterfaceOnTypeInAssembly ("library", typeof (CanVerifyInterfacesOnTypesInAssembly_Lib.A), "library", typeof (CanVerifyInterfacesOnTypesInAssembly_Lib.IBar))]
+	public class CanVerifyInterfacesOnTypesInAssembly {
+		public static void Main ()
+		{
+			CanVerifyInterfacesOnTypesInAssembly_Lib.IFoo a = new CanVerifyInterfacesOnTypesInAssembly_Lib.A ();
+			a.Foo ();
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/TestFramework/Dependencies/CanVerifyInterfacesOnTypesInAssembly_Lib.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/TestFramework/Dependencies/CanVerifyInterfacesOnTypesInAssembly_Lib.cs
@@ -1,0 +1,20 @@
+namespace Mono.Linker.Tests.Cases.TestFramework.Dependencies {
+	public class CanVerifyInterfacesOnTypesInAssembly_Lib {
+		public interface IFoo {
+			void Foo ();
+		}
+		public interface IBar {
+			void Bar ();
+		}
+
+		public class A : IFoo, IBar {
+			public void Foo ()
+			{
+			}
+
+			public void Bar ()
+			{
+			}
+		}
+	}
+}


### PR DESCRIPTION
Add support for [KeptInterfaceOnTypeInAssembly]

Add support for [RemovedInterfaceOnTypeInAssembly]

With the introduction of interface sweeping there are going to be situations where it is handy to have these attributes.  I have a PR coming that will make use of them.