### PR TITLE
Add attributes for asserting changes to method bodies

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/ExpectBodyModifiedAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/ExpectBodyModifiedAttribute.cs
@@ -1,0 +1,7 @@
+using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Assertions {
+	[AttributeUsage (AttributeTargets.Method | AttributeTargets.Constructor, Inherited = false, AllowMultiple = false)]
+	public class ExpectBodyModifiedAttribute : BaseInAssemblyAttribute {
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/ExpectExceptionHandlersModifiedAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/ExpectExceptionHandlersModifiedAttribute.cs
@@ -1,0 +1,7 @@
+using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Assertions {
+	[AttributeUsage (AttributeTargets.Method | AttributeTargets.Constructor, Inherited = false, AllowMultiple = false)]
+	public class ExpectExceptionHandlersModifiedAttribute : BaseInAssemblyAttribute {
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/ExpectLocalsModifiedAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/ExpectLocalsModifiedAttribute.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Assertions
+{
+	[AttributeUsage (AttributeTargets.Method | AttributeTargets.Constructor, Inherited = false, AllowMultiple = false)]
+	public class ExpectLocalsModifiedAttribute : BaseInAssemblyAttribute {
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/ExpectedExceptionHandlerSequenceAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/ExpectedExceptionHandlerSequenceAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Assertions {
+	[AttributeUsage (AttributeTargets.Method | AttributeTargets.Constructor, Inherited = false, AllowMultiple = false)]
+	public class ExpectedExceptionHandlerSequenceAttribute : BaseInAssemblyAttribute {
+		public ExpectedExceptionHandlerSequenceAttribute (string[] types)
+		{
+			if (types == null)
+				throw new ArgumentNullException ();
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/ExpectedInstructionSequenceAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/ExpectedInstructionSequenceAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Assertions {
+	[AttributeUsage (AttributeTargets.Method | AttributeTargets.Constructor, Inherited = false, AllowMultiple = false)]
+	public class ExpectedInstructionSequenceAttribute : BaseInAssemblyAttribute {
+		public ExpectedInstructionSequenceAttribute (string[] opCodes)
+		{
+			if (opCodes == null)
+				throw new ArgumentNullException ();
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/ExpectedLocalsSequenceAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/ExpectedLocalsSequenceAttribute.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Assertions {
+	[AttributeUsage (AttributeTargets.Method | AttributeTargets.Constructor, Inherited = false, AllowMultiple = false)]
+	public class ExpectedLocalsSequenceAttribute : BaseInAssemblyAttribute {
+		public ExpectedLocalsSequenceAttribute (string [] types)
+		{
+			if (types == null)
+				throw new ArgumentNullException ();
+		}
+
+		public ExpectedLocalsSequenceAttribute (Type [] types)
+		{
+			if (types == null)
+				throw new ArgumentNullException ();
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
@@ -38,6 +38,12 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Assertions\BaseInAssemblyAttribute.cs" />
+    <Compile Include="Assertions\ExpectBodyModifiedAttribute.cs" />
+    <Compile Include="Assertions\ExpectedExceptionHandlerSequenceAttribute.cs" />
+    <Compile Include="Assertions\ExpectedInstructionSequenceAttribute.cs" />
+    <Compile Include="Assertions\ExpectedLocalsSequenceAttribute.cs" />
+    <Compile Include="Assertions\ExpectExceptionHandlersModifiedAttribute.cs" />
+    <Compile Include="Assertions\ExpectLocalsModifiedAttribute.cs" />
     <Compile Include="Assertions\IgnoreTestCaseAttribute.cs" />
     <Compile Include="Assertions\KeptAllTypesAndMembersInAssemblyAttribute.cs" />
     <Compile Include="Assertions\KeptAssemblyAttribute.cs" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/BCLFeatures/ETW/BaseRemovedEventSource.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/BCLFeatures/ETW/BaseRemovedEventSource.cs
@@ -30,17 +30,35 @@ namespace Mono.Linker.Tests.Cases.BCLFeatures.ETW {
 		public static CustomCtorEventSource Log = new MyEventSourceBasedOnCustomCtorEventSource (1);
 
 		[Kept]
+		[ExpectedInstructionSequence (new []
+		{
+			"ldarg.0",
+			"call",
+			"ret",
+		})]
 		public CustomCtorEventSource (int value)
 		{
 			Removed ();
 		}
 
 		[Kept]
+		[ExpectedInstructionSequence (new []
+		{
+			"ldstr",
+			"newobj",
+			"throw",
+		})]
 		protected override void OnEventCommand (EventCommandEventArgs command)
 		{
 		}
 
 		[Kept]
+		[ExpectedInstructionSequence (new []
+		{
+			"ldstr",
+			"newobj",
+			"throw",
+		})]
 		[Event (8)]
 		public void SomeMethod ()
 		{

--- a/linker/Tests/Mono.Linker.Tests.Cases/BCLFeatures/ETW/LocalsOfModifiedMethodAreRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/BCLFeatures/ETW/LocalsOfModifiedMethodAreRemoved.cs
@@ -1,0 +1,63 @@
+using System.Diagnostics.Tracing;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.BCLFeatures.ETW {
+	[SetupLinkerArgument ("--exclude-feature", "etw")]
+	public class LocalsOfModifiedMethodAreRemoved {
+		public static void Main ()
+		{
+			var b = LocalsAreCleared_RemovedEventSource.Log.IsEnabled ();
+			if (b)
+				LocalsAreCleared_RemovedEventSource.Log.SomeMethod ();
+		}
+
+		public class ClassForLocal {
+		}
+
+		public static void CallsToForceALocal (int arg1, int arg2, int arg3)
+		{
+		}
+	}
+	
+	[Kept]
+	[KeptBaseType (typeof (EventSource))]
+	[KeptMember (".ctor()")]
+	[KeptMember (".cctor()")]
+	[EventSource (Name = "MyCompany")]
+	class LocalsAreCleared_RemovedEventSource : EventSource {
+		public class Keywords {
+			public const EventKeywords Page = (EventKeywords)1;
+
+			public int Unused;
+		}
+
+		[Kept]
+		public static LocalsAreCleared_RemovedEventSource Log = new LocalsAreCleared_RemovedEventSource ();
+
+		[Kept]
+		[ExpectBodyModified]
+		[ExpectedLocalsSequence (new string[0])]
+		protected override void OnEventCommand (EventCommandEventArgs command)
+		{
+			// Do some extra stuff to be extra certain the compiler introduced a local instead of using `dup`
+			var tmp = new LocalsOfModifiedMethodAreRemoved.ClassForLocal ();
+			LocalsOfModifiedMethodAreRemoved.CallsToForceALocal (1, 3, 4);
+			LocalsOfModifiedMethodAreRemoved.CallsToForceALocal (1, 4, 4);
+			var hashcode = tmp.GetHashCode ();
+			LocalsOfModifiedMethodAreRemoved.CallsToForceALocal(1, hashcode, 3);
+		}
+
+		[Kept]
+		[Event (8)]
+		[ExpectBodyModified]
+		public void SomeMethod ()
+		{
+			Removed ();
+		}
+
+		public void Removed ()
+		{
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/BCLFeatures/ETW/NonEventWithLog.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/BCLFeatures/ETW/NonEventWithLog.cs
@@ -29,6 +29,12 @@ namespace Mono.Linker.Tests.Cases.BCLFeatures.ETW {
 		}
 
 		[Kept]
+		[ExpectedInstructionSequence (new []
+		{
+			"ldstr",
+			"newobj",
+			"throw",
+		})]
 		private void Test2 ()
 		{
 			Console.WriteLine ();

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -168,6 +168,8 @@
     <Compile Include="Basic\UsedEventOnInterfaceIsRemovedWhenUsedFromClass.cs" />
     <Compile Include="Basic\UsedPropertyIsKept.cs" />
     <Compile Include="Basic\UsedStructIsKept.cs" />
+    <Compile Include="BCLFeatures\ETW\LocalsOfModifiedMethodAreRemoved.cs" />
+    <Compile Include="BCLFeatures\ETW\StubbedMethodWithExceptionHandlers.cs" />
     <Compile Include="CoreLink\CanIncludeI18nAssemblies.cs" />
     <Compile Include="CoreLink\NoSecurityPlusOnlyKeepUsedRemovesAllSecurityAttributesFromCoreLibraries.cs" />
     <Compile Include="Inheritance.AbstractClasses\UnusedAbstractMethodRemoved.cs" />
@@ -375,6 +377,7 @@
     <Compile Include="TestFramework\VerifyAttributesInAssemblyWorksWithStrings.cs" />
     <Compile Include="TestFramework\VerifyDefineAttributeBehavior.cs" />
     <None Include="TypeForwarding\Dependencies\ForwarderLibrary.cs" />
+    <Compile Include="TestFramework\VerifyExpectModifiedAttributesWork.cs" />
     <Compile Include="TestFramework\VerifyResourceInAssemblyAttributesBehavior.cs" />
     <Compile Include="Tracing\Individual\CanDumpDependenciesToUncompressedXml.cs" />
     <Compile Include="Tracing\Individual\CanEnableDependenciesDump.cs" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/TestFramework/VerifyExpectModifiedAttributesWork.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/TestFramework/VerifyExpectModifiedAttributesWork.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Diagnostics.Tracing;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.TestFramework {
+	/// <summary>
+	/// This test is here to give some coverage to the attribute to ensure it doesn't break.  We need to leverage the ETW feature since it is the only
+	/// one that modifies bodies currently
+	/// </summary>
+	[SetupLinkerArgument ("--exclude-feature", "etw")]
+	public class VerifyExpectModifiedAttributesWork {
+		public static void Main ()
+		{
+			var b = VerifyExpectModifiedAttributesWork_RemovedEventSource.Log.IsEnabled ();
+			if (b)
+				VerifyExpectModifiedAttributesWork_RemovedEventSource.Log.SomeMethod ();
+		}
+		
+		public class ClassForLocal {
+		}
+
+		public static void CallsToForceALocal (int arg1, int arg2, int arg3)
+		{
+		}
+	}
+	
+	[Kept]
+	[KeptBaseType (typeof (EventSource))]
+	[KeptMember (".ctor()")]
+	[KeptMember (".cctor()")]
+	[EventSource (Name = "MyCompany")]
+	class VerifyExpectModifiedAttributesWork_RemovedEventSource : EventSource {
+		public class Keywords {
+			public const EventKeywords Page = (EventKeywords)1;
+
+			public int Unused;
+		}
+
+		[Kept]
+		public static VerifyExpectModifiedAttributesWork_RemovedEventSource Log = new VerifyExpectModifiedAttributesWork_RemovedEventSource ();
+
+		[Kept]
+		[ExpectBodyModified]
+		[ExpectExceptionHandlersModified]
+		[ExpectLocalsModified]
+		protected override void OnEventCommand (EventCommandEventArgs command)
+		{
+			try {
+				// Do some extra stuff to be extra certain the compiler introduced a local instead of using `dup`
+				var tmp = new VerifyExpectModifiedAttributesWork.ClassForLocal ();
+				VerifyExpectModifiedAttributesWork.CallsToForceALocal (1, 3, 4);
+				VerifyExpectModifiedAttributesWork.CallsToForceALocal (1, 4, 4);
+				var hashcode = tmp.GetHashCode ();
+				VerifyExpectModifiedAttributesWork.CallsToForceALocal(1, hashcode, 3);
+			} catch {
+				try {
+					Removed ();
+				} catch {
+					var tmp = new VerifyExpectModifiedAttributesWork.ClassForLocal ();
+					VerifyExpectModifiedAttributesWork.CallsToForceALocal (1, 3, 4);
+					VerifyExpectModifiedAttributesWork.CallsToForceALocal (1, 4, 4);
+					var hashcode = tmp.GetHashCode ();
+					VerifyExpectModifiedAttributesWork.CallsToForceALocal(1, hashcode, 3);
+					throw;
+				}
+				throw;
+			}
+		}
+
+		[Kept]
+		[Event (8)]
+		[ExpectBodyModified]
+		public void SomeMethod ()
+		{
+			Removed ();
+		}
+
+		public void Removed ()
+		{
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.csproj
+++ b/linker/Tests/Mono.Linker.Tests.csproj
@@ -81,6 +81,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="TestCasesRunner\CompilerOptions.cs" />
+    <Compile Include="TestCasesRunner\FormattingUtils.cs" />
     <Compile Include="TestCasesRunner\ILCompiler.cs" />
     <Compile Include="TestCasesRunner\SourceAndDestinationPair.cs" />
     <Compile Include="TestCasesRunner\SetupCompileInfo.cs" />

--- a/linker/Tests/TestCasesRunner/FormattingUtils.cs
+++ b/linker/Tests/TestCasesRunner/FormattingUtils.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Mono.Linker.Tests.TestCasesRunner {
+	public static class FormattingUtils {
+		public static string FormatSequenceCompareFailureMessage (IEnumerable<string> actual, IEnumerable<string> expected)
+		{
+			var builder = new StringBuilder ();
+			builder.AppendLine ("---------------");
+			builder.AppendLine ($"Expected/Original (Total : {expected.Count ()})");
+			builder.AppendLine ("---------------");
+			// Format in a quoted array form for easier copying into a expected sequence attribute
+			builder.AppendLine (expected.Select (c => $"\"{c}\",").AggregateWithNewLine ());
+			builder.AppendLine ("---------------");
+			builder.AppendLine ($"Actual/Linked (Total : {actual.Count ()})");
+			builder.AppendLine ("---------------");
+			// Format in a quoted array form for easier copying into a expected sequence attribute
+			builder.AppendLine (actual.Select(c => $"\"{c}\",").AggregateWithNewLine ());
+			builder.AppendLine ("---------------");
+			return builder.ToString ();
+		}
+
+		public static string FormatSequenceCompareFailureMessage2 (IEnumerable<string> actual, IEnumerable<string> expected, IEnumerable<string> original)
+		{
+			var builder = new StringBuilder ();
+			builder.AppendLine ("---------------");
+			builder.AppendLine ($"Expected (Total : {expected.Count ()})");
+			builder.AppendLine ("---------------");
+			// Format in a quoted array form for easier copying into a expected sequence attribute
+			builder.AppendLine (expected.Select(c => $"\"{c}\",").AggregateWithNewLine ());
+			builder.AppendLine ("---------------");
+			builder.AppendLine ($"Actual/Linked (Total : {actual.Count ()})");
+			builder.AppendLine ("---------------");
+			// Format in a quoted array form for easier copying into a expected sequence attribute
+			builder.AppendLine (actual.Select(c => $"\"{c}\",").AggregateWithNewLine ());
+			builder.AppendLine ("---------------");
+			builder.AppendLine ($"Original (Total : {original.Count()})");
+			builder.AppendLine ("---------------");
+			// Format in a quoted array form for easier copying into a expected sequence attribute
+			builder.AppendLine (original.Select(c => $"\"{c}\",").AggregateWithNewLine ());
+			builder.AppendLine ("---------------");
+			return builder.ToString ();
+		}
+		
+		private static string AggregateWithNewLine (this IEnumerable<string> elements)
+		{
+			return elements.AggregateWith (System.Environment.NewLine);
+		}
+
+		private static string AggregateWith (this IEnumerable<string> elements, string separator)
+		{
+			if (elements.Any ())
+				return elements.Aggregate ((buff, s) => buff + separator + s);
+
+			return string.Empty;
+		}
+	}
+}


### PR DESCRIPTION
This PR brings a handful of test framework attributes that we have had in the UnityLinker test framework for some time.  It adds support to the test framework for 

* Asserting instructions
* Asserting exception handlers
* Asserting locals

For each collection there are 2 attributes that can be used.  A sequence attribute which can be used for explicit checking.  These can become tedious to maintain and so you generally don't want to use them in any test that is concerned with testing something different.  For these cases there is a general, "expect the value to be different" attribute that you can use.

Also updates some ETW tests to take advantage of these new attributes.

Added new ETW tests for checking locals and exception handlers

