### PR TITLE
Optionally ignore field resolution errors

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -881,7 +881,10 @@ namespace Mono.Linker.Steps {
 			FieldDefinition field = ResolveFieldDefinition (reference);
 
 			if (field == null)
-				throw new ResolutionException (reference);
+			{
+				HandleUnresolvedField (reference);
+				return;
+			}
 
 			if (CheckProcessed (field))
 				return;
@@ -2086,6 +2089,13 @@ namespace Mono.Linker.Steps {
 		}
 
 		protected virtual void HandleUnresolvedMethod (MethodReference reference)
+		{
+			if (!_context.IgnoreUnresolved) {
+				throw new ResolutionException (reference);
+			}
+		}
+
+		protected virtual void HandleUnresolvedField (FieldReference reference)
 		{
 			if (!_context.IgnoreUnresolved) {
 				throw new ResolutionException (reference);

--- a/src/linker/Linker/MethodBodyScanner.cs
+++ b/src/linker/Linker/MethodBodyScanner.cs
@@ -110,7 +110,7 @@ namespace Mono.Linker {
 
 		static void AddIfResolved (HashSet<TypeDefinition> set, TypeReference item)
 		{
-			var resolved = item.Resolve ();
+			var resolved = item?.Resolve ();
 			if (resolved == null)
 				return;
 			set.Add (resolved);


### PR DESCRIPTION
We already have this behavior for unresolved methods. This introduces
the same for fields to prevent some more resolution failures in cases
where the assembly containing the field's type is not present at link
time.