### PR TITLE
Set up Azure Pipelines to build illink

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -4,7 +4,8 @@
     <!-- nuget-build is necessary for the integration package to
          depend on the same NuGet package that the sdk uses -->
     <add key="nuget-build" value="https://dotnet.myget.org/F/nuget-build/api/v3/index.json" />
-    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="dotnet-core-myget" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
   </packageSources>
 </configuration>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -5,7 +5,5 @@
     <FileSignInfo Include="Mono.Cecil.Mdb.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Mono.Cecil.Pdb.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="illink.dll" CertificateName="3PartySHA2" />
-    <!-- <FileSignInfo Include="ILLink.CustomSteps.dll" CertificateName="3PartySHA2" /> -->
-    <!-- Why not ILLink.Tasks.dll? -->
   </ItemGroup>
 </Project>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -5,7 +5,7 @@
     <FileSignInfo Include="Mono.Cecil.Mdb.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Mono.Cecil.Pdb.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="illink.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="ILLink.CustomSteps.dll" CertificateName="3PartySHA2" />
+    <!-- <FileSignInfo Include="ILLink.CustomSteps.dll" CertificateName="3PartySHA2" /> -->
     <!-- Why not ILLink.Tasks.dll? -->
   </ItemGroup>
 </Project>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -1,0 +1,8 @@
+<Project>
+  <!-- These libraries are 3rd-party based on the copyright info. -->
+  <FileSignInfo Include="Mono.Cecil.dll" CertificateName="3PartySHA2" />
+  <FileSignInfo Include="Mono.Cecil.Mdb.dll" CertificateName="3PartySHA2" />
+  <FileSignInfo Include="Mono.Cecil.Pdb.dll" CertificateName="3PartySHA2" />
+  <FileSignInfo Include="illink.dll" CertificateName="3PartySHA2" />
+  <FileSignInfo Include="ILLink.CustomSteps.dll" CertificateName="3PartySHA2" />
+</Project>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -1,8 +1,11 @@
 <Project>
-  <!-- These libraries are 3rd-party based on the copyright info. -->
-  <FileSignInfo Include="Mono.Cecil.dll" CertificateName="3PartySHA2" />
-  <FileSignInfo Include="Mono.Cecil.Mdb.dll" CertificateName="3PartySHA2" />
-  <FileSignInfo Include="Mono.Cecil.Pdb.dll" CertificateName="3PartySHA2" />
-  <FileSignInfo Include="illink.dll" CertificateName="3PartySHA2" />
-  <FileSignInfo Include="ILLink.CustomSteps.dll" CertificateName="3PartySHA2" />
+  <ItemGroup>
+    <!-- These libraries are 3rd-party based on the copyright info. -->
+    <FileSignInfo Include="Mono.Cecil.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Mono.Cecil.Mdb.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Mono.Cecil.Pdb.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="illink.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="ILLink.CustomSteps.dll" CertificateName="3PartySHA2" />
+    <!-- Why not ILLink.Tasks.dll? -->
+  </ItemGroup>
 </Project>

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -1,58 +1,68 @@
 variables:
-- group: DotNet-HelixApi-Access # TODO: make available internally only
 - name: _BuildConfig
   value: Release
 - name: _BuildArgs
   value: /p:OfficialBuildId=$(Build.BuildNumber)
          /p:ArcadeBuild=true
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  # Provide HelixApiAccessToken for telemetry
+  - group: DotNet-HelixApi-Access
 
 
 jobs:
-- template: /eng/common/templates/job/job.yml
+- template: /eng/common/templates/jobs/jobs.yml
   parameters:
-    name: build_linux
-    displayName: Build linker on linux
-    enableTelemetry: true
-    pool:
-      'Hosted Ubuntu 1604' # available on internal and public. recommended for both.
-    # enablePublishTestResults
-    # Publish build logs to pipeline storage
-    enablePublishBuildArtifacts: true
-    helixRepo: 'mono/linker'
-    steps:
-    - checkout: self
-      submodules: true
-    - script: eng/common/cibuild.sh --projects $(Build.SourcesDirectory)/illink.sln
-              --configuration $(_BuildConfig) $(_BuildArgs)
-      displayName: Build illink.sln $(_BuildConfig)
 
