### PR TITLE
Fix an edge case with interface sweeping, no instance ctor, and preserve all

### DIFF
--- a/linker/Linker.Steps/MarkStep.cs
+++ b/linker/Linker.Steps/MarkStep.cs
@@ -105,6 +105,12 @@ namespace Mono.Linker.Steps {
 
 			MarkType (type);
 
+			// Edge case to cover a scenario where a type has preserve all, implements interfaces, but does not have any instance ctors.
+			// Normally TypePreserve.All would cause an instance ctor to be marked and that would in turn lead to MarkInterfaceImplementations being called
+			// Without an instance ctor, MarkInterfaceImplementations is not called and then TypePreserve.All isn't truly respected.
+			if (Annotations.TryGetPreserve (type, out TypePreserve preserve) && preserve == TypePreserve.All)
+				MarkInterfaceImplementations (type);
+
 			if (type.HasFields)
 				InitializeFields (type);
 			if (type.HasMethods)

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/Dependencies/NoInstanceCtorAndAssemblyPreserveAll_Lib.il
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/Dependencies/NoInstanceCtorAndAssemblyPreserveAll_Lib.il
@@ -1,0 +1,68 @@
+﻿.assembly extern mscorlib
+{
+}
+.assembly 'library'
+{
+  .hash algorithm 0x00008004
+  .ver 0:0:0:0
+}
+.module 'library.dll'
+
+
+// =============== CLASS MEMBERS DECLARATION ===================
+
+.class public auto ansi beforefieldinit Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib
+       extends [mscorlib]System.Object
+{
+  .class interface abstract auto ansi nested public IFoo
+  {
+    .method public hidebysig newslot abstract virtual 
+            instance void  Foo() cil managed
+    {
+    } // end of method IFoo::Foo
+
+  } // end of class IFoo
+
+  .class interface abstract auto ansi nested public IBar
+  {
+    .method public hidebysig newslot abstract virtual 
+            instance void  Bar() cil managed
+    {
+    } // end of method IBar::Bar
+
+  } // end of class IBar
+
+  .class auto ansi nested private beforefieldinit A
+         extends [mscorlib]System.Object
+         implements Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/IBar,
+                    Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/IFoo
+  {
+    .method public hidebysig newslot virtual final 
+            instance void  Foo() cil managed
+    {
+      // Code size       1 (0x1)
+      .maxstack  8
+      IL_0000:  ret
+    } // end of method A::Foo
+
+    .method public hidebysig newslot virtual final 
+            instance void  Bar() cil managed
+    {
+      // Code size       1 (0x1)
+      .maxstack  8
+      IL_0000:  ret
+    } // end of method A::Bar
+
+  } // end of class A
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  ret
+  }
+
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndAssemblyPreserveAll.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndAssemblyPreserveAll.cs
@@ -1,0 +1,27 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor
+{
+	[SetupCompileBefore ("library.dll", new [] { "Dependencies/NoInstanceCtorAndAssemblyPreserveAll_Lib.il" })]
+	[KeptInterfaceOnTypeInAssemblyAttribute ("library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A",
+		"library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/IFoo")]
+	[KeptInterfaceOnTypeInAssemblyAttribute ("library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A",
+		"library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/IBar")]
+	[KeptMemberInAssembly ("library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A",
+		"Foo()")]
+	[KeptMemberInAssembly ("library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A",
+		"Bar()")]
+	public class NoInstanceCtorAndAssemblyPreserveAll
+	{
+		public static void Main ()
+		{
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndAssemblyPreserveAll.xml
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndAssemblyPreserveAll.xml
@@ -1,0 +1,3 @@
+<linker>
+    <assembly fullname="library, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null" preserve="all"/>
+</linker>

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveAll.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveAll.cs
@@ -1,0 +1,25 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor {
+	[SetupCompileBefore ("library.dll", new [] { "Dependencies/NoInstanceCtorAndAssemblyPreserveAll_Lib.il" })]
+	[KeptInterfaceOnTypeInAssembly ("library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A",
+		"library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/IFoo")]
+	[KeptInterfaceOnTypeInAssemblyAttribute ("library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A",
+		"library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/IBar")]
+	[KeptMemberInAssembly ("library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A",
+		"Foo()")]
+	[KeptMemberInAssembly ("library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A",
+		"Bar()")]
+	public class NoInstanceCtorAndTypePreserveAll {
+		public static void Main ()
+		{
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveAll.xml
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveAll.xml
@@ -1,0 +1,5 @@
+<linker>
+    <assembly fullname="library, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+        <type fullname="Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A" preserve="all"/>
+    </assembly>
+</linker>

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveFields.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveFields.cs
@@ -1,0 +1,35 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor {
+	[SetupCompileBefore ("library.dll", new [] { "Dependencies/NoInstanceCtorAndAssemblyPreserveAll_Lib.il" })]
+
+	// The interfaces should be removed because the interface types are not marked
+	[RemovedInterfaceOnTypeInAssembly ("library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A",
+		"library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/IFoo")]
+	[RemovedInterfaceOnTypeInAssemblyAttribute ("library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A",
+		"library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/IBar")]
+
+	[RemovedMemberInAssembly ("library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A",
+		"Foo()")]
+	[RemovedMemberInAssembly ("library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A",
+		"Bar()")]
+	
+	// pedump reports this is valid with the following error.
+	//
+	// Assertion at metadata.c:1073, condition `index < meta->heap_blob.size' not met
+	//
+	// Not worried about it since this is already a niche edge case.  Let's just skip verify for pedump
+	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
+	public class NoInstanceCtorAndTypePreserveFields {
+		public static void Main ()
+		{
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveFields.xml
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveFields.xml
@@ -1,0 +1,5 @@
+<linker>
+    <assembly fullname="library, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+        <type fullname="Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A" preserve="fields"/>
+    </assembly>
+</linker>

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveFieldsWithInterfacesMarked.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveFieldsWithInterfacesMarked.cs
@@ -1,0 +1,41 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor {
+	[Define("IL_ASSEMBLY_COMPILED")]
+	[SetupCompileBefore ("library.dll", new [] { "Dependencies/NoInstanceCtorAndAssemblyPreserveAll_Lib.il" })]
+
+	// Interfaces should be removed because preserve fields would not normally cause an instance ctor to be marked.  This means that no instance ctor
+	// sweeping logic should kick in and remove interfaces
+	[RemovedInterfaceOnTypeInAssembly ("library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A",
+		"library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/IFoo")]
+	[RemovedInterfaceOnTypeInAssemblyAttribute ("library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A",
+		"library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/IBar")]
+
+	// Methods are removed because we only preserved fields
+	[RemovedMemberInAssembly ("library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A",
+		"Foo()")]
+	[RemovedMemberInAssembly ("library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A",
+		"Bar()")]
+	
+	// pedump reports this is valid with the following error.
+	//
+	// Assertion at metadata.c:1073, condition `index < meta->heap_blob.size' not met
+	//
+	// Not worried about it since this is already a niche edge case.  Let's just skip verify for pedump
+	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
+	public class NoInstanceCtorAndTypePreserveFieldsWithInterfacesMarked {
+		public static void Main ()
+		{
+#if IL_ASSEMBLY_COMPILED
+			var tmp = typeof (Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib.IFoo).ToString ();
+#endif
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveFieldsWithInterfacesMarked.xml
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveFieldsWithInterfacesMarked.xml
@@ -1,0 +1,6 @@
+<linker>
+    <assembly fullname="library, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+        <type fullname="Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A" preserve="fields"/>
+        <type fullname="Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/IBar" preserve="none"/>
+    </assembly>
+</linker>

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveMethods.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveMethods.cs
@@ -1,0 +1,29 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor {
+	[SetupCompileBefore ("library.dll", new [] { "Dependencies/NoInstanceCtorAndAssemblyPreserveAll_Lib.il" })]
+
+	// The interfaces should be removed because the interface types are not marked
+	[RemovedInterfaceOnTypeInAssembly ("library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A",
+		"library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/IFoo")]
+	[RemovedInterfaceOnTypeInAssemblyAttribute ("library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A",
+		"library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/IBar")]
+
+	// Methods should be kept because of the preserve methods
+	[KeptMemberInAssembly ("library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A",
+		"Foo()")]
+	[KeptMemberInAssembly ("library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A",
+		"Bar()")]
+	public class NoInstanceCtorAndTypePreserveMethods {
+		public static void Main ()
+		{
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveMethods.xml
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveMethods.xml
@@ -1,0 +1,5 @@
+<linker>
+    <assembly fullname="library, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+        <type fullname="Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A" preserve="methods"/>
+    </assembly>
+</linker>

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveMethodsWithInterfacesMarked.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveMethodsWithInterfacesMarked.cs
@@ -1,0 +1,35 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor {
+	[Define("IL_ASSEMBLY_COMPILED")]
+	[SetupCompileBefore ("library.dll", new [] { "Dependencies/NoInstanceCtorAndAssemblyPreserveAll_Lib.il" })]
+
+	// Interfaces will be removed because there is no instance ctor that is marked.
+	[RemovedInterfaceOnTypeInAssembly ("library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A",
+		"library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/IFoo")]
+	[RemovedInterfaceOnTypeInAssemblyAttribute ("library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A",
+		"library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/IBar")]
+
+	// Methods should be kept because of the preserve methods
+	[KeptMemberInAssembly ("library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A",
+		"Foo()")]
+	[KeptMemberInAssembly ("library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A",
+		"Bar()")]
+	public class NoInstanceCtorAndTypePreserveMethodsWithInterfacesMarked
+	{
+		public static void Main()
+		{
+			// We'll mark one interface in code and one via xml, the end result should be the same
+#if IL_ASSEMBLY_COMPILED
+			var tmp = typeof (Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib.IFoo).ToString ();
+#endif
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveMethodsWithInterfacesMarked.xml
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveMethodsWithInterfacesMarked.xml
@@ -1,0 +1,6 @@
+<linker>
+    <assembly fullname="library, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+        <type fullname="Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A" preserve="methods"/>
+        <type fullname="Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/IBar" preserve="none"/>
+    </assembly>
+</linker>

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveNone.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveNone.cs
@@ -1,0 +1,25 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor {
+	[SetupCompileBefore ("library.dll", new [] { "Dependencies/NoInstanceCtorAndAssemblyPreserveAll_Lib.il" })]
+	[RemovedInterfaceOnTypeInAssembly ("library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A",
+		"library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/IFoo")]
+	[RemovedInterfaceOnTypeInAssemblyAttribute ("library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A",
+		"library",
+		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/IBar")]
+	// pedump reports this is valid with the following error.
+	//
+	// Assertion at metadata.c:1073, condition `index < meta->heap_blob.size' not met
+	//
+	// Not worried about it since this is already a niche edge case.  Let's just skip verify for pedump
+	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
+	public class NoInstanceCtorAndTypePreserveNone {
+		public static void Main ()
+		{
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveNone.xml
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveNone.xml
@@ -1,0 +1,5 @@
+<linker>
+    <assembly fullname="library, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+        <type fullname="Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A" preserve="none"/>
+    </assembly>
+</linker>

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -191,6 +191,13 @@
     <Compile Include="Inheritance.Interfaces\OnReferenceType\InterfaceUsedOnlyAsConstraintIsKept.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\InterfaceWithInterfaceFromOtherAssemblyWhenExplicitMethodUsed.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\InterfaceTypeOnlyUsedHasInterfacesRemoved.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\NoInstanceCtor\NoInstanceCtorAndAssemblyPreserveAll.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\NoInstanceCtor\NoInstanceCtorAndTypePreserveAll.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\NoInstanceCtor\NoInstanceCtorAndTypePreserveFields.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\NoInstanceCtor\NoInstanceCtorAndTypePreserveFieldsWithInterfacesMarked.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\NoInstanceCtor\NoInstanceCtorAndTypePreserveMethods.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\NoInstanceCtor\NoInstanceCtorAndTypePreserveMethodsWithInterfacesMarked.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\NoInstanceCtor\NoInstanceCtorAndTypePreserveNone.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtor\ComInterfaceTypeRemovedWhenOnlyUsedByClassWithOnlyStaticMethod.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtor\InterfaceCanBeRemovedFromClassWithOnlyStaticMethodUsed.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtor\InterfaceCanBeRemovedFromClassWithOnlyStaticMethodUsedWithCctor.cs" />
@@ -449,6 +456,14 @@
   <ItemGroup>
     <Content Include="Attributes\OnlyKeepUsed\Dependencies\AssemblyWithUnusedAttributeOnReturnParameterDefinition.il" />
     <Content Include="Attributes\OnlyKeepUsed\UnusedAttributePreservedViaLinkXmlIsKept.xml" />
+    <Content Include="Inheritance.Interfaces\OnReferenceType\NoInstanceCtor\Dependencies\NoInstanceCtorAndAssemblyPreserveAll_Lib.il" />
+    <Content Include="Inheritance.Interfaces\OnReferenceType\NoInstanceCtor\NoInstanceCtorAndAssemblyPreserveAll.xml" />
+    <Content Include="Inheritance.Interfaces\OnReferenceType\NoInstanceCtor\NoInstanceCtorAndTypePreserveAll.xml" />
+    <Content Include="Inheritance.Interfaces\OnReferenceType\NoInstanceCtor\NoInstanceCtorAndTypePreserveFields.xml" />
+    <Content Include="Inheritance.Interfaces\OnReferenceType\NoInstanceCtor\NoInstanceCtorAndTypePreserveFieldsWithInterfacesMarked.xml" />
+    <Content Include="Inheritance.Interfaces\OnReferenceType\NoInstanceCtor\NoInstanceCtorAndTypePreserveMethods.xml" />
+    <Content Include="Inheritance.Interfaces\OnReferenceType\NoInstanceCtor\NoInstanceCtorAndTypePreserveMethodsWithInterfacesMarked.xml" />
+    <Content Include="Inheritance.Interfaces\OnReferenceType\NoInstanceCtor\NoInstanceCtorAndTypePreserveNone.xml" />
     <Content Include="Inheritance.Interfaces\OnReferenceType\InterfaceMarkOrderingDoesNotMatter.xml" />
     <Content Include="Inheritance.Interfaces\OnReferenceType\InterfaceMarkOrderingDoesNotMatter2.xml" />
     <Content Include="Inheritance.Interfaces\OnReferenceType\InterfaceMarkOrderingDoesNotMatter3.xml" />


### PR DESCRIPTION
When a type has TypePreserve.All it should retain all of it's interfaces.  This was not happening when the type had no instance constructors.  This is a rare border line invalid edge cases, however, we ran into it and PEVerify says the assembly is valid even though the type has no instance constructors.

This PR adds a check during `InitializeType` to ensure this scenario is handled

Note : This branch won't compile until the following open PR's land

https://github.com/mono/linker/pull/407
https://github.com/mono/linker/pull/406
