### PR TITLE
Always mark Delegate types as instantiated

### DIFF
--- a/linker/Linker.Steps/MarkStep.cs
+++ b/linker/Linker.Steps/MarkStep.cs
@@ -982,6 +982,8 @@ namespace Mono.Linker.Steps {
 				//    and there are no other usages of that interface type, then we need to make sure the interface type is still marked because
 				//    this type is going to retain the interface implementation
 				MarkRequirementsForInstantiatedTypes (type);
+			} else if (AlwaysMarkTypeAsInstantiated (type)) {
+				MarkRequirementsForInstantiatedTypes (type);
 			}
 
 			if (type.HasInterfaces)
@@ -1399,6 +1401,20 @@ namespace Mono.Linker.Steps {
 		static bool IsMulticastDelegate (TypeDefinition td)
 		{
 			return td.BaseType != null && td.BaseType.FullName == "System.MulticastDelegate";
+		}
+
+		protected virtual bool AlwaysMarkTypeAsInstantiated (TypeDefinition td)
+		{
+			switch (td.Name) {
+				// These types are created from native code which means we are unable to track when they are instantiated
+				// Since these are such foundational types, let's take the easy route and just always assume an instance of one of these
+				// could exist
+				case "Delegate":
+				case "MulticastDelegate":
+					return td.Namespace == "System";
+			}
+
+			return false;
 		}
 
 		void MarkEventSourceProviders (TypeDefinition td)

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptBaseOnTypeInAssemblyAttribute.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptBaseOnTypeInAssemblyAttribute.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Assertions {
+	[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+	public class KeptBaseOnTypeInAssemblyAttribute : BaseInAssemblyAttribute {
+		public KeptBaseOnTypeInAssemblyAttribute (string assemblyFileName, Type type, string baseAssemblyFileName, Type baseType)
+		{
+			if (type == null)
+				throw new ArgumentNullException (nameof (type));
+			if (string.IsNullOrEmpty (assemblyFileName))
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (assemblyFileName));
+			
+			if (string.IsNullOrEmpty (baseAssemblyFileName))
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (baseAssemblyFileName));
+			if (baseType == null)
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (baseType));
+		}
+
+		public KeptBaseOnTypeInAssemblyAttribute (string assemblyFileName, string typeName, string baseAssemblyFileName, string baseTypeName)
+		{
+			if (string.IsNullOrEmpty (assemblyFileName))
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (assemblyFileName));
+			if (string.IsNullOrEmpty (typeName))
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (typeName));
+			
+			if (string.IsNullOrEmpty (baseAssemblyFileName))
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (baseAssemblyFileName));
+			if (string.IsNullOrEmpty (baseTypeName))
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (baseTypeName));
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Assertions\KeptAttributeInAssemblyAttribute.cs" />
     <Compile Include="Assertions\KeptAttributeOnFixedBufferTypeAttribute.cs" />
     <Compile Include="Assertions\KeptBackingFieldAttribute.cs" />