-- template: /eng/common/templates/job/job.yml
-  parameters:
-    name: build_windows
-    displayName: Build linker on windows
-    enableTelemetry: true
-    enableMicrobuild: true
-    pool:
-      'dotnet-internal-temp' # internal
-      # for public, need to use 'Hosted VS2017'
-    # publish asset manifests to pipeline storage (only for legs that publish)
-    enablePublishBuildAssets: true
-    enablePublishBuildArtifacts: true
-    helixRepo: 'mono/linker'
-    variables:
-    - group: DotNet-Blob-Feed
-    - _DotNetPublishToBlobFeed: true
-    # required by microbuild install step
-    - _TeamName: .NET
-    # DotNetSignType needs to be passed for arcade signing targets, otherwise it defaults to real.
-    # _SignType is used in the arcade templates that install microbuild.
-    - DotNetSignType: $(_SignType)
-    - _PublishArgs: /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
-                    /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
-                    /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
-    steps:
-    - checkout: self
-      submodules: true
-    - script: eng\common\cibuild.cmd -projects $(Build.SourcesDirectory)\illink.sln
-              -configuration $(_BuildConfig) $(_BuildArgs) $(_PublishArgs)
-      displayName: Build and publish illink.sln $(_BuildConfig)
+    enableTelemetry: true # send helix telemetry
+    helixRepo: mono/linker
+    enablePublishBuildArtifacts: true # publish build logs to pipeline storage
+    # enablePublishTestResults
+    enablePublishBuildAssets: true # generate build manifests and publish to BAR in internal builds
+    enableMicrobuild: true # only affects internal builds
+
+    jobs:
+
+    - job: Windows_NT
+      pool:
+        ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          name: Hosted VS2017
+        ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+          name: dotnet-internal-temp
+      ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+        variables:
+        - group: DotNet-Blob-Feed
+        - _DotNetPublishToBlobFeed: true
+        - _TeamName: .NET # required by microbuild install step
+        # _SignType is used in the arcade templates that install microbuild.
+        - DotNetSignType: $(_SignType) # DotNetSignType defaults to real if not specified
+        - _PublishArgs: /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
+                        /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+                        /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
+      steps:
+      - checkout: self
+        submodules: true
+      - script: eng\common\cibuild.cmd -projects $(Build.SourcesDirectory)\illink.sln
+                -configuration $(_BuildConfig) $(_BuildArgs) $(_PublishArgs)
+        displayName: Build and publish illink.sln $(_BuildConfig)
+
+    - job: Linux
+      pool:
+        name: Hosted Ubuntu 1604
+      steps:
+      - checkout: self
+        submodules: true
+      - script: eng/common/cibuild.sh --projects $(Build.SourcesDirectory)/illink.sln
+                --configuration $(_BuildConfig) $(_BuildArgs)
+        displayName: Build illink.sln $(_BuildConfig)
+
+    - job: macOS
+      pool:
+        ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          name: Hosted MacOS
+        ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+          name: Hosted Mac Internal
+      steps:
+      - checkout: self
+        submodules: true
+      - script: eng/common/cibuild.sh --projects $(Build.SourcesDirectory)/illink.sln
+                --configuration $(_BuildConfig) $(_BuildArgs)

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -1,11 +1,19 @@
 pool:
   vmImage: 'Ubuntu-16.04'
 
-steps:
-- script: echo Hello, world!
-  displayName: 'Run a one-line script'
-
-- script: |
-    echo Add other tasks to build, test, and deploy your project.
-    echo See https://aka.ms/yaml
-  displayName: 'Run a multi-line script'
+jobs:
+- template: /eng/common/templates/job/job.yml
+  parameters:
+    name: build
+    displayName: Build linker
+    enableTelemetry: true
+    enableMicrobuild: true
+    pool:
+      dnceng-linux-internal-temp
+    # Publish asset manifests to pipeline storage
+    enablePublishBuildAssets: true
+    # enablePublishTestResults
+    # enablePublishBuildArtifacts
+    # helixRepo
+    steps:
+    - script: eng/common/cibuild.sh --projects $(Build.SourcesDirectory)/illink.sln /p:ArcadeBuild=true

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -1,6 +1,7 @@
 variables:
 - group: 'DotNet-HelixApi-Access' # TODO: make available internally only
