### PR TITLE
Build and link using 3.0 SDK

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "2.1.403"
+    "dotnet": "3.0.100-preview-010184"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19125.2"

--- a/src/ILLink.Tasks/ILLink.Tasks.targets
+++ b/src/ILLink.Tasks/ILLink.Tasks.targets
@@ -90,7 +90,7 @@
        ComputeFilesToPublish, but after all of its dependencies. -->
   <Target Name="ComputeLinkedFilesToPublish"
           BeforeTargets="ComputeFilesToPublish"
-          DependsOnTargets="_ComputeLinkedAssemblies;_FindNativeDeps"
+          DependsOnTargets="_ComputeLinkedAssemblies;_FindNativeDeps;_RemoveDuplicatesFrom_ResolvedCopyLocalPublishAssets"
           Condition=" '$(LinkDuringPublish)' == 'true' ">
     <!-- Rewrite ResolvedAssembliesToPublish, which is an input to
          ComputeFilesToPublish. -->
@@ -116,6 +116,19 @@
     </ItemGroup>
   </Target>
 
+  <!-- Work around duplicate items in
+       _ResolvedCopyLocalPublishAssets. See
+       https://github.com/dotnet/sdk/issues/3007. -->
+  <Target Name="_RemoveDuplicatesFrom_ResolvedCopyLocalPublishAssets">
+    <RemoveDuplicates Inputs="@(_ResolvedCopyLocalPublishAssets)">
+      <Output TaskParameter="Filtered" ItemName="_Unique_ResolvedCopyLocalPublishAssets" />
+    </RemoveDuplicates>
+    <ItemGroup>
+      <_ResolvedCopyLocalPublishAssets Remove="@(_ResolvedCopyLocalPublishAssets)" />
+      <_ResolvedCopyLocalPublishAssets Include="@(_Unique_ResolvedCopyLocalPublishAssets)" />
+    </ItemGroup>
+  </Target>
+
   <!-- The SDK has a target called ComputeRefAssembliesToPublish that
        runs after ComputeFilesToPublish and rewrites
        ResolvedFileToPublish to include any reference assemblies that
@@ -129,7 +142,8 @@
        restore it to its pre-link state before
        ComputeRefAssembliesToPublish. -->
   <Target Name="SaveResolvedAssembliesToPublish"
-          BeforeTargets="ComputeLinkedFilesToPublish">
+          BeforeTargets="ComputeLinkedFilesToPublish"
+          DependsOnTargets="_RemoveDuplicatesFrom_ResolvedCopyLocalPublishAssets">
     <ItemGroup>
       <PreLinkResolvedAssembliesToPublish Include="@(_ResolvedCopyLocalPublishAssets)" />
     </ItemGroup>
@@ -151,7 +165,7 @@
   <UsingTask TaskName="CompareAssemblySizes" AssemblyFile="$(LinkTaskDllPath)" />
   <Target Name="_CompareLinkedAssemblySizes"
           AfterTargets="ComputeFilesToPublish"
-          DependsOnTargets="_ComputeManagedAssembliesToLink;_ComputeLinkedAssemblies"
+          DependsOnTargets="_ComputeManagedAssembliesToLink;_ComputeLinkedAssemblies;_RemoveDuplicatesFrom_ResolvedCopyLocalPublishAssets"
           Condition=" '$(LinkDuringPublish)' == 'true' And '$(ShowLinkerSizeComparison)' == 'true' ">
     <FilterByMetadata Items="@(_ResolvedCopyLocalPublishAssets);@(IntermediateAssembly)"
                       MetadataName="Filename"
@@ -280,7 +294,7 @@
        dependencies, and these are prevented from being published. -->
   <UsingTask TaskName="FindNativeDeps" AssemblyFile="$(LinkTaskDllPath)" />
   <Target Name="_FindNativeDeps"
-          DependsOnTargets="_ComputeLinkedAssemblies"
+          DependsOnTargets="_ComputeLinkedAssemblies;_RemoveDuplicatesFrom_ResolvedCopyLocalPublishAssets"
           Condition=" '$(LinkerTrimNativeDeps)' == 'true' ">
     <ItemGroup>
       <_NativeResolvedDepsToPublish Include="@(_ResolvedCopyLocalPublishAssets)" />
