### PR TITLE
Preparation for base type sweeping

### DIFF
--- a/linker/Linker.Steps/SweepStep.cs
+++ b/linker/Linker.Steps/SweepStep.cs
@@ -292,6 +292,24 @@ namespace Mono.Linker.Steps {
 
 			if (type.HasFields && !type.IsBeforeFieldInit && !Annotations.HasPreservedStaticCtor (type) && !type.IsEnum)
 				type.IsBeforeFieldInit = true;
+			
+			SweepBaseType (type);
+		}
+
+		protected void SweepBaseType (TypeDefinition type)
+		{
+			if (!type.IsClass)
+				return;
+
+			if (type.BaseType == type.Module.TypeSystem.Object)
+				return;
+
+			if (Annotations.IsBaseRequired (type))
+				return;
+
+			var oldBase = type.BaseType;
+			type.BaseType = type.Module.TypeSystem.Object;
+			BaseTypeReduced (type, oldBase, type.BaseType);
 		}
 
 		protected void SweepNestedTypes (TypeDefinition type)
@@ -515,6 +533,10 @@ namespace Mono.Linker.Steps {
 		}
 
 		protected virtual void CustomAttributeUsageRemoved (ICustomAttributeProvider provider, CustomAttribute attribute)
+		{
+		}
+
+		protected virtual void BaseTypeReduced (TypeDefinition type, TypeReference oldBase, TypeReference newBase)
 		{
 		}
 	}

--- a/linker/Linker.Steps/TypeMapStep.cs
+++ b/linker/Linker.Steps/TypeMapStep.cs
@@ -44,6 +44,7 @@ namespace Mono.Linker.Steps {
 		{
 			MapVirtualMethods (type);
 			MapInterfaceMethodsInTypeHierarchy (type);
+			MapBaseTypeHierarchy (type);
 
 			if (!type.HasNestedTypes)
 				return;
@@ -121,6 +122,30 @@ namespace Mono.Linker.Steps {
 
 				AnnotateMethods (@override, method);
 			}
+		}
+
+		void MapBaseTypeHierarchy (TypeDefinition type)
+		{
+			if (!type.IsClass)
+				return;
+
+			var bases = new List<TypeDefinition> ();
+			var current = type.BaseType;
+
+			while (current != null) {
+				var resolved = current.Resolve ();
+				if (resolved == null)
+					break;
+
+				// Exclude Object.  That's implied and adding it to the list will just lead to lots of extra unnecessary processing
+				if (resolved.BaseType == null)
+					break;
+
+				bases.Add (resolved);
+				current = resolved.BaseType;
+			}
+
+			Annotations.SetBaseHierarchy (type, bases);
 		}
 
 		void AnnotateMethods (MethodDefinition @base, MethodDefinition @override)

--- a/linker/Linker/Annotations.cs
+++ b/linker/Linker/Annotations.cs
@@ -48,12 +48,14 @@ namespace Mono.Linker {
 		protected readonly Dictionary<MethodDefinition, List<MethodDefinition>> override_methods = new Dictionary<MethodDefinition, List<MethodDefinition>> ();
 		protected readonly Dictionary<MethodDefinition, List<MethodDefinition>> base_methods = new Dictionary<MethodDefinition, List<MethodDefinition>> ();
 		protected readonly Dictionary<AssemblyDefinition, ISymbolReader> symbol_readers = new Dictionary<AssemblyDefinition, ISymbolReader> ();
+		protected readonly Dictionary<TypeDefinition, List<TypeDefinition>> type_base_hierarchy = new Dictionary<TypeDefinition, List<TypeDefinition>>();
 
 		protected readonly Dictionary<object, Dictionary<IMetadataTokenProvider, object>> custom_annotations = new Dictionary<object, Dictionary<IMetadataTokenProvider, object>> ();
 		protected readonly Dictionary<AssemblyDefinition, HashSet<string>> resources_to_remove = new Dictionary<AssemblyDefinition, HashSet<string>> ();
 		protected readonly HashSet<CustomAttribute> marked_attributes = new HashSet<CustomAttribute> ();
 		readonly HashSet<TypeDefinition> marked_types_with_cctor = new HashSet<TypeDefinition> ();
 		protected readonly HashSet<TypeDefinition> marked_instantiated = new HashSet<TypeDefinition> ();
+		protected readonly HashSet<TypeDefinition> marked_base_required = new HashSet<TypeDefinition> ();
 
 		public AnnotationStore (LinkContext context) => this.context = context;
 
@@ -149,6 +151,16 @@ namespace Mono.Linker {
 		public bool IsInstantiated (TypeDefinition type)
 		{
 			return marked_instantiated.Contains (type);
+		}
+
+		public void MarkBaseRequired (TypeDefinition type)
+		{
+			marked_base_required.Add (type);
+		}
+		
+		public bool IsBaseRequired (TypeDefinition type)
+		{
+			return marked_base_required.Contains (type);
 		}
 
 		public void Processed (IMetadataTokenProvider provider)
@@ -355,5 +367,17 @@ namespace Mono.Linker {
 			return marked_types_with_cctor.Add (type);
 		}
 
+		public void SetBaseHierarchy (TypeDefinition type, List<TypeDefinition> bases)
+		{
+			type_base_hierarchy [type] = bases;
+		}
+
+		public List<TypeDefinition> GetBaseHierarchy (TypeDefinition type)
+		{
+			if (type_base_hierarchy.TryGetValue (type, out List<TypeDefinition> bases))
+				return bases;
+
+			return null;
+		}
 	}
 }


### PR DESCRIPTION
This change adds plumbing that will be used by a follow on PR to change a type's base to Object when the base type is not needed.  For example, a class with a base and only a simple static method on the class is marked.

There should be no change in behavior as a result of this change.

I choose to PR these changes ahead of the changes that will actually implement support for base type sweeping in order to reduce the size of the implementation PR.

* Build up a type hierarchy table during the TypeMapStep so that a type's base classes are easily accessible for processing during the MarkStep.

* Sweep step will now change the base type of any class that does not need it's base to Object.

* MarkStep will mark all classes as needing their base type.  The follow on PR will remove this behavior and replace it with logic that will actually result in base types being changed.