### PR TITLE
Prevent duplicate keys when resolving typerefs

### DIFF
--- a/linker/Linker.Steps/SweepStep.cs
+++ b/linker/Linker.Steps/SweepStep.cs
@@ -250,7 +250,8 @@ namespace Mono.Linker.Steps {
 					IMetadataScope scope = et.Scope;
 					if ((td != null) && Annotations.IsMarked (td)) {
 						scope = assembly.MainModule.ImportReference (td).Scope;
-						hash.Add (td, scope);
+						if (!hash.ContainsKey (td))
+							hash.Add (td, scope);
 						et.Scope = scope;
 					}
 				}

--- a/linker/Linker.Steps/SweepStep.cs
+++ b/linker/Linker.Steps/SweepStep.cs
@@ -250,8 +250,6 @@ namespace Mono.Linker.Steps {
 					IMetadataScope scope = et.Scope;
 					if ((td != null) && Annotations.IsMarked (td)) {
 						scope = assembly.MainModule.ImportReference (td).Scope;
-						if (!hash.ContainsKey (td))
-							hash.Add (td, scope);
 						et.Scope = scope;
 					}
 				}


### PR DESCRIPTION
A hash is used to detect if types have already been resolved. But this cache wasn't consulted for exported typerefs.

This caused duplicate key argument exceptions to be thrown.

I'm not sure if the exported code should be changing the hash since it wasn't used before. But I left it and just added a guard.