-- _DotNetPublishToBlobFeed: true
+- name: _DotNetPublishToBlobFeed
+  value: true
 
 jobs:
 - template: /eng/common/templates/job/job.yml

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -4,6 +4,8 @@ variables:
   value: true
 - name: _BuildConfig
   value: Release
+- name: _PublishArgs
+  value: /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
 
 jobs:
 - template: /eng/common/templates/job/job.yml
@@ -23,7 +25,7 @@ jobs:
     steps:
     - checkout: self
       submodules: true
-    - script: eng/common/cibuild.sh --projects $(Build.SourcesDirectory)/illink.sln --configuration $(_BuildConfig) /p:ArcadeBuild=true
+    - script: eng/common/cibuild.sh --projects $(Build.SourcesDirectory)/illink.sln --configuration $(_BuildConfig) $(_PublishArgs) /p:ArcadeBuild=true
 
 - template: /eng/common/templates/job/job.yml
   parameters:
@@ -40,4 +42,4 @@ jobs:
     steps:
     - checkout: self
       submodules: true
-    - script: eng\common\cibuild.cmd -projects $(Build.SourcesDirectory)\illink.sln -configuration $(_BuildConfig) /p:ArcadeBuild=true
+    - script: eng\common\cibuild.cmd -projects $(Build.SourcesDirectory)\illink.sln -configuration $(_BuildConfig) $(_PublishArgs) /p:ArcadeBuild=true

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -1,16 +1,10 @@
 variables:
 - group: DotNet-HelixApi-Access # TODO: make available internally only
-- group: DotNet-Blob-Feed
-- name: _DotNetPublishToBlobFeed
-  value: true
 - name: _BuildConfig
   value: Release
-- name: _PublishArgs
-         # these args are for publish only AFAIK
-  value: /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
-         /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
-         /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
-         /p:OfficialBuildId=$(Build.BuildNumber)
+- name: _BuildArgs
+  value: /p:OfficialBuildId=$(Build.BuildNumber)
+         /p:ArcadeBuild=true
 
   # official build I believe is used for publish and pack?? maybe also build, for versioning...
   # _SignType is used for microbuild install step
@@ -27,7 +21,6 @@ jobs:
     name: build_linux
     displayName: Build linker on linux
     enableTelemetry: true
-    enableMicrobuild: true
     pool:
       'Hosted Ubuntu 1604' # available on internal and public. recommended for both.
     # Publish asset manifests to pipeline storage
@@ -39,7 +32,8 @@ jobs:
     steps:
     - checkout: self
       submodules: true
-    - script: eng/common/cibuild.sh --projects $(Build.SourcesDirectory)/illink.sln --configuration $(_BuildConfig) $(_PublishArgs) /p:ArcadeBuild=true
+    - script: eng/common/cibuild.sh --projects $(Build.SourcesDirectory)/illink.sln
+              --configuration $(_BuildConfig) $(_BuildArgs)
 
 - template: /eng/common/templates/job/job.yml
   parameters:
@@ -53,7 +47,14 @@ jobs:
     enablePublishBuildAssets: true
     enablePublishBuildArtifacts: true
     helixRepo: 'mono/linker'
+    variables:
+    - group: DotNet-Blob-Feed
+    - _DotNetPublishToBlobFeed: true
     steps:
     - checkout: self
       submodules: true
-    - script: eng\common\cibuild.cmd -projects $(Build.SourcesDirectory)\illink.sln -configuration $(_BuildConfig) $(_PublishArgs) /p:ArcadeBuild=true
+    - script: eng\common\cibuild.cmd -projects $(Build.SourcesDirectory)\illink.sln
+              -configuration $(_BuildConfig) $(_BuildArgs)
+              /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
+              /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+              /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -6,14 +6,6 @@ variables:
   value: /p:OfficialBuildId=$(Build.BuildNumber)
          /p:ArcadeBuild=true
 
