### PR TITLE
Follow up fix for csc quirk

### DIFF
--- a/linker/Linker.Steps/SweepStep.cs
+++ b/linker/Linker.Steps/SweepStep.cs
@@ -190,10 +190,12 @@ namespace Mono.Linker.Steps {
 				// That depends on the AssemblyAction set for the `assembly`
 				switch (Annotations.GetAction (assembly)) {
 				case AssemblyAction.Copy:
+					// We need to save the assembly if a reference was removed, otherwise we can end up
+					// with an assembly that references an assembly that no longer exists
+					Annotations.SetAction (assembly, AssemblyAction.Save);
 					// Copy means even if "unlinked" we still want that assembly to be saved back 
 					// to disk (OutputStep) without the (removed) reference
 					if (!Context.KeepTypeForwarderOnlyAssemblies) {
-						Annotations.SetAction (assembly, AssemblyAction.Save);
 						ResolveAllTypeReferences (assembly);
 					}
 					break;

--- a/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/linker/Tests/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -305,6 +305,7 @@
     <Compile Include="PreserveDependencies\PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithCopyUsedAction.cs" />
     <Compile Include="PreserveDependencies\PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithEmbeddedXml.cs" />
     <Compile Include="References\AssemblyOnlyUsedByUsingWithCsc.cs" />
+    <Compile Include="References\AssemblyOnlyUsedByUsingWithCscWithKeepFacades.cs" />
     <Compile Include="References\AssemblyOnlyUsedByUsingWithMcs.cs" />
     <Compile Include="References\Dependencies\AssemblyOnlyUsedByUsing_Copied.cs" />
     <Compile Include="References\Dependencies\AssemblyOnlyUsedByUsing_Lib.cs" />

--- a/linker/Tests/Mono.Linker.Tests.Cases/References/AssemblyOnlyUsedByUsingWithCscWithKeepFacades.cs
+++ b/linker/Tests/Mono.Linker.Tests.Cases/References/AssemblyOnlyUsedByUsingWithCscWithKeepFacades.cs
@@ -8,7 +8,9 @@ namespace Mono.Linker.Tests.Cases.References {
 	/// Because of that, `copied` needs to have it's reference to `library` removed even though we specified an assembly action of `copy`
 	/// </summary>
 	[SetupLinkerAction ("copy", "copied")]
-	[SetupLinkerArgument ("--keep-facades", "false")]
+
+	// --keep-facades sends the sweep step down a different code path that caused problems for this corner case
+	[SetupLinkerArgument ("--keep-facades", "true")]
 	[SetupCompileBefore ("library.dll", new [] {"Dependencies/AssemblyOnlyUsedByUsing_Lib.cs"})]
 	
 	// When csc is used, `copied.dll` will have a reference to `library.dll`
@@ -20,7 +22,7 @@ namespace Mono.Linker.Tests.Cases.References {
 	// We library should be gone.  The `using` statement leaves no traces in the IL so nothing in `library` will be marked
 	[RemovedAssembly ("library.dll")]
 	[KeptReferencesInAssembly ("copied.dll", new [] {"mscorlib"})]
-	public class AssemblyOnlyUsedByUsingWithCsc {
+	public class AssemblyOnlyUsedByUsingWithCscWithKeepFacades {
 		public static void Main ()
 		{
 			// Use something to keep the reference at compile time


### PR DESCRIPTION
While pulling https://github.com/mono/linker/commit/1195feacc5bf27cc7250dec86238caf8682c10a1 into UnityLinker I hit  `AssemblyOnlyUsedByUsingWithCsc` failing with UnityLinker because `copied.dll` still had a reference to `library.dll`.  I did some digging and we keep facades by default where as upstream does not.   This also happens to be why there was no issue on master.  Once you turn on `--keep-facades` the linker will no longer remove the reference.