### PR TITLE
Support [KeptInterface] with generics

### DIFF
--- a/test/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptInterfaceAttribute.cs
+++ b/test/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptInterfaceAttribute.cs
@@ -11,5 +11,13 @@ namespace Mono.Linker.Tests.Cases.Expectations.Assertions
 			if (interfaceType == null)
 				throw new ArgumentNullException (nameof (interfaceType));
 		}
+		
+		public KeptInterfaceAttribute (Type interfaceType, params object[] typeArguments)
+		{
+			if (interfaceType == null)
+				throw new ArgumentNullException (nameof (interfaceType));
+			if (typeArguments == null)
+				throw new ArgumentNullException (nameof (typeArguments));
+		}
 	}
 }


### PR DESCRIPTION
I'll need support for this in an upcoming PR. 

Follows the same pattern as KeptBaseType's `public KeptBaseTypeAttribute (Type baseType, params object[] typeArguments)`