-  # official build I believe is used for publish and pack?? maybe also build, for versioning...
-  # _SignType is used for microbuild install step
-  # DotNetSignType needs to be passed for the arcade signing targets, otherwise it defaults to real.
-- name: DotNetSignType
-  value: $(_SignType)
-  # required by microbuild install step
-- name: _TeamName
-  value: .NET
 
 jobs:
 - template: /eng/common/templates/job/job.yml
@@ -49,6 +41,11 @@ jobs:
     variables:
     - group: DotNet-Blob-Feed
     - _DotNetPublishToBlobFeed: true
+    # required by microbuild install step
+    - _TeamName: .NET
+    # DotNetSignType needs to be passed for arcade signing targets, otherwise it defaults to real.
+    # _SignType is used in the arcade templates that install microbuild.
+    - DotNetSignType: $(_SignType)
     steps:
     - checkout: self
       submodules: true

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -11,6 +11,6 @@ jobs:
     enablePublishBuildAssets: true
     # enablePublishTestResults
     # enablePublishBuildArtifacts
-    # helixRepo
+    helixRepo: 'mono/linker'
     steps:
     - script: eng/common/cibuild.sh --projects $(Build.SourcesDirectory)/illink.sln /p:ArcadeBuild=true

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -1,5 +1,6 @@
 variables:
-- group: 'DotNet-HelixApi-Access' # TODO: make available internally only
+- group: DotNet-HelixApi-Access # TODO: make available internally only
+- group: DotNet-Blob-Feed
 - name: _DotNetPublishToBlobFeed
   value: true
 - name: _BuildConfig
@@ -7,6 +8,8 @@ variables:
 - name: _PublishArgs
   value: /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
          /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+         /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
+         /p:OfficialBuildId=$(Build.BuildNumber)
 
 jobs:
 - template: /eng/common/templates/job/job.yml

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -47,12 +47,12 @@ jobs:
     # DotNetSignType needs to be passed for arcade signing targets, otherwise it defaults to real.
     # _SignType is used in the arcade templates that install microbuild.
     - DotNetSignType: $(_SignType)
+    - _PublishArgs: /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
+                    /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+                    /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
     steps:
     - checkout: self
       submodules: true
     - script: eng\common\cibuild.cmd -projects $(Build.SourcesDirectory)\illink.sln
-              -configuration $(_BuildConfig) $(_BuildArgs)
-              /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
-              /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
-              /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
-      displayName: Build illink.sln $(_BuildConfig)
+              -configuration $(_BuildConfig) $(_BuildArgs) $(_PublishArgs)
+      displayName: Build and publish illink.sln $(_BuildConfig)

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -16,6 +16,8 @@ jobs:
     # enablePublishBuildArtifacts
     helixRepo: 'mono/linker'
     steps:
+    - checkout: self
+      submodules: true
     - script: eng/common/cibuild.sh --projects $(Build.SourcesDirectory)/illink.sln /p:ArcadeBuild=true
 
 - template: /eng/common/templates/job/job.yml
@@ -30,4 +32,6 @@ jobs:
     enablePublishBuildAssets: true
     helixRepo: 'mono/linker'
     steps:
+    - checkout: self
+      submodules: true
     - script: eng\common\cibuild.cmd -projects $(Build.SourcesDirectory)\illink.sln /p:ArcadeBuild=true

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -24,6 +24,7 @@ jobs:
       submodules: true
     - script: eng/common/cibuild.sh --projects $(Build.SourcesDirectory)/illink.sln
               --configuration $(_BuildConfig) $(_BuildArgs)
+      displayName: Build illink.sln $(_BuildConfig)
 
 - template: /eng/common/templates/job/job.yml
   parameters:
@@ -54,3 +55,4 @@ jobs:
               /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
               /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
               /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
+      displayName: Build illink.sln $(_BuildConfig)

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -1,5 +1,6 @@
 variables:
 - group: 'DotNet-HelixApi-Access' # TODO: make available internally only
