### PR TITLE
Include a fixed GenerateDepsFile task

### DIFF
--- a/src/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/src/ILLink.Tasks/ILLink.Tasks.csproj
@@ -7,6 +7,7 @@
     <BaseOutputPath>bin/</BaseOutputPath>
     <PackageOutputPath>$(BaseOutputPath)nupkgs</PackageOutputPath>
     <IsPackable>true</IsPackable>
+    <LangVersion>7.2</LangVersion> <!-- Required to build GenerateDepsFile -->
     <!-- IsTool true causes the build output to be placed in the
          package's tools folder. This allows projects to reference the
          tasks package without including the tasks dll in their

--- a/src/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/src/ILLink.Tasks/ILLink.Tasks.csproj
@@ -115,6 +115,8 @@
     <None Include="GetRuntimeLibraries.cs" />
     <None Include="Microsoft.NET.Build.Tasks/LockFileCache.cs" />
     <None Include="Microsoft.NET.Build.Tasks/BuildErrorException.cs" />
+    <!-- Include sources for generating the deps file. -->
+    <Compile Include="Microsoft.NET.Build.Tasks/**/*.cs" />
   </ItemGroup>
 
   <!-- TODO: Uncomment this once we can avoid hard-coding this in a
@@ -221,5 +223,15 @@
                       PrivateAssets="All" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.3.0"
                       PrivateAssets="All" />
+
+    <!-- Used for generating the deps file. -->
+    <PackageReference Include="NuGet.ProjectModel" Version="4.9.3"
+                      PrivateAssets="All" />
+    <!-- Used for generating the deps file. We use the same version as the SDK:
+         https://github.com/dotnet/sdk/blob/master/eng/Versions.props -->
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0-preview2-26306-03"
+                      PrivateAssets="All" />
+
   </ItemGroup>
+
 </Project>

--- a/src/ILLink.Tasks/ILLink.Tasks.targets
+++ b/src/ILLink.Tasks/ILLink.Tasks.targets
@@ -525,4 +525,6 @@
     </ItemGroup>
   </Target>
 
+  <!-- Workaround for https://github.com/dotnet/sdk/issues/3010 -->
+  <UsingTask TaskName="GenerateDepsFile" AssemblyFile="$(LinkTaskDllPath)" />
 </Project>

--- a/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/Common/ConflictResolution/ConflictItem.cs
+++ b/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/Common/ConflictResolution/ConflictItem.cs
@@ -1,0 +1,228 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Framework;
+using System;
+using System.IO;
+
+namespace Microsoft.NET.Build.Tasks.ConflictResolution
+{
+    internal enum ConflictItemType
+    {
+        Reference,
+        CopyLocal,
+        Runtime,
+        Platform
+    }
+
+    internal interface IConflictItem
+    {
+        Version AssemblyVersion { get; }
+        ConflictItemType ItemType { get; }
+        bool Exists { get; }
+        string FileName { get; }
+        Version FileVersion { get; }
+        string PackageId { get; }
+        string DisplayName { get; }
+
+        // NOTE: Technically this should be NuGetVersion because System.Version doesn't work with semver.
+        // However, the only scenarios we need to support this property for in conflict resolution is stable versions
+        // of System packages. PackageVersion will be null if System.Version can't parse the version (i.e. if is pre-release)
+        Version PackageVersion { get; }
+    }
+
+    // Wraps an ITask item and adds lazy evaluated properties used by Conflict resolution.
+    internal class ConflictItem : IConflictItem
+    {
+        public ConflictItem(ITaskItem originalItem, ConflictItemType itemType)
+        {
+            OriginalItem = originalItem;
+            ItemType = itemType;
+        }
+
+        public ConflictItem(string fileName, string packageId, Version assemblyVersion, Version fileVersion)
+        {
+            OriginalItem = null;
+            ItemType = ConflictItemType.Platform;
+            FileName = fileName;
+            SourcePath = fileName;
+            PackageId = packageId;
+            AssemblyVersion = assemblyVersion;
+            FileVersion = fileVersion;
+        }
+
+        private bool _hasAssemblyVersion;
+        private Version _assemblyVersion;
+        public Version AssemblyVersion
+        {
+            get
+            {
+                if (!_hasAssemblyVersion)
+                {
+                    _assemblyVersion = null;
+
+                    var assemblyVersionString = OriginalItem?.GetMetadata(nameof(AssemblyVersion)) ?? String.Empty;
+
+                    if (assemblyVersionString.Length != 0)
+                    {
+                        Version.TryParse(assemblyVersionString, out _assemblyVersion);
+                    }
+                    else
+                    {
+                        _assemblyVersion = FileUtilities.TryGetAssemblyVersion(SourcePath);
+                    }
+
+                    // assemblyVersion may be null but don't try to recalculate it
+                    _hasAssemblyVersion = true;
+                }
+
+                return _assemblyVersion;
+            }
+            private set
+            {
+                _assemblyVersion = value;
+                _hasAssemblyVersion = true;
+            }
+        }
+
+        public ConflictItemType ItemType { get; }
+
+        private bool? _exists;
+        public bool Exists
+        {
+            get
+            {
+                if (_exists == null)
+                {
+                    _exists = ItemType == ConflictItemType.Platform || File.Exists(SourcePath);
+                }
+
+                return _exists.Value;
+            }
+        }
+
+        private string _fileName;
+        public string FileName
+        {
+            get
+            {
+                if (_fileName == null)
+                {
+                    _fileName = OriginalItem == null ? String.Empty : Path.GetFileName(OriginalItem.ItemSpec);
+                }
+                return _fileName;
+            }
+            private set { _fileName = value; }
+        }
+
+        private bool _hasFileVersion;
+        private Version _fileVersion;
+        public Version FileVersion
+        {
+            get
+            {
+                if (!_hasFileVersion)
+                {
+                    _fileVersion = null;
+
+                    var fileVersionString = OriginalItem?.GetMetadata(nameof(FileVersion)) ?? String.Empty;
+
+                    if (fileVersionString.Length != 0)
+                    {
+                        Version.TryParse(fileVersionString, out _fileVersion);
+                    }
+                    else
+                    {
+                        _fileVersion = FileUtilities.GetFileVersion(SourcePath);
+                    }
+
+                    // fileVersion may be null but don't try to recalculate it
+                    _hasFileVersion = true;
+                }
+
+                return _fileVersion;
+            }
+            private set
+            {
+                _fileVersion = value;
+                _hasFileVersion = true;
+            }
+        }
+
+        public ITaskItem OriginalItem { get; }
+
+        private string _packageId;
+        public string PackageId
+        {
+            get
+            {
+                if (_packageId == null)
+                {
+                    _packageId = OriginalItem?.GetMetadata(MetadataNames.NuGetPackageId) ?? String.Empty;
+
+                    if (_packageId.Length == 0)
+                    {
+                        _packageId = NuGetUtils.GetPackageIdFromSourcePath(SourcePath) ?? String.Empty;
+                    }
+                }
+
+                return _packageId.Length == 0 ? null : _packageId;
+            }
+            private set { _packageId = value; }
+        }
+
+        private bool _hasPackageVersion;
+        private Version _packageVersion;
+        public Version PackageVersion
+        {
+            get
+            {
+                if (!_hasPackageVersion)
+                {
+                    _packageVersion = null;
+
+                    var packageVersionString = OriginalItem?.GetMetadata(nameof(MetadataNames.NuGetPackageVersion)) ?? String.Empty;
+
+                    if (packageVersionString.Length != 0)
+                    {
+                        Version.TryParse(packageVersionString, out _packageVersion);
+                    }
+
+                    // PackageVersion may be null but don't try to recalculate it
+                    _hasPackageVersion = true;
+                }
+
+                return _packageVersion;
+            }
+        }
+
+        private string _sourcePath;
+        public string SourcePath
+        {
+            get
+            {
+                if (_sourcePath == null)
+                {
+                    _sourcePath = ItemUtilities.GetSourcePath(OriginalItem) ?? String.Empty;
+                }
+
+                return _sourcePath.Length == 0 ? null : _sourcePath;
+            }
+            private set { _sourcePath = value; }
+        }
+        
+        private string _displayName;
+        public string DisplayName
+        {
+            get
+            {
+                if (_displayName == null)
+                {
+                    var itemSpec = OriginalItem == null ? FileName : OriginalItem.ItemSpec;
+                    _displayName = $"{ItemType}:{itemSpec}";
+                }
+                return _displayName;
+            }
+        }
+    }
+}

--- a/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/Common/ConflictResolution/MetadataNames.cs
+++ b/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/Common/ConflictResolution/MetadataNames.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.NET.Build.Tasks.ConflictResolution
+
+{
+    static class MetadataNames
+    {
+        public const string Aliases = "Aliases";
+        public const string DestinationSubPath = "DestinationSubPath";
+        public const string Extension = "Extension";
+        public const string FileName = "FileName";
+        public const string HintPath = "HintPath";
+        public const string NuGetPackageId = "NuGetPackageId";
+        public const string NuGetPackageVersion = "NuGetPackageVersion";
+        public const string Path = "Path";
+        public const string Private = "Private";
+        public const string TargetPath = "TargetPath";
+    }
+}

--- a/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/Common/FileUtilities.MetadataReader.cs
+++ b/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/Common/FileUtilities.MetadataReader.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+//  Use MetadataReader version of GetAssemblyVersion for:
+//  - netcoreapp version of Microsoft.NET.Build.Extensions.Tasks
+//  - All versions of Microsoft.NET.Build.Tasks
+
+//  We don't use it for the .NET Framework version of Microsoft.NET.Build.Extensions in order to
+//  avoid loading the System.Reflection.Metadata assembly in vanilla .NET Framework build scenarios
+
+//  We do use the MetadataReader version for the SDK tasks in order to correctly read the assembly
+//  versions of cross-gened assemblies.  See https://github.com/dotnet/sdk/issues/1502
+#if NETCOREAPP2_0 || !EXTENSIONS
+
+using System;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    static partial class FileUtilities
+    {
+        private static Version GetAssemblyVersion(string sourcePath)
+        {
+            using (var assemblyStream = new FileStream(sourcePath, FileMode.Open, FileAccess.Read, FileShare.Delete | FileShare.Read))
+            {
+                Version result = null;
+                try
+                {
+                    using (PEReader peReader = new PEReader(assemblyStream, PEStreamOptions.LeaveOpen))
+                    {
+                        if (peReader.HasMetadata)
+                        {
+                            MetadataReader reader = peReader.GetMetadataReader();
+                            if (reader.IsAssembly)
+                            {
+                                result = reader.GetAssemblyDefinition().Version;
+                            }
+                        }
+                    }
+                }
+                catch (BadImageFormatException)
+                {
+                    // not a PE
+                }
+
+                return result;
+            }
+        }
+    }
+}
+
+#endif

--- a/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/Common/FileUtilities.cs
+++ b/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/Common/FileUtilities.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    static partial class FileUtilities
+    {
+        public static Version GetFileVersion(string sourcePath)
+        {
+            if (sourcePath != null)
+            {
+                var fvi = FileVersionInfo.GetVersionInfo(sourcePath);
+
+                if (fvi != null)
+                {
+                    return new Version(fvi.FileMajorPart, fvi.FileMinorPart, fvi.FileBuildPart, fvi.FilePrivatePart);
+                }
+            }
+
+            return null;
+        }
+
+        static readonly HashSet<string> s_assemblyExtensions = new HashSet<string>(new[] { ".dll", ".exe", ".winmd" }, StringComparer.OrdinalIgnoreCase);
+        public static Version TryGetAssemblyVersion(string sourcePath)
+        {
+            var extension = Path.GetExtension(sourcePath);
+
+            return s_assemblyExtensions.Contains(extension) ? GetAssemblyVersion(sourcePath) : null;
+        }
+
+    }
+}

--- a/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/Common/ItemUtilities.cs
+++ b/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/Common/ItemUtilities.cs
@@ -1,0 +1,148 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Framework;
+using Microsoft.NET.Build.Tasks.ConflictResolution;
+using System;
+using System.IO;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    internal static partial class ItemUtilities
+    {
+        public static bool? GetBooleanMetadata(this ITaskItem item, string metadataName)
+        {
+            bool? result = null;
+
+            string value = item.GetMetadata(metadataName);
+            bool parsedResult;
+            if (bool.TryParse(value, out parsedResult))
+            {
+                result = parsedResult;
+            }
+
+            return result;
+        }
+
+        public static bool HasMetadataValue(this ITaskItem item, string name, string expectedValue)
+        {
+            string value = item.GetMetadata(name);
+
+            return string.Equals(value, expectedValue, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Get's the filename to use for identifying reference conflicts
+        /// </summary>
+        /// <param name="item"></param>
+        /// <returns></returns>
+        public static string GetReferenceFileName(ITaskItem item)
+        {
+            var aliases = item.GetMetadata(MetadataNames.Aliases);
+
+            if (!String.IsNullOrEmpty(aliases))
+            {
+                // skip compile-time conflict detection for aliased assemblies.
+                // An alias is the way to avoid a conflict
+                //   eg: System, v1.0.0.0 in global will not conflict with System, v2.0.0.0 in `private` alias
+                // We could model each alias scope and try to check for conflicts within that scope,
+                // but this is a ton of complexity for a fringe feature.
+                // Instead, we'll treat an alias as an indication that the developer has opted out of 
+                // conflict resolution.
+                return null;
+            }
+
+            // We only handle references that have path information since we're only concerned
+            // with resolving conflicts between file references.  If conflicts exist between 
+            // named references that are found from AssemblySearchPaths we'll leave those to
+            // RAR to handle or not as it sees fit.
+            var sourcePath = GetSourcePath(item);
+
+            if (String.IsNullOrEmpty(sourcePath))
+            {
+                return null;
+            }
+
+            try
+            {
+                return Path.GetFileName(sourcePath);
+            }
+            catch (ArgumentException)
+            {
+                // We won't even try to resolve a conflict if we can't open the file, so ignore invalid paths
+                return null;
+            }
+        }
+
+        public static string GetReferenceTargetPath(ITaskItem item)
+        {
+            // Determine if the reference will be copied local.  
+            // We're only dealing with primary file references.  For these RAR will 
+            // copy local if Private is true or unset.
+
+            var isPrivate = MSBuildUtilities.ConvertStringToBool(item.GetMetadata(MetadataNames.Private), defaultValue: true);
+
+            if (!isPrivate)
+            {
+                // Private = false means the reference shouldn't be copied.
+                return null;
+            }
+
+            return GetTargetPath(item);
+        }
+
+        public static string GetReferenceTargetFileName(ITaskItem item)
+        {
+            var targetPath = GetReferenceTargetPath(item);
+
+            return targetPath != null ? Path.GetFileName(targetPath) : null;
+        }
+
+        public static string GetSourcePath(ITaskItem item)
+        {
+            var sourcePath = item.GetMetadata(MetadataNames.HintPath)?.Trim();
+
+            if (String.IsNullOrWhiteSpace(sourcePath))
+            {
+                // assume item-spec points to the file.
+                // this won't work if it comes from a targeting pack or SDK, but
+                // in that case the file won't exist and we'll skip it.
+                sourcePath = item.ItemSpec;
+            }
+
+            return sourcePath;
+        }
+
+        static readonly string[] s_targetPathMetadata = new[] { MetadataNames.TargetPath, MetadataNames.DestinationSubPath };
+        public static string GetTargetPath(ITaskItem item)
+        {
+            // first use TargetPath, then DestinationSubPath, then fallback to filename+extension alone
+            // Can't use Path, as this is the path of the file in the package, which is usually not the target path
+            // (for example the target path for lib/netcoreapp2.0/lib.dll is just lib.dll)
+            foreach (var metadata in s_targetPathMetadata)
+            {
+                var value = item.GetMetadata(metadata)?.Trim();
+
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    // normalize path
+                    return value.Replace('\\', '/');
+                }
+            }
+
+            var sourcePath = GetSourcePath(item);
+
+            var fileName = Path.GetFileName(sourcePath);
+
+            //  Get subdirectory for satellite assemblies / runtime targets
+            var destinationSubDirectory = item.GetMetadata("DestinationSubDirectory");
+
+            if (!string.IsNullOrWhiteSpace(destinationSubDirectory))
+            {
+                return Path.Combine(destinationSubDirectory, fileName);
+            }
+
+            return fileName;
+        }
+    }
+}

