### PR TITLE
Fix interface sweep bug with mix of copy and link assembly actions

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/Dependencies/InterfaceTypeInOtherUsedOnlyByCopiedAssemblyExplicit_Copy.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/Dependencies/InterfaceTypeInOtherUsedOnlyByCopiedAssemblyExplicit_Copy.cs
@@ -1,0 +1,13 @@
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.Dependencies {
+	public class InterfaceTypeInOtherUsedOnlyByCopiedAssemblyExplicit_Copy {
+		public static void ToKeepReferenceAtCompileTime ()
+		{
+		}
+		
+		public class A : InterfaceTypeInOtherUsedOnlyByCopiedAssemblyExplicit_Link.IFoo {
+			void InterfaceTypeInOtherUsedOnlyByCopiedAssemblyExplicit_Link.IFoo.Method ()
+			{
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/Dependencies/InterfaceTypeInOtherUsedOnlyByCopiedAssemblyExplicit_Link.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/Dependencies/InterfaceTypeInOtherUsedOnlyByCopiedAssemblyExplicit_Link.cs
@@ -1,0 +1,7 @@
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.Dependencies {
+	public class InterfaceTypeInOtherUsedOnlyByCopiedAssemblyExplicit_Link {
+		public interface IFoo {
+			void Method ();
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/Dependencies/InterfaceTypeInOtherUsedOnlyByCopiedAssembly_Copy.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/Dependencies/InterfaceTypeInOtherUsedOnlyByCopiedAssembly_Copy.cs
@@ -1,0 +1,13 @@
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.Dependencies {
+	public class InterfaceTypeInOtherUsedOnlyByCopiedAssembly_Copy {
+		public static void ToKeepReferenceAtCompileTime ()
+		{
+		}
+		
+		public class A : InterfaceTypeInOtherUsedOnlyByCopiedAssembly_Link.IFoo {
+			public void Method ()
+			{
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/Dependencies/InterfaceTypeInOtherUsedOnlyByCopiedAssembly_Link.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/Dependencies/InterfaceTypeInOtherUsedOnlyByCopiedAssembly_Link.cs
@@ -1,0 +1,7 @@
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.Dependencies {
+	public class InterfaceTypeInOtherUsedOnlyByCopiedAssembly_Link {
+		public interface IFoo {
+			void Method ();
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/InterfaceTypeInOtherUsedOnlyByCopiedAssembly.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/InterfaceTypeInOtherUsedOnlyByCopiedAssembly.cs
@@ -1,0 +1,21 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Inheritance.Interfaces.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType {
+	[SetupCompileBefore ("linked.dll", new [] {typeof (InterfaceTypeInOtherUsedOnlyByCopiedAssembly_Link)})]
+	[SetupCompileBefore ("copy.dll", new [] {typeof (InterfaceTypeInOtherUsedOnlyByCopiedAssembly_Copy)}, new [] {"linked.dll"})]
+
+	[SetupLinkerAction ("copy", "copy")]
+	[SetupLinkerArgument ("-a", "copy")]
+	
+	[KeptTypeInAssembly ("linked.dll", typeof (InterfaceTypeInOtherUsedOnlyByCopiedAssembly_Link.IFoo))]
+	[KeptMemberInAssembly ("copy.dll", typeof (InterfaceTypeInOtherUsedOnlyByCopiedAssembly_Copy.A), "Method()")]
+	[KeptInterfaceOnTypeInAssembly ("copy.dll", typeof (InterfaceTypeInOtherUsedOnlyByCopiedAssembly_Copy.A), "linked.dll", typeof (InterfaceTypeInOtherUsedOnlyByCopiedAssembly_Link.IFoo))]
+	public class InterfaceTypeInOtherUsedOnlyByCopiedAssembly {
+		public static void Main ()
+		{
+			InterfaceTypeInOtherUsedOnlyByCopiedAssembly_Copy.ToKeepReferenceAtCompileTime ();
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/InterfaceTypeInOtherUsedOnlyByCopiedAssemblyExplicit.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/InterfaceTypeInOtherUsedOnlyByCopiedAssemblyExplicit.cs
@@ -1,0 +1,21 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Inheritance.Interfaces.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType {
+	[SetupCompileBefore ("linked.dll", new [] {typeof (InterfaceTypeInOtherUsedOnlyByCopiedAssemblyExplicit_Link)})]
+	[SetupCompileBefore ("copy.dll", new [] {typeof (InterfaceTypeInOtherUsedOnlyByCopiedAssemblyExplicit_Copy)}, new [] {"linked.dll"})]
+
+	[SetupLinkerAction ("copy", "copy")]
+	[SetupLinkerArgument ("-a", "copy")]
+
+	[KeptMemberInAssembly ("linked.dll", typeof (InterfaceTypeInOtherUsedOnlyByCopiedAssemblyExplicit_Link.IFoo), "Method()")]
+	[KeptMemberInAssembly ("copy.dll", typeof (InterfaceTypeInOtherUsedOnlyByCopiedAssemblyExplicit_Copy.A), "Mono.Linker.Tests.Cases.Inheritance.Interfaces.Dependencies.InterfaceTypeInOtherUsedOnlyByCopiedAssemblyExplicit_Link.IFoo.Method()")]
+	[KeptInterfaceOnTypeInAssembly ("copy.dll", typeof (InterfaceTypeInOtherUsedOnlyByCopiedAssemblyExplicit_Copy.A), "linked.dll", typeof (InterfaceTypeInOtherUsedOnlyByCopiedAssemblyExplicit_Link.IFoo))]
+	public class InterfaceTypeInOtherUsedOnlyByCopiedAssemblyExplicit {
+		public static void Main ()
+		{
+			InterfaceTypeInOtherUsedOnlyByCopiedAssemblyExplicit_Copy.ToKeepReferenceAtCompileTime ();
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -176,6 +176,10 @@
     <Compile Include="Inheritance.AbstractClasses\UnusedVirtualMethodRemoved.cs" />
     <Compile Include="Inheritance.AbstractClasses\UsedOverrideOfAbstractMethodIsKept.cs" />
     <Compile Include="Inheritance.AbstractClasses\UsedOverrideOfVirtualMethodIsKept.cs" />
+    <Compile Include="Inheritance.Interfaces\Dependencies\InterfaceTypeInOtherUsedOnlyByCopiedAssemblyExplicit_Copy.cs" />
+    <Compile Include="Inheritance.Interfaces\Dependencies\InterfaceTypeInOtherUsedOnlyByCopiedAssemblyExplicit_Link.cs" />
+    <Compile Include="Inheritance.Interfaces\Dependencies\InterfaceTypeInOtherUsedOnlyByCopiedAssembly_Copy.cs" />
+    <Compile Include="Inheritance.Interfaces\Dependencies\InterfaceTypeInOtherUsedOnlyByCopiedAssembly_Link.cs" />
     <Compile Include="Inheritance.Interfaces\Dependencies\InterfaceWithInterfaceFromOtherAssemblyWhenExplicitMethodUsed_Lib.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\ClassImplementingInterfaceMethodsNested.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\ClassImplementingInterfaceMethodsNested2.cs" />
@@ -190,6 +194,8 @@
     <Compile Include="Inheritance.Interfaces\OnReferenceType\InterfaceMarkOrderingDoesNotMatter.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\InterfaceMarkOrderingDoesNotMatter2.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\InterfaceMarkOrderingDoesNotMatter3.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\InterfaceTypeInOtherUsedOnlyByCopiedAssembly.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\InterfaceTypeInOtherUsedOnlyByCopiedAssemblyExplicit.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\InterfaceUsedOnlyAsConstraintIsKept.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\InterfaceWithInterfaceFromOtherAssemblyWhenExplicitMethodUsed.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\InterfaceTypeOnlyUsedHasInterfacesRemoved.cs" />


### PR DESCRIPTION
Fix a bug where interface types would be stripped even when types that implement the interface exist in the output.

This would happen in the following scenario
Assembly `A` implements an interface defined in assembly `B`.  Assembly `A` is assigned `AssemblyAction.Copy` where as assembly `B` is `AssemblyAction.Link`.

When this happens the type in assembly `A` is marked during ResolveFromAssemblyStep.  However, upon getting to the MarkStep `InitializeType` will only mark the fields and methods.  Note that just because the AssemblyAction is copy doesn't mean that types in that assembly will be assigned `TypePreserve.All` As a result, an existing guard in `InitializeType` to mark interface implementations was not helpful.

To fix this, and hopefully reduce the odds of a similar issue, I've done a few things

* Moved the if check that was in `IntitializeType` down into `MarkType` so that it will apply under any condition that a type is marked.

* Expanded the if from only checking for `TypePreserve.All` to also checking for any AssemblyAction that will result in everything on the type being marked.

* Switched from calling `MarkInterfaceImplementations` to `MarkRequirementsOfIntantiatedTypes`.  The latter is more thorough and will future proof this situation a bit since `MarkRequirementsOfIntantiatedTypes` is the method that will do base type requirement marking when I'm able to land my base type sweeping enhancement.