+- _DotNetPublishToBlobFeed: true
 
 jobs:
 - template: /eng/common/templates/job/job.yml

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -10,8 +10,9 @@ variables:
   value: /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
          /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
          /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
-         # this I believe is used for publish and pack?? maybe also build, for versioning...
          /p:OfficialBuildId=$(Build.BuildNumber)
+
+  # official build I believe is used for publish and pack?? maybe also build, for versioning...
   # _SignType is used for microbuild install step
   # DotNetSignType needs to be passed for the arcade signing targets
   # required by microbuild install step

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -6,6 +6,7 @@ variables:
   value: Release
 - name: _PublishArgs
   value: /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
+         /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
 
 jobs:
 - template: /eng/common/templates/job/job.yml

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -1,12 +1,12 @@
 jobs:
 - template: /eng/common/templates/job/job.yml
   parameters:
-    name: build
-    displayName: Build linker
+    name: build_linux
+    displayName: Build linker on linux
     enableTelemetry: true
     enableMicrobuild: true
     pool:
-      dnceng-linux-internal-temp
+      'Hosted Ubuntu 1604' # available on internal and public. recommended for both.
     # Publish asset manifests to pipeline storage
     enablePublishBuildAssets: true
     # enablePublishTestResults
@@ -14,3 +14,17 @@ jobs:
     helixRepo: 'mono/linker'
     steps:
     - script: eng/common/cibuild.sh --projects $(Build.SourcesDirectory)/illink.sln /p:ArcadeBuild=true
+
+- template: /eng/common/templates/job/job.yml
+  parameters:
+    name: build_windows
+    displayName: Build linker on windows
+    enableTelemetry: true
+    enableMicrobuild: true
+    pool:
+      'dotnet-internal-temp' # internal
+      # for public, need to use 'Hosted VS2017'
+    enablePublishBuildAssets: true
+    helixRepo: 'mono/linker'
+    steps:
+    - script: eng\common\cibuild.cmd -projects $(Build.SourcesDirectory)\illink.sln /p:ArcadeBuild=true

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - checkout: self
       submodules: true
-    - script: eng/common/cibuild.sh --projects $(Build.SourcesDirectory)/illink.sln /p:ArcadeBuild=true
+    - script: eng/common/cibuild.sh --projects $(Build.SourcesDirectory)/illink.sln --configuration Release /p:ArcadeBuild=true
 
 - template: /eng/common/templates/job/job.yml
   parameters:
@@ -34,4 +34,4 @@ jobs:
     steps:
     - checkout: self
       submodules: true
-    - script: eng\common\cibuild.cmd -projects $(Build.SourcesDirectory)\illink.sln /p:ArcadeBuild=true
+    - script: eng\common\cibuild.cmd -projects $(Build.SourcesDirectory)\illink.sln -configuration Release /p:ArcadeBuild=true

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -23,8 +23,6 @@ jobs:
     enableTelemetry: true
     pool:
       'Hosted Ubuntu 1604' # available on internal and public. recommended for both.
-    # Publish asset manifests to pipeline storage
-    enablePublishBuildAssets: true
     # enablePublishTestResults
     # Publish build logs to pipeline storage
     enablePublishBuildArtifacts: true
@@ -44,6 +42,7 @@ jobs:
     pool:
       'dotnet-internal-temp' # internal
       # for public, need to use 'Hosted VS2017'
+    # publish asset manifests to pipeline storage (only for legs that publish)
     enablePublishBuildAssets: true
     enablePublishBuildArtifacts: true
     helixRepo: 'mono/linker'

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -13,7 +13,8 @@ jobs:
     # Publish asset manifests to pipeline storage
     enablePublishBuildAssets: true
     # enablePublishTestResults
-    # enablePublishBuildArtifacts
+    # Publish build logs to pipeline storage
+    enablePublishBuildArtifacts: true
     helixRepo: 'mono/linker'
     steps:
     - checkout: self
@@ -30,6 +31,7 @@ jobs:
       'dotnet-internal-temp' # internal
       # for public, need to use 'Hosted VS2017'
     enablePublishBuildAssets: true
