### PR TITLE
Fix invalid IL when inherited interfaces

### DIFF
--- a/src/linker/Linker.Steps/TypeMapStep.cs
+++ b/src/linker/Linker.Steps/TypeMapStep.cs
@@ -44,6 +44,7 @@ namespace Mono.Linker.Steps {
 		{
 			MapVirtualMethods (type);
 			MapInterfaceMethodsInTypeHierarchy (type);
+			MapInterfaceHierarchy (type);
 			MapBaseTypeHierarchy (type);
 
 			if (!type.HasNestedTypes)
@@ -51,6 +52,20 @@ namespace Mono.Linker.Steps {
 
 			foreach (var nested in type.NestedTypes)
 				MapType (nested);
+		}
+
+		void MapInterfaceHierarchy (TypeDefinition type)
+		{
+			if (!type.IsInterface || !type.HasInterfaces)
+				return;
+
+			foreach (var iface in type.Interfaces) {
+				var resolved = iface.InterfaceType.Resolve ();
+				if (resolved == null)
+					continue;
+				
+				Annotations.AddDerivedInterfaceForInterface (resolved, type);
+			}
 		}
 
 		void MapInterfaceMethodsInTypeHierarchy (TypeDefinition type)

--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -49,6 +49,7 @@ namespace Mono.Linker {
 		protected readonly Dictionary<MethodDefinition, List<MethodDefinition>> base_methods = new Dictionary<MethodDefinition, List<MethodDefinition>> ();
 		protected readonly Dictionary<AssemblyDefinition, ISymbolReader> symbol_readers = new Dictionary<AssemblyDefinition, ISymbolReader> ();
 		protected readonly Dictionary<TypeDefinition, List<TypeDefinition>> class_type_base_hierarchy = new Dictionary<TypeDefinition, List<TypeDefinition>> ();
+		protected readonly Dictionary<TypeDefinition, List<TypeDefinition>> derived_interfaces = new Dictionary<TypeDefinition, List<TypeDefinition>>();
 
 		protected readonly Dictionary<object, Dictionary<IMetadataTokenProvider, object>> custom_annotations = new Dictionary<object, Dictionary<IMetadataTokenProvider, object>> ();
 		protected readonly Dictionary<AssemblyDefinition, HashSet<string>> resources_to_remove = new Dictionary<AssemblyDefinition, HashSet<string>> ();
@@ -365,6 +366,33 @@ namespace Mono.Linker {
 		{
 			if (class_type_base_hierarchy.TryGetValue (type, out List<TypeDefinition> bases))
 				return bases;
+
+			return null;
+		}
+
+		public void AddDerivedInterfaceForInterface (TypeDefinition @base, TypeDefinition derived)
+		{
+			if (!@base.IsInterface)
+				throw new ArgumentException ($"{nameof (@base)} must be an interface");
+
+			if (!derived.IsInterface)
+				throw new ArgumentException ($"{nameof (derived)} must be an interface");
+
+			List<TypeDefinition> derivedInterfaces;
+			if (!derived_interfaces.TryGetValue (@base, out derivedInterfaces))
+				derived_interfaces [@base] = derivedInterfaces = new List<TypeDefinition> ();
+			
+			derivedInterfaces.Add(derived);
+		}
+
+		public List<TypeDefinition> GetDerivedInterfacesForInterface (TypeDefinition @interface)
+		{
+			if (!@interface.IsInterface)
+				throw new ArgumentException ($"{nameof (@interface)} must be an interface");
+			
+			List<TypeDefinition> derivedInterfaces;
+			if (derived_interfaces.TryGetValue (@interface, out derivedInterfaces))
+				return derivedInterfaces;
 
 			return null;
 		}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtorButInterfaceNeeded/LocalAndNestedInterfaces.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtorButInterfaceNeeded/LocalAndNestedInterfaces.cs
@@ -1,0 +1,37 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoKeptCtorButInterfaceNeeded {
+	public class LocalAndNestedInterfaces {
+		public static void Main ()
+		{
+			Foo f = null;
+			IFoo i = f;
+			IBase2 b = i;
+			
+			Helper (b);
+		}
+
+		[Kept]
+		static void Helper (IBase2 f)
+		{
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IFoo))]
+		[KeptInterface (typeof (IBase2))]
+		class Foo : IFoo {
+		}
+
+		interface IBase {
+		}
+
+		[Kept]
+		interface IBase2 : IBase {
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IBase2))]
+		interface IFoo : IBase2 {
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtorButInterfaceNeeded/NestedInterfaces1.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtorButInterfaceNeeded/NestedInterfaces1.cs
@@ -1,0 +1,52 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoKeptCtorButInterfaceNeeded {
+	public class NestedInterfaces1 {
+		public static void Main ()
+		{
+			MarkBase1AndBase3 (null, null);
+			MarkClassTypeOnly (null);
+		}
+
+		[Kept]
+		static void MarkBase1AndBase3 (IBase arg1, IBase3 arg3)
+		{
+			arg3.Method ();
+		}
+
+		[Kept]
+		static void MarkClassTypeOnly (Foo arg)
+		{
+		}
+
+		[Kept]
+		interface IBase {
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IBase))]
+		interface IBase2 : IBase {
+			[Kept]
+			void Method ();
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IBase2))]
+		[KeptInterface (typeof (IBase))]
+		interface IBase3 : IBase2 {
+		}
+
+		/// <summary>
+		/// Foo does not need to keep it's IBase2 interface implementation but it does need to keep the method from IBase2 since Foo still needs to keep IBase3
+		/// </summary>
+		[Kept]
+		[KeptInterface (typeof (IBase3))]
+		[KeptInterface (typeof (IBase))]
+		class Foo : IBase3 {
+			[Kept]
+			public void Method ()
+			{
+			}
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtorButInterfaceNeeded/NestedInterfaces2.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtorButInterfaceNeeded/NestedInterfaces2.cs
@@ -1,0 +1,43 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoKeptCtorButInterfaceNeeded {
+	public class NestedInterfaces2 {
+		public static void Main ()
+		{
+			MarkBase1AndBase3 (null, null);
+			MarkClassTypeOnly (null);
+		}
+
+		[Kept]
+		static void MarkBase1AndBase3 (IBase arg1, IBase3 arg3)
+		{
+		}
+
+		[Kept]
+		static void MarkClassTypeOnly (Foo arg)
+		{
+		}
+
+		[Kept]
+		interface IBase {
+		}
+
+		interface IBase2 : IBase {
+			void Method ();
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IBase))]
+		interface IBase3 : IBase2 {
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IBase3))]
+		[KeptInterface (typeof (IBase))]
+		class Foo : IBase3 {
+			public void Method ()
+			{
+			}
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtorButInterfaceNeeded/NestedInterfaces3.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtorButInterfaceNeeded/NestedInterfaces3.cs
@@ -1,0 +1,52 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoKeptCtorButInterfaceNeeded {
+	public class NestedInterfaces3 {
+		public static void Main ()
+		{
+			MarkBase1AndBase3 (null, null);
+			MarkClassTypeOnly (null);
+		}
+
+		[Kept]
+		static void MarkBase1AndBase3 (IBase arg1, IBase3 arg3)
+		{
+		}
+
+		[Kept]
+		static void MarkClassTypeOnly (Foo arg)
+		{
+		}
+
+		[Kept]
+		interface IBase {
+		}
+
+		interface IBase2 : IBase {
+			void Method ();
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IBase))]
+		interface IBase3 : IBase2 {
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IBase))]
+		class Base : IBase2 {
+			public void Method ()
+			{
+			}
+		}
+
+		[Kept]
+		[KeptBaseType(typeof(Base))]
+		[KeptInterface (typeof (IBase3))]
+		[KeptInterface (typeof (IBase))]
+		class Foo : Base, IBase3, IBase2 {
+			public void Method ()
+			{
+			}
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtorButInterfaceNeeded/NestedInterfacesWithExplicit1.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtorButInterfaceNeeded/NestedInterfacesWithExplicit1.cs
@@ -1,0 +1,50 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoKeptCtorButInterfaceNeeded {
+	public class NestedInterfacesWithExplicit1 {
+		public static void Main ()
+		{
+			MarkBase1AndBase3 (null, null);
+			MarkClassTypeOnly (null);
+		}
+
+		[Kept]
+		static void MarkBase1AndBase3 (IBase arg1, IBase3 arg3)
+		{
+			arg3.Method ();
+		}
+
+		[Kept]
+		static void MarkClassTypeOnly (Foo arg)
+		{
+		}
+
+		[Kept]
+		interface IBase {
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IBase))]
+		interface IBase2 : IBase {
+			[Kept]
+			void Method ();
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IBase2))]
+		[KeptInterface (typeof (IBase))]
+		interface IBase3 : IBase2 {
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IBase3))]
+		[KeptInterface (typeof (IBase2))]
+		[KeptInterface (typeof (IBase))]
+		class Foo : IBase3 {
+			[Kept]
+			void IBase2.Method ()
+			{
+			}
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtorButInterfaceNeeded/NestedInterfacesWithExplicitAndNormal1.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtorButInterfaceNeeded/NestedInterfacesWithExplicitAndNormal1.cs
@@ -1,0 +1,54 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoKeptCtorButInterfaceNeeded {
+	public class NestedInterfacesWithExplicitAndNormal1 {
+		public static void Main ()
+		{
+			MarkBase1AndBase3 (null, null);
+			MarkClassTypeOnly (null);
+		}
+
+		[Kept]
+		static void MarkBase1AndBase3 (IBase arg1, IBase3 arg3)
+		{
+			arg3.Method ();
+		}
+
+		[Kept]
+		static void MarkClassTypeOnly (Foo arg)
+		{
+		}
+
+		[Kept]
+		interface IBase {
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IBase))]
+		interface IBase2 : IBase {
+			[Kept]
+			void Method ();
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IBase2))]
+		[KeptInterface (typeof (IBase))]
+		interface IBase3 : IBase2 {
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IBase3))]
+		[KeptInterface (typeof (IBase2))]
+		[KeptInterface (typeof (IBase))]
+		class Foo : IBase3 {
+			[Kept]
+			void IBase2.Method ()
+			{
+			}
+
+			public void Method ()
+			{
+			}
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/test/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -228,11 +228,17 @@
     <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtorButInterfaceNeeded\GenericTypeWithConstraint2.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtorButInterfaceNeeded\GenericTypeWithConstraint3.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtorButInterfaceNeeded\InterfaceOnMultipleBases.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtorButInterfaceNeeded\LocalAndNestedInterfaces.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtorButInterfaceNeeded\LocalDowncastedToInterface.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtorButInterfaceNeeded\LocalPassedAsParameter.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtorButInterfaceNeeded\LocalPassedAsParameterToGeneric.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtorButInterfaceNeeded\LocalPassedAsParameterToGenericWithConstraint.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtorButInterfaceNeeded\LocalPassedAsParameterToGenericWithConstraint2.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtorButInterfaceNeeded\NestedInterfaces1.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtorButInterfaceNeeded\NestedInterfaces2.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtorButInterfaceNeeded\NestedInterfaces3.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtorButInterfaceNeeded\NestedInterfacesWithExplicit1.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtorButInterfaceNeeded\NestedInterfacesWithExplicitAndNormal1.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtorButInterfaceNeeded\ReturnValueDowncastedToInterface.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtorButInterfaceNeeded\GenericTypeWithConstraint.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtor\ComInterfaceTypeRemovedWhenOnlyUsedByClassWithOnlyStaticMethod.cs" />


### PR DESCRIPTION
When processing overrides on a type that is never instantiated, it is only safe to skip marking of an interface method if the interface implementation corresponding to that method is *not* marked *and* no other interface implementations that implement that interface are marked