### PR TITLE
Write stack traces to stderr

### DIFF
--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -61,9 +61,14 @@ namespace Mono.Linker {
 				driver.Run (customLogger);
 
 			} catch (Exception e) {
+#if FEATURE_ILLINK
+				Console.Error.WriteLine ("Fatal error in {0}", _linker);
+				throw;
+#else
 				Console.WriteLine ("Fatal error in {0}", _linker);
 				Console.WriteLine (e);
 				return 1;
+#endif
 			}
 
 			return 0;

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -61,14 +61,8 @@ namespace Mono.Linker {
 				driver.Run (customLogger);
 
 			} catch (Exception e) {
-#if FEATURE_ILLINK
 				Console.Error.WriteLine ("Fatal error in {0}", _linker);
 				throw;
-#else
-				Console.WriteLine ("Fatal error in {0}", _linker);
-				Console.WriteLine (e);
-				return 1;
-#endif
 			}
 
 			return 0;


### PR DESCRIPTION
This will show up in the msbuild output with a higher importance by
default, and may also align more closely with the expectations of
command line users.

@marek-safar the other option is to make this the behavior of monolinker as well. What do you think?