--- a/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/Common/MSBuildUtilities.cs
+++ b/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/Common/MSBuildUtilities.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    /// <summary>
+    /// Internal utilties copied from microsoft/MSBuild repo.
+    /// </summary>
+    class MSBuildUtilities
+    {
+        /// <summary>
+        /// Converts a string to a bool.  We consider "true/false", "on/off", and 
+        /// "yes/no" to be valid boolean representations in the XML.
+        /// Modified from its original version to not throw, but return a default value.
+        /// </summary>
+        /// <param name="parameterValue">The string to convert.</param>
+        /// <returns>Boolean true or false, corresponding to the string.</returns>
+        internal static bool ConvertStringToBool(string parameterValue, bool defaultValue = false)
+        {
+            if (String.IsNullOrEmpty(parameterValue))
+            {
+                return defaultValue;
+            }
+            else if (ValidBooleanTrue(parameterValue))
+            {
+                return true;
+            }
+            else if (ValidBooleanFalse(parameterValue))
+            {
+                return false;
+            }
+            else
+            {
+                // Unsupported boolean representation.
+                return defaultValue;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if the string represents a valid MSBuild boolean true value,
+        /// such as "on", "!false", "yes"
+        /// </summary>
+        private static bool ValidBooleanTrue(string parameterValue)
+        {
+            return ((String.Compare(parameterValue, "true", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (String.Compare(parameterValue, "on", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (String.Compare(parameterValue, "yes", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (String.Compare(parameterValue, "!false", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (String.Compare(parameterValue, "!off", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (String.Compare(parameterValue, "!no", StringComparison.OrdinalIgnoreCase) == 0));
+        }
+
+        /// <summary>
+        /// Returns true if the string represents a valid MSBuild boolean false value,
+        /// such as "!on" "off" "no" "!true"
+        /// </summary>
+        private static bool ValidBooleanFalse(string parameterValue)
+        {
+            return ((String.Compare(parameterValue, "false", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (String.Compare(parameterValue, "off", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (String.Compare(parameterValue, "no", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (String.Compare(parameterValue, "!true", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (String.Compare(parameterValue, "!on", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (String.Compare(parameterValue, "!yes", StringComparison.OrdinalIgnoreCase) == 0));
+        }
+    }
+}

--- a/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/Common/MetadataKeys.cs
+++ b/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/Common/MetadataKeys.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.NET.Build.Tasks
+{
+    internal static class MetadataKeys
+    {
+        // General Metadata
+        public const string Name = "Name";
+        public const string Type = "Type";
+        public const string Version = "Version";
+        public const string FileGroup = "FileGroup";
+        public const string Path = "Path";
+        public const string ResolvedPath = "ResolvedPath";
+        public const string PackageName = "PackageName";
+        public const string PackageVersion = "PackageVersion";
+        public const string IsImplicitlyDefined = "IsImplicitlyDefined";
+        public const string IsTopLevelDependency = "IsTopLevelDependency";
+        public const string AllowExplicitVersion = "AllowExplicitVersion";
+
+        // Target Metadata
+        public const string RuntimeIdentifier = "RuntimeIdentifier";
+        public const string TargetFrameworkMoniker = "TargetFrameworkMoniker";
+        public const string FrameworkName = "FrameworkName";
+        public const string FrameworkVersion = "FrameworkVersion";
+
+        // SDK Metadata
+        public const string SDKPackageItemSpec = "SDKPackageItemSpec";
+        public const string OriginalItemSpec = "OriginalItemSpec";
+        public const string SDKRootFolder = "SDKRootFolder";
+        public const string ShimRuntimeIdentifier = "ShimRuntimeIdentifier";
+
+        // Foreign Keys
+        public const string ParentTarget = "ParentTarget";
+        public const string ParentTargetLibrary = "ParentTargetLibrary";
+        public const string ParentPackage = "ParentPackage";
+
+        // Tags
+        public const string Analyzer = "Analyzer";
+        public const string AnalyzerLanguage = "AnalyzerLanguage";
+        public const string TransitiveProjectReference = "TransitiveProjectReference";
+
+        // Diagnostics
+        public const string DiagnosticCode = "DiagnosticCode";
+        public const string Message = "Message";
+        public const string FilePath = "FilePath";
+        public const string Severity = "Severity";
+        public const string StartLine = "StartLine";
+        public const string StartColumn = "StartColumn";
+        public const string EndLine = "EndLine";
+        public const string EndColumn = "EndColumn";
+
+        // Publish Target Manifest
+        public const string RuntimeStoreManifestNames = "RuntimeStoreManifestNames";
+
+        // Conflict Resolution
+        public const string OverriddenPackages = "OverriddenPackages";
+
+        // Package assets
+        public const string NuGetIsFrameworkReference = "NuGetIsFrameworkReference";
+        public const string NuGetPackageId = "NuGetPackageId";
+        public const string NuGetPackageVersion = "NuGetPackageVersion";
+        public const string NuGetSourceType = "NuGetSourceType";
+        public const string RelativePath = "RelativePath";
+        public const string PackageDirectory = "PackageDirectory";
+
+        // References
+        public const string ExternallyResolved = "ExternallyResolved";
+        public const string HintPath = "HintPath";
+        public const string MSBuildSourceProjectFile = "MSBuildSourceProjectFile";
+        public const string Private = "Private";
+        public const string Pack = "Pack";
+        public const string ReferenceSourceTarget = "ReferenceSourceTarget";
+        public const string TargetPath = "TargetPath";
+        public const string CopyLocal = "CopyLocal";
+
+        // Content files
+        public const string PPOutputPath = "PPOutputPath";
+        public const string CodeLanguage = "CodeLanguage";
+        public const string CopyToOutput = "CopyToOutput";
+        public const string BuildAction = "BuildAction";
+        public const string OutputPath = "OutputPath";
+
+        // Resource assemblies
+        public const string Culture = "Culture";
+        // The DestinationSubDirectory is the directory containing the asset, relative to the destination folder.
+        public const string DestinationSubDirectory = "DestinationSubDirectory";
+
+        // Copy local assets
+        // The DestinationSubPath is the path to the asset, relative to the destination folder.
+        public const string DestinationSubPath = "DestinationSubPath";
+        public const string AssetType = "AssetType";
+    }
+}

--- a/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/Common/NuGetUtils.cs
+++ b/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/Common/NuGetUtils.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    internal static partial class NuGetUtils
+    {
+        /// <summary>
+        /// Gets PackageId from sourcePath.
+        /// </summary>
+        /// <param name="item"></param>
+        /// <returns></returns>
+        public static string GetPackageIdFromSourcePath(string sourcePath)
+        {
+            string packageId, unused;
+            GetPackageParts(sourcePath, out packageId, out unused);
+            return packageId;
+        }
+
+        /// <summary>
+        /// Gets PackageId and package subpath from source path
+        /// </summary>
+        /// <param name="fullPath">full path to package file</param>
+        /// <param name="packageId">package ID</param>
+        /// <param name="packageSubPath">subpath of asset within package</param>
+        public static void GetPackageParts(string fullPath, out string packageId, out string packageSubPath)
+        {
+            packageId = null;
+            packageSubPath = null;
+            try
+            {
+                // this method is just a temporary heuristic until we flow the NuGet metadata through the right items
+                // https://github.com/dotnet/sdk/issues/1091
+
+                // Don't try to recurse a relative path.
+                if (!Path.IsPathRooted(fullPath))
+                {
+                    return;
+                }
+
+                for (var dir = Directory.GetParent(fullPath); dir != null; dir = dir.Parent)
+                {
+                    var nuspecs = dir.GetFiles("*.nuspec");
+
+                    if (nuspecs.Length > 0)
+                    {
+                        packageId = Path.GetFileNameWithoutExtension(nuspecs[0].Name);
+                        packageSubPath = fullPath.Substring(dir.FullName.Length + 1).Replace('\\', '/');
+                        break;
+                    }
+                }
+            }
+            catch (Exception)
+            { }
+
+            return;
+
+        }
+    }
+}

--- a/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/CompilationOptionsConverter.cs
+++ b/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/CompilationOptionsConverter.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Build.Framework;
+using Microsoft.Extensions.DependencyModel;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    internal static class CompilationOptionsConverter
+    {
+        public static CompilationOptions ConvertFrom(ITaskItem compilerOptionsItem)
+        {
+            if (compilerOptionsItem == null)
+            {
+                return null;
+            }
+
+            return new CompilationOptions(
+                compilerOptionsItem.GetMetadata("DefineConstants")?.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries),
+                compilerOptionsItem.GetMetadata("LangVersion"),
+                compilerOptionsItem.GetMetadata("PlatformTarget"),
+                compilerOptionsItem.GetBooleanMetadata("AllowUnsafeBlocks"),
+                compilerOptionsItem.GetBooleanMetadata("TreatWarningsAsErrors"),
+                compilerOptionsItem.GetBooleanMetadata("Optimize"),
+                compilerOptionsItem.GetMetadata("AssemblyOriginatorKeyFile"),
+                compilerOptionsItem.GetBooleanMetadata("DelaySign"),
+                compilerOptionsItem.GetBooleanMetadata("PublicSign"),
+                compilerOptionsItem.GetMetadata("DebugType"),
+                "exe".Equals(compilerOptionsItem.GetMetadata("OutputType"), StringComparison.OrdinalIgnoreCase),
+                compilerOptionsItem.GetBooleanMetadata("GenerateDocumentationFile"));
+        }
+    }
+}

--- a/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
+++ b/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
@@ -1,0 +1,753 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.DependencyModel;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.ProjectModel;
+using NuGet.Versioning;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    internal class DependencyContextBuilder
+    {
+        private readonly VersionFolderPathResolver _versionFolderPathResolver;
+        private readonly SingleProjectInfo _mainProjectInfo;
+        private readonly ProjectContext _projectContext;
+        private readonly bool _includeRuntimeFileVersions;
+        private readonly NuGetPackageResolver _packageResolver;
+        private IEnumerable<ReferenceInfo> _referenceAssemblies;
+        private IEnumerable<ReferenceInfo> _directReferences;
+        private IEnumerable<ReferenceInfo> _dependencyReferences;
+        private Dictionary<string, SingleProjectInfo> _referenceProjectInfos;
+        private IEnumerable<string> _excludeFromPublishPackageIds;
+        private IEnumerable<RuntimePackAssetInfo> _runtimePackAssets = Enumerable.Empty<RuntimePackAssetInfo>();
+        private CompilationOptions _compilationOptions;
+        private string _referenceAssembliesPath;
+        private Dictionary<PackageIdentity, string> _filteredPackages;
+        private bool _includeMainProjectInDepsFile = true;
+        private HashSet<string> _usedLibraryNames;
+        private Dictionary<ReferenceInfo, string> _referenceLibraryNames;
+
+        public DependencyContextBuilder(SingleProjectInfo mainProjectInfo, ProjectContext projectContext, bool includeRuntimeFileVersions)
+        {
+            _mainProjectInfo = mainProjectInfo;
+            _projectContext = projectContext;
+            _includeRuntimeFileVersions = includeRuntimeFileVersions;
+
+            // This resolver is only used for building file names, so that base path is not required.
+            _versionFolderPathResolver = new VersionFolderPathResolver(rootPath: null);
+
+            if (_includeRuntimeFileVersions)
+            {
+                //  This is used to look up the paths to package files on disk, which is only needed in this class if
+                //  it needs to read the file versions
+                _packageResolver = NuGetPackageResolver.CreateResolver(projectContext.LockFile);
+            }
+        }
+
+        /// <summary>
+        /// Keeps track of the Library names being used in the DependencyContext.
+        /// </summary>
+        /// <remarks>
+        /// Since `Reference` and `PackageReference` names can conflict, we need to ensure
+        /// each separate Library has a unique name. Since PackageReference names are guaranteed
+        /// to be unique amongst other PackageReferences, start with that set, and ensure
+        /// Reference names are unique amongst all.
+        /// </remarks>
+        private HashSet<string> UsedLibraryNames
+        {
+            get
+            {
+                if (_usedLibraryNames == null)
+                {
+                    _usedLibraryNames = new HashSet<string>(
+                        _projectContext.LockFile.Libraries.Select(l => l.Name),
+                        StringComparer.OrdinalIgnoreCase);
+                }
+
+                return _usedLibraryNames;
+            }
+        }
+
+        private Dictionary<ReferenceInfo, string> ReferenceLibraryNames
+        {
+            get
+            {
+                if (_referenceLibraryNames == null)
+                {
+                    _referenceLibraryNames = new Dictionary<ReferenceInfo, string>();
+                }
+
+                return _referenceLibraryNames;
+            }
+        }
+
+        public DependencyContextBuilder WithMainProjectInDepsFile(bool includeMainProjectInDepsFile)
+        {
+            _includeMainProjectInDepsFile = includeMainProjectInDepsFile;
+            return this;
+        }
+
+        public DependencyContextBuilder WithReferenceAssemblies(IEnumerable<ReferenceInfo> referenceAssemblies)
+        {
+            // note: ReferenceAssembly libraries only export compile-time stuff
+            // since they assume the runtime library is present already
+            _referenceAssemblies = referenceAssemblies;
+            return this;
+        }
+
+        public DependencyContextBuilder WithDirectReferences(IEnumerable<ReferenceInfo> directReferences)
+        {
+            _directReferences = directReferences;
+            return this;
+        }
+
+        public DependencyContextBuilder WithDependencyReferences(IEnumerable<ReferenceInfo> dependencyReferences)
+        {
+            _dependencyReferences = dependencyReferences;
+            return this;
+        }
+
+        public DependencyContextBuilder WithReferenceProjectInfos(Dictionary<string, SingleProjectInfo> referenceProjectInfos)
+        {
+            _referenceProjectInfos = referenceProjectInfos;
+            return this;
+        }
+
+        public DependencyContextBuilder WithExcludeFromPublishAssets(IEnumerable<string> excludeFromPublishPackageIds)
+        {
+            _excludeFromPublishPackageIds = excludeFromPublishPackageIds;
+            return this;
+        }
+
+        public DependencyContextBuilder WithRuntimePackAssets(IEnumerable<RuntimePackAssetInfo> runtimePackAssets)
+        {
+            _runtimePackAssets = runtimePackAssets;
+            return this;
+        }
+
+        public DependencyContextBuilder WithCompilationOptions(CompilationOptions compilationOptions)
+        {
+            _compilationOptions = compilationOptions;
+            return this;
+        }
+
+        public DependencyContextBuilder WithReferenceAssembliesPath(string referenceAssembliesPath)
+        {
+            _referenceAssembliesPath = EnsureTrailingSlash(referenceAssembliesPath);
+            return this;
+        }
+
+        public DependencyContextBuilder WithPackagesThatWhereFiltered(Dictionary<PackageIdentity, string> packagesThatWhereFiltered)
+        {
+            _filteredPackages = packagesThatWhereFiltered;
+            return this;
+        }
+
+        public DependencyContext Build()
+        {
+            bool includeCompilationLibraries = _compilationOptions != null;
+
+            IEnumerable<LockFileTargetLibrary> runtimeExports = _projectContext.GetRuntimeLibraries(_excludeFromPublishPackageIds);
+            IEnumerable<LockFileTargetLibrary> compilationExports =
+                includeCompilationLibraries ?
+                    _projectContext.GetCompileLibraries(_excludeFromPublishPackageIds) :
+                    Enumerable.Empty<LockFileTargetLibrary>();
+
+            var dependencyLookup = compilationExports
+                .Concat(runtimeExports)
+                .Distinct()
+                .Select(library => new Dependency(library.Name, library.Version.ToString()))
+                .ToDictionary(dependency => dependency.Name, StringComparer.OrdinalIgnoreCase);
+
+            var libraryLookup = new LockFileLookup(_projectContext.LockFile);
+
+            var runtimeSignature = GenerateRuntimeSignature(runtimeExports);
+
+            IEnumerable<RuntimeLibrary> runtimeLibraries = Enumerable.Empty<RuntimeLibrary>();
+            if (_includeMainProjectInDepsFile)
+            {
+                runtimeLibraries = runtimeLibraries.Concat(new[]
+                {
+                    GetProjectRuntimeLibrary(
+                        _mainProjectInfo,
+                        _projectContext,
+                        dependencyLookup,
+                        includeCompilationLibraries)
+                });
+            }
+            runtimeLibraries = runtimeLibraries
+                .Concat(GetRuntimePackLibraries(_runtimePackAssets))
+                .Concat(GetLibraries(runtimeExports, libraryLookup, dependencyLookup, runtime: true).Cast<RuntimeLibrary>())
+                .Concat(GetDirectReferenceRuntimeLibraries())
+                .Concat(GetDependencyReferenceRuntimeLibraries());
+
+            IEnumerable<CompilationLibrary> compilationLibraries = Enumerable.Empty<CompilationLibrary>();
+            if (includeCompilationLibraries)
+            {
+                if (_includeMainProjectInDepsFile)
+                {
+                    compilationLibraries = compilationLibraries.Concat(new[]
+                    {
+                        GetProjectCompilationLibrary(
+                            _mainProjectInfo,
+                            _projectContext,
+                            dependencyLookup,
+                            includeCompilationLibraries)
+                    });
+                }
+
+                compilationLibraries = compilationLibraries
+                    .Concat(GetReferenceAssemblyLibraries())
+                    .Concat(GetLibraries(compilationExports, libraryLookup, dependencyLookup, runtime: false).Cast<CompilationLibrary>())
+                    .Concat(GetDirectReferenceCompilationLibraries());
+            }
+
+            var targetInfo = new TargetInfo(
+                _projectContext.LockFileTarget.TargetFramework.DotNetFrameworkName,
+                _projectContext.LockFileTarget.RuntimeIdentifier,
+                runtimeSignature,
+                _projectContext.IsPortable);
+
+            return new DependencyContext(
+                targetInfo,
+                _compilationOptions ?? CompilationOptions.Default,
+                compilationLibraries,
+                runtimeLibraries,
+                new RuntimeFallbacks[] { });
+        }
+
+        private static string GenerateRuntimeSignature(IEnumerable<LockFileTargetLibrary> runtimeExports)
+        {
+            var sha1 = SHA1.Create();
+            var builder = new StringBuilder();
+            var packages = runtimeExports
+                .Where(libraryExport => libraryExport.IsPackage());
+            var separator = "|";
+            foreach (var libraryExport in packages)
+            {
+                builder.Append(libraryExport.Name);
+                builder.Append(separator);
+                builder.Append(libraryExport.Version.ToString());
+                builder.Append(separator);
+            }
+            var hash = sha1.ComputeHash(Encoding.UTF8.GetBytes(builder.ToString()));
+
+            builder.Clear();
+            foreach (var hashByte in hash)
+            {
+                builder.AppendFormat("{0:x2}", hashByte);
+            }
+            return builder.ToString();
+        }
+
+        private List<Dependency> GetProjectDependencies(
+            ProjectContext projectContext,
+            Dictionary<string, Dependency> dependencyLookup,
+            bool includeCompilationLibraries)
+        {
+            List<Dependency> dependencies = new List<Dependency>();
+
+            foreach (string dependencyName in projectContext.GetTopLevelDependencies())
+            {
+                Dependency dependency;
+                if (dependencyLookup.TryGetValue(dependencyName, out dependency))
+                {
+                    dependencies.Add(dependency);
+                }
+            }
+
+            var referenceInfos = Enumerable.Concat(
+                includeCompilationLibraries && _referenceAssemblies != null ? 
+                    _referenceAssemblies : 
+                    Enumerable.Empty<ReferenceInfo>(),
+                _directReferences ?? Enumerable.Empty<ReferenceInfo>());
+
+            foreach (ReferenceInfo referenceInfo in referenceInfos)
+            {
+                dependencies.Add(
+                    new Dependency(
+                        GetReferenceLibraryName(referenceInfo), 
+                        referenceInfo.Version));
+            }
+
+            return dependencies;
+        }
+
+        private RuntimeLibrary CreateRuntimeLibrary(
+            string type,
+            string name,
+            string version,
+            string hash,
+            IReadOnlyList<RuntimeAssetGroup> runtimeAssemblyGroups,
+            IReadOnlyList<RuntimeAssetGroup> nativeLibraryGroups,
+            IEnumerable<ResourceAssembly> resourceAssemblies,
+            IEnumerable<Dependency> dependencies,
+            bool serviceable,
+            string path = null,
+            string hashPath = null)
+        {
+            string runtimeStoreManifestName = null;
+            var pkg = new PackageIdentity(name, NuGetVersion.Parse(version));
+            _filteredPackages?.TryGetValue(pkg, out runtimeStoreManifestName);
+
+            return new RuntimeLibrary(
+                type,
+                name: name,
+                version: version,
+                hash: hash,
+                runtimeAssemblyGroups: runtimeAssemblyGroups,
+                nativeLibraryGroups: nativeLibraryGroups,
+                resourceAssemblies: resourceAssemblies,
+                dependencies: dependencies,
+                path: path,
+                hashPath: hashPath,
+                runtimeStoreManifestName: runtimeStoreManifestName,
+                serviceable: serviceable);
+        }
+
+        private RuntimeLibrary GetProjectRuntimeLibrary(
+            SingleProjectInfo projectInfo,
+            ProjectContext projectContext,
+            Dictionary<string, Dependency> dependencyLookup,
+            bool includeCompilationLibraries)
+        {
+            RuntimeAssetGroup[] runtimeAssemblyGroups = new[] { new RuntimeAssetGroup(string.Empty, projectInfo.OutputName) };
+
+            List<Dependency> dependencies = GetProjectDependencies(projectContext, dependencyLookup, includeCompilationLibraries);
+            foreach (var runtimePackGroup in _runtimePackAssets.GroupBy(asset => asset.PackageName + "/" + asset.PackageVersion))
+            {
+                dependencies.Add(new Dependency("runtimepack." + runtimePackGroup.First().PackageName, runtimePackGroup.First().PackageVersion));
+            }
+
+            return CreateRuntimeLibrary(
+                type: "project",
+                name: projectInfo.Name,
+                version: projectInfo.Version,
+                hash: string.Empty,
+                runtimeAssemblyGroups: runtimeAssemblyGroups,
+                nativeLibraryGroups: new RuntimeAssetGroup[] { },
+                resourceAssemblies: CreateResourceAssemblies(projectInfo.ResourceAssemblies),
+                dependencies: dependencies.ToArray(),
+                serviceable: false);
+        }
+
+        private CompilationLibrary GetProjectCompilationLibrary(
+            SingleProjectInfo projectInfo,
+            ProjectContext projectContext,
+            Dictionary<string, Dependency> dependencyLookup,
+            bool includeCompilationLibraries)
+        {
+            List<Dependency> dependencies = GetProjectDependencies(projectContext, dependencyLookup, includeCompilationLibraries);
+
+            return new CompilationLibrary(
+                type: "project",
+                name: projectInfo.Name,
+                version: projectInfo.Version,
+                hash: string.Empty,
+                assemblies: new[] { projectInfo.OutputName },
+                dependencies: dependencies.ToArray(),
+                serviceable: false);
+        }
+
+        private IEnumerable<RuntimeLibrary> GetRuntimePackLibraries(IEnumerable<RuntimePackAssetInfo> runtimePackAssets)
+        {
+            return runtimePackAssets.GroupBy(asset => asset.PackageName + "/" + asset.PackageVersion).Select(
+                runtimePackAssetGroup =>
+                {
+                    List<RuntimeAssetGroup> runtimeAssemblyGroups = new List<RuntimeAssetGroup>()
+                    {
+                        new RuntimeAssetGroup(string.Empty,
+                            runtimePackAssetGroup.Where(asset => asset.AssetType == AssetType.Runtime)
+                            .Select(asset => CreateRuntimeFile(asset.DestinationSubPath, asset.SourcePath)))
+                    };
+                    List<RuntimeAssetGroup> nativeLibraryGroups = new List<RuntimeAssetGroup>()
+                    {
+                        new RuntimeAssetGroup(string.Empty,
+                            runtimePackAssetGroup.Where(asset => asset.AssetType == AssetType.Native)
+                            .Select(asset => CreateRuntimeFile(asset.DestinationSubPath, asset.SourcePath)))
+                    };
+                    
+                    return new RuntimeLibrary("runtimepack",
+                        "runtimepack." + runtimePackAssetGroup.First().PackageName,
+                        runtimePackAssetGroup.First().PackageVersion,
+                        hash: string.Empty,
+                        runtimeAssemblyGroups,
+                        nativeLibraryGroups,
+                        resourceAssemblies: Enumerable.Empty<ResourceAssembly>(),
+                        dependencies: Enumerable.Empty<Dependency>(),
+                        serviceable: false);
+                });
+        }
+
+        private IEnumerable<Library> GetLibraries(
+            IEnumerable<LockFileTargetLibrary> exports,
+            LockFileLookup libraryLookup,
+            IDictionary<string, Dependency> dependencyLookup,
+            bool runtime)
+        {
+            return exports.Select(export => GetLibrary(export, libraryLookup, dependencyLookup, runtime)).Where(l => l != null);
+        }
+
+        private Library GetLibrary(
+            LockFileTargetLibrary export,
+            LockFileLookup libraryLookup,
+            IDictionary<string, Dependency> dependencyLookup,
+            bool runtime)
+        {
+            var type = export.Type;
+            bool isPackage = export.IsPackage();
+
+            // TEMPORARY: All packages are serviceable in RC2
+            // See https://github.com/dotnet/cli/issues/2569
+            var serviceable = isPackage;
+            var libraryDependencies = new HashSet<Dependency>();
+
+            foreach (PackageDependency libraryDependency in export.Dependencies)
+            {
+                Dependency dependency;
+                if (dependencyLookup.TryGetValue(libraryDependency.Id, out dependency))
+                {
+                    libraryDependencies.Add(dependency);
+                }
+            }
+
+            string hash = string.Empty;
+            string path = null;
+            string hashPath = null;
+            LockFileLibrary library;
+            SingleProjectInfo referenceProjectInfo = null;
+            if (libraryLookup.TryGetLibrary(export, out library))
+            {
+                if (isPackage)
+                {
+                    if (!string.IsNullOrEmpty(library.Sha512))
+                    {
+                        hash = "sha512-" + library.Sha512;
+                        hashPath = _versionFolderPathResolver.GetHashFileName(export.Name, export.Version);
+                    }
+
+                    path = library.Path;
+                }
+                else if (export.IsProject())
+                {
+                    referenceProjectInfo = GetProjectInfo(library);
+
+                    if (referenceProjectInfo is UnreferencedProjectInfo)
+                    {
+                        // unreferenced ProjectInfos will be added later as simple dll dependencies
+                        return null;
+                    }
+
+                    if (runtime)
+                    {
+                        // DependencyReferences do not get passed to the compilation, so we should only
+                        // process them when getting the runtime libraries.
+
+                        foreach (var dependencyReference in referenceProjectInfo.DependencyReferences)
+                        {
+                            libraryDependencies.Add(
+                                new Dependency(
+                                    GetReferenceLibraryName(dependencyReference),
+                                    dependencyReference.Version));
+                        }
+                    }
+                }
+            }
+
+            if (runtime)
+            {
+                return CreateRuntimeLibrary(
+                    type.ToLowerInvariant(),
+                    export.Name,
+                    export.Version.ToString(),
+                    hash,
+                    CreateRuntimeAssemblyGroups(export, referenceProjectInfo),
+                    CreateNativeLibraryGroups(export),
+                    CreateResourceAssemblyGroups(export, referenceProjectInfo),
+                    libraryDependencies,
+                    serviceable,
+                    path,
+                    hashPath);
+            }
+            else
+            {
+                IEnumerable<string> assemblies = GetCompileTimeAssemblies(export, referenceProjectInfo);
+
+                return new CompilationLibrary(
+                    type.ToLowerInvariant(),
+                    export.Name,
+                    export.Version.ToString(),
+                    hash,
+                    assemblies,
+                    libraryDependencies,
+                    serviceable,
+                    path,
+                    hashPath);
+            }
+        }
+
+        private RuntimeFile CreateRuntimeFile(LockFileTargetLibrary library, LockFileItem item)
+        {
+            //  _packageResolver will be null if _includeRuntimeFileVersions is false, hence the "?."
+            var itemFullPath = _packageResolver?.ResolvePackageAssetPath(library, item.Path);
+            return CreateRuntimeFile(item.Path, itemFullPath);
+        }
+
+        private RuntimeFile CreateRuntimeFile(string path, string fullPath)
+        {
+            if (_includeRuntimeFileVersions)
+            {
+                string fileVersion = FileUtilities.GetFileVersion(fullPath).ToString();
+                string assemblyVersion = FileUtilities.TryGetAssemblyVersion(fullPath)?.ToString();
+                return new RuntimeFile(path, assemblyVersion, fileVersion);
+            }
+            else
+            {
+                return new RuntimeFile(path, null, null);
+            }
+        }
+
+        private IReadOnlyList<RuntimeAssetGroup> CreateRuntimeAssemblyGroups(LockFileTargetLibrary targetLibrary, SingleProjectInfo referenceProjectInfo)
+        {
+            if (targetLibrary.IsProject() && !(referenceProjectInfo is UnreferencedProjectInfo))
+            {
+                return new[] { new RuntimeAssetGroup(string.Empty, referenceProjectInfo.OutputName) };
+            }
+            else
+            {
+                List<RuntimeAssetGroup> assemblyGroups = new List<RuntimeAssetGroup>();
+
+                assemblyGroups.Add(
+                    new RuntimeAssetGroup(
+                        string.Empty,
+                        targetLibrary.RuntimeAssemblies.FilterPlaceholderFiles().Select(a => CreateRuntimeFile(targetLibrary, a))));
+
+                foreach (var runtimeTargetsGroup in targetLibrary.GetRuntimeTargetsGroups("runtime"))
+                {
+                    assemblyGroups.Add(
+                        new RuntimeAssetGroup(
+                            runtimeTargetsGroup.Key,
+                            runtimeTargetsGroup.Select(t => CreateRuntimeFile(targetLibrary, t))));
+                }
+
+                return assemblyGroups;
+            }
+        }
+
+        private IReadOnlyList<RuntimeAssetGroup> CreateNativeLibraryGroups(LockFileTargetLibrary export)
+        {
+            List<RuntimeAssetGroup> nativeGroups = new List<RuntimeAssetGroup>();
+
+            nativeGroups.Add(
+                new RuntimeAssetGroup(
+                    string.Empty,
+                    export.NativeLibraries.FilterPlaceholderFiles().Select(a => CreateRuntimeFile(export, a))));
+
+            foreach (var runtimeTargetsGroup in export.GetRuntimeTargetsGroups("native"))
+            {
+                nativeGroups.Add(
+                    new RuntimeAssetGroup(
+                        runtimeTargetsGroup.Key,
+                        runtimeTargetsGroup.Select(t => CreateRuntimeFile(export, t))));
+            }
+
+            return nativeGroups;
+        }
+
+        private IEnumerable<ResourceAssembly> CreateResourceAssemblyGroups(LockFileTargetLibrary targetLibrary, SingleProjectInfo referenceProjectInfo)
+        {
+            if (targetLibrary.IsProject() && !(referenceProjectInfo is UnreferencedProjectInfo))
+            {
+                return CreateResourceAssemblies(referenceProjectInfo.ResourceAssemblies);
+            }
+            else
+            {
+                return targetLibrary.ResourceAssemblies.FilterPlaceholderFiles().Select(CreateResourceAssembly);
+            }
+        }
+
+        private ResourceAssembly CreateResourceAssembly(LockFileItem resourceAssembly)
+        {
+            string locale;
+            if (!resourceAssembly.Properties.TryGetValue("locale", out locale))
+            {
+                locale = null;
+            }
+
+            return new ResourceAssembly(resourceAssembly.Path, locale);
+        }
+
+        private IEnumerable<string> GetCompileTimeAssemblies(LockFileTargetLibrary targetLibrary, SingleProjectInfo referenceProjectInfo)
+        {
+            if (targetLibrary.IsProject() && !(referenceProjectInfo is UnreferencedProjectInfo))
+            {
+                return new[] { referenceProjectInfo.OutputName };
+            }
+            else
+            {
+                return targetLibrary
+                    .CompileTimeAssemblies
+                    .FilterPlaceholderFiles()
+                    .Select(libraryAsset => libraryAsset.Path);
+            }
+        }
+
+        private IEnumerable<CompilationLibrary> GetReferenceAssemblyLibraries()
+        {
+            return _referenceAssemblies
+                ?.Select(r => new CompilationLibrary(
+                    type: "referenceassembly",
+                    name: GetReferenceLibraryName(r),
+                    version: r.Version,
+                    hash: string.Empty,
+                    assemblies: new[] { ResolveFrameworkReferencePath(r.FullPath) },
+                    dependencies: Enumerable.Empty<Dependency>(),
+                    serviceable: false))
+                ??
+                Enumerable.Empty<CompilationLibrary>();
+        }
+
+        private string ResolveFrameworkReferencePath(string fullPath)
+        {
+            // If resolved path is under ReferenceAssembliesPath store it as a relative to it
+            // if not, save only assembly name and try to find it somehow later
+            if (!string.IsNullOrEmpty(_referenceAssembliesPath) &&
+                fullPath?.StartsWith(_referenceAssembliesPath) == true)
+            {
+                return fullPath.Substring(_referenceAssembliesPath.Length);
+            }
+
+            return Path.GetFileName(fullPath);
+        }
+
+        private IEnumerable<RuntimeLibrary> GetReferenceRuntimeLibraries(IEnumerable<ReferenceInfo> references)
+        {
+            return references
+                ?.Select(r => CreateRuntimeLibrary(
+                    type: "reference",
+                    name: GetReferenceLibraryName(r),
+                    version: r.Version,
+                    hash: string.Empty,
+                    runtimeAssemblyGroups: new[] { new RuntimeAssetGroup(string.Empty, new[] { CreateRuntimeFile(r.FileName, r.FullPath) }) },
+                    nativeLibraryGroups: new RuntimeAssetGroup[] { },
+                    resourceAssemblies: CreateResourceAssemblies(r.ResourceAssemblies),
+                    dependencies: Enumerable.Empty<Dependency>(),
+                    serviceable: false))
+                ??
+                Enumerable.Empty<RuntimeLibrary>();
+        }
+
+        private IEnumerable<CompilationLibrary> GetReferenceCompilationLibraries(IEnumerable<ReferenceInfo> references)
+        {
+            return references
+                ?.Select(r => new CompilationLibrary(
+                    type: "reference",
+                    name: GetReferenceLibraryName(r),
+                    version: r.Version,
+                    hash: string.Empty,
+                    assemblies: new[] { r.FileName },
+                    dependencies: Enumerable.Empty<Dependency>(),
+                    serviceable: false))
+                ??
+                Enumerable.Empty<CompilationLibrary>();
+        }
+
+        private IEnumerable<RuntimeLibrary> GetDirectReferenceRuntimeLibraries()
+        {
+            return GetReferenceRuntimeLibraries(_directReferences);
+        }
+
+        private IEnumerable<CompilationLibrary> GetDirectReferenceCompilationLibraries()
+        {
+            return GetReferenceCompilationLibraries(_directReferences);
+        }
+
+        private IEnumerable<RuntimeLibrary> GetDependencyReferenceRuntimeLibraries()
+        {
+            return GetReferenceRuntimeLibraries(_dependencyReferences);
+        }
+
+        private string GetReferenceLibraryName(ReferenceInfo reference)
+        {
+            if (!ReferenceLibraryNames.TryGetValue(reference, out string name))
+            {
+                // Reference names can conflict with PackageReference names, so
+                // ensure that the Reference names are unique when creating libraries
+                name = GetUniqueReferenceName(reference.Name);
+
+                ReferenceLibraryNames.Add(reference, name);
+                UsedLibraryNames.Add(name);
+            }
+
+            return name;
+        }
+
+        private string GetUniqueReferenceName(string name)
+        {
+            if (UsedLibraryNames.Contains(name))
+            {
+                string startingName = $"{name}.Reference";
+                name = startingName;
+
+                int suffix = 1;
+                while (UsedLibraryNames.Contains(name))
+                {
+                    name = $"{startingName}{suffix++}";
+                }
+            }
+
+            return name;
+        }
+
+        private static IEnumerable<ResourceAssembly> CreateResourceAssemblies(IEnumerable<ResourceAssemblyInfo> resourceAssemblyInfos)
+        {
+            return resourceAssemblyInfos
+                .Select(r => new ResourceAssembly(r.RelativePath, r.Culture));
+        }
+
+        private SingleProjectInfo GetProjectInfo(LockFileLibrary library)
+        {
+            string projectPath = library.MSBuildProject;
+            if (string.IsNullOrEmpty(projectPath))
+            {
+                throw new BuildErrorException(Strings.CannotFindProjectInfo, library.Name);
+            }
+
+            string mainProjectDirectory = Path.GetDirectoryName(_mainProjectInfo.ProjectPath);
+            string fullProjectPath = Path.GetFullPath(Path.Combine(mainProjectDirectory, projectPath));
+
+            SingleProjectInfo referenceProjectInfo = null;
+            if (_referenceProjectInfos?.TryGetValue(fullProjectPath, out referenceProjectInfo) != true ||
+                referenceProjectInfo == null)
+            {
+                return UnreferencedProjectInfo.Default;
+            }
+
+            return referenceProjectInfo;
+        }
+
+        private static string EnsureTrailingSlash(string path)
+        {
+            return EnsureTrailingCharacter(path, Path.DirectorySeparatorChar);
+        }
+
+        private static string EnsureTrailingCharacter(string path, char trailingCharacter)
+        {
+            // if the path is empty, we want to return the original string instead of a single trailing character.
+            if (string.IsNullOrEmpty(path) || path[path.Length - 1] == trailingCharacter)
+            {
+                return path;
+            }
+
+            return path + trailingCharacter;
+        }
+    }
+}

--- a/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
+++ b/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
@@ -366,13 +366,13 @@ namespace Microsoft.NET.Build.Tasks
                     {
                         new RuntimeAssetGroup(string.Empty,
                             runtimePackAssetGroup.Where(asset => asset.AssetType == AssetType.Runtime)
-                            .Select(asset => CreateRuntimeFile(asset.DestinationSubPath, asset.SourcePath)))
+                            .Select(asset => CreateRuntimeFile("./" + asset.DestinationSubPath, asset.SourcePath)))
                     };
                     List<RuntimeAssetGroup> nativeLibraryGroups = new List<RuntimeAssetGroup>()
                     {
                         new RuntimeAssetGroup(string.Empty,
                             runtimePackAssetGroup.Where(asset => asset.AssetType == AssetType.Native)
-                            .Select(asset => CreateRuntimeFile(asset.DestinationSubPath, asset.SourcePath)))
+                            .Select(asset => CreateRuntimeFile("./" + asset.DestinationSubPath, asset.SourcePath)))
                     };
                     
                     return new RuntimeLibrary("runtimepack",

--- a/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
+++ b/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/DependencyContextBuilder.cs
@@ -718,7 +718,7 @@ namespace Microsoft.NET.Build.Tasks
             string projectPath = library.MSBuildProject;
             if (string.IsNullOrEmpty(projectPath))
             {
-                throw new BuildErrorException(Strings.CannotFindProjectInfo, library.Name);
+                throw new BuildErrorException("Cannot find project info", library.Name);
             }
 
             string mainProjectDirectory = Path.GetDirectoryName(_mainProjectInfo.ProjectPath);

--- a/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/FrameworkReferenceResolver.cs
+++ b/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/FrameworkReferenceResolver.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.DotNet.PlatformAbstractions;
+using Microsoft.Extensions.DependencyModel.Resolution;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    internal static class FrameworkReferenceResolver
+    {
+        public static string GetDefaultReferenceAssembliesPath()
+        {
+            // Allow setting the reference assemblies path via an environment variable
+            var referenceAssembliesPath = DotNetReferenceAssembliesPathResolver.Resolve();
+
+            if (!string.IsNullOrEmpty(referenceAssembliesPath))
+            {
+                return referenceAssembliesPath;
+            }
+
+            if (RuntimeEnvironment.OperatingSystemPlatform != Platform.Windows)
+            {
+                // There is no reference assemblies path outside of windows
+                // The environment variable can be used to specify one
+                return null;
+            }
+
+            // References assemblies are in %ProgramFiles(x86)% on
+            // 64 bit machines
+            var programFiles = Environment.GetEnvironmentVariable("ProgramFiles(x86)");
+
+            if (string.IsNullOrEmpty(programFiles))
+            {
+                // On 32 bit machines they are in %ProgramFiles%
+                programFiles = Environment.GetEnvironmentVariable("ProgramFiles");
+            }
+
+            if (string.IsNullOrEmpty(programFiles))
+            {
+                // Reference assemblies aren't installed
+                return null;
+            }
+
+            return Path.Combine(
+                    programFiles,
+                    "Reference Assemblies", "Microsoft", "Framework");
+        }
+    }
+}

--- a/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
+++ b/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
@@ -1,0 +1,301 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.Extensions.DependencyModel;
+using Newtonsoft.Json;
+using NuGet.Packaging.Core;
+using NuGet.ProjectModel;
+using NuGet.Versioning;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    /// <summary>
+    /// Generates the $(project).deps.json file.
+    /// </summary>
+    public class GenerateDepsFile : TaskBase
+    {
+        [Required]
+        public string ProjectPath { get; set; }
+
+        public string AssetsFilePath { get; set; }
+
+        [Required]
+        public string DepsFilePath { get; set; }
+
+        [Required]
+        public string TargetFramework { get; set; }
+
+        public string RuntimeIdentifier { get; set; }
+
+        public string PlatformLibraryName { get; set; }
+
+        public ITaskItem[] RuntimeFrameworks { get; set; }
+
+        [Required]
+        public string AssemblyName { get; set; }
+
+        [Required]
+        public string AssemblyExtension { get; set; }
+
+        [Required]
+        public string AssemblyVersion { get; set; }
+
+        public ITaskItem[] AssemblySatelliteAssemblies { get; set; } = Array.Empty<ITaskItem>();
+
+        [Required]
+        public bool IncludeMainProject { get; set; }
+
+
+        public ITaskItem[] ReferencePaths { get; set; } = Array.Empty<ITaskItem>();
+
+        public ITaskItem[] ReferenceDependencyPaths { get; set; } = Array.Empty<ITaskItem>();
+
+        public ITaskItem[] ReferenceSatellitePaths { get; set; } = Array.Empty<ITaskItem>();
+
+        public ITaskItem[] ReferenceAssemblies { get; set; } = Array.Empty<ITaskItem>();
+
+        [Required]
+        public ITaskItem[] FilesToSkip { get; set; }
+
+        public ITaskItem[] RuntimePackAssets { get; set; } = Array.Empty<ITaskItem>();
+
+        public ITaskItem CompilerOptions { get; set; }
+
+        public ITaskItem[] ExcludeFromPublishPackageReferences { get; set; }
+
+        public ITaskItem[] RuntimeStorePackages { get; set; }
+
+        public bool IsSelfContained { get; set; }
+
+        public bool IncludeRuntimeFileVersions { get; set; }
+
+        List<ITaskItem> _filesWritten = new List<ITaskItem>();
+
+        [Output]
+        public ITaskItem[] FilesWritten
+        {
+            get { return _filesWritten.ToArray(); }
+        }
+
+        private Dictionary<string, HashSet<string>> compileFilesToSkip = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        private Dictionary<string, HashSet<string>> runtimeFilesToSkip = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+
+        private Dictionary<PackageIdentity, string> GetFilteredPackages()
+        {
+            Dictionary<PackageIdentity, string> filteredPackages = null;
+
+            if (RuntimeStorePackages != null && RuntimeStorePackages.Length > 0)
+            {
+                filteredPackages = new Dictionary<PackageIdentity, string>();
+                foreach (var package in RuntimeStorePackages)
+                {
+                    filteredPackages.Add(
+                        ItemUtilities.GetPackageIdentity(package),
+                        package.GetMetadata(MetadataKeys.RuntimeStoreManifestNames));
+                }
+            }
+
+            return filteredPackages;
+        }
+
+        protected override void ExecuteCore()
+        {
+            LoadFilesToSkip();
+
+            LockFile lockFile = new LockFileCache(this).GetLockFile(AssetsFilePath);
+            CompilationOptions compilationOptions = CompilationOptionsConverter.ConvertFrom(CompilerOptions);
+
+            SingleProjectInfo mainProject = SingleProjectInfo.Create(
+                    ProjectPath,
+                    AssemblyName,
+                    AssemblyExtension,
+                    AssemblyVersion,
+                    AssemblySatelliteAssemblies);
+
+            IEnumerable<ReferenceInfo> referenceAssemblyInfos =
+                ReferenceInfo.CreateReferenceInfos(ReferenceAssemblies);
+
+            IEnumerable<ReferenceInfo> directReferences =
+                ReferenceInfo.CreateDirectReferenceInfos(ReferencePaths, ReferenceSatellitePaths);
+
+            IEnumerable<ReferenceInfo> dependencyReferences =
+                ReferenceInfo.CreateDependencyReferenceInfos(ReferenceDependencyPaths, ReferenceSatellitePaths);
+
+            Dictionary<string, SingleProjectInfo> referenceProjects = SingleProjectInfo.CreateProjectReferenceInfos(
+                ReferencePaths,
+                ReferenceDependencyPaths,
+                ReferenceSatellitePaths);
+
+            IEnumerable<string> excludeFromPublishAssets = PackageReferenceConverter.GetPackageIds(ExcludeFromPublishPackageReferences);
+
+            IEnumerable<RuntimePackAssetInfo> runtimePackAssets = 
+                RuntimePackAssets.Select(item => RuntimePackAssetInfo.FromItem(item));
+
+            ProjectContext projectContext = lockFile.CreateProjectContext(
+                NuGetUtils.ParseFrameworkName(TargetFramework),
+                RuntimeIdentifier,
+                PlatformLibraryName,
+                RuntimeFrameworks,
+                IsSelfContained);
+
+            DependencyContext dependencyContext = new DependencyContextBuilder(mainProject, projectContext, IncludeRuntimeFileVersions)
+                .WithMainProjectInDepsFile(IncludeMainProject)
+                .WithReferenceAssemblies(referenceAssemblyInfos)
+                .WithDirectReferences(directReferences)
+                .WithDependencyReferences(dependencyReferences)
+                .WithReferenceProjectInfos(referenceProjects)
+                .WithExcludeFromPublishAssets(excludeFromPublishAssets)
+                .WithRuntimePackAssets(runtimePackAssets)
+                .WithCompilationOptions(compilationOptions)
+                .WithReferenceAssembliesPath(FrameworkReferenceResolver.GetDefaultReferenceAssembliesPath())
+                .WithPackagesThatWhereFiltered(GetFilteredPackages())
+                .Build();
+
+            if (compileFilesToSkip.Any() || runtimeFilesToSkip.Any())
+            {
+                dependencyContext = TrimFilesToSkip(dependencyContext);
+            }
+
+            var writer = new DependencyContextWriter();
+            using (var fileStream = File.Create(DepsFilePath))
+            {
+                writer.Write(dependencyContext, fileStream);
+            }
+            _filesWritten.Add(new TaskItem(DepsFilePath));
+
+        }
+
+        private void LoadFilesToSkip()
+        {
+            foreach (var fileToSkip in FilesToSkip)
+            {
+                string packageId, packageSubPath;
+                NuGetUtils.GetPackageParts(fileToSkip.ItemSpec, out packageId, out packageSubPath);
+
+                if (String.IsNullOrEmpty(packageId) || String.IsNullOrEmpty(packageSubPath))
+                {
+                    continue;
+                }
+
+                var itemType = fileToSkip.GetMetadata(nameof(ConflictResolution.ConflictItemType));
+                var packagesWithFilesToSkip = (itemType == nameof(ConflictResolution.ConflictItemType.Reference)) ? compileFilesToSkip : runtimeFilesToSkip;
+
+                HashSet<string> filesToSkipForPackage;
+                if (!packagesWithFilesToSkip.TryGetValue(packageId, out filesToSkipForPackage))
+                {
+                    packagesWithFilesToSkip[packageId] = filesToSkipForPackage = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                }
+
+                filesToSkipForPackage.Add(packageSubPath);
+            }
+        }
+
+        private DependencyContext TrimFilesToSkip(DependencyContext sourceDeps)
+        {
+            return new DependencyContext(sourceDeps.Target,
+                                         sourceDeps.CompilationOptions,
+                                         TrimCompilationLibraries(sourceDeps.CompileLibraries),
+                                         TrimRuntimeLibraries(sourceDeps.RuntimeLibraries),
+                                         sourceDeps.RuntimeGraph);
+        }
+
+        private IEnumerable<RuntimeLibrary> TrimRuntimeLibraries(IReadOnlyList<RuntimeLibrary> runtimeLibraries)
+        {
+            foreach (var runtimeLibrary in runtimeLibraries)
+            {
+                HashSet<string> filesToSkip;
+                if (runtimeFilesToSkip.TryGetValue(runtimeLibrary.Name, out filesToSkip))
+                {
+                    yield return new RuntimeLibrary(runtimeLibrary.Type,
+                                              runtimeLibrary.Name,
+                                              runtimeLibrary.Version,
+                                              runtimeLibrary.Hash,
+                                              TrimAssetGroups(runtimeLibrary.RuntimeAssemblyGroups, filesToSkip).ToArray(),
+                                              TrimAssetGroups(runtimeLibrary.NativeLibraryGroups, filesToSkip).ToArray(),
+                                              TrimResourceAssemblies(runtimeLibrary.ResourceAssemblies, filesToSkip),
+                                              runtimeLibrary.Dependencies,
+                                              runtimeLibrary.Serviceable,
+                                              runtimeLibrary.Path,
+                                              runtimeLibrary.HashPath,
+                                              runtimeLibrary.RuntimeStoreManifestName);
+                }
+                else
+                {
+                    yield return runtimeLibrary;
+                }
+            }
+        }
+
+        private IEnumerable<RuntimeAssetGroup> TrimAssetGroups(IEnumerable<RuntimeAssetGroup> assetGroups, ISet<string> filesToTrim)
+        {
+            foreach (var assetGroup in assetGroups)
+            {
+                yield return new RuntimeAssetGroup(assetGroup.Runtime, TrimRuntimeFiles(assetGroup.RuntimeFiles, filesToTrim));
+            }
+        }
+
+        private IEnumerable<ResourceAssembly> TrimResourceAssemblies(IEnumerable<ResourceAssembly> resourceAssemblies, ISet<string> filesToTrim)
+        {
+            foreach (var resourceAssembly in resourceAssemblies)
+            {
+                if (!filesToTrim.Contains(resourceAssembly.Path))
+                {
+                    yield return resourceAssembly;
+                }
+            }
+        }
+
+        private IEnumerable<CompilationLibrary> TrimCompilationLibraries(IReadOnlyList<CompilationLibrary> compileLibraries)
+        {
+            foreach (var compileLibrary in compileLibraries)
+            {
+                HashSet<string> filesToSkip;
+                if (compileFilesToSkip.TryGetValue(compileLibrary.Name, out filesToSkip))
+                {
+                    yield return new CompilationLibrary(compileLibrary.Type,
+                                              compileLibrary.Name,
+                                              compileLibrary.Version,
+                                              compileLibrary.Hash,
+                                              TrimAssemblies(compileLibrary.Assemblies, filesToSkip),
+                                              compileLibrary.Dependencies,
+                                              compileLibrary.Serviceable,
+                                              compileLibrary.Path,
+                                              compileLibrary.HashPath);
+                }
+                else
+                {
+                    yield return compileLibrary;
+                }
+            }
+        }
+
+        private IEnumerable<string> TrimAssemblies(IEnumerable<string> assemblies, ISet<string> filesToTrim)
+        {
+            foreach (var assembly in assemblies)
+            {
+                if (!filesToTrim.Contains(assembly))
+                {
+                    yield return assembly;
+                }
+            }
+        }
+
+
+        private IEnumerable<RuntimeFile> TrimRuntimeFiles(IEnumerable<RuntimeFile> assemblies, ISet<string> filesToTrim)
+        {
+            foreach (var assembly in assemblies)
+            {
+                if (!filesToTrim.Contains(assembly.Path))
+                {
+                    yield return assembly;
+                }
+            }
+        }
+    }
+}

--- a/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/IPackageResolver.cs
+++ b/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/IPackageResolver.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using NuGet.Versioning;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    internal interface IPackageResolver
+    {
+        string GetPackageDirectory(string packageId, NuGetVersion version);
+        string GetPackageDirectory(string packageId, NuGetVersion version, out string packageRoot);
+    }
+}

--- a/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/ItemUtilities.NuGet.cs
+++ b/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/ItemUtilities.NuGet.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Framework;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    internal static partial class ItemUtilities
+    {
+        public static PackageIdentity GetPackageIdentity(ITaskItem item)
+        {
+            string packageName = item.GetMetadata(MetadataKeys.PackageName);
+            string packageVersion = item.GetMetadata(MetadataKeys.PackageVersion);
+
+            if (string.IsNullOrEmpty(packageName) || string.IsNullOrEmpty(packageVersion))
+            {
+                packageName = item.GetMetadata(MetadataKeys.NuGetPackageId);
+                packageVersion = item.GetMetadata(MetadataKeys.NuGetPackageVersion);
+            }
+
+            if (string.IsNullOrEmpty(packageName) || string.IsNullOrEmpty(packageVersion))
+            {
+                return null;
+            }
+
+            return new PackageIdentity(
+                packageName,
+                NuGetVersion.Parse(packageVersion));
+        }
+    }
+}

--- a/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/LockFileExtensions.cs
+++ b/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/LockFileExtensions.cs
@@ -1,0 +1,261 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NuGet.Frameworks;
+using NuGet.Packaging.Core;
+using NuGet.ProjectModel;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    internal static class LockFileExtensions
+    {
+        public static LockFileTarget GetTargetAndThrowIfNotFound(this LockFile lockFile, NuGetFramework framework, string runtime)
+        {
+            LockFileTarget lockFileTarget = lockFile.GetTarget(framework, runtime);
+
+            if (lockFileTarget == null)
+            {
+                string frameworkString = framework.DotNetFrameworkName;
+                string targetMoniker = string.IsNullOrEmpty(runtime) ?
+                    frameworkString :
+                    $"{frameworkString}/{runtime}";
+
+                string message;
+                if (string.IsNullOrEmpty(runtime))
+                {
+                    message = string.Format(Strings.AssetsFileMissingTarget, lockFile.Path, targetMoniker, framework.GetShortFolderName());
+                }
+                else
+                {
+                    message = string.Format(Strings.AssetsFileMissingRuntimeIdentifier, lockFile.Path, targetMoniker, framework.GetShortFolderName(), runtime);
+                }
+
+                throw new BuildErrorException(message);
+            }
+
+            return lockFileTarget;
+        }
+
+        public static ProjectContext CreateProjectContext(
+            this LockFile lockFile,
+            NuGetFramework framework,
+            string runtime,
+            //  Trimmed from publish output, and if there are no runtimeFrameworks, written to runtimeconfig.json
+            string platformLibraryName,
+            //  Written to runtimeconfig.json
+            Microsoft.Build.Framework.ITaskItem[] runtimeFrameworks,
+            bool isSelfContained)
+        {
+            if (lockFile == null)
+            {
+                throw new ArgumentNullException(nameof(lockFile));
+            }
+            if (framework == null)
+            {
+                throw new ArgumentNullException(nameof(framework));
+            }
+
+            var lockFileTarget = lockFile.GetTargetAndThrowIfNotFound(framework, runtime);
+
+            LockFileTargetLibrary platformLibrary = lockFileTarget.GetLibrary(platformLibraryName);
+            bool isFrameworkDependent = (platformLibrary != null || runtimeFrameworks?.Any() == true) &&
+                (!isSelfContained || string.IsNullOrEmpty(lockFileTarget.RuntimeIdentifier));
+
+            return new ProjectContext(lockFile, lockFileTarget, platformLibrary,
+                runtimeFrameworks?.Select(i => new ProjectContext.RuntimeFramework(i))?.ToArray(),
+                isFrameworkDependent);
+        }
+
+        public static LockFileTargetLibrary GetLibrary(this LockFileTarget lockFileTarget, string libraryName)
+        {
+            if (string.IsNullOrEmpty(libraryName))
+            {
+                return null;
+            }
+
+            return lockFileTarget
+                .Libraries
+                .FirstOrDefault(e => e.Name.Equals(libraryName, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static readonly char[] DependencySeparators = new char[] { '<', '=', '>' };
+
+        public static Dictionary<string, string> GetProjectFileDependencies(this LockFile lockFile)
+        {
+            var projectDeps = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var group in lockFile.ProjectFileDependencyGroups)
+            {
+                foreach (var dep in group.Dependencies)
+                {
+                    var parts = dep.Split(DependencySeparators, StringSplitOptions.RemoveEmptyEntries);
+                    var packageName = parts[0].Trim();
+
+                    if (!projectDeps.ContainsKey(packageName))
+                    {
+                        projectDeps.Add(packageName, parts.Length == 2 ? parts[1].Trim() : null);
+                    }
+                }
+            }
+
+            return projectDeps;
+        }
+
+        public static HashSet<string> GetProjectFileDependencySet(this LockFile lockFile)
+        {
+            // Get package name from e.g. Microsoft.VSSDK.BuildTools >= 15.0.25604-Preview4
+            string GetPackageNameFromDependency(string dependency)
+            {
+                int indexOfWhiteSpace = IndexOfWhiteSpace(dependency);
+                if (indexOfWhiteSpace < 0)
+                {
+                    return dependency;
+                }
+
+                return dependency.Substring(0, indexOfWhiteSpace);
+            }
+
+            int IndexOfWhiteSpace(string s)
+            {
+                for (int i = 0; i < s.Length; i++)
+                {
+                    if (char.IsWhiteSpace(s[i]))
+                    {
+                        return i;
+                    }
+                }
+
+                return -1;
+            }
+
+            var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var group in lockFile.ProjectFileDependencyGroups)
+            {
+                foreach (string dependency in group.Dependencies)
+                {
+                    string packageName = GetPackageNameFromDependency(dependency);
+                    set.Add(packageName);
+                }
+            }
+
+            return set;
+        }
+
+        public static HashSet<string> GetPlatformExclusionList(
+            this LockFileTarget lockFileTarget,
+            LockFileTargetLibrary platformLibrary,
+            IDictionary<string, LockFileTargetLibrary> libraryLookup)
+        {
+            var exclusionList = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            exclusionList.Add(platformLibrary.Name);
+            CollectDependencies(libraryLookup, platformLibrary.Dependencies, exclusionList);
+
+            return exclusionList;
+        }
+
+        public static HashSet<PackageIdentity> GetTransitivePackagesList(
+            this LockFileTarget lockFileTarget,
+            LockFileTargetLibrary package,
+            IDictionary<string, LockFileTargetLibrary> libraryLookup)
+        {
+            var exclusionList = new HashSet<PackageIdentity>();
+
+            exclusionList.Add(new PackageIdentity(package.Name, package.Version));
+            CollectDependencies(libraryLookup, package.Dependencies, exclusionList);
+
+            return exclusionList;
+        }
+
+        private static void CollectDependencies(
+            IDictionary<string, LockFileTargetLibrary> libraryLookup,
+            IEnumerable<PackageDependency> dependencies,
+            HashSet<string> exclusionList)
+        {
+            var excludedPackages = new HashSet<PackageIdentity>();
+            CollectDependencies(libraryLookup, dependencies, excludedPackages);
+
+            foreach (var pkg in excludedPackages)
+            {
+                exclusionList.Add(pkg.Id);
+            }
+        }
+
+        private static void CollectDependencies(
+            IDictionary<string, LockFileTargetLibrary> libraryLookup,
+            IEnumerable<PackageDependency> dependencies,
+            HashSet<PackageIdentity> exclusionList)
+        {
+            foreach (PackageDependency dependency in dependencies)
+            {
+                LockFileTargetLibrary library = libraryLookup[dependency.Id];
+                if (library.Version.Equals(dependency.VersionRange.MinVersion))
+                {
+                    if (exclusionList.Add(new PackageIdentity(library.Name, library.Version)))
+                    {
+                        CollectDependencies(libraryLookup, library.Dependencies, exclusionList);
+                    }
+                }
+            }
+        }
+
+        public static IEnumerable<LockFileTargetLibrary> Filter(
+            this IEnumerable<LockFileTargetLibrary> libraries, 
+            HashSet<string> exclusionList)
+        {
+            return libraries.Where(e => !exclusionList.Contains(e.Name));
+        }
+
+        public static IEnumerable<IGrouping<string, LockFileRuntimeTarget>> GetRuntimeTargetsGroups(
+            this LockFileTargetLibrary library, 
+            string assetType)
+        {
+            return library.RuntimeTargets
+                .FilterPlaceholderFiles()
+                .Cast<LockFileRuntimeTarget>()
+                .Where(t => string.Equals(t.AssetType, assetType, StringComparison.OrdinalIgnoreCase))
+                .GroupBy(t => t.Runtime);
+        }
+
+
+        // A package is a TransitiveProjectReference if it is a project, is not directly referenced,
+        // and does not contain a placeholder compile time assembly
+        public static bool IsTransitiveProjectReference(this LockFileTargetLibrary library, LockFile lockFile, ref HashSet<string> directProjectDependencies)
+        {
+            if (!library.IsProject())
+            {
+                return false;
+            }
+
+            if (directProjectDependencies == null)
+            {
+                directProjectDependencies = lockFile.GetProjectFileDependencySet();
+            }
+
+            return !directProjectDependencies.Contains(library.Name) 
+                && !library.CompileTimeAssemblies.Any(f => f.IsPlaceholderFile());
+        }
+
+        public static IEnumerable<LockFileItem> FilterPlaceholderFiles(this IEnumerable<LockFileItem> files)
+            => files.Where(f => !f.IsPlaceholderFile());
+
+        public static bool IsPlaceholderFile(this LockFileItem item)
+            => NuGetUtils.IsPlaceholderFile(item.Path);
+
+        public static bool IsPackage(this LockFileTargetLibrary library)
+            => library.Type == "package";
+
+        public static bool IsPackage(this LockFileLibrary library)
+            => library.Type == "package";
+
+        public static bool IsProject(this LockFileTargetLibrary library)
+            => library.Type == "project";
+
+        public static bool IsProject(this LockFileLibrary library)
+            => library.Type == "project";
+    }
+}

--- a/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/LockFileExtensions.cs
+++ b/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/LockFileExtensions.cs
@@ -26,11 +26,11 @@ namespace Microsoft.NET.Build.Tasks
                 string message;
                 if (string.IsNullOrEmpty(runtime))
                 {
-                    message = string.Format(Strings.AssetsFileMissingTarget, lockFile.Path, targetMoniker, framework.GetShortFolderName());
+                    message = string.Format("Assets file missing target", lockFile.Path, targetMoniker, framework.GetShortFolderName());
                 }
                 else
                 {
-                    message = string.Format(Strings.AssetsFileMissingRuntimeIdentifier, lockFile.Path, targetMoniker, framework.GetShortFolderName(), runtime);
+                    message = string.Format("Assets file missing runtime identifier", lockFile.Path, targetMoniker, framework.GetShortFolderName(), runtime);
                 }
 
                 throw new BuildErrorException(message);

--- a/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/LockFileLookup.cs
+++ b/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/LockFileLookup.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using NuGet.LibraryModel;
+using NuGet.ProjectModel;
+using NuGet.Versioning;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    internal class LockFileLookup
+    {
+        private readonly Dictionary<KeyValuePair<string, NuGetVersion>, LockFileLibrary> _packages;
+        private readonly Dictionary<string, LockFileLibrary> _projects;
+
+        public LockFileLookup(LockFile lockFile)
+        {
+            _packages = new Dictionary<KeyValuePair<string, NuGetVersion>, LockFileLibrary>(PackageCacheKeyComparer.Instance);
+            _projects = new Dictionary<string, LockFileLibrary>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var library in lockFile.Libraries)
+            {
+                // TODO-ARM: Workaround for JIT bug on arm processors. See https://github.com/dotnet/coreclr/issues/10780
+                if (string.Empty == null)
+                {
+                    throw new Exception();
+                }
+
+                var libraryType = LibraryType.Parse(library.Type);
+
+                if (libraryType == LibraryType.Package)
+                {
+                    _packages[new KeyValuePair<string, NuGetVersion>(library.Name, library.Version)] = library;
+                }
+                if (libraryType == LibraryType.Project)
+                {
+                    _projects[library.Name] = library;
+                }
+            }
+        }
+
+        public LockFileLibrary GetProject(string name)
+        {
+            LockFileLibrary project;
+            if (_projects.TryGetValue(name, out project))
+            {
+                return project;
+            }
+
+            return null;
+        }
+
+        public LockFileLibrary GetPackage(string id, NuGetVersion version)
+        {
+            LockFileLibrary package;
+            if (_packages.TryGetValue(new KeyValuePair<string, NuGetVersion>(id, version), out package))
+            {
+                return package;
+            }
+
+            return null;
+        }
+
+        public bool TryGetLibrary(LockFileTargetLibrary targetLibrary, out LockFileLibrary library)
+        {
+            var libraryType = LibraryType.Parse(targetLibrary.Type);
+            if (libraryType == LibraryType.Package)
+            {
+                library = GetPackage(targetLibrary.Name, targetLibrary.Version);
+            }
+            else
+            {
+                library = GetProject(targetLibrary.Name);
+            }
+
+            return library != null;
+        }
+
+        public void Clear()
+        {
+            _packages.Clear();
+            _projects.Clear();
+        }
+
+        private class PackageCacheKeyComparer : IEqualityComparer<KeyValuePair<string, NuGetVersion>>
+        {
+            public static readonly PackageCacheKeyComparer Instance = new PackageCacheKeyComparer();
+
+            private PackageCacheKeyComparer()
+            {
+            }
+
+            public bool Equals(KeyValuePair<string, NuGetVersion> x, KeyValuePair<string, NuGetVersion> y)
+            {
+                return string.Equals(x.Key, y.Key, StringComparison.OrdinalIgnoreCase) &&
+                    x.Value == y.Value;
+            }
+
+            public int GetHashCode(KeyValuePair<string, NuGetVersion> obj)
+            {
+                var hashCode = 0;
+                if (obj.Key != null)
+                {
+                    hashCode ^= StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Key);
+                }
+
+                hashCode ^= obj.Value?.GetHashCode() ?? 0;
+                return hashCode;
+            }
+        }
+    }
+}

--- a/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/NuGetPackageResolver.cs
+++ b/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/NuGetPackageResolver.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Packaging;
+using NuGet.ProjectModel;
+using NuGet.Versioning;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    internal sealed class NuGetPackageResolver : IPackageResolver
+    {
+        private readonly FallbackPackagePathResolver _packagePathResolver;
+
+        // Used when no package folders are provided, finds no packages.
+        private static readonly NuGetPackageResolver s_noPackageFolderResolver = new NuGetPackageResolver();
+
+        private NuGetPackageResolver()
+        {
+        }
+
+        private NuGetPackageResolver(string userPackageFolder, IEnumerable<string> fallbackPackageFolders)
+        {
+            _packagePathResolver = new FallbackPackagePathResolver(userPackageFolder, fallbackPackageFolders);
+        }
+
+        public string GetPackageDirectory(string packageId, NuGetVersion version)
+            => _packagePathResolver?.GetPackageDirectory(packageId, version);
+        
+        public string GetPackageDirectory(string packageId, NuGetVersion version, out string packageRoot)
+        {
+            var packageInfo = _packagePathResolver?.GetPackageInfo(packageId, version);
+            if (packageInfo == null)
+            {
+                packageRoot = null;
+                return null;
+            }
+
+            packageRoot = packageInfo.PathResolver.RootPath;
+            return packageInfo.PathResolver.GetInstallPath(packageId, version);
+        }
+
+        public string ResolvePackageAssetPath(LockFileTargetLibrary package, string relativePath)
+        {
+            string packagePath = GetPackageDirectory(package.Name, package.Version);
+
+            if (packagePath == null)
+            {
+                throw new BuildErrorException(
+                    string.Format(Strings.PackageNotFound, package.Name, package.Version));
+            }
+
+            return Path.Combine(packagePath, NormalizeRelativePath(relativePath));
+        }
+
+        public static string NormalizeRelativePath(string relativePath)
+            => relativePath.Replace('/', Path.DirectorySeparatorChar);
+
+        public static NuGetPackageResolver CreateResolver(LockFile lockFile)
+            => CreateResolver(lockFile.PackageFolders.Select(f => f.Path));
+
+        public static NuGetPackageResolver CreateResolver(IEnumerable<string> packageFolders)
+        {
+            string userPackageFolder = packageFolders.FirstOrDefault();
+
+            if (userPackageFolder == null)
+            {
+                return s_noPackageFolderResolver;
+            }
+
+            return new NuGetPackageResolver(userPackageFolder, packageFolders.Skip(1));
+        }
+    }
+}

--- a/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/NuGetPackageResolver.cs
+++ b/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/NuGetPackageResolver.cs
@@ -51,7 +51,7 @@ namespace Microsoft.NET.Build.Tasks
             if (packagePath == null)
             {
                 throw new BuildErrorException(
-                    string.Format(Strings.PackageNotFound, package.Name, package.Version));
+                    string.Format("Package not found", package.Name, package.Version));
             }
 
             return Path.Combine(packagePath, NormalizeRelativePath(relativePath));

--- a/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/NuGetUtils.NuGet.cs
+++ b/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/NuGetUtils.NuGet.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using NuGet.Frameworks;
+using NuGet.Packaging.Core;
+using NuGet.ProjectModel;
+using NuGet.RuntimeModel;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    internal static partial class NuGetUtils
+    {
+        public static bool IsPlaceholderFile(string path)
+        {
+            // PERF: avoid allocations here as we check this for every file in project.assets.json
+            if (!path.EndsWith("_._", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            if (path.Length == 3)
+            {
+                return true;
+            }
+
+            char separator = path[path.Length - 4];
+            return separator == '\\' || separator == '/';
+        }
+
+        public static string GetLockFileLanguageName(string projectLanguage)
+        {
+            switch (projectLanguage)
+            {
+                case "C#": return "cs";
+                case "F#": return "fs";
+                default: return projectLanguage?.ToLowerInvariant();
+            }
+        }
+
+        public static NuGetFramework ParseFrameworkName(string frameworkName)
+        {
+            return frameworkName == null ? null : NuGetFramework.Parse(frameworkName);
+        }
+
+        public static bool IsApplicableAnalyzer(string file, string projectLanguage)
+        {
+            // This logic is preserved from previous implementations.
+            // See https://github.com/NuGet/Home/issues/6279#issuecomment-353696160 for possible issues with it.
+
+            bool IsAnalyzer()
+            {
+                return file.StartsWith("analyzers", StringComparison.Ordinal)
+                    && file.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
+                    && !file.EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase);
+            }
+
+            bool CS() => file.IndexOf("/cs/", StringComparison.OrdinalIgnoreCase) >= 0;
+            bool VB() => file.IndexOf("/vb/", StringComparison.OrdinalIgnoreCase) >= 0;
+
+            bool FileMatchesProjectLanguage()
+            {
+                switch (projectLanguage)
+                {
+                    case "C#":
+                        return CS() || !VB();
+
+                    case "VB":
+                        return VB() || !CS();
+
+                    default:
+                        return false;
+                }
+            }
+
+            return IsAnalyzer() && FileMatchesProjectLanguage();
+        }
+
+        public static string GetBestMatchingRid(RuntimeGraph runtimeGraph, string runtimeIdentifier,
+            IEnumerable<string> availableRuntimeIdentifiers, out bool wasInGraph)
+        {
+            wasInGraph = runtimeGraph.Runtimes.ContainsKey(runtimeIdentifier);
+
+            HashSet<string> availableRids = new HashSet<string>(availableRuntimeIdentifiers);
+            foreach (var candidateRuntimeIdentifier in runtimeGraph.ExpandRuntime(runtimeIdentifier))
+            {
+                if (availableRids.Contains(candidateRuntimeIdentifier))
+                {
+                    return candidateRuntimeIdentifier;
+                }
+            }
+
+            //  No compatible RID found in availableRuntimeIdentifiers
+            return null;
+        }
+    }
+}

--- a/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/PackageReferenceConverter.cs
+++ b/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/PackageReferenceConverter.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    internal static class PackageReferenceConverter
+    {
+        public static IEnumerable<string> GetPackageIds(ITaskItem[] packageReferences)
+        {
+            if (packageReferences == null)
+            {
+                return Enumerable.Empty<string>();
+            }
+
+            return packageReferences
+                .Select(p => p.ItemSpec)
+                .ToArray();
+        }
+    }
+}

--- a/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/ProjectContext.cs
+++ b/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/ProjectContext.cs
@@ -1,0 +1,280 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Framework;
+using NuGet.Packaging.Core;
+using NuGet.ProjectModel;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    internal class ProjectContext
+    {
+        public class RuntimeFramework
+        {
+            public string Name { get; set; }
+            public string Version { get; set; }
+
+            public RuntimeFramework() { }
+
+            public RuntimeFramework(ITaskItem item)
+            {
+                Name = item.ItemSpec;
+                Version = item.GetMetadata(MetadataKeys.Version);
+            }
+        }
+
+        private readonly LockFile _lockFile;
+        private readonly LockFileTarget _lockFileTarget;
+        internal HashSet<PackageIdentity> PackagesToBeFiltered { get; set; }
+
+        /// <summary>
+        /// A value indicating that this project runs on a shared system-wide framework.
+        /// (ex. Microsoft.NETCore.App for .NET Core)
+        /// </summary>
+        public bool IsFrameworkDependent { get; }
+
+        /// <summary>
+        /// A value indicating that this project is portable across operating systems, processor architectures, etc.
+        /// </summary>
+        /// <remarks>
+        /// Returns <c>true</c> for projects running on shared frameworks (<see cref="IsFrameworkDependent" />)
+        /// that do not target a specific RID.
+        /// </remarks>
+        public bool IsPortable => IsFrameworkDependent && string.IsNullOrEmpty(_lockFileTarget.RuntimeIdentifier);
+
+        public LockFileTargetLibrary PlatformLibrary { get; }
+
+        public RuntimeFramework [] RuntimeFrameworks { get; }
+
+        public LockFile LockFile => _lockFile;
+        public LockFileTarget LockFileTarget => _lockFileTarget;
+
+        public ProjectContext(LockFile lockFile, LockFileTarget lockFileTarget,
+            //  Trimmed from publish output, and if there are no runtimeFrameworks, written to runtimeconfig.json
+            LockFileTargetLibrary platformLibrary,
+            //  Written to runtimeconfig.json
+            RuntimeFramework[] runtimeFrameworks,
+            bool isFrameworkDependent)
+        {
+            Debug.Assert(lockFile != null);
+            Debug.Assert(lockFileTarget != null);
+            if (isFrameworkDependent)
+            {
+                Debug.Assert(platformLibrary != null || 
+                    (runtimeFrameworks != null && runtimeFrameworks.Any()));
+            }
+
+            _lockFile = lockFile;
+            _lockFileTarget = lockFileTarget;
+
+            PlatformLibrary = platformLibrary;
+            RuntimeFrameworks = runtimeFrameworks;
+            IsFrameworkDependent = isFrameworkDependent;
+        }
+
+        public IEnumerable<LockFileTargetLibrary> GetRuntimeLibraries(IEnumerable<string> excludeFromPublishPackageIds)
+        {
+            IEnumerable<LockFileTargetLibrary> runtimeLibraries = _lockFileTarget.Libraries;
+            Dictionary<string, LockFileTargetLibrary> libraryLookup =
+                runtimeLibraries.ToDictionary(e => e.Name, StringComparer.OrdinalIgnoreCase);
+
+            HashSet<string> allExclusionList = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            if (IsFrameworkDependent)
+            {
+                if (PlatformLibrary != null)
+                {
+                    allExclusionList.UnionWith(_lockFileTarget.GetPlatformExclusionList(PlatformLibrary, libraryLookup));
+                }
+            }
+
+            if (excludeFromPublishPackageIds?.Any() == true)
+            {
+                HashSet<string> excludeFromPublishList =
+                    GetExcludeFromPublishList(
+                        excludeFromPublishPackageIds,
+                        libraryLookup);
+
+                allExclusionList.UnionWith(excludeFromPublishList);
+            }
+
+            if (PackagesToBeFiltered != null)
+            {
+                var filterLookup = new Dictionary<string, HashSet<PackageIdentity>>(StringComparer.OrdinalIgnoreCase);
+                foreach (var pkg in PackagesToBeFiltered)
+                {
+                    HashSet<PackageIdentity> packageinfos;
+                    if (filterLookup.TryGetValue(pkg.Id, out packageinfos))
+                    {
+                        packageinfos.Add(pkg);
+                    }
+                    else
+                    {
+                        packageinfos = new HashSet<PackageIdentity>();
+                        packageinfos.Add(pkg);
+                        filterLookup.Add(pkg.Id, packageinfos);
+                    }
+                }
+
+                allExclusionList.UnionWith(GetPackagesToBeFiltered(filterLookup, libraryLookup));
+            }
+
+            return runtimeLibraries.Filter(allExclusionList).ToArray();
+        }
+
+        internal IEnumerable<PackageIdentity> GetTransitiveList(string package)
+        {
+            LockFileTargetLibrary platformLibrary = _lockFileTarget.GetLibrary(package);
+            IEnumerable<LockFileTargetLibrary> runtimeLibraries = _lockFileTarget.Libraries;
+            Dictionary<string, LockFileTargetLibrary> libraryLookup =
+                runtimeLibraries.ToDictionary(e => e.Name, StringComparer.OrdinalIgnoreCase);
+
+            return  _lockFileTarget.GetTransitivePackagesList(platformLibrary, libraryLookup);
+        }
+
+        public IEnumerable<LockFileTargetLibrary> GetCompileLibraries(IEnumerable<string> compileExcludeFromPublishPackageIds)
+        {
+            IEnumerable<LockFileTargetLibrary> compileLibraries = _lockFileTarget.Libraries;
+
+            if (compileExcludeFromPublishPackageIds?.Any() == true)
+            {
+                Dictionary<string, LockFileTargetLibrary> libraryLookup =
+                    compileLibraries.ToDictionary(e => e.Name, StringComparer.OrdinalIgnoreCase);
+
+                HashSet<string> excludeFromPublishList =
+                    GetExcludeFromPublishList(
+                        compileExcludeFromPublishPackageIds,
+                        libraryLookup);
+
+                compileLibraries = compileLibraries.Filter(excludeFromPublishList);
+            }
+
+            return compileLibraries.ToArray();
+        }
+
+        public IEnumerable<string> GetTopLevelDependencies()
+        {
+            Dictionary<string, LockFileTargetLibrary> libraryLookup =
+                LockFileTarget.Libraries.ToDictionary(l => l.Name, StringComparer.OrdinalIgnoreCase);
+
+            return LockFile
+                .ProjectFileDependencyGroups
+                .Where(dg => dg.FrameworkName == string.Empty ||
+                             dg.FrameworkName == LockFileTarget.TargetFramework.DotNetFrameworkName)
+                .SelectMany(g => g.Dependencies)
+                .Select(projectFileDependency =>
+                {
+                    int separatorIndex = projectFileDependency.IndexOf(' ');
+                    string libraryName = separatorIndex > 0 ?
+                        projectFileDependency.Substring(0, separatorIndex) :
+                        projectFileDependency;
+
+                    if (!string.IsNullOrEmpty(libraryName) && libraryLookup.ContainsKey(libraryName))
+                    {
+                        return libraryName;
+                    }
+
+                    return null;
+                })
+                .Where(libraryName => libraryName != null)
+                .ToArray();
+        }
+
+        public HashSet<string> GetExcludeFromPublishList(
+            IEnumerable<string> excludeFromPublishPackageIds,
+            IDictionary<string, LockFileTargetLibrary> libraryLookup)
+        {
+            var nonExcludeFromPublishAssets = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            var nonExcludeFromPublishAssetsToSearch = new Stack<string>();
+            var excludeFromPublishAssetsToSearch = new Stack<string>();
+
+            // Start with the top-level dependencies, and put them into "private" or "non-private" buckets
+            var excludeFromPublishPackagesLookup = new HashSet<string>(excludeFromPublishPackageIds, StringComparer.OrdinalIgnoreCase);
+            foreach (var topLevelDependency in GetTopLevelDependencies())
+            {
+                if (!excludeFromPublishPackagesLookup.Contains(topLevelDependency))
+                {
+                    nonExcludeFromPublishAssetsToSearch.Push(topLevelDependency);
+                    nonExcludeFromPublishAssets.Add(topLevelDependency);
+                }
+                else
+                {
+                    excludeFromPublishAssetsToSearch.Push(topLevelDependency);
+                }
+            }
+
+            LockFileTargetLibrary library;
+            string libraryName;
+
+            // Walk all the non-private assets' dependencies and mark them as non-private
+            while (nonExcludeFromPublishAssetsToSearch.Count > 0)
+            {
+                libraryName = nonExcludeFromPublishAssetsToSearch.Pop();
+                if (libraryLookup.TryGetValue(libraryName, out library))
+                {
+                    foreach (var dependency in library.Dependencies)
+                    {
+                        if (!nonExcludeFromPublishAssets.Contains(dependency.Id))
+                        {
+                            nonExcludeFromPublishAssetsToSearch.Push(dependency.Id);
+                            nonExcludeFromPublishAssets.Add(dependency.Id);
+                        }
+                    }
+                }
+            }
+
+            // Go through assets marked private and their dependencies
+            // For libraries not marked as non-private, mark them down as private
+            var assetsToExcludeFromPublish = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            while (excludeFromPublishAssetsToSearch.Count > 0)
+            {
+                libraryName = excludeFromPublishAssetsToSearch.Pop();
+                if (libraryLookup.TryGetValue(libraryName, out library))
+                {
+                    assetsToExcludeFromPublish.Add(libraryName);
+
+                    foreach (var dependency in library.Dependencies)
+                    {
+                        if (!nonExcludeFromPublishAssets.Contains(dependency.Id))
+                        {
+                            excludeFromPublishAssetsToSearch.Push(dependency.Id);
+                        }
+                    }
+                }
+            }
+
+            return assetsToExcludeFromPublish;
+        }
+        private static HashSet<string> GetPackagesToBeFiltered(
+          IDictionary<string, HashSet<PackageIdentity>> packagesToBeFiltered,
+          IDictionary<string, LockFileTargetLibrary> packagesToBePublished)
+        {
+            var exclusionList = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var entry in packagesToBePublished)
+            {
+                HashSet<PackageIdentity> librarySet;
+
+                if (packagesToBeFiltered.TryGetValue(entry.Key, out librarySet))
+                {
+                    LockFileTargetLibrary dependency = entry.Value;
+                    foreach (var library in librarySet)
+                    {
+                        if (dependency.Version.Equals(library.Version))
+                        {
+                            exclusionList.Add(entry.Key);
+                            break;
+                        }
+                    }
+                }
+            }
+
+            return exclusionList;
+        }
+    }
+}

--- a/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/ReferenceInfo.cs
+++ b/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/ReferenceInfo.cs
@@ -1,0 +1,137 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    internal class ReferenceInfo
+    {
+        public string Name { get; }
+        public string Version { get; }
+        public string FullPath { get; }
+        public string FileName => Path.GetFileName(FullPath);
+
+        private List<ResourceAssemblyInfo> _resourceAssemblies;
+        public IEnumerable<ResourceAssemblyInfo> ResourceAssemblies
+        {
+            get { return _resourceAssemblies; }
+        }
+
+        private ReferenceInfo(string name, string version, string fullPath)
+        {
+            Name = name;
+            Version = version;
+            FullPath = fullPath;
+
+            _resourceAssemblies = new List<ResourceAssemblyInfo>();
+        }
+
+        public static IEnumerable<ReferenceInfo> CreateReferenceInfos(IEnumerable<ITaskItem> referencePaths)
+        {
+            List<ReferenceInfo> referenceInfos = new List<ReferenceInfo>();
+            foreach (ITaskItem referencePath in referencePaths)
+            {
+                referenceInfos.Add(CreateReferenceInfo(referencePath));
+            }
+
+            return referenceInfos;
+        }
+
+        public static IEnumerable<ReferenceInfo> CreateDirectReferenceInfos(
+            IEnumerable<ITaskItem> referencePaths,
+            IEnumerable<ITaskItem> referenceSatellitePaths)
+        {
+            IEnumerable<ITaskItem> directReferencePaths = referencePaths
+                .Where(r => r.HasMetadataValue("CopyLocal", "true") &&
+                            r.HasMetadataValue("ReferenceSourceTarget", "ResolveAssemblyReference") &&
+                            !IsNuGetReference(r));
+
+            return CreateFilteredReferenceInfos(directReferencePaths, referenceSatellitePaths);
+        }
+
+        private static bool IsNuGetReference(ITaskItem reference)
+        {
+            return !string.IsNullOrEmpty(reference.GetMetadata("NuGetSourceType")) &&
+                   reference.GetMetadata("NuGetIsFrameworkReference") != "true";
+        }
+
+        public static IEnumerable<ReferenceInfo> CreateDependencyReferenceInfos(
+            IEnumerable<ITaskItem> referenceDependencyPaths,
+            IEnumerable<ITaskItem> referenceSatellitePaths)
+        {
+            IEnumerable<ITaskItem> indirectReferencePaths = referenceDependencyPaths
+                .Where(r => r.HasMetadataValue("CopyLocal", "true") &&
+                            !IsNuGetReference(r));
+
+            return CreateFilteredReferenceInfos(indirectReferencePaths, referenceSatellitePaths);
+        }
+
+        private static IEnumerable<ReferenceInfo> CreateFilteredReferenceInfos(
+            IEnumerable<ITaskItem> referencePaths,
+            IEnumerable<ITaskItem> referenceSatellitePaths)
+        {
+            Dictionary<string, ReferenceInfo> directReferences = new Dictionary<string, ReferenceInfo>();
+
+            foreach (ITaskItem referencePath in referencePaths)
+            {
+                ReferenceInfo referenceInfo = CreateReferenceInfo(referencePath);
+                directReferences.Add(referenceInfo.FullPath, referenceInfo);
+            }
+
+            foreach (ITaskItem referenceSatellitePath in referenceSatellitePaths)
+            {
+                string originalItemSpec = referenceSatellitePath.GetMetadata("OriginalItemSpec");
+                if (!string.IsNullOrEmpty(originalItemSpec))
+                {
+                    ReferenceInfo referenceInfo;
+                    if (directReferences.TryGetValue(originalItemSpec, out referenceInfo))
+                    {
+                        ResourceAssemblyInfo resourceAssemblyInfo =
+                            ResourceAssemblyInfo.CreateFromReferenceSatellitePath(referenceSatellitePath);
+                        referenceInfo._resourceAssemblies.Add(resourceAssemblyInfo);
+                    }
+                }
+            }
+
+            return directReferences.Values;
+        }
+
+        internal static ReferenceInfo CreateReferenceInfo(ITaskItem referencePath)
+        {
+            string fullPath = referencePath.ItemSpec;
+            string name = Path.GetFileNameWithoutExtension(fullPath);
+            string version = GetVersion(referencePath);
+
+            return new ReferenceInfo(name, version, fullPath);
+        }
+
+        private static string GetVersion(ITaskItem referencePath)
+        {
+            string version = referencePath.GetMetadata("Version");
+
+            if (string.IsNullOrEmpty(version))
+            {
+                string fusionName = referencePath.GetMetadata("FusionName");
+                if (!string.IsNullOrEmpty(fusionName))
+                {
+                    AssemblyName assemblyName = new AssemblyName(fusionName);
+                    version = assemblyName.Version.ToString();
+                }
+
+                if (string.IsNullOrEmpty(version))
+                {
+                    // Use 0.0.0.0 as placeholder, if we can't find a version any
+                    // other way
+                    version = "0.0.0.0";
+                }
+            }
+
+            return version;
+        }
+    }
+}

--- a/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/ResolvedFile.cs
+++ b/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/ResolvedFile.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using System;
+using NuGet.Packaging.Core;
+namespace Microsoft.NET.Build.Tasks
+{
+    internal enum AssetType
+    {
+        None,
+        Runtime,
+        Native,
+        Resources
+    }
+
+    internal class ResolvedFile
+    {
+        public string SourcePath { get; }
+        public PackageIdentity Package { get; }
+        public string DestinationSubDirectory { get; }
+        public AssetType Asset{ get; }
+        public string FileName
+        {
+            get { return Path.GetFileName(SourcePath); }
+        }
+
+        public string DestinationSubPath
+        {
+            get
+            {
+                return string.IsNullOrEmpty(DestinationSubDirectory) ?
+                      FileName :
+                      Path.Combine(DestinationSubDirectory, FileName);
+            }
+        }
+
+        public ResolvedFile(string sourcePath, string destinationSubDirectory, PackageIdentity package, AssetType assetType = AssetType.None)
+        {
+            SourcePath = Path.GetFullPath(sourcePath);
+            DestinationSubDirectory = destinationSubDirectory;
+            Asset = assetType;
+            Package = package;
+
+        }
+
+        public override bool Equals(object obj)
+        {
+            ResolvedFile other = obj as ResolvedFile;
+            return other != null &&
+                other.Asset == Asset &&
+                other.SourcePath == SourcePath &&
+                other.DestinationSubDirectory == DestinationSubDirectory;
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return SourcePath.GetHashCode() + DestinationSubDirectory.GetHashCode();
+            }
+        }
+    }
+}

--- a/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/ResourceAssemblyInfo.cs
+++ b/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/ResourceAssemblyInfo.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    internal class ResourceAssemblyInfo
+    {
+        public string Culture { get; }
+        public string RelativePath { get; }
+
+        public ResourceAssemblyInfo(string culture, string relativePath)
+        {
+            Culture = culture;
+            RelativePath = relativePath;
+        }
+
+        public static ResourceAssemblyInfo CreateFromReferenceSatellitePath(ITaskItem referenceSatellitePath)
+        {
+            string destinationSubDirectory = referenceSatellitePath.GetMetadata("DestinationSubDirectory");
+
+            string culture = destinationSubDirectory.Trim('\\', '/');
+            string relativePath = Path.Combine(destinationSubDirectory, Path.GetFileName(referenceSatellitePath.ItemSpec));
+
+            return new ResourceAssemblyInfo(culture, relativePath);
+        }
+    }
+}

--- a/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/RuntimePackAssetInfo.cs
+++ b/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/RuntimePackAssetInfo.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    internal class RuntimePackAssetInfo
+    {
+        public string SourcePath { get; set; }
+
+        public string DestinationSubPath { get; set; }
+
+        public AssetType AssetType { get; set; }
+
+        public string PackageName { get; set; }
+
+        public string PackageVersion { get; set; }
+
+        public string PackageRuntimeIdentifier { get; set; }
+
+        public static RuntimePackAssetInfo FromItem(ITaskItem item)
+        {
+            var assetInfo = new RuntimePackAssetInfo();
+            assetInfo.SourcePath = item.ItemSpec;
+            assetInfo.DestinationSubPath = item.GetMetadata(MetadataKeys.DestinationSubPath);
+
+            string assetTypeString = item.GetMetadata(MetadataKeys.AssetType);
+            if (assetTypeString.Equals("runtime", StringComparison.OrdinalIgnoreCase))
+            {
+                assetInfo.AssetType = AssetType.Runtime;
+            }
+            else if (assetTypeString.Equals("native", StringComparison.OrdinalIgnoreCase))
+            {
+                assetInfo.AssetType = AssetType.Native;
+            }
+            else
+            {
+                throw new InvalidOperationException("Unexpected asset type: " + item.GetMetadata(MetadataKeys.AssetType));
+            }
+
+            assetInfo.PackageName = item.GetMetadata(MetadataKeys.PackageName);
+            assetInfo.PackageVersion = item.GetMetadata(MetadataKeys.PackageVersion);
+            assetInfo.PackageRuntimeIdentifier = item.GetMetadata(MetadataKeys.RuntimeIdentifier);
+
+            return assetInfo;
+        }
+    }
+}