@@ -365,7 +379,8 @@
        because we use the list of managed assemblies to filter the
        publish output. -->
   <UsingTask TaskName="ComputeManagedAssemblies" AssemblyFile="$(LinkTaskDllPath)" />
-  <Target Name="_ComputeManagedResolvedAssembliesToPublish">
+  <Target Name="_ComputeManagedResolvedAssembliesToPublish"
+          DependsOnTargets="_RemoveDuplicatesFrom_ResolvedCopyLocalPublishAssets">
     <!-- TODO: Is there a better way to get the managed assemblies
          from ResolvedAssembliesToPublish? We may be able to check for
          AssetType="runtime" on managed assemblies - would that give

--- a/src/ILLink.Tasks/ILLink.Tasks.targets
+++ b/src/ILLink.Tasks/ILLink.Tasks.targets
@@ -508,7 +508,7 @@
        file. -->
   <UsingTask TaskName="ComputeRemovedAssemblies" AssemblyFile="$(LinkTaskDllPath)" />
   <Target Name="_ExcludeRemovedFilesFromDepFileGeneration"
-          DependsOnTargets="_ComputeManagedResolvedAssembliesToPublish;_ComputeLinkedAssemblies;_FindNativeDeps;_HandlePublishFileConflicts"
+          DependsOnTargets="_ComputeManagedResolvedAssembliesToPublish;_ComputeLinkedAssemblies;_FindNativeDeps;_HandlePackageFileConflictsForPublish"
           BeforeTargets="GeneratePublishDependencyFile"
           Condition=" '$(LinkDuringPublish)' == 'true' ">
     <ComputeRemovedAssemblies InputAssemblies="@(_ManagedAssembliesToLink)"

--- a/src/ILLink.Tasks/ILLink.Tasks.targets
+++ b/src/ILLink.Tasks/ILLink.Tasks.targets
@@ -472,14 +472,11 @@
        "platform", currently Microsoft.NETCore.App. -->
   <UsingTask TaskName="GetRuntimeLibraries" AssemblyFile="$(LinkTaskDllPath)" />
   <Target Name="_ComputePlatformLibraries"
-          DependsOnTargets="_ComputeManagedAssembliesToLink">
-    <GetRuntimeLibraries Condition=" '$(SelfContained)' == 'true' "
-                         AssetsFilePath="$(ProjectAssetsFile)"
-                         TargetFramework="$(TargetFrameworkMoniker)"
-                         RuntimeIdentifier="$(RuntimeIdentifier)"
-                         PackageNames="$(MicrosoftNETPlatformLibrary)">
-      <Output TaskParameter="RuntimeLibraries" ItemName="PlatformLibraries" />
-    </GetRuntimeLibraries>
+          DependsOnTargets="_ComputeManagedAssembliesToLink;ResolveRuntimePackAssets">
+
+    <ItemGroup>
+      <PlatformLibraries Include="@(RuntimePackAssets)" />
+    </ItemGroup>
 
     <ItemGroup>
       <PlatformLibraries Include="@(_ManagedAssembliesToLink)" Condition=" '%(Filename)' == 'System.Private.CoreLib' " />

--- a/src/ILLink.Tasks/ILLink.Tasks.targets
+++ b/src/ILLink.Tasks/ILLink.Tasks.targets
@@ -95,10 +95,10 @@
     <!-- Rewrite ResolvedAssembliesToPublish, which is an input to
          ComputeFilesToPublish. -->
     <ItemGroup>
