### PR TITLE
Support finding test case source file when dot in top level dir name

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly.cs
@@ -9,7 +9,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.Attributes.Debugger {
 	[SetupLinkerCoreAction ("link")]
 	[SetupLinkerKeepDebugMembers ("false")]
-	[SetupCompileBefore ("library.dll", new [] { "Dependencies/DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly_Lib.cs" })]
+	[SetupCompileBefore ("library.dll", new [] { typeof (DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly_Lib) })]
 	
 	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168
 	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]


### PR DESCRIPTION
Dot's in the top level test directory name are becoming more common. 

Ex: `Attributes.Debugger`

 It would be helpful if finding the source file based on type worked in this case.