### PR TITLE
ETW test tweaks

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases/BCLFeatures/ETW/Excluded.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/BCLFeatures/ETW/Excluded.cs
@@ -5,6 +5,8 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.BCLFeatures.ETW {
 	[SetupLinkerArgument ("--exclude-feature", "etw")]
+	// Used to avoid different compilers generating different IL which can mess up the instruction asserts
+	[SetupCompileArgument ("/optimize+")]
 	public class Excluded 
 	{
 		public static void Main ()

--- a/linker/Tests/Mono.Linker.Tests.Cases/BCLFeatures/ETW/LocalsOfModifiedMethodAreRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/BCLFeatures/ETW/LocalsOfModifiedMethodAreRemoved.cs
@@ -4,6 +4,8 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.BCLFeatures.ETW {
 	[SetupLinkerArgument ("--exclude-feature", "etw")]
+	// Used to avoid different compilers generating different IL which can mess up the instruction asserts
+	[SetupCompileArgument ("/optimize+")]
 	public class LocalsOfModifiedMethodAreRemoved {
 		public static void Main ()
 		{

--- a/linker/Tests/Mono.Linker.Tests.Cases/BCLFeatures/ETW/NonEventWithLog.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/BCLFeatures/ETW/NonEventWithLog.cs
@@ -5,6 +5,8 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.BCLFeatures.ETW {
 	[SetupLinkerArgument ("--exclude-feature", "etw")]
+	// Used to avoid different compilers generating different IL which can mess up the instruction asserts
+	[SetupCompileArgument ("/optimize+")]
 	public class NonEventWithLog {
 		public static void Main ()
 		{

--- a/linker/Tests/Mono.Linker.Tests.Cases/BCLFeatures/ETW/StubbedMethodWithExceptionHandlers.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/BCLFeatures/ETW/StubbedMethodWithExceptionHandlers.cs
@@ -5,6 +5,8 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.BCLFeatures.ETW {
 	[SetupLinkerArgument ("--exclude-feature", "etw")]
+	// Used to avoid different compilers generating different IL which can mess up the instruction asserts
+	[SetupCompileArgument ("/optimize+")]
 	public class StubbedMethodWithExceptionHandlers {
 		public static void Main ()
 		{

--- a/linker/Tests/Mono.Linker.Tests.Cases/TestFramework/VerifyExpectModifiedAttributesWork.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/TestFramework/VerifyExpectModifiedAttributesWork.cs
@@ -9,6 +9,8 @@ namespace Mono.Linker.Tests.Cases.TestFramework {
 	/// one that modifies bodies currently
 	/// </summary>
 	[SetupLinkerArgument ("--exclude-feature", "etw")]
+	// Used to avoid different compilers generating different IL which can mess up the instruction asserts
+	[SetupCompileArgument ("/optimize+")]
 	public class VerifyExpectModifiedAttributesWork {
 		public static void Main ()
 		{


### PR DESCRIPTION
Compile the tests with /optimize+ to avoid different compilers, or slightly different compiler arguments, producing slightly different IL which can then lead to instruction change asserting differences.

The case I ran across was types such as `LocalsAreCleared_RemovedEventSource` are technically having their `.ctor()` instructions cleared.  We just didn't notice because we add back instructions with the same opcode.

For some reason our tests compiled with a noop in the body, so when the CodeRewriterStep rewrite the body the noop went away and the test failed.