### PR TITLE
Adjustments to delegate test

### DIFF
--- a/linker/Tests/Mono.Linker.Tests.Cases/CoreLink/DelegateAndMulticastDelegateKeepInstantiatedReqs.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/CoreLink/DelegateAndMulticastDelegateKeepInstantiatedReqs.cs
@@ -12,7 +12,7 @@ namespace Mono.Linker.Tests.Cases.CoreLink {
 	
 	// Check a couple override methods to verify they were not removed
 	[KeptMemberInAssembly ("mscorlib.dll", typeof (MulticastDelegate), "GetHashCode()")]
-	[KeptMemberInAssembly ("mscorlib.dll", typeof (MulticastDelegate), "GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)")]
+	[KeptMemberInAssembly ("mscorlib.dll", typeof (MulticastDelegate), "Equals(System.Object)")]
 	
 	[KeptMemberInAssembly ("mscorlib.dll", typeof (Delegate), "GetHashCode()")]
 	[KeptMemberInAssembly ("mscorlib.dll", typeof (Delegate), "Equals(System.Object)")]
@@ -25,6 +25,11 @@ namespace Mono.Linker.Tests.Cases.CoreLink {
 		public static void Main ()
 		{
 			typeof (MulticastDelegate).ToString ();
+			
+			// Cause the interfaces to be marked in order to eliminate the possibility of them being removed
+			// due to no code path marking the interface type
+			typeof (ISerializable).ToString ();
+			typeof (ICloneable).ToString();
 		}
 	}
 }


### PR DESCRIPTION
A couple of adjustments to keep this test green in our UnityLinker test suite.

* Pick a different method to assert other than GetObjectData.  Use Equals since that is less prone to being removable

* Add a usage of ISerializable so that the interface isn't removed due to the interface type never being used.