### PR TITLE
Fix bug with Finalize() being removed

### DIFF
--- a/linker/Linker.Steps/MarkStep.cs
+++ b/linker/Linker.Steps/MarkStep.cs
@@ -1790,7 +1790,14 @@ namespace Mono.Linker.Steps {
 			Annotations.MarkInstantiated (type);
 
 			MarkInterfaceImplementations (type);
-			MarkMethodsIf (type.Methods, IsVirtualAndHasPreservedParent);
+
+			foreach (var method in type.Methods) {
+				if (method.IsFinalizer ())
+					MarkMethod (method);
+				else if (IsVirtualAndHasPreservedParent (method))
+					MarkMethod (method);
+			}
+
 			DoAdditionalInstantiatedTypeProcessing (type);
 		}
 

--- a/linker/Tests/Mono.Linker.Tests.Cases/Basic/InstantiatedTypeWithOverridesFromObject.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Basic/InstantiatedTypeWithOverridesFromObject.cs
@@ -1,0 +1,44 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Basic {
+	public class InstantiatedTypeWithOverridesFromObject {
+		public static void Main ()
+		{
+			var f = new Foo ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		class Foo {
+			[Kept]
+			~Foo ()
+			{
+				// Finalize shouldn't be empty
+				DoCleanupStuff ();
+			}
+
+			[Kept]
+			void DoCleanupStuff ()
+			{
+			}
+
+			[Kept]
+			public override bool Equals (object obj)
+			{
+				return false;
+			}
+
+			[Kept]
+			public override string ToString ()
+			{
+				return null;
+			}
+
+			[Kept]
+			public override int GetHashCode ()
+			{
+				return 0;
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Basic/NeverInstantiatedTypeWithOverridesFromObject.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Basic/NeverInstantiatedTypeWithOverridesFromObject.cs
@@ -1,0 +1,43 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Basic {
+	public class NeverInstantiatedTypeWithOverridesFromObject {
+		public static void Main ()
+		{
+			typeof (Foo).ToString ();
+		}
+
+		[Kept]
+		class Foo {
+			[Kept] // Future improvements will allow this to be removed
+			~Foo ()
+			{
+				// Finalize shouldn't be empty
+				DoCleanupStuff ();
+			}
+
+			[Kept]
+			void DoCleanupStuff ()
+			{
+			}
+
+			[Kept] // Future improvements will allow this to be removed
+			public override bool Equals (object obj)
+			{
+				return false;
+			}
+
+			[Kept] // Future improvements will allow this to be removed
+			public override string ToString ()
+			{
+				return null;
+			}
+
+			[Kept] // Future improvements will allow this to be removed
+			public override int GetHashCode ()
+			{
+				return 0;
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/CoreLink/InstantiatedTypeWithOverridesFromObject.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/CoreLink/InstantiatedTypeWithOverridesFromObject.cs
@@ -1,0 +1,48 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.CoreLink {
+	[SetupLinkerCoreAction ("link")]
+	// Need to skip due to `Runtime critical type System.Reflection.CustomAttributeData not found` failure
+	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
+	public class InstantiatedTypeWithOverridesFromObject {
+		public static void Main ()
+		{
+			var f = new Foo ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		class Foo {
+			[Kept]
+			~Foo ()
+			{
+				// Finalize shouldn't be empty
+				DoCleanupStuff ();
+			}
+
+			[Kept]
+			void DoCleanupStuff ()
+			{
+			}
+
+			[Kept]
+			public override bool Equals (object obj)
+			{
+				return false;
+			}
+
+			[Kept]
+			public override string ToString ()
+			{
+				return null;
+			}
+
+			[Kept]
+			public override int GetHashCode ()
+			{
+				return 0;
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/CoreLink/NeverInstantiatedTypeWithOverridesFromObject.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/CoreLink/NeverInstantiatedTypeWithOverridesFromObject.cs
@@ -1,0 +1,47 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.CoreLink {
+	[SetupLinkerCoreAction ("link")]
+	// Need to skip due to `Runtime critical type System.Reflection.CustomAttributeData not found` failure
+	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
+	public class NeverInstantiatedTypeWithOverridesFromObject {
+		public static void Main ()
+		{
+			typeof (Foo).ToString ();
+		}
+
+		[Kept]
+		class Foo {
+			[Kept] // Future improvements will allow this to be removed
+			~Foo ()
+			{
+				// Finalize shouldn't be empty
+				DoCleanupStuff ();
+			}
+
+			[Kept] // Future improvements will allow this to be removed
+			void DoCleanupStuff ()
+			{
+			}
+
+			[Kept] // Future improvements will allow this to be removed
+			public override bool Equals (object obj)
+			{
+				return false;
+			}
+
+			[Kept] // Future improvements will allow this to be removed
+			public override string ToString ()
+			{
+				return null;
+			}
+
+			[Kept] // Future improvements will allow this to be removed
+			public override int GetHashCode ()
+			{
+				return 0;
+			}
+		}
+	}
+}

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -153,6 +153,8 @@
     <Compile Include="Basic\InterfaceMethodImplementedOnBaseClassDoesNotGetStripped.cs" />
     <Compile Include="Basic\MultiLevelNestedClassesAllRemovedWhenNonUsed.cs" />
     <Compile Include="Basic\NestedDelegateInvokeMethodsPreserved.cs" />
+    <Compile Include="Basic\InstantiatedTypeWithOverridesFromObject.cs" />
+    <Compile Include="Basic\NeverInstantiatedTypeWithOverridesFromObject.cs" />
     <Compile Include="Basic\UninvokedInterfaceMemberGetsRemoved.cs" />
     <Compile Include="Basic\UnusedDelegateGetsRemoved.cs" />
     <Compile Include="Basic\UnusedEnumGetsRemoved.cs" />
@@ -173,7 +175,9 @@
     <Compile Include="BCLFeatures\ETW\StubbedMethodWithExceptionHandlers.cs" />
     <Compile Include="CoreLink\CanIncludeI18nAssemblies.cs" />
     <Compile Include="CoreLink\DelegateAndMulticastDelegateKeepInstantiatedReqs.cs" />
+    <Compile Include="CoreLink\NeverInstantiatedTypeWithOverridesFromObject.cs" />
     <Compile Include="CoreLink\NoSecurityPlusOnlyKeepUsedRemovesAllSecurityAttributesFromCoreLibraries.cs" />
+    <Compile Include="CoreLink\InstantiatedTypeWithOverridesFromObject.cs" />
     <Compile Include="Inheritance.AbstractClasses\UnusedAbstractMethodRemoved.cs" />
     <Compile Include="Inheritance.AbstractClasses\UnusedVirtualMethodRemoved.cs" />
     <Compile Include="Inheritance.AbstractClasses\UsedOverrideOfAbstractMethodIsKept.cs" />


### PR DESCRIPTION
The CoreLink version of `InstantiatedTypeWithOverridesFromObject` is the test that triggers the bug. 

Up until this PR, the way Finalize() methods would be marked was via `IsVirtualAndHasPreservedParent`.  Which is to say, once System.Object.Finalize() was marked, all the other FInalize() methods would be marked.  However, given that Finalize() is never explicitly called from managed code, the only way I can think of that Object.FInalize would be marked is via link xml.

With this PR, once the we deem that an instance of a type could exist we will mark the Finalize() method.