### PR TITLE
Run illink out of process

### DIFF
--- a/src/ILLink.Tasks/ILLink.Tasks.nuspec
+++ b/src/ILLink.Tasks/ILLink.Tasks.nuspec
@@ -10,5 +10,6 @@
     <file src="ILLink.Tasks.targets" target="build" />
     <file src="ILLink.CrossGen.targets" target="build" />
     <file src="netcoreapp2.0/**/*.dll" target="tools" />
+    <file src="netcoreapp2.0/**/*.json" target="tools" />
   </files>
 </package>

--- a/src/ILLink.Tasks/LinkTask.cs
+++ b/src/ILLink.Tasks/LinkTask.cs
@@ -123,14 +123,12 @@ namespace ILLink.Tasks
 
 			if (RootDescriptorFiles != null) {
 				foreach (var rootFile in RootDescriptorFiles) {
-					args.Append (" -x");
-					args.Append ($" {rootFile.ItemSpec}");
+					args.Append (" -x ").Append (rootFile.ItemSpec);
 				}
 			}
 
 			foreach (var assemblyItem in RootAssemblyNames) {
-				args.Append (" -a");
-				args.Append ($" {assemblyItem.ItemSpec}");
+				args.Append (" -a ").Append (assemblyItem.ItemSpec);
 			}
 
 			HashSet<string> directories = new HashSet<string> ();
@@ -139,36 +137,33 @@ namespace ILLink.Tasks
 				var dir = Path.GetDirectoryName (assemblyPath);
 				if (!directories.Contains (dir)) {
 					directories.Add (dir);
-					args.Append (" -d");
-					args.Append ($" {dir}");
+					args.Append (" -d ").Append (dir);
 				}
 
 				string action = assembly.GetMetadata ("action");
 				if ((action != null) && (action.Length > 0)) {
-					args.Append (" -p");
-					args.Append ($" {action}");
-					args.Append (" " + Path.GetFileNameWithoutExtension (assemblyPath));
+					args.Append (" -p ");
+					args.Append (action);
+					args.Append (" ").Append (Path.GetFileNameWithoutExtension (assemblyPath));
 				}
 			}
 
 			if (OutputDirectory != null) {
-				args.Append (" -out");
-				args.Append ($" {OutputDirectory.ItemSpec}");
+				args.Append (" -out ").Append (OutputDirectory.ItemSpec);
 			}
 
 			if (ClearInitLocals) {
-				args.Append (" -s");
+				args.Append (" -s ");
 				// Version of ILLink.CustomSteps is passed as a workaround for msbuild issue #3016
-				args.Append (" LLink.CustomSteps.ClearInitLocalsStep,ILLink.CustomSteps,Version=0.0.0.0:OutputStep");
+				args.Append ("LLink.CustomSteps.ClearInitLocalsStep,ILLink.CustomSteps,Version=0.0.0.0:OutputStep");
 				if ((ClearInitLocalsAssemblies != null) && (ClearInitLocalsAssemblies.Length > 0)) {
-					args.Append (" -m");
-					args.Append (" ClearInitLocalsAssemblies");
-					args.Append ($" {ClearInitLocalsAssemblies}");
+					args.Append (" -m ClearInitLocalsAssemblies ");
+					args.Append (ClearInitLocalsAssemblies);
 				}
 			}
 
 			if (ExtraArgs != null) {
-				args.Append ($" {ExtraArgs}");
+				args.Append (" ").Append (ExtraArgs);
 			}
 
 			if (DumpDependencies)