+    enablePublishBuildArtifacts: true
     helixRepo: 'mono/linker'
     steps:
     - checkout: self

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -1,0 +1,11 @@
+pool:
+  vmImage: 'Ubuntu-16.04'
+
+steps:
+- script: echo Hello, world!
+  displayName: 'Run a one-line script'
+
+- script: |
+    echo Add other tasks to build, test, and deploy your project.
+    echo See https://aka.ms/yaml
+  displayName: 'Run a multi-line script'

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -1,6 +1,3 @@
-pool:
-  vmImage: 'Ubuntu-16.04'
-
 jobs:
 - template: /eng/common/templates/job/job.yml
   parameters:

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -2,6 +2,8 @@ variables:
 - group: 'DotNet-HelixApi-Access' # TODO: make available internally only
 - name: _DotNetPublishToBlobFeed
   value: true
+- name: _BuildConfig
+  value: Release
 
 jobs:
 - template: /eng/common/templates/job/job.yml
@@ -21,7 +23,7 @@ jobs:
     steps:
     - checkout: self
       submodules: true
-    - script: eng/common/cibuild.sh --projects $(Build.SourcesDirectory)/illink.sln --configuration Release /p:ArcadeBuild=true
+    - script: eng/common/cibuild.sh --projects $(Build.SourcesDirectory)/illink.sln --configuration $(_BuildConfig) /p:ArcadeBuild=true
 
 - template: /eng/common/templates/job/job.yml
   parameters:
@@ -38,4 +40,4 @@ jobs:
     steps:
     - checkout: self
       submodules: true
-    - script: eng\common\cibuild.cmd -projects $(Build.SourcesDirectory)\illink.sln -configuration Release /p:ArcadeBuild=true
+    - script: eng\common\cibuild.cmd -projects $(Build.SourcesDirectory)\illink.sln -configuration $(_BuildConfig) /p:ArcadeBuild=true

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -14,7 +14,9 @@ variables:
 
   # official build I believe is used for publish and pack?? maybe also build, for versioning...
   # _SignType is used for microbuild install step
-  # DotNetSignType needs to be passed for the arcade signing targets
+  # DotNetSignType needs to be passed for the arcade signing targets, otherwise it defaults to real.
+- name: DotNetSignType
+  value: $(_SignType)
   # required by microbuild install step
 - name: _TeamName
   value: .NET

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -6,10 +6,17 @@ variables:
 - name: _BuildConfig
   value: Release
 - name: _PublishArgs
+         # these args are for publish only AFAIK
   value: /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
          /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
          /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
+         # this I believe is used for publish and pack?? maybe also build, for versioning...
          /p:OfficialBuildId=$(Build.BuildNumber)
+  # _SignType is used for microbuild install step
+  # DotNetSignType needs to be passed for the arcade signing targets
+  # required by microbuild install step
+- name: _TeamName
+  value: .NET
 
 jobs:
 - template: /eng/common/templates/job/job.yml

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -1,3 +1,6 @@
+variables:
+- group: 'DotNet-HelixApi-Access' # TODO: make available internally only
+
 jobs:
 - template: /eng/common/templates/job/job.yml
   parameters:

--- a/src/ILLink.CustomSteps/ILLink.CustomSteps.csproj
+++ b/src/ILLink.CustomSteps/ILLink.CustomSteps.csproj
@@ -5,12 +5,6 @@
     <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);FEATURE_ILLINK</DefineConstants>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <AssemblyName>ILLink.CustomSteps</AssemblyName>
-    <OutputType>Library</OutputType>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <ProjectGuid>{275C1D10-168A-4AC4-8F3E-AD969F580B9C}</ProjectGuid>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ILLink.CustomSteps/ILLink.CustomSteps.csproj
+++ b/src/ILLink.CustomSteps/ILLink.CustomSteps.csproj
@@ -5,7 +5,6 @@
     <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);FEATURE_ILLINK</DefineConstants>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>ILLink.CustomSteps</AssemblyName>
     <OutputType>Library</OutputType>
   </PropertyGroup>

