### PR TITLE
Override removal

### DIFF
--- a/linker/Linker.Steps/MarkStep.cs
+++ b/linker/Linker.Steps/MarkStep.cs
@@ -262,9 +262,14 @@ namespace Mono.Linker.Steps {
 			if (Annotations.IsMarked (method))
 				return;
 
+			var isInstantiated = Annotations.IsInstantiated (method.DeclaringType);
+
 			// We don't need to mark overrides until it is possible that the type could be instantiated
 			// Note : The base type is interface check should be removed once we have base type sweeping
-			if (!Annotations.IsInstantiated (method.DeclaringType) && @base.DeclaringType.IsInterface)
+			if (!isInstantiated && @base.DeclaringType.IsInterface)
+				return;
+
+			if (!isInstantiated && !@base.IsAbstract)
 				return;
 
 			MarkMethod (method);

--- a/linker/Tests/Mono.Linker.Tests.Cases/Basic/NeverInstantiatedTypeWithOverridesFromObject.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Basic/NeverInstantiatedTypeWithOverridesFromObject.cs
@@ -9,31 +9,26 @@ namespace Mono.Linker.Tests.Cases.Basic {
 
 		[Kept]
 		class Foo {
-			[Kept] // Future improvements will allow this to be removed
 			~Foo ()
 			{
 				// Finalize shouldn't be empty
 				DoCleanupStuff ();
 			}
 
-			[Kept]
 			void DoCleanupStuff ()
 			{
 			}
 
-			[Kept] // Future improvements will allow this to be removed
 			public override bool Equals (object obj)
 			{
 				return false;
 			}
 
-			[Kept] // Future improvements will allow this to be removed
 			public override string ToString ()
 			{
 				return null;
 			}
 
-			[Kept] // Future improvements will allow this to be removed
 			public override int GetHashCode ()
 			{
 				return 0;

--- a/linker/Tests/Mono.Linker.Tests.Cases/CoreLink/NeverInstantiatedTypeWithOverridesFromObject.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/CoreLink/NeverInstantiatedTypeWithOverridesFromObject.cs
@@ -13,31 +13,26 @@ namespace Mono.Linker.Tests.Cases.CoreLink {
 
 		[Kept]
 		class Foo {
-			[Kept] // Future improvements will allow this to be removed
 			~Foo ()
 			{
 				// Finalize shouldn't be empty
 				DoCleanupStuff ();
 			}
 
-			[Kept] // Future improvements will allow this to be removed
 			void DoCleanupStuff ()
 			{
 			}
 
-			[Kept] // Future improvements will allow this to be removed
 			public override bool Equals (object obj)
 			{
 				return false;
 			}
 
-			[Kept] // Future improvements will allow this to be removed
 			public override string ToString ()
 			{
 				return null;
 			}
 
-			[Kept] // Future improvements will allow this to be removed
 			public override int GetHashCode ()
 			{
 				return 0;

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NoKeptCtor/OverrideRemoval/OverrideOfAbstractIsKept.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NoKeptCtor/OverrideRemoval/OverrideOfAbstractIsKept.cs
@@ -1,0 +1,42 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.NoKeptCtor.OverrideRemoval {
+	public class OverrideOfAbstractIsKept {
+		public static void Main ()
+		{
+			Base b = HelperToMarkFooAndRequireBase ();
+			b.Method ();
+		}
+
+		[Kept]
+		static Foo HelperToMarkFooAndRequireBase ()
+		{
+			return null;
+		}
+
+		[Kept]
+		abstract class Base {
+			[Kept]
+			public abstract void Method ();
+		}
+		
+		[Kept]
+		[KeptBaseType (typeof(Base))]
+		abstract class Base2 : Base {
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (Base2))]
+		abstract class Base3 : Base2 {
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (Base3))]
+		class Foo : Base3 {
+			[Kept]
+			public override void Method ()
+			{
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NoKeptCtor/OverrideRemoval/OverrideOfVirtualCanBeRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NoKeptCtor/OverrideRemoval/OverrideOfVirtualCanBeRemoved.cs
@@ -1,0 +1,33 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.NoKeptCtor.OverrideRemoval {
+	public class OverrideOfVirtualCanBeRemoved {
+		public static void Main ()
+		{
+			Base b = HelperToMarkFooAndRequireBase ();
+			b.Method ();
+		}
+
+		[Kept]
+		static Foo HelperToMarkFooAndRequireBase ()
+		{
+			return null;
+		}
+
+		[Kept]
+		class Base {
+			[Kept]
+			public virtual void Method ()
+			{
+			}
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (Base))]
+		class Foo : Base {
+			public override void Method ()
+			{
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NoKeptCtor/OverrideRemoval/OverrideOfVirtualCanBeRemoved2.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NoKeptCtor/OverrideRemoval/OverrideOfVirtualCanBeRemoved2.cs
@@ -1,0 +1,46 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.NoKeptCtor.OverrideRemoval {
+	public class OverrideOfVirtualCanBeRemoved2 {
+		public static void Main ()
+		{
+			Base b = HelperToMarkFooAndRequireBase ();
+			b.Method ();
+		}
+
+		[Kept]
+		static Foo HelperToMarkFooAndRequireBase ()
+		{
+			return null;
+		}
+
+		[Kept]
+		abstract class Base {
+			[Kept]
+			public abstract void Method ();
+		}
+		
+		[Kept]
+		[KeptBaseType (typeof (Base))]
+		abstract class Base2 : Base
+		{
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (Base2))]
+		class Base3 : Base2 {
+			[Kept]
+			public override void Method ()
+			{
+			}
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (Base3))]
+		class Foo : Base3 {
+			public override void Method ()
+			{
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NoKeptCtor/OverrideRemoval/OverrideOfVirtualCanBeRemoved3.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NoKeptCtor/OverrideRemoval/OverrideOfVirtualCanBeRemoved3.cs
@@ -1,0 +1,45 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.NoKeptCtor.OverrideRemoval {
+	public class OverrideOfVirtualCanBeRemoved3 {
+		public static void Main ()
+		{
+			HelperToMarkFoo2AndRequireBase();
+			Base b = HelperToMarkFooAndRequireBase ();
+			b.Method ();
+		}
+
+		[Kept]
+		static Foo HelperToMarkFooAndRequireBase ()
+		{
+			return null;
+		}
+		
+		[Kept]
+		static Foo2 HelperToMarkFoo2AndRequireBase ()
+		{
+			return null;
+		}
+
+		[Kept]
+		class Base {
+			[Kept]
+			public virtual void Method ()
+			{
+			}
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (Base))]
+		class Foo : Base {
+			public override void Method ()
+			{
+			}
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (Foo))]
+		class Foo2 : Foo {
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NoKeptCtor/OverrideRemoval/OverrideThatAlsoFulfilsInterface.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NoKeptCtor/OverrideRemoval/OverrideThatAlsoFulfilsInterface.cs
@@ -1,0 +1,53 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.NoKeptCtor.OverrideRemoval {
+	public class OverrideThatAlsoFulfilsInterface {
+		public static void Main ()
+		{
+			Base b = HelperToMarkFooAndRequireBase ();
+			b.Method ();
+			
+			// Now use the interface method so that it is kept
+			IFoo f = new Bar ();
+			f.Method ();
+		}
+
+		[Kept]
+		static Foo HelperToMarkFooAndRequireBase ()
+		{
+			return null;
+		}
+
+		[Kept]
+		class Base {
+			[Kept]
+			public virtual void Method ()
+			{
+			}
+		}
+
+		[Kept]
+		interface IFoo {
+			[Kept]
+			void Method ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptInterface (typeof (IFoo))]
+		class Bar : IFoo {
+			[Kept]
+			public void Method ()
+			{
+			}
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (Base))]
+		class Foo : Base, IFoo {
+			public override void Method ()
+			{
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NoKeptCtor/OverrideRemoval/PreservesOverriddenMethodOverrideOfUsedVirtualStillRemoved.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NoKeptCtor/OverrideRemoval/PreservesOverriddenMethodOverrideOfUsedVirtualStillRemoved.cs
@@ -1,0 +1,51 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.NoKeptCtor.OverrideRemoval {
+	public class PreservesOverriddenMethodOverrideOfUsedVirtualStillRemoved {
+		public static void Main ()
+		{
+			Base j = new Jar ();
+			j.One ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		abstract class Base {
+			[Kept]
+			public abstract void Foo ();
+
+			[Kept]
+			public virtual void One ()
+			{
+			}
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (Base))]
+		class Bar : Base {
+			[Kept]
+			public override void Foo ()
+			{
+			}
+
+			public override void One ()
+			{
+			}
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof (Base))]
+		class Jar : Base {
+			[Kept]
+			public override void Foo ()
+			{
+			}
+
+			[Kept]
+			public override void One ()
+			{
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NoKeptCtor/OverrideRemoval/PreservesOverriddenMethodOverrideOfUsedVirtualStillRemoved.xml
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NoKeptCtor/OverrideRemoval/PreservesOverriddenMethodOverrideOfUsedVirtualStillRemoved.xml
@@ -1,0 +1,7 @@
+<linker>
+    <assembly fullname="test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+        <type fullname="Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.NoKeptCtor.OverrideRemoval.PreservesOverriddenMethodOverrideOfUsedVirtualStillRemoved/Bar">
+            <method name="Foo"/>
+        </type>
+    </assembly>
+</linker>

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NoKeptCtor/OverrideRemoval/PreservesOverriddenMethodOverrideOfUsedVirtualStillRemoved2.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NoKeptCtor/OverrideRemoval/PreservesOverriddenMethodOverrideOfUsedVirtualStillRemoved2.cs
@@ -1,0 +1,60 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.NoKeptCtor.OverrideRemoval {
+	public class PreservesOverriddenMethodOverrideOfUsedVirtualStillRemoved2 {
+		public static void Main ()
+		{
+			Base j = new Jar ();
+			j.One ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		abstract class Base {
+			[Kept]
+			public abstract void Foo ();
+
+			[Kept]
+			public abstract void One ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof (Base))]
+		abstract class Base2 : Base
+		{
+			[Kept]
+			public override void One ()
+			{
+			}
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (Base2))]
+		class Bar : Base2 {
+			[Kept]
+			public override void Foo ()
+			{
+			}
+
+			public override void One ()
+			{
+			}
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof (Base2))]
+		class Jar : Base2 {
+			[Kept]
+			public override void Foo ()
+			{
+			}
+
+			[Kept]
+			public override void One ()
+			{
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NoKeptCtor/OverrideRemoval/PreservesOverriddenMethodOverrideOfUsedVirtualStillRemoved2.xml
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NoKeptCtor/OverrideRemoval/PreservesOverriddenMethodOverrideOfUsedVirtualStillRemoved2.xml
@@ -1,0 +1,7 @@
+<linker>
+    <assembly fullname="test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+        <type fullname="Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.NoKeptCtor.OverrideRemoval.PreservesOverriddenMethodOverrideOfUsedVirtualStillRemoved2/Bar">
+            <method name="Foo"/>
+        </type>
+    </assembly>
+</linker>

--- a/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/Dependencies/EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod/Library1.xml
+++ b/linker/Tests/Mono.Linker.Tests.Cases/LinkXml/Dependencies/EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod/Library1.xml
@@ -1,10 +1,14 @@
 ﻿<linker>
     <assembly fullname="Library1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
         <type fullname="Mono.Linker.Tests.Cases.LinkXml.Dependencies.EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod.Library1Secondary" preserve="nothing">
+            <!-- Need to preserve a ctor so that an instance of the type is possible-->
+            <method name=".ctor"/>
         </type>
     </assembly>
     <assembly fullname="Library2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
         <type fullname="Mono.Linker.Tests.Cases.LinkXml.Dependencies.EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod.Library2" preserve="nothing">
+            <!-- Need to preserve a ctor so that an instance of the type is possible-->
+            <method name=".ctor"/>
         </type>
     </assembly>
 </linker>

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -179,6 +179,13 @@
     <Compile Include="CoreLink\NeverInstantiatedTypeWithOverridesFromObject.cs" />
     <Compile Include="CoreLink\NoSecurityPlusOnlyKeepUsedRemovesAllSecurityAttributesFromCoreLibraries.cs" />
     <Compile Include="CoreLink\InstantiatedTypeWithOverridesFromObject.cs" />
+    <Compile Include="Inheritance.AbstractClasses\NoKeptCtor\OverrideRemoval\OverrideOfAbstractIsKept.cs" />
+    <Compile Include="Inheritance.AbstractClasses\NoKeptCtor\OverrideRemoval\OverrideOfVirtualCanBeRemoved.cs" />
+    <Compile Include="Inheritance.AbstractClasses\NoKeptCtor\OverrideRemoval\OverrideOfVirtualCanBeRemoved2.cs" />
+    <Compile Include="Inheritance.AbstractClasses\NoKeptCtor\OverrideRemoval\OverrideOfVirtualCanBeRemoved3.cs" />
+    <Compile Include="Inheritance.AbstractClasses\NoKeptCtor\OverrideRemoval\OverrideThatAlsoFulfilsInterface.cs" />
+    <Compile Include="Inheritance.AbstractClasses\NoKeptCtor\OverrideRemoval\PreservesOverriddenMethodOverrideOfUsedVirtualStillRemoved.cs" />
+    <Compile Include="Inheritance.AbstractClasses\NoKeptCtor\OverrideRemoval\PreservesOverriddenMethodOverrideOfUsedVirtualStillRemoved2.cs" />
     <Compile Include="Inheritance.AbstractClasses\UnusedAbstractMethodRemoved.cs" />
     <Compile Include="Inheritance.AbstractClasses\UnusedVirtualMethodRemoved.cs" />
     <Compile Include="Inheritance.AbstractClasses\UsedOverrideOfAbstractMethodIsKept.cs" />
@@ -492,6 +499,8 @@
     <Content Include="Attributes\OnlyKeepUsed\Dependencies\AssemblyWithUnusedAttributeOnReturnParameterDefinition.il" />
     <Content Include="Attributes\OnlyKeepUsed\UnusedAttributePreservedViaLinkXmlIsKept.xml" />
     <Content Include="CommandLine\Dependencies\ResponseFilesWork.rsp" />
+    <Content Include="Inheritance.AbstractClasses\NoKeptCtor\OverrideRemoval\PreservesOverriddenMethodOverrideOfUsedVirtualStillRemoved.xml" />
+    <Content Include="Inheritance.AbstractClasses\NoKeptCtor\OverrideRemoval\PreservesOverriddenMethodOverrideOfUsedVirtualStillRemoved2.xml" />
     <Content Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtor\UnusedTypeHasExplicitInterfaceMethodPreservedViaXml.xml" />
     <Content Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtor\UnusedTypeHasExplicitInterfacePropertyPreservedViaXml.xml" />
     <Content Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtor\UnusedTypeHasInterfaceMethodPreservedViaXml.xml" />


### PR DESCRIPTION
If no instance of a type can exist, then it's safe to not mark overrides as long as the method being overridden is not abstract.

This change should be good to go.  I've added `WIP` as I'm still running these changes through our il2cpp test suite as that is a valuable way to get some extra coverage on linker changes.

Do not land this branch before https://github.com/mono/linker/pull/454 otherwise there will be problems.