### PR TITLE
Add an option to disable override removal

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -269,7 +269,7 @@ namespace Mono.Linker.Steps {
 			if (@base.DeclaringType.IsInterface && !isInstantiated && !IsInterfaceImplementationMarked (method.DeclaringType, @base.DeclaringType))
 				return;
 
-			if (!isInstantiated && !@base.IsAbstract)
+			if (!isInstantiated && !@base.IsAbstract && _context.IsOptimizationEnabled (CodeOptimizations.OverrideRemoval))
 				return;
 
 			MarkMethod (method);

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -361,6 +361,9 @@ namespace Mono.Linker {
 						case "beforefieldinit":
 							context.DisabledOptimizations |= CodeOptimizations.BeforeFieldInit;
 							break;
+						case "overrideremoval":
+							context.DisabledOptimizations |= CodeOptimizations.OverrideRemoval;
+							break;
 						}
 					}
 				}
@@ -519,6 +522,7 @@ namespace Mono.Linker {
 			Console.WriteLine ("  --custom-step <name>      Add a custom step to the pipeline");
 			Console.WriteLine ("  --disable-opt <name>      Disable one of the default optimizations");
 			Console.WriteLine ("                              beforefieldinit: Unused static fields are removed if there is no static ctor");
+			Console.WriteLine ("                              overrideremoval: Overrides of virtual methods on types that are never instantiated are removed");
 			Console.WriteLine ("  --exclude-feature <name>  Any code which has a feature <name> in linked assemblies will be removed");
 			Console.WriteLine ("                              com: Support for COM Interop");
 			Console.WriteLine ("                              etw: Event Tracing for Windows");

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -387,5 +387,13 @@ namespace Mono.Linker {
 	public enum CodeOptimizations
 	{
 		BeforeFieldInit = 1 << 0,
+		
+		/// <summary>
+		/// Option to disable removal of overrides of virtual methods when a type is never instantiated
+		///
+		/// Being able to disable this optimization is helpful when trying to troubleshoot problems caused by types created via reflection or from native
+		/// that do not get an instance constructor marked.
+		/// </summary>
+		OverrideRemoval = 1 << 1,
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NoKeptCtor/OverrideRemoval/CanDisableOverrideRemoval.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NoKeptCtor/OverrideRemoval/CanDisableOverrideRemoval.cs
@@ -1,0 +1,36 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.NoKeptCtor.OverrideRemoval {
+	[SetupLinkerArgument ("--disable-opt", "overrideremoval")]
+	public class CanDisableOverrideRemoval {
+		public static void Main ()
+		{
+			Base b = HelperToMarkFooAndRequireBase ();
+			b.Method ();
+		}
+
+		[Kept]
+		static Foo HelperToMarkFooAndRequireBase ()
+		{
+			return null;
+		}
+
+		[Kept]
+		class Base {
+			[Kept]
+			public virtual void Method ()
+			{
+			}
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (Base))]
+		class Foo : Base {
+			[Kept]
+			public override void Method ()
+			{
+			}
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/test/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -179,6 +179,7 @@
     <Compile Include="CoreLink\NeverInstantiatedTypeWithOverridesFromObject.cs" />
     <Compile Include="CoreLink\NoSecurityPlusOnlyKeepUsedRemovesAllSecurityAttributesFromCoreLibraries.cs" />
     <Compile Include="CoreLink\InstantiatedTypeWithOverridesFromObject.cs" />
+    <Compile Include="Inheritance.AbstractClasses\NoKeptCtor\OverrideRemoval\CanDisableOverrideRemoval.cs" />
     <Compile Include="Inheritance.AbstractClasses\NoKeptCtor\OverrideRemoval\OverrideOfAbstractIsKept.cs" />
     <Compile Include="Inheritance.AbstractClasses\NoKeptCtor\OverrideRemoval\OverrideOfVirtualCanBeRemoved.cs" />
     <Compile Include="Inheritance.AbstractClasses\NoKeptCtor\OverrideRemoval\OverrideOfVirtualCanBeRemoved2.cs" />


### PR DESCRIPTION
Being able to disable this optimization is helpful when trying to troubleshoot problems caused by types created via reflection or from native that do not get an instance constructor marked.

This also gives me the flexibility to pull in the latest `master` without being ready to turn on override removal.