--- a/src/ILLink.Tasks/LinkTask.cs
+++ b/src/ILLink.Tasks/LinkTask.cs
@@ -1,12 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
+using System.Reflection;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
 namespace ILLink.Tasks
 {
-	public class ILLink : Task
+	public class ILLink : ToolTask
 	{
 		/// <summary>
 		///   Paths to the assembly files that should be considered as
@@ -70,30 +72,65 @@ namespace ILLink.Tasks
 		/// </summary>
 		public bool DumpDependencies { get; set; }
 
-		public override bool Execute ()
+
+		private static string DotNetHostPathEnvironmentName = "DOTNET_HOST_PATH";
+
+		private string _dotnetPath;
+
+		private string DotNetPath
 		{
-			string [] args = GenerateCommandLineCommands ();
-			var argsString = String.Join (" ", args);
-			Log.LogMessageFromText ($"illink {argsString}", MessageImportance.Normal);
-			var logger = new AdapterLogger (Log);
-			int ret = Mono.Linker.Driver.Execute (args, logger);
-			return ret == 0;
+			get
+			{
+				if (!String.IsNullOrEmpty (_dotnetPath))
+				{
+					return _dotnetPath;
+				}
+				_dotnetPath = Environment.GetEnvironmentVariable (DotNetHostPathEnvironmentName);
+				if (String.IsNullOrEmpty (_dotnetPath))
+				{
+					throw new InvalidOperationException ($"{DotNetHostPathEnvironmentName} is not set");
+				}
+				return _dotnetPath;
+			}
 		}
 
-		string [] GenerateCommandLineCommands ()
+
+		/// ToolTask implementation
+
+		protected override string ToolName => Path.GetFileName (DotNetPath);
+
+		protected override string GenerateFullPathToTool () => DotNetPath;
+
+		private string _illinkPath = "";
+
+		public string ILLinkPath {
+			get {
+				if (!String.IsNullOrEmpty (_illinkPath))
+				{
+					return _illinkPath;
+				}
+				var taskDirectory = Path.GetDirectoryName (Assembly.GetExecutingAssembly ().Location);
+				_illinkPath = Path.Combine (taskDirectory, "illink.dll");
+				return _illinkPath;
+			}
+			set => _illinkPath = value;
+		}
+
+		protected override string GenerateCommandLineCommands ()
 		{
-			var args = new List<string> ();
+			var args = new StringBuilder ();
+			args.Append (ILLinkPath);
 
 			if (RootDescriptorFiles != null) {
 				foreach (var rootFile in RootDescriptorFiles) {
-					args.Add ("-x");
-					args.Add (rootFile.ItemSpec);
+					args.Append (" -x");
+					args.Append ($" {rootFile.ItemSpec}");
 				}
 			}
 
 			foreach (var assemblyItem in RootAssemblyNames) {
-				args.Add ("-a");
-				args.Add (assemblyItem.ItemSpec);
+				args.Append (" -a");
+				args.Append ($" {assemblyItem.ItemSpec}");
 			}
 
 			HashSet<string> directories = new HashSet<string> ();
@@ -102,42 +139,42 @@ namespace ILLink.Tasks
 				var dir = Path.GetDirectoryName (assemblyPath);
 				if (!directories.Contains (dir)) {
 					directories.Add (dir);
-					args.Add ("-d");
-					args.Add (dir);
+					args.Append (" -d");
+					args.Append ($" {dir}");
 				}
 
 				string action = assembly.GetMetadata ("action");
 				if ((action != null) && (action.Length > 0)) {
-					args.Add ("-p");
-					args.Add (action);
-					args.Add (Path.GetFileNameWithoutExtension (assemblyPath));
+					args.Append (" -p");
+					args.Append ($" {action}");
+					args.Append (" " + Path.GetFileNameWithoutExtension (assemblyPath));
 				}
 			}
 
 			if (OutputDirectory != null) {
-				args.Add ("-out");
-				args.Add (OutputDirectory.ItemSpec);
+				args.Append (" -out");
+				args.Append ($" {OutputDirectory.ItemSpec}");
 			}
 
 			if (ClearInitLocals) {
-				args.Add ("-s");
+				args.Append (" -s");
 				// Version of ILLink.CustomSteps is passed as a workaround for msbuild issue #3016
-				args.Add ("ILLink.CustomSteps.ClearInitLocalsStep,ILLink.CustomSteps,Version=0.0.0.0:OutputStep");
+				args.Append (" LLink.CustomSteps.ClearInitLocalsStep,ILLink.CustomSteps,Version=0.0.0.0:OutputStep");
 				if ((ClearInitLocalsAssemblies != null) && (ClearInitLocalsAssemblies.Length > 0)) {
-					args.Add ("-m");
-					args.Add ("ClearInitLocalsAssemblies");
-					args.Add (ClearInitLocalsAssemblies);
+					args.Append (" -m");
+					args.Append (" ClearInitLocalsAssemblies");
+					args.Append ($" {ClearInitLocalsAssemblies}");
 				}
 			}
 
 			if (ExtraArgs != null) {
-				args.AddRange (ExtraArgs.Split (' '));
+				args.Append ($" {ExtraArgs}");
 			}
 
 			if (DumpDependencies)
-				args.Add ("--dump-dependencies");
+				args.Append (" --dump-dependencies");
 
-			return args.ToArray ();
+			return args.ToString ();
 		}
 
 	}

--- a/src/linker/ILLink.props
+++ b/src/linker/ILLink.props
@@ -7,7 +7,8 @@
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>illink</AssemblyName>
-    <OutputType>Library</OutputType>
+    <!-- OutputType is Exe in Mono.Linker.csproj, but it needs to be set before importing SDK targets. -->
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
 </Project>

--- a/src/linker/ILLink.props
+++ b/src/linker/ILLink.props
@@ -11,4 +11,14 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
+  <!-- When publishing illink as a dependency of ILLink.Tasks, we want
+       to include files needed to run it as an application in the
+       publish output. See https://github.com/dotnet/sdk/issues/1675. -->
+  <Target Name="AddRuntimeDependenciesToContent" Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp'" BeforeTargets="GetCopyToOutputDirectoryItems">
+    <ItemGroup>
+      <ContentWithTargetPath Include="$(ProjectDepsFilePath)" CopyToOutputDirectory="PreserveNewest" TargetPath="$(ProjectDepsFileName)" />
+      <ContentWithTargetPath Include="$(ProjectRuntimeConfigFilePath)" CopyToOutputDirectory="PreserveNewest" TargetPath="$(ProjectRuntimeConfigFileName)" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/linker/ILLink.props
+++ b/src/linker/ILLink.props
@@ -14,7 +14,10 @@
   <!-- When publishing illink as a dependency of ILLink.Tasks, we want
        to include files needed to run it as an application in the
        publish output. See https://github.com/dotnet/sdk/issues/1675. -->
-  <Target Name="AddRuntimeDependenciesToContent" Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp'" BeforeTargets="GetCopyToOutputDirectoryItems">
+  <Target Name="AddRuntimeDependenciesToContent"
+          BeforeTargets="GetCopyToOutputDirectoryItems"
+          DependsOnTargets="GenerateBuildDependencyFile;GenerateBuildRuntimeConfigurationFiles"
+          Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <ItemGroup>
       <ContentWithTargetPath Include="$(ProjectDepsFilePath)" CopyToOutputDirectory="PreserveNewest" TargetPath="$(ProjectDepsFileName)" />
       <ContentWithTargetPath Include="$(ProjectRuntimeConfigFilePath)" CopyToOutputDirectory="PreserveNewest" TargetPath="$(ProjectRuntimeConfigFileName)" />


### PR DESCRIPTION
This changes illink to build as a framework-dependent app. Its runtimeconfig.json and deps.json get published in the package, alongside ILLink.Tasks.dll. The ILLink task will now run the linker in a new process, by implementing MSBuild's ToolTask.

This will make it possible to run illink more easily from the command line, and will give us a little more flexibility in the dependencies of illink (since they no longer have to unify with the dependencies of other tasks in the msbuild process).