### PR TITLE
Fix test assembly not compiling

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.csproj
+++ b/linker/Tests/Mono.Linker.Tests.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>Mono.Linker.Tests</AssemblyName>
     <StartupObject>
     </StartupObject>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <RootNamespace>Mono.Linker.Tests</RootNamespace>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
The Mono.Linker.Tests.Cases project received a version bump in https://github.com/mono/linker/commit/4acf7b132aeff86f4535e1d0b1635d961a0b81c5

Mono.Linker.Tests  references this project and since Mono.LInker.Tests was on 4.6.2 it stopped compiled once Mono.Linker.Tests.Cases bumped to 4.7.1