+    <Compile Include="Assertions\KeptBaseOnTypeInAssemblyAttribute.cs" />
     <Compile Include="Assertions\KeptDelegateCacheFieldAttribute.cs" />
     <Compile Include="Assertions\KeptEventAddMethodAttribute.cs" />
     <Compile Include="Assertions\KeptEventRemoveMethodAttribute.cs" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/CoreLink/DelegateAndMulticastDelegateKeepInstantiatedReqs.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/CoreLink/DelegateAndMulticastDelegateKeepInstantiatedReqs.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Runtime.Serialization;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.CoreLink {
+	/// <summary>
+	/// Delegate and is created from 
+	/// </summary>
+	[SetupLinkerCoreAction ("link")]
+	[KeptBaseOnTypeInAssembly ("mscorlib.dll", typeof (MulticastDelegate), "mscorlib.dll", typeof (Delegate))]
+	
+	// Check a couple override methods to verify they were not removed
+	[KeptMemberInAssembly ("mscorlib.dll", typeof (MulticastDelegate), "GetHashCode()")]
+	[KeptMemberInAssembly ("mscorlib.dll", typeof (MulticastDelegate), "GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)")]
+	
+	[KeptMemberInAssembly ("mscorlib.dll", typeof (Delegate), "GetHashCode()")]
+	[KeptMemberInAssembly ("mscorlib.dll", typeof (Delegate), "Equals(System.Object)")]
+	[KeptInterfaceOnTypeInAssembly("mscorlib.dll", typeof (Delegate), "mscorlib.dll", typeof (ICloneable))]
+	[KeptInterfaceOnTypeInAssembly("mscorlib.dll", typeof (Delegate), "mscorlib.dll", typeof (ISerializable))]
+	
+	// Fails due to Runtime critical type System.Reflection.CustomAttributeData not found.
+	[SkipPeVerify(SkipPeVerifyForToolchian.Pedump)]
+	public class DelegateAndMulticastDelegateKeepInstantiatedReqs {
+		public static void Main ()
+		{
+			typeof (MulticastDelegate).ToString ();
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -172,6 +172,7 @@
     <Compile Include="BCLFeatures\ETW\LocalsOfModifiedMethodAreRemoved.cs" />
     <Compile Include="BCLFeatures\ETW\StubbedMethodWithExceptionHandlers.cs" />
     <Compile Include="CoreLink\CanIncludeI18nAssemblies.cs" />
+    <Compile Include="CoreLink\DelegateAndMulticastDelegateKeepInstantiatedReqs.cs" />
     <Compile Include="CoreLink\NoSecurityPlusOnlyKeepUsedRemovesAllSecurityAttributesFromCoreLibraries.cs" />
     <Compile Include="Inheritance.AbstractClasses\UnusedAbstractMethodRemoved.cs" />
     <Compile Include="Inheritance.AbstractClasses\UnusedVirtualMethodRemoved.cs" />

--- a/linker/Tests/TestCasesRunner/ResultChecker.cs
+++ b/linker/Tests/TestCasesRunner/ResultChecker.cs
@@ -227,6 +227,11 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 
 								VerifyRemovedMemberInAssembly (checkAttrInAssembly, linkedType);
 								break;
+							case nameof (KeptBaseOnTypeInAssemblyAttribute):
+								if (linkedType == null)
+									Assert.Fail ($"Type `{expectedTypeName}' should have been kept");
+								VerifyKeptBaseOnTypeInAssembly (checkAttrInAssembly, linkedType);
+								break;
 							case nameof (KeptMemberInAssemblyAttribute):
 								if (linkedType == null)
 									Assert.Fail ($"Type `{expectedTypeName}' should have been kept");
@@ -391,6 +396,21 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			var linkedInterfaceImpl = GetMatchingInterfaceImplementationOnType (linkedType, originalInterface.FullName);
 			if (linkedInterfaceImpl == null)
 				Assert.Fail ($"Expected `{linkedType}` to have interface of type {originalInterface.FullName}");
+		}
+
+		void VerifyKeptBaseOnTypeInAssembly (CustomAttribute inAssemblyAttribute, TypeDefinition linkedType)
+		{
+			var originalType = GetOriginalTypeFromInAssemblyAttribute (inAssemblyAttribute);
+			
+			var baseAssemblyName = inAssemblyAttribute.ConstructorArguments [2].Value.ToString ();
+			var baseType = inAssemblyAttribute.ConstructorArguments [3].Value;
+
+			var originalBase = GetOriginalTypeFromInAssemblyAttribute (baseAssemblyName, baseType);
+			if (originalType.BaseType.Resolve () != originalBase)
+				Assert.Fail ("Invalid assertion.  Original type's base does not match the expected base");
+
+			Assert.That (originalBase.FullName, Is.EqualTo (linkedType.BaseType.FullName),
+				$"Incorrect base on `{linkedType.FullName}`.  Expected `{originalBase.FullName}` but was `{linkedType.BaseType.FullName}`");
 		}
 
 		protected static InterfaceImplementation GetMatchingInterfaceImplementationOnType (TypeDefinition type, string expectedInterfaceTypeName)


### PR DESCRIPTION
Delegate and MulticastDelegate are instantiated from native code which causes us to not record that instances of these types could exist.  As a result, today we remove the interfaces from Delegate.  Removing the interfaces doesn't seem to cause any issues today, but it's probably not the greatest idea.

In the future with base sweeping or uninstantiated type method stubbing, this lack of recording these types as instance possible causes bigger problems. 