--- a/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/SingleProjectInfo.cs
+++ b/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/SingleProjectInfo.cs
@@ -1,0 +1,164 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Collections.Generic;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.NET.Build.Tasks
+{
+    /// <summary>
+    /// These are Projects for which there is no csproj path info in RAR (indirect project references)
+    /// </summary>
+    internal class UnreferencedProjectInfo : SingleProjectInfo
+    {
+        internal static UnreferencedProjectInfo Default = new UnreferencedProjectInfo();
+
+        private UnreferencedProjectInfo() : base(string.Empty, string.Empty, string.Empty, string.Empty, new List<ReferenceInfo>(), new List<ResourceAssemblyInfo>())
+        {
+        }
+    }
+
+    internal class SingleProjectInfo
+    {
+        public string ProjectPath { get; }
+        public string Name { get; }
+        public string Version { get; }
+        public string OutputName { get; }
+
+        private List<ReferenceInfo> _dependencyReferences;
+        public IEnumerable<ReferenceInfo> DependencyReferences
+        {
+            get { return _dependencyReferences; }
+        }
+
+        private List<ResourceAssemblyInfo> _resourceAssemblies;
+        public IEnumerable<ResourceAssemblyInfo> ResourceAssemblies
+        {
+            get { return _resourceAssemblies; }
+        }
+
+        protected SingleProjectInfo()
+        {
+        }
+
+        protected SingleProjectInfo(string projectPath, string name, string version, string outputName, List<ReferenceInfo> dependencyReferences, List<ResourceAssemblyInfo> resourceAssemblies)
+        {
+            ProjectPath = projectPath;
+            Name = name;
+            Version = version;
+            OutputName = outputName;
+            _dependencyReferences = dependencyReferences ?? new List<ReferenceInfo>();
+            _resourceAssemblies = resourceAssemblies ?? new List<ResourceAssemblyInfo>();
+        }
+
+        public static SingleProjectInfo Create(string projectPath, string name, string fileExtension, string version, ITaskItem[] satelliteAssemblies)
+        {
+            List<ResourceAssemblyInfo> resourceAssemblies = new List<ResourceAssemblyInfo>();
+
+            foreach (ITaskItem satelliteAssembly in satelliteAssemblies)
+            {
+                string culture = satelliteAssembly.GetMetadata(MetadataKeys.Culture);
+                string relativePath = satelliteAssembly.GetMetadata(MetadataKeys.TargetPath);
+
+                resourceAssemblies.Add(new ResourceAssemblyInfo(culture, relativePath));
+            }
+
+            string outputName = name + fileExtension;
+            return new SingleProjectInfo(projectPath, name, version, outputName, dependencyReferences: null, resourceAssemblies: resourceAssemblies);
+        }
+
+        public static Dictionary<string, SingleProjectInfo> CreateProjectReferenceInfos(
+            IEnumerable<ITaskItem> referencePaths,
+            IEnumerable<ITaskItem> referenceDependencyPaths,
+            IEnumerable<ITaskItem> referenceSatellitePaths)
+        {
+            Dictionary<string, SingleProjectInfo> projectReferences = new Dictionary<string, SingleProjectInfo>(StringComparer.OrdinalIgnoreCase);
+
+            IEnumerable<ITaskItem> projectReferencePaths = referencePaths
+                .Where(r => IsProjectReference(r));
+
+            foreach (ITaskItem projectReferencePath in projectReferencePaths)
+            {
+                string sourceProjectFile = projectReferencePath.GetMetadata(MetadataKeys.MSBuildSourceProjectFile);
+
+                if (string.IsNullOrEmpty(sourceProjectFile))
+                {
+                    throw new BuildErrorException(Strings.MissingItemMetadata, MetadataKeys.MSBuildSourceProjectFile, "ReferencePath", projectReferencePath.ItemSpec);
+                }
+
+                string outputName = Path.GetFileName(projectReferencePath.ItemSpec);
+                string name = Path.GetFileNameWithoutExtension(outputName);
+                string version = null; // it isn't possible to know the version from the MSBuild info.
+                                       // The version will be retrieved from the project assets file.
+
+                projectReferences.Add(
+                    sourceProjectFile,
+                    new SingleProjectInfo(sourceProjectFile, name, version, outputName, dependencyReferences: null, resourceAssemblies: null));
+            }
+
+            //  Include direct references of referenced projects, but only if they are CopyLocal
+            IEnumerable<ITaskItem> projectReferenceDependencyPaths = referenceDependencyPaths
+                .Where(r => IsProjectReference(r) &&
+                            MSBuildUtilities.ConvertStringToBool(r.GetMetadata(MetadataKeys.CopyLocal)));
+
+            foreach (ITaskItem projectReferenceDependencyPath in projectReferenceDependencyPaths)
+            {
+                string sourceProjectFile = projectReferenceDependencyPath.GetMetadata(MetadataKeys.MSBuildSourceProjectFile);
+
+                if (string.IsNullOrEmpty(sourceProjectFile))
+                {
+                    throw new BuildErrorException(Strings.MissingItemMetadata, MetadataKeys.MSBuildSourceProjectFile, "ReferenceDependencyPath", projectReferenceDependencyPath.ItemSpec);
+                }
+
+                SingleProjectInfo referenceProjectInfo;
+                if (projectReferences.TryGetValue(sourceProjectFile, out referenceProjectInfo))
+                {
+                    ReferenceInfo dependencyReferenceInfo = ReferenceInfo.CreateReferenceInfo(projectReferenceDependencyPath);
+                    referenceProjectInfo._dependencyReferences.Add(dependencyReferenceInfo);
+                }
+            }
+
+            IEnumerable<ITaskItem> projectReferenceSatellitePaths = referenceSatellitePaths.Where(r => IsProjectReference(r));
+
+            foreach (ITaskItem projectReferenceSatellitePath in projectReferenceSatellitePaths)
+            {
+                string sourceProjectFile = projectReferenceSatellitePath.GetMetadata(MetadataKeys.MSBuildSourceProjectFile);
+
+                if (string.IsNullOrEmpty(sourceProjectFile))
+                {
+                    throw new BuildErrorException(Strings.MissingItemMetadata, MetadataKeys.MSBuildSourceProjectFile, "ReferenceSatellitePath", projectReferenceSatellitePath.ItemSpec);
+                }
+
+                SingleProjectInfo referenceProjectInfo;
+                if (projectReferences.TryGetValue(sourceProjectFile, out referenceProjectInfo))
+                {
+                    string originalItemSpec = projectReferenceSatellitePath.GetMetadata(MetadataKeys.OriginalItemSpec);
+
+                    if (!string.IsNullOrEmpty(originalItemSpec))
+                    {
+                        ReferenceInfo referenceInfo = referenceProjectInfo._dependencyReferences.SingleOrDefault(r => r.FullPath.Equals(originalItemSpec));
+
+                        if (referenceInfo is null)
+                        {
+                            // We only want to add the reference satellite path if it isn't already covered by a dependency
+
+                            ResourceAssemblyInfo resourceAssemblyInfo =
+                                ResourceAssemblyInfo.CreateFromReferenceSatellitePath(projectReferenceSatellitePath);
+                            referenceProjectInfo._resourceAssemblies.Add(resourceAssemblyInfo);
+                        }
+                    }
+                }
+            }
+
+            return projectReferences;
+        }
+
+        private static bool IsProjectReference(ITaskItem i)
+        {
+            return string.Equals(i.GetMetadata(MetadataKeys.ReferenceSourceTarget), "ProjectReference", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/SingleProjectInfo.cs
+++ b/src/ILLink.Tasks/Microsoft.NET.Build.Tasks/SingleProjectInfo.cs
@@ -86,7 +86,7 @@ namespace Microsoft.NET.Build.Tasks
 
                 if (string.IsNullOrEmpty(sourceProjectFile))
                 {
-                    throw new BuildErrorException(Strings.MissingItemMetadata, MetadataKeys.MSBuildSourceProjectFile, "ReferencePath", projectReferencePath.ItemSpec);
+                    throw new BuildErrorException("Missing item metadata", MetadataKeys.MSBuildSourceProjectFile, "ReferencePath", projectReferencePath.ItemSpec);
                 }
 
                 string outputName = Path.GetFileName(projectReferencePath.ItemSpec);
@@ -110,7 +110,7 @@ namespace Microsoft.NET.Build.Tasks
 
                 if (string.IsNullOrEmpty(sourceProjectFile))
                 {
-                    throw new BuildErrorException(Strings.MissingItemMetadata, MetadataKeys.MSBuildSourceProjectFile, "ReferenceDependencyPath", projectReferenceDependencyPath.ItemSpec);
+                    throw new BuildErrorException("Missing item metadata", MetadataKeys.MSBuildSourceProjectFile, "ReferenceDependencyPath", projectReferenceDependencyPath.ItemSpec);
                 }
 
                 SingleProjectInfo referenceProjectInfo;
@@ -129,7 +129,7 @@ namespace Microsoft.NET.Build.Tasks
 
                 if (string.IsNullOrEmpty(sourceProjectFile))
                 {
-                    throw new BuildErrorException(Strings.MissingItemMetadata, MetadataKeys.MSBuildSourceProjectFile, "ReferenceSatellitePath", projectReferenceSatellitePath.ItemSpec);
+                    throw new BuildErrorException("Missing item metadata", MetadataKeys.MSBuildSourceProjectFile, "ReferenceSatellitePath", projectReferenceSatellitePath.ItemSpec);
                 }
 
                 SingleProjectInfo referenceProjectInfo;


### PR DESCRIPTION
This works around a bug in the SDK's deps file generation logic: https://github.com/dotnet/sdk/issues/3010. I'm building ILLink.Tasks with a copy of the sources used by the SDK to generate deps files. It's a temporary replacement for the GenerateDepsFile task, with a fix for the issue mentioned above in https://github.com/mono/linker/commit/39a6ae7936cd72acbdb1dd42071ddb4931b6f71a. I intend to remove it as soon as the SDK issue is fixed. I'm doing this mostly to get our integration tests up and running in the interim - I definitely don't want to ship this fix in the SDK.

@nguerrera