### PR TITLE
Add diagnostics message for unknown assembly

### DIFF
--- a/linker/Linker/Annotations.cs
+++ b/linker/Linker/Annotations.cs
@@ -87,7 +87,7 @@ namespace Mono.Linker {
 			if (assembly_actions.TryGetValue (assembly, out action))
 				return action;
 
-			throw new InvalidOperationException($"No action for the assembly {assembly.Name.Name} defined");
+			throw new InvalidOperationException($"No action for the assembly {assembly.Name} defined");
 		}
 
 		public MethodAction GetAction (MethodDefinition method)

--- a/linker/Linker/Annotations.cs
+++ b/linker/Linker/Annotations.cs
@@ -87,7 +87,7 @@ namespace Mono.Linker {
 			if (assembly_actions.TryGetValue (assembly, out action))
 				return action;
 
-			throw new NotSupportedException ();
+			throw new InvalidOperationException($"No action for the assembly {assembly.Name.Name} defined");
 		}
 
 		public MethodAction GetAction (MethodDefinition method)


### PR DESCRIPTION
When encounter unknown assemble ruring linking phase,
which happens a lot when working with Blazor, previously IlLink
silently fails without indication what cause the error.
Now displayed name of the offending assembly