### PR TITLE
Add another GetType test

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -306,6 +306,7 @@
     <Compile Include="Reflection\PropertyUsedViaReflection.cs" />
     <Compile Include="Reflection\TypeUsedViaReflection.cs" />
     <Compile Include="Reflection\TypeUsedViaReflectionAssemblyDoesntExist.cs" />
+    <Compile Include="Reflection\TypeUsedViaReflectionInDifferentAssembly.cs" />
     <Compile Include="Reflection\TypeUsedViaReflectionLdstrIncomplete.cs" />
     <Compile Include="Reflection\TypeUsedViaReflectionLdstrValidButChanged.cs" />
     <Compile Include="Reflection\TypeUsedViaReflectionTypeDoesntExist.cs" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/Reflection/Dependencies/AssemblyDependency.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Reflection/Dependencies/AssemblyDependency.cs
@@ -7,5 +7,12 @@ namespace Mono.Linker.Tests.Cases.Reflection.Dependencies
 		public AssemblyDependency ()
 		{
 		}
+
+		public static void UsedToKeepReferenceAtCompileTime ()
+		{
+		}
+
+		class TypeThatIsUsedViaReflection {
+		}
 	}
 }

--- a/linker/Tests/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflectionInDifferentAssembly.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflectionInDifferentAssembly.cs
@@ -1,0 +1,23 @@
+using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Reflection.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.Reflection {
+	[SetupCompileBefore ("library.dll", new [] { "Dependencies/AssemblyDependency.cs" })]
+	[KeptAssembly ("library.dll")]
+	[KeptTypeInAssembly ("library.dll", "Mono.Linker.Tests.Cases.Reflection.Dependencies.AssemblyDependency/TypeThatIsUsedViaReflection")]
+	public class TypeUsedViaReflectionInDifferentAssembly {
+		public static void Main ()
+		{
+			AssemblyDependency.UsedToKeepReferenceAtCompileTime ();
+			Helper ();
+		}
+
+		[Kept]
+		static Type Helper ()
+		{
+			return Type.GetType ("Mono.Linker.Tests.Cases.Reflection.Dependencies.AssemblyDependency+TypeThatIsUsedViaReflection, library");
+		}
+	}
+}


### PR DESCRIPTION
I'm helping someone with a reflection usage that doesn't seem to be picked up.  We didn't have a test for their exact usage so I wanted to add one.  It works fine so the issue is something else, but I'd like to keep a test for this exact case since I think it's a common one.