### PR TITLE
Add a test for a struct with unused fields

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases/Basic/UnusedFieldsOfStructsAreKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Basic/UnusedFieldsOfStructsAreKept.cs
@@ -1,0 +1,28 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Basic {
+	public class UnusedFieldsOfStructsAreKept {
+		public static void Main ()
+		{
+			A a = new A ();
+			PreventCompilerOptimization (a);
+		}
+
+		[Kept]
+		static void PreventCompilerOptimization (A a)
+		{
+		}
+
+		[Kept]
+		struct A {
+			[Kept]
+			private int UnusedField1;
+			[Kept]
+			private int UnusedField2;
+
+			public void UnusedMethod ()
+			{
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -158,6 +158,7 @@
     <Compile Include="Basic\UnusedEnumGetsRemoved.cs" />
     <Compile Include="Basic\UnusedEventGetsRemoved.cs" />
     <Compile Include="Basic\InitializerForArrayIsKept.cs" />
+    <Compile Include="Basic\UnusedFieldsOfStructsAreKept.cs" />
     <Compile Include="Basic\UsedEnumIsKept.cs" />
     <Compile Include="Basic\UsedEventOnInterfaceIsKept.cs" />
     <Compile Include="Basic\UnusedFieldGetsRemoved.cs" />


### PR DESCRIPTION
There was no test verifying the behavior of marking the fields of a struct once the type is marked