--- a/src/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/src/ILLink.Tasks/ILLink.Tasks.csproj
@@ -99,25 +99,22 @@
   <ItemGroup>
     <Compile Include="AdapterLogger.cs" />
     <Compile Include="LinkTask.cs" />
+    <Compile Include="CheckEmbeddedRootDescriptor.cs" />
     <Compile Include="CompareSizes.cs" />
-    <Compile Include="ComputeManagedAssemblies.cs" />
     <Compile Include="ComputeCrossgenedAssemblies.cs" />
-    <!--
-    <Compile Include="GetRuntimeLibraries.cs" />
-    -->
+    <Compile Include="ComputeManagedAssemblies.cs" />
+    <Compile Include="ComputeRemovedAssemblies.cs" />
     <Compile Include="CreateRootDescriptorFile.cs" />
     <Compile Include="CreateRuntimeRootDescriptorFile.cs" />
     <Compile Include="FilterByMetadata.cs" />
     <Compile Include="FindDuplicatesByMetadata.cs" />
-    <Compile Include="Utils.cs" />
-    <!--
-    <Compile Include="Microsoft.NET.Build.Tasks/LockFileCache.cs" />
-    -->
-    <Compile Include="Microsoft.NET.Build.Tasks/BuildErrorException.cs" />
     <Compile Include="FindNativeDeps.cs" />
-    <Compile Include="ComputeRemovedAssemblies.cs" />
-    <Compile Include="CheckEmbeddedRootDescriptor.cs" />
     <Compile Include="SetAssemblyActions.cs" />
+    <Compile Include="Utils.cs" />
+    <!-- Don't support enumerating runtime libraries in this version -->
+    <None Include="GetRuntimeLibraries.cs" />
+    <None Include="Microsoft.NET.Build.Tasks/LockFileCache.cs" />
+    <None Include="Microsoft.NET.Build.Tasks/BuildErrorException.cs" />
   </ItemGroup>
 
   <!-- TODO: Uncomment this once we can avoid hard-coding this in a
@@ -222,9 +219,6 @@
                       PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.1012"
                       PrivateAssets="All" />
-                      <!--
-    <PackageReference Include="NuGet.ProjectModel" Version="4.3.0-preview1-2500" />
-    -->
     <PackageReference Include="System.Reflection.Metadata" Version="1.3.0"
                       PrivateAssets="All" />
   </ItemGroup>

--- a/src/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/src/ILLink.Tasks/ILLink.Tasks.csproj
@@ -102,13 +102,17 @@
     <Compile Include="CompareSizes.cs" />
     <Compile Include="ComputeManagedAssemblies.cs" />
     <Compile Include="ComputeCrossgenedAssemblies.cs" />
+    <!--
     <Compile Include="GetRuntimeLibraries.cs" />
+    -->
     <Compile Include="CreateRootDescriptorFile.cs" />
     <Compile Include="CreateRuntimeRootDescriptorFile.cs" />
     <Compile Include="FilterByMetadata.cs" />
     <Compile Include="FindDuplicatesByMetadata.cs" />
     <Compile Include="Utils.cs" />
+    <!--
     <Compile Include="Microsoft.NET.Build.Tasks/LockFileCache.cs" />
+    -->
     <Compile Include="Microsoft.NET.Build.Tasks/BuildErrorException.cs" />
     <Compile Include="FindNativeDeps.cs" />
     <Compile Include="ComputeRemovedAssemblies.cs" />
@@ -218,7 +222,9 @@
                       PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.1012"
                       PrivateAssets="All" />
+                      <!--
     <PackageReference Include="NuGet.ProjectModel" Version="4.3.0-preview1-2500" />
+    -->
     <PackageReference Include="System.Reflection.Metadata" Version="1.3.0"
                       PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
This sets up an azure-pipelines build definition to build illink.
- Set certificates to use for signing in our official builds
- Remove dependency on NuGet.ProjectModel. This gets rid of a third-party dependency on Newtonsoft.Json. We shouldn't need the task that was using this (GetRuntimeLibraries) any more if the SDK can tell us which libraries are runtime libraries.

I will also be adding a public build definition (using the same .yml file) for ci on github PRs.

Depends on https://github.com/mono/linker/pull/475.