-      <ResolvedAssembliesToPublish Remove="@(_ManagedAssembliesToLink)" />
-      <ResolvedAssembliesToPublish Remove="@(_NativeResolvedDepsToPublish)" />
-      <ResolvedAssembliesToPublish Include="@(_NativeKeptDepsToPublish)" />
-      <ResolvedAssembliesToPublish Include="@(_LinkedResolvedAssemblies)" />
+      <_ResolvedCopyLocalPublishAssets Remove="@(_ManagedAssembliesToLink)" />
+      <_ResolvedCopyLocalPublishAssets Remove="@(_NativeResolvedDepsToPublish)" />
+      <_ResolvedCopyLocalPublishAssets Include="@(_NativeKeptDepsToPublish)" />
+      <_ResolvedCopyLocalPublishAssets Include="@(_LinkedResolvedAssemblies)" />
     </ItemGroup>
 
     <!-- Rewrite IntermediateAssembly, which is an input to
@@ -131,14 +131,14 @@
   <Target Name="SaveResolvedAssembliesToPublish"
           BeforeTargets="ComputeLinkedFilesToPublish">
     <ItemGroup>
-      <PreLinkResolvedAssembliesToPublish Include="@(ResolvedAssembliesToPublish)" />
+      <PreLinkResolvedAssembliesToPublish Include="@(_ResolvedCopyLocalPublishAssets)" />
     </ItemGroup>
   </Target>
   <Target Name="RestoreResolvedAssembliesToPublish"
           BeforeTargets="ComputeRefAssembliesToPublish">
     <ItemGroup>
-      <ResolvedAssembliesToPublish Remove="@(ResolvedAssembliesToPublish)" />
-      <ResolvedAssembliesToPublish Include="@(PreLinkResolvedAssembliesToPublish)" />
+      <_ResolvedCopyLocalPublishAssets Remove="@(_ResolvedCopyLocalPublishAssets)" />
+      <_ResolvedCopyLocalPublishAssets Include="@(PreLinkResolvedAssembliesToPublish)" />
     </ItemGroup>
   </Target>
 
@@ -153,7 +153,7 @@
           AfterTargets="ComputeFilesToPublish"
           DependsOnTargets="_ComputeManagedAssembliesToLink;_ComputeLinkedAssemblies"
           Condition=" '$(LinkDuringPublish)' == 'true' And '$(ShowLinkerSizeComparison)' == 'true' ">
-    <FilterByMetadata Items="@(ResolvedAssembliesToPublish);@(IntermediateAssembly)"
+    <FilterByMetadata Items="@(_ResolvedCopyLocalPublishAssets);@(IntermediateAssembly)"
                       MetadataName="Filename"
                       MetadataValues="@(_ManagedAssembliesToLink->'%(Filename)')">
       <Output TaskParameter="FilteredItems" ItemName="_FinalAssembliesTouchedByLinker" />
@@ -283,7 +283,7 @@
           DependsOnTargets="_ComputeLinkedAssemblies"
           Condition=" '$(LinkerTrimNativeDeps)' == 'true' ">
     <ItemGroup>
-      <_NativeResolvedDepsToPublish Include="@(ResolvedAssembliesToPublish)" />
+      <_NativeResolvedDepsToPublish Include="@(_ResolvedCopyLocalPublishAssets)" />
       <_NativeResolvedDepsToPublish Remove="@(_ManagedResolvedAssembliesToPublish)" />
       <_NativeResolvedDepsToPublish Remove="@(_NativeResolvedDepsToPublish->WithMetadataValue('AssetType', 'resources'))" />
     </ItemGroup>
@@ -370,7 +370,7 @@
          from ResolvedAssembliesToPublish? We may be able to check for
          AssetType="runtime" on managed assemblies - would that give
          the same set of assemblies? -->
-    <ComputeManagedAssemblies Assemblies="@(ResolvedAssembliesToPublish)">
+    <ComputeManagedAssemblies Assemblies="@(_ResolvedCopyLocalPublishAssets)">
       <Output TaskParameter="ManagedAssemblies" ItemName="_ManagedResolvedAssembliesToPublish" />
     </ComputeManagedAssemblies>
     <!-- For now, hard-code System.Private.CoreLib.ni, the only .ni


### PR DESCRIPTION
This will bootstrap the 3.0 SDK and use it to build illink. The targets have been updated in response to some SDK changes, along with a fix for an SDK bug: https://github.com/dotnet/sdk/issues/3007.
