### PR TITLE
Fix bug with interface sweeping, explicit impl, and xml

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtor/ExplicitInterfaceCanBeRemovedFromClassWithOnlyStaticMethodUsed.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtor/ExplicitInterfaceCanBeRemovedFromClassWithOnlyStaticMethodUsed.cs
@@ -1,0 +1,40 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoKeptCtor {
+	public class ExplicitInterfaceCanBeRemovedFromClassWithOnlyStaticMethodUsed {
+		public static void Main ()
+		{
+			IUsedInterface p = new UsedClass ();
+			StaticMethodOnlyUsed.StaticMethod ();
+			p.Foo ();
+		}
+
+		[Kept]
+		interface IUsedInterface {
+			[Kept]
+			void Foo ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptInterface (typeof (IUsedInterface))]
+		class UsedClass : IUsedInterface {
+			[Kept]
+			public void Foo ()
+			{
+			}
+		}
+
+		[Kept]
+		class StaticMethodOnlyUsed : IUsedInterface {
+			void IUsedInterface.Foo ()
+			{
+			}
+
+			[Kept]
+			public static void StaticMethod ()
+			{
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtor/UnusedTypeHasExplicitInterfaceMethodPreservedViaXml.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtor/UnusedTypeHasExplicitInterfaceMethodPreservedViaXml.cs
@@ -1,0 +1,34 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoKeptCtor {
+	public class UnusedTypeHasExplicitInterfaceMethodPreservedViaXml {
+		public static void Main ()
+		{
+		}
+
+		[Kept]
+		interface IFoo {
+			[Kept]
+			void Foo ();
+		}
+
+		interface IBar {
+			void Bar ();
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IFoo))]
+		class A : IBar, IFoo {
+			
+			// Because an explicit interface method was preserved via xml, we need to now mark the interface implementation
+			[Kept]
+			void IFoo.Foo ()
+			{
+			}
+
+			void IBar.Bar ()
+			{
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtor/UnusedTypeHasExplicitInterfaceMethodPreservedViaXml.xml
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtor/UnusedTypeHasExplicitInterfaceMethodPreservedViaXml.xml
@@ -1,0 +1,7 @@
+<linker>
+    <assembly fullname="test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+        <type fullname="Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoKeptCtor.UnusedTypeHasExplicitInterfaceMethodPreservedViaXml/A">
+            <method signature="System.Void Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoKeptCtor.UnusedTypeHasExplicitInterfaceMethodPreservedViaXml.IFoo.Foo()"/>
+        </type>
+    </assembly>
+</linker>

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtor/UnusedTypeHasExplicitInterfacePropertyPreservedViaXml.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtor/UnusedTypeHasExplicitInterfacePropertyPreservedViaXml.cs
@@ -1,0 +1,29 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoKeptCtor {
+	public class UnusedTypeHasExplicitInterfacePropertyPreservedViaXml {
+		public static void Main ()
+		{
+		}
+
+		[Kept]
+		interface IFoo {
+			[Kept]
+			int Foo { [Kept] get; [Kept] set; }
+		}
+
+		interface IBar {
+			int Bar { get; set; }
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IFoo))]
+		class A : IBar, IFoo {
+			[Kept]
+			[KeptBackingField]
+			int IFoo.Foo { [Kept] get; [Kept] set; }
+
+			int IBar.Bar { get; set; }
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtor/UnusedTypeHasExplicitInterfacePropertyPreservedViaXml.xml
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtor/UnusedTypeHasExplicitInterfacePropertyPreservedViaXml.xml
@@ -1,0 +1,7 @@
+<linker>
+    <assembly fullname="test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+        <type fullname="Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoKeptCtor.UnusedTypeHasExplicitInterfacePropertyPreservedViaXml/A">
+            <property signature="System.Int32 Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoKeptCtor.UnusedTypeHasExplicitInterfacePropertyPreservedViaXml.IFoo.Foo"/>
+        </type>
+    </assembly>
+</linker>

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtor/UnusedTypeHasInterfaceMethodPreservedViaXml.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtor/UnusedTypeHasInterfaceMethodPreservedViaXml.cs
@@ -1,0 +1,29 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoKeptCtor {
+	public class UnusedTypeHasInterfaceMethodPreservedViaXml {
+		public static void Main ()
+		{
+		}
+
+		interface IFoo {
+			void Foo ();
+		}
+
+		interface IBar {
+			void Bar ();
+		}
+
+		[Kept]
+		class A : IBar, IFoo {
+			[Kept]
+			public void Foo ()
+			{
+			}
+
+			public void Bar ()
+			{
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtor/UnusedTypeHasInterfaceMethodPreservedViaXml.xml
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtor/UnusedTypeHasInterfaceMethodPreservedViaXml.xml
@@ -1,0 +1,7 @@
+<linker>
+    <assembly fullname="test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+        <type fullname="Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoKeptCtor.UnusedTypeHasInterfaceMethodPreservedViaXml/A">
+            <method signature="System.Void Foo()"/>
+        </type>
+    </assembly>
+</linker>

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/UnusedExplicitInterfaceHasMethodPreservedViaXml.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/UnusedExplicitInterfaceHasMethodPreservedViaXml.cs
@@ -1,0 +1,39 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType {
+	public class UnusedExplicitInterfaceHasMethodPreservedViaXml {
+		public static void Main ()
+		{
+			IFoo i = new A ();
+			i.Foo ();
+		}
+
+		[Kept]
+		interface IFoo {
+			[Kept]
+			void Foo ();
+		}
+
+		[Kept]
+		interface IBar {
+			[Kept]
+			void Bar ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptInterface (typeof (IFoo))]
+		[KeptInterface (typeof (IBar))]
+		class A : IBar, IFoo {
+			[Kept]
+			void IFoo.Foo ()
+			{
+			}
+
+			[Kept]
+			void IBar.Bar ()
+			{
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/UnusedExplicitInterfaceHasMethodPreservedViaXml.xml
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/UnusedExplicitInterfaceHasMethodPreservedViaXml.xml
@@ -1,0 +1,5 @@
+<linker>
+    <assembly fullname="test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+        <type fullname="Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.UnusedExplicitInterfaceHasMethodPreservedViaXml/A" preserve="methods"/>
+    </assembly>
+</linker>

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/UnusedExplicitInterfaceIsRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/UnusedExplicitInterfaceIsRemoved.cs
@@ -1,0 +1,35 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType {
+	public class UnusedExplicitInterfaceIsRemoved {
+		public static void Main ()
+		{
+			IFoo i = new A ();
+			i.Foo ();
+		}
+
+		[Kept]
+		interface IFoo {
+			[Kept]
+			void Foo ();
+		}
+
+		interface IBar {
+			void Bar ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptInterface (typeof (IFoo))]
+		class A : IBar, IFoo {
+			[Kept]
+			void IFoo.Foo ()
+			{
+			}
+
+			void IBar.Bar ()
+			{
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnValueType/UnusedExplicitInterfaceIsRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnValueType/UnusedExplicitInterfaceIsRemoved.cs
@@ -1,0 +1,35 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnValueType {
+	public class UnusedExplicitInterfaceIsRemoved {
+		public static void Main ()
+		{
+			IFoo i = new A ();
+			i.Foo ();
+		}
+
+		[Kept]
+		interface IFoo {
+			[Kept]
+			void Foo ();
+		}
+
+		interface IBar {
+			void Bar ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptInterface (typeof (IFoo))]
+		struct A : IBar, IFoo {
+			[Kept]
+			void IFoo.Foo ()
+			{
+			}
+
+			void IBar.Bar ()
+			{
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -199,6 +199,7 @@
     <Compile Include="Inheritance.Interfaces\OnReferenceType\NoInstanceCtor\NoInstanceCtorAndTypePreserveMethodsWithInterfacesMarked.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\NoInstanceCtor\NoInstanceCtorAndTypePreserveNone.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtor\ComInterfaceTypeRemovedWhenOnlyUsedByClassWithOnlyStaticMethod.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtor\ExplicitInterfaceCanBeRemovedFromClassWithOnlyStaticMethodUsed.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtor\InterfaceCanBeRemovedFromClassWithOnlyStaticMethodUsed.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtor\InterfaceCanBeRemovedFromClassWithOnlyStaticMethodUsedWithCctor.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtor\InterfaceFromCopiedAssemblyCanBeRemoved.cs" />
@@ -208,11 +209,16 @@
     <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtor\UnusedTypeWithPreserveFields.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtor\UnusedTypeWithPreserveMethods.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtor\UnusedTypeWithPreserveMethodsAndInterfaceTypeMarked.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtor\UnusedTypeHasExplicitInterfacePropertyPreservedViaXml.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtor\UnusedTypeHasExplicitInterfaceMethodPreservedViaXml.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtor\UnusedTypeHasInterfaceMethodPreservedViaXml.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\ObjectCastedToSecondInterfaceHasMemberRemovedButInterfaceKept.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\ExplicitInterfaceMethodWhichCreatesInstanceOfParentType.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\TypeGetsMarkedThatImplementsAlreadyMarkedInterfaceMethod.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\UnusedComInterfaceIsKept.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\UnusedComInterfaceIsRemovedWhenComFeatureExcluded.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\UnusedExplicitInterfaceHasMethodPreservedViaXml.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\UnusedExplicitInterfaceIsRemoved.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\UnusedInterfaceTypeIsRemoved.cs" />
     <Compile Include="Inheritance.Interfaces\OnValueType\NoKeptCtor\InterfaceCanBeRemovedFromClassWithOnlyStaticMethodUsed.cs" />
     <Compile Include="Inheritance.Interfaces\OnValueType\NoKeptCtor\InterfaceCanBeRemovedFromClassWithOnlyStaticMethodUsedWithCctor.cs" />
@@ -223,6 +229,7 @@
     <Compile Include="Inheritance.Interfaces\OnValueType\StructUsedFromConcreteTypeHasInterfaceMethodRemoved.cs" />
     <Compile Include="Inheritance.Interfaces\OnValueType\StructUsedFromConcreteTypeHasInterfaceMethodRemoved2.cs" />
     <Compile Include="Inheritance.Interfaces\OnValueType\StructUsedFromInterfaceHasInterfaceMethodKept.cs" />
+    <Compile Include="Inheritance.Interfaces\OnValueType\UnusedExplicitInterfaceIsRemoved.cs" />
     <Compile Include="Inheritance.Interfaces\OnValueType\UnusedInterfaceTypeIsRemoved.cs" />
     <Compile Include="Inheritance.VirtualMethods\HarderToDetectUnusedVirtualMethodGetsRemoved.cs" />
     <Compile Include="Inheritance.VirtualMethods\UnusedTypeWithOverrideOfVirtualMethodIsRemoved.cs" />
@@ -459,6 +466,10 @@
   <ItemGroup>
     <Content Include="Attributes\OnlyKeepUsed\Dependencies\AssemblyWithUnusedAttributeOnReturnParameterDefinition.il" />
     <Content Include="Attributes\OnlyKeepUsed\UnusedAttributePreservedViaLinkXmlIsKept.xml" />
+    <Content Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtor\UnusedTypeHasExplicitInterfaceMethodPreservedViaXml.xml" />
+    <Content Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtor\UnusedTypeHasExplicitInterfacePropertyPreservedViaXml.xml" />
+    <Content Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtor\UnusedTypeHasInterfaceMethodPreservedViaXml.xml" />
+    <Content Include="Inheritance.Interfaces\OnReferenceType\UnusedExplicitInterfaceHasMethodPreservedViaXml.xml" />
     <Content Include="Inheritance.Interfaces\OnReferenceType\NoInstanceCtor\Dependencies\NoInstanceCtorAndAssemblyPreserveAll_Lib.il" />
     <Content Include="Inheritance.Interfaces\OnReferenceType\NoInstanceCtor\NoInstanceCtorAndAssemblyPreserveAll.xml" />
     <Content Include="Inheritance.Interfaces\OnReferenceType\NoInstanceCtor\NoInstanceCtorAndTypePreserveAll.xml" />


### PR DESCRIPTION
If a type somehow (ex: via link.xml) has an explicit interface member marked, then we need to mark the interface implementation for that member.  Otherwise you end up with invalid IL.

The new tests that reproduced the bug were

`UnusedTypeHasExplicitInterfaceMethodPreservedViaXml `
`UnusedTypeHasExplicitInterfacePropertyPreservedViaXml `

The other tests in this PR were added to fill out coverage of expected behavior with explicitly implemented interfaces