### PR TITLE
Hack to address tracing of interface implemtnations

### DIFF
--- a/linker/Linker/Tracer.cs
+++ b/linker/Linker/Tracer.cs
@@ -176,6 +176,12 @@ namespace Mono.Linker
 			if (context.EnableReducedTracing && pair.Key is MarkStep && !ShouldRecord (pair.Value))
 				return;
 
+			// This is another hack to prevent useless information from being logged.  With the introduction of interface sweeping there are a lot of edges such as
+			// `e="InterfaceImpl:Mono.Cecil.InterfaceImplementation"` which are useless information.  Ideally we would format the interface implementation into a meaningful format
+			// however I don't think that is worth the effort at the moment.
+			if (pair.Value is InterfaceImplementation)
+				return;
+
 			if (pair.Key != pair.Value) {
 				writer.WriteStartElement ("edge");
 				if (marked)


### PR DESCRIPTION
The interface sweeping PR https://github.com/mono/linker/pull/394 introduced some useless information to the dependencies xml.  More detailed explanation here https://github.com/mono/linker/pull/394#issuecomment-434427588

Another PR https://github.com/mono/linker/pull/411 to fix a bug results in another 250+ entries being added with the same useless information.

```
<edge mark="1" b="Method:System.UInt32 System.UInt16::System.IConvertible.ToUInt32(System.IFormatProvider)" e="InterfaceImpl:Mono.Cecil.InterfaceImplementation" />
	<edge mark="1" b="Method:System.Int64 System.UInt16::System.IConvertible.ToInt64(System.IFormatProvider)" e="InterfaceImpl:Mono.Cecil.InterfaceImplementation" />
	<edge mark="1" b="Method:System.UInt64 System.UInt16::System.IConvertible.ToUInt64(System.IFormatProvider)" e="InterfaceImpl:Mono.Cecil.InterfaceImplementation" />
	<edge mark="1" b="Method:System.Single System.UInt16::System.IConvertible.ToSingle(System.IFormatProvider)" e="InterfaceImpl:Mono.Cecil.InterfaceImplementation" />
	<edge mark="1" b="Method:System.Double System.UInt16::System.IConvertible.ToDouble(System.IFormatProvider)" e="InterfaceImpl:Mono.Cecil.InterfaceImplementation" />
```

I don't think it's worth the time to improve the recording of this information and with that bug fix PR the number of useless elements becomes too high.  Let's just not log these for now.