### PR TITLE
Fix a bug with preserve parent

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1014,6 +1014,7 @@ namespace Mono.Linker.Steps {
 				_typesWithInterfaces.Add (type);
 
 			if (type.HasMethods) {
+				MarkMethodsIf (type.Methods, IsVirtualNeededByTypeDueToPreservedScope);
 				if (ShouldMarkTypeStaticConstructor (type))
 					MarkStaticConstructor (type);
 
@@ -1325,7 +1326,38 @@ namespace Mono.Linker.Steps {
 				MarkType (constraint);
 		}
 
-		bool IsVirtualAndHasPreservedParent (MethodDefinition method)
+		bool IsVirtualNeededByTypeDueToPreservedScope (MethodDefinition method)
+		{
+			if (!method.IsVirtual)
+				return false;
+
+			var base_list = Annotations.GetBaseMethods (method);
+			if (base_list == null)
+				return false;
+
+			foreach (MethodDefinition @base in base_list) {
+				// Just because the type is marked does not mean we need interface methods.
+				// if the type is never instantiated, interfaces will be removed
+				if (@base.DeclaringType.IsInterface)
+					continue;
+				
+				// If the type is marked, we need to keep overrides of abstract members defined in assemblies
+				// that are copied.  However, if the base method is virtual, then we don't need to keep the override
+				// until the type could be instantiated
+				if (!@base.IsAbstract)
+					continue;
+
+				if (IgnoreScope (@base.DeclaringType.Scope))
+					return true;
+
+				if (IsVirtualNeededByTypeDueToPreservedScope (@base))
+					return true;
+			}
+
+			return false;
+		}
+		
+		bool IsVirtualNeededByInstantiatedTypeDueToPreservedScope (MethodDefinition method)
 		{
 			if (!method.IsVirtual)
 				return false;
@@ -1338,7 +1370,7 @@ namespace Mono.Linker.Steps {
 				if (IgnoreScope (@base.DeclaringType.Scope))
 					return true;
 
-				if (IsVirtualAndHasPreservedParent (@base))
+				if (IsVirtualNeededByTypeDueToPreservedScope (@base))
 					return true;
 			}
 
@@ -1818,7 +1850,7 @@ namespace Mono.Linker.Steps {
 			foreach (var method in type.Methods) {
 				if (method.IsFinalizer ())
 					MarkMethod (method);
-				else if (IsVirtualAndHasPreservedParent (method))
+				else if (IsVirtualNeededByInstantiatedTypeDueToPreservedScope (method))
 					MarkMethod (method);
 			}
 

--- a/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/Dependencies/TypeWithBaseInCopiedAssembly2_Base.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/Dependencies/TypeWithBaseInCopiedAssembly2_Base.cs
@@ -1,0 +1,11 @@
+namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.Dependencies {
+	public class TypeWithBaseInCopiedAssembly2_Base {
+		public abstract class Base : IBase {
+			public abstract void Method ();
+		}
+		
+		public interface IBase {
+			void Method ();
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/Dependencies/TypeWithBaseInCopiedAssembly3_Base.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/Dependencies/TypeWithBaseInCopiedAssembly3_Base.cs
@@ -1,0 +1,7 @@
+namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.Dependencies {
+	public class TypeWithBaseInCopiedAssembly3_Base {
+		public abstract class Base {
+			public abstract void Method ();
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/Dependencies/TypeWithBaseInCopiedAssembly4_Base.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/Dependencies/TypeWithBaseInCopiedAssembly4_Base.cs
@@ -1,0 +1,13 @@
+namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.Dependencies {
+	public class TypeWithBaseInCopiedAssembly4_Base {
+		public abstract class Base {
+			public abstract void Method ();
+		}
+
+		public class Base2 : Base {
+			public override void Method ()
+			{
+			}
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/Dependencies/TypeWithBaseInCopiedAssembly6_Base.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/Dependencies/TypeWithBaseInCopiedAssembly6_Base.cs
@@ -1,0 +1,11 @@
+namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.Dependencies {
+	public class TypeWithBaseInCopiedAssembly6_Base {
+		public abstract class Base {
+			public abstract void Method ();
+		}
+		
+		public interface IBase {
+			void Method ();
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/Dependencies/TypeWithBaseInCopiedAssembly_Base.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/Dependencies/TypeWithBaseInCopiedAssembly_Base.cs
@@ -1,0 +1,8 @@
+namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.Dependencies {
+	public class TypeWithBaseInCopiedAssembly_Base {
+		public abstract class Base
+		{
+			public abstract void Method();
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NotKeptCtor/NeverInstantiatedTypeWithBaseInCopiedAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NotKeptCtor/NeverInstantiatedTypeWithBaseInCopiedAssembly.cs
@@ -1,0 +1,29 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.NotKeptCtor {
+	[SetupLinkerAction ("copy", "base")]
+	[SetupCompileBefore ("base.dll", new [] {typeof (TypeWithBaseInCopiedAssembly_Base)})]
+	[KeptMemberInAssembly ("base.dll", typeof (TypeWithBaseInCopiedAssembly_Base.Base), "Method()")]
+	public class NeverInstantiatedTypeWithBaseInCopiedAssembly {
+		public static void Main ()
+		{
+			Helper (null);
+		}
+
+		[Kept]
+		static void Helper (Foo arg)
+		{
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (TypeWithBaseInCopiedAssembly_Base.Base))]
+		class Foo : TypeWithBaseInCopiedAssembly_Base.Base {
+			[Kept]
+			public override void Method ()
+			{
+			}
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NotKeptCtor/NeverInstantiatedTypeWithBaseInCopiedAssembly2.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NotKeptCtor/NeverInstantiatedTypeWithBaseInCopiedAssembly2.cs
@@ -1,0 +1,30 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.NotKeptCtor {
+	[SetupLinkerAction ("copy", "base")]
+	[SetupCompileBefore ("base.dll", new [] { typeof (TypeWithBaseInCopiedAssembly2_Base)})]
+	[KeptMemberInAssembly ("base.dll", typeof (TypeWithBaseInCopiedAssembly2_Base.Base), "Method()")]
+	[KeptMemberInAssembly ("base.dll", typeof (TypeWithBaseInCopiedAssembly2_Base.IBase), "Method()")]
+	public class NeverInstantiatedTypeWithBaseInCopiedAssembly2 {
+		public static void Main ()
+		{
+			Helper (null);
+		}
+
+		[Kept]
+		static void Helper (Foo arg)
+		{
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (TypeWithBaseInCopiedAssembly2_Base.Base))]
+		class Foo : TypeWithBaseInCopiedAssembly2_Base.Base {
+			[Kept]
+			public override void Method ()
+			{
+			}
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NotKeptCtor/NeverInstantiatedTypeWithBaseInCopiedAssembly3.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NotKeptCtor/NeverInstantiatedTypeWithBaseInCopiedAssembly3.cs
@@ -1,0 +1,40 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.NotKeptCtor {
+	[SetupLinkerAction ("copy", "base")]
+	[SetupCompileBefore ("base.dll", new [] {typeof (TypeWithBaseInCopiedAssembly3_Base)})]
+	[KeptMemberInAssembly ("base.dll", typeof (TypeWithBaseInCopiedAssembly3_Base.Base), "Method()")]
+	public class NeverInstantiatedTypeWithBaseInCopiedAssembly3 {
+		public static void Main ()
+		{
+			Helper (null);
+		}
+
+		[Kept]
+		static void Helper (Foo arg)
+		{
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (Base2))]
+		class Foo : Base2 {
+			// This method can be removed because the type is never instantiated and the base class
+			// will keep it's override in order to keep the IL valid
+			public override void Method ()
+			{
+			}
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (TypeWithBaseInCopiedAssembly3_Base.Base))]
+		class Base2 : TypeWithBaseInCopiedAssembly3_Base.Base
+		{
+			[Kept]
+			public override void Method ()
+			{
+			}
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NotKeptCtor/NeverInstantiatedTypeWithBaseInCopiedAssembly4.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NotKeptCtor/NeverInstantiatedTypeWithBaseInCopiedAssembly4.cs
@@ -1,0 +1,30 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.NotKeptCtor {
+	[SetupLinkerAction ("copy", "base")]
+	[SetupCompileBefore ("base.dll", new [] {typeof (TypeWithBaseInCopiedAssembly4_Base)})]
+	[KeptMemberInAssembly ("base.dll", typeof (TypeWithBaseInCopiedAssembly4_Base.Base), "Method()")]
+	public class NeverInstantiatedTypeWithBaseInCopiedAssembly4 {
+		public static void Main ()
+		{
+			Helper (null);
+		}
+
+		[Kept]
+		static void Helper (Foo arg)
+		{
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (TypeWithBaseInCopiedAssembly4_Base.Base2))]
+		class Foo : TypeWithBaseInCopiedAssembly4_Base.Base2 {
+			// This method can be removed because the type is never instantiated and the base class
+			// overrides the original abstract method
+			public override void Method ()
+			{
+			}
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NotKeptCtor/NeverInstantiatedTypeWithBaseInCopiedAssembly5.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NotKeptCtor/NeverInstantiatedTypeWithBaseInCopiedAssembly5.cs
@@ -1,0 +1,39 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.NotKeptCtor {
+	[SetupLinkerAction ("copy", "base")]
+	[SetupCompileBefore ("base.dll", new [] {typeof (TypeWithBaseInCopiedAssembly4_Base)})]
+	[KeptMemberInAssembly ("base.dll", typeof (TypeWithBaseInCopiedAssembly4_Base.Base), "Method()")]
+	public class NeverInstantiatedTypeWithBaseInCopiedAssembly5 {
+		public static void Main ()
+		{
+			Helper (null, null);
+		}
+
+		[Kept]
+		static void Helper (Foo arg, Bar arg2)
+		{
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (TypeWithBaseInCopiedAssembly4_Base.Base2))]
+		class Foo : TypeWithBaseInCopiedAssembly4_Base.Base2 {
+			// This method can be removed because the type is never instantiated and the base class
+			// overrides the original abstract method
+			public override void Method ()
+			{
+			}
+		}
+		[Kept]
+		[KeptBaseType (typeof (TypeWithBaseInCopiedAssembly4_Base.Base2))]
+		class Bar : TypeWithBaseInCopiedAssembly4_Base.Base2 {
+			// This method can be removed because the type is never instantiated and the base class
+			// overrides the original abstract method
+			public override void Method ()
+			{
+			}
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NotKeptCtor/NeverInstantiatedTypeWithBaseInCopiedAssembly6.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NotKeptCtor/NeverInstantiatedTypeWithBaseInCopiedAssembly6.cs
@@ -1,0 +1,31 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.NotKeptCtor {
+	[SetupLinkerAction ("copy", "base")]
+	[SetupCompileBefore ("base.dll", new [] { typeof (TypeWithBaseInCopiedAssembly6_Base)})]
+	[KeptMemberInAssembly ("base.dll", typeof (TypeWithBaseInCopiedAssembly6_Base.Base), "Method()")]
+	[KeptMemberInAssembly ("base.dll", typeof (TypeWithBaseInCopiedAssembly6_Base.IBase), "Method()")]
+	public class NeverInstantiatedTypeWithBaseInCopiedAssembly6 {
+		public static void Main ()
+		{
+			Helper (null);
+		}
+
+		[Kept]
+		static void Helper (Foo arg)
+		{
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (TypeWithBaseInCopiedAssembly6_Base.Base))]
+		class Foo : TypeWithBaseInCopiedAssembly6_Base.Base, TypeWithBaseInCopiedAssembly6_Base.IBase {
+			// Must be kept because there is an abstract base method
+			[Kept]
+			public override void Method ()
+			{
+			}
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/TypeWithBaseInCopiedAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/TypeWithBaseInCopiedAssembly.cs
@@ -1,0 +1,25 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses {
+	[SetupLinkerAction ("copy", "base")]
+	[SetupCompileBefore ("base.dll", new [] {typeof (TypeWithBaseInCopiedAssembly_Base)})]
+	[KeptMemberInAssembly ("base.dll", typeof (TypeWithBaseInCopiedAssembly_Base.Base), "Method()")]
+	public class TypeWithBaseInCopiedAssembly {
+		public static void Main ()
+		{
+			new Foo ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof (TypeWithBaseInCopiedAssembly_Base.Base))]
+		class Foo : TypeWithBaseInCopiedAssembly_Base.Base {
+			[Kept]
+			public override void Method ()
+			{
+			}
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/TypeWithBaseInCopiedAssembly2.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/TypeWithBaseInCopiedAssembly2.cs
@@ -1,0 +1,26 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses {
+	[SetupLinkerAction ("copy", "base")]
+	[SetupCompileBefore ("base.dll", new [] { typeof (TypeWithBaseInCopiedAssembly2_Base)})]
+	[KeptMemberInAssembly ("base.dll", typeof (TypeWithBaseInCopiedAssembly2_Base.Base), "Method()")]
+	[KeptMemberInAssembly ("base.dll", typeof(TypeWithBaseInCopiedAssembly2_Base.IBase), "Method()")]
+	public class TypeWithBaseInCopiedAssembly2 {
+		public static void Main ()
+		{
+			new Foo ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof (TypeWithBaseInCopiedAssembly2_Base.Base))]
+		class Foo : TypeWithBaseInCopiedAssembly2_Base.Base {
+			[Kept]
+			public override void Method ()
+			{
+			}
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/TypeWithBaseInCopiedAssembly3.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/TypeWithBaseInCopiedAssembly3.cs
@@ -1,0 +1,35 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses {
+	[SetupLinkerAction ("copy", "base")]
+	[SetupCompileBefore ("base.dll", new [] {typeof (TypeWithBaseInCopiedAssembly3_Base)})]
+	[KeptMemberInAssembly ("base.dll", typeof (TypeWithBaseInCopiedAssembly3_Base.Base), "Method()")]
+	public class TypeWithBaseInCopiedAssembly3 {
+		public static void Main ()
+		{
+			new Foo ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof (Base2))]
+		class Foo : Base2 {
+			[Kept]
+			public override void Method ()
+			{
+			}
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof (TypeWithBaseInCopiedAssembly3_Base.Base))]
+		class Base2 : TypeWithBaseInCopiedAssembly3_Base.Base {
+			[Kept]
+			public override void Method ()
+			{
+			}
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/TypeWithBaseInCopiedAssembly4.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/TypeWithBaseInCopiedAssembly4.cs
@@ -1,0 +1,25 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses {
+	[SetupLinkerAction ("copy", "base")]
+	[SetupCompileBefore ("base.dll", new [] {typeof (TypeWithBaseInCopiedAssembly4_Base)})]
+	[KeptMemberInAssembly ("base.dll", typeof (TypeWithBaseInCopiedAssembly4_Base.Base), "Method()")]
+	public class TypeWithBaseInCopiedAssembly4 {
+		public static void Main ()
+		{
+			new Foo ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof (TypeWithBaseInCopiedAssembly4_Base.Base2))]
+		class Foo : TypeWithBaseInCopiedAssembly4_Base.Base2 {
+			[Kept]
+			public override void Method ()
+			{
+			}
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/TypeWithBaseInCopiedAssembly5.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/TypeWithBaseInCopiedAssembly5.cs
@@ -1,0 +1,36 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses {
+	[SetupLinkerAction ("copy", "base")]
+	[SetupCompileBefore ("base.dll", new [] {typeof (TypeWithBaseInCopiedAssembly4_Base)})]
+	[KeptMemberInAssembly ("base.dll", typeof (TypeWithBaseInCopiedAssembly4_Base.Base), "Method()")]
+	public class TypeWithBaseInCopiedAssembly5 {
+		public static void Main ()
+		{
+			new Foo ();
+			new Bar ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof (TypeWithBaseInCopiedAssembly4_Base.Base2))]
+		class Foo : TypeWithBaseInCopiedAssembly4_Base.Base2 {
+			[Kept]
+			public override void Method ()
+			{
+			}
+		}
+		
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof (TypeWithBaseInCopiedAssembly4_Base.Base2))]
+		class Bar : TypeWithBaseInCopiedAssembly4_Base.Base2 {
+			[Kept]
+			public override void Method ()
+			{
+			}
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/TypeWithBaseInCopiedAssembly6.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/TypeWithBaseInCopiedAssembly6.cs
@@ -1,0 +1,32 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses {
+	[SetupLinkerAction ("copy", "base")]
+	[SetupCompileBefore ("base.dll", new [] { typeof (TypeWithBaseInCopiedAssembly6_Base)})]
+	[KeptMemberInAssembly ("base.dll", typeof (TypeWithBaseInCopiedAssembly6_Base.Base), "Method()")]
+	[KeptMemberInAssembly ("base.dll", typeof (TypeWithBaseInCopiedAssembly6_Base.IBase), "Method()")]
+	public class TypeWithBaseInCopiedAssembly6 {
+		public static void Main ()
+		{
+			Helper (new Foo ());
+		}
+
+		[Kept]
+		static void Helper (TypeWithBaseInCopiedAssembly6_Base.IBase arg)
+		{
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof (TypeWithBaseInCopiedAssembly6_Base.Base))]
+		[KeptInterface (typeof (TypeWithBaseInCopiedAssembly6_Base.IBase))]
+		class Foo : TypeWithBaseInCopiedAssembly6_Base.Base, TypeWithBaseInCopiedAssembly6_Base.IBase {
+			[Kept]
+			public override void Method ()
+			{
+			}
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.VirtualMethods/Dependencies/TypeWithBaseInCopiedAssembly_Base.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.VirtualMethods/Dependencies/TypeWithBaseInCopiedAssembly_Base.cs
@@ -1,0 +1,7 @@
+namespace Mono.Linker.Tests.Cases.Inheritance.VirtualMethods.Dependencies {
+	public class TypeWithBaseInCopiedAssembly_Base {
+		public virtual void Method ()
+		{
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.VirtualMethods/NotKeptCtor/NeverInstantiatedTypeWithBaseInCopiedAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.VirtualMethods/NotKeptCtor/NeverInstantiatedTypeWithBaseInCopiedAssembly.cs
@@ -1,0 +1,29 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Inheritance.VirtualMethods.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.VirtualMethods.NotKeptCtor {
+	[SetupLinkerAction ("copy", "base")]
+	[SetupCompileBefore ("base.dll", new [] {typeof (TypeWithBaseInCopiedAssembly_Base)})]
+	[KeptMemberInAssembly ("base.dll", typeof (TypeWithBaseInCopiedAssembly_Base), "Method()")]
+	public class NeverInstantiatedTypeWithBaseInCopiedAssembly {
+		public static void Main ()
+		{
+			Helper (null);
+		}
+
+		[Kept]
+		static void Helper (Foo arg)
+		{
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (TypeWithBaseInCopiedAssembly_Base))]
+		class Foo : TypeWithBaseInCopiedAssembly_Base {
+			// It's safe to remove this because the type is never instantiated and the base method is virtual
+			public override void Method ()
+			{
+			}
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.VirtualMethods/TypeWithBaseInCopiedAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.VirtualMethods/TypeWithBaseInCopiedAssembly.cs
@@ -1,0 +1,25 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Inheritance.VirtualMethods.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.VirtualMethods {
+	[SetupLinkerAction ("copy", "base")]
+	[SetupCompileBefore ("base.dll", new [] {typeof (TypeWithBaseInCopiedAssembly_Base)})]
+	[KeptMemberInAssembly ("base.dll", typeof (TypeWithBaseInCopiedAssembly_Base), "Method()")]
+	public class NeverInstantiatedTypeWithBaseInCopiedAssembly {
+		public static void Main ()
+		{
+			new Foo ();
+		}
+
+		[Kept]
+		[KeptMember(".ctor()")]
+		[KeptBaseType (typeof (TypeWithBaseInCopiedAssembly_Base))]
+		class Foo : TypeWithBaseInCopiedAssembly_Base {
+			[Kept]
+			public override void Method ()
+			{
+			}
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/test/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -187,6 +187,23 @@
     <Compile Include="Inheritance.AbstractClasses\NoKeptCtor\OverrideRemoval\OverrideThatAlsoFulfilsInterface.cs" />
     <Compile Include="Inheritance.AbstractClasses\NoKeptCtor\OverrideRemoval\PreservesOverriddenMethodOverrideOfUsedVirtualStillRemoved.cs" />
     <Compile Include="Inheritance.AbstractClasses\NoKeptCtor\OverrideRemoval\PreservesOverriddenMethodOverrideOfUsedVirtualStillRemoved2.cs" />
+    <Compile Include="Inheritance.AbstractClasses\Dependencies\TypeWithBaseInCopiedAssembly2_Base.cs" />
+    <Compile Include="Inheritance.AbstractClasses\Dependencies\TypeWithBaseInCopiedAssembly3_Base.cs" />
+    <Compile Include="Inheritance.AbstractClasses\Dependencies\TypeWithBaseInCopiedAssembly4_Base.cs" />
+    <Compile Include="Inheritance.AbstractClasses\Dependencies\TypeWithBaseInCopiedAssembly6_Base.cs" />
+    <Compile Include="Inheritance.AbstractClasses\Dependencies\TypeWithBaseInCopiedAssembly_Base.cs" />
+    <Compile Include="Inheritance.AbstractClasses\NotKeptCtor\NeverInstantiatedTypeWithBaseInCopiedAssembly.cs" />
+    <Compile Include="Inheritance.AbstractClasses\NotKeptCtor\NeverInstantiatedTypeWithBaseInCopiedAssembly2.cs" />
+    <Compile Include="Inheritance.AbstractClasses\NotKeptCtor\NeverInstantiatedTypeWithBaseInCopiedAssembly3.cs" />
+    <Compile Include="Inheritance.AbstractClasses\NotKeptCtor\NeverInstantiatedTypeWithBaseInCopiedAssembly4.cs" />
+    <Compile Include="Inheritance.AbstractClasses\NotKeptCtor\NeverInstantiatedTypeWithBaseInCopiedAssembly5.cs" />
+    <Compile Include="Inheritance.AbstractClasses\NotKeptCtor\NeverInstantiatedTypeWithBaseInCopiedAssembly6.cs" />
+    <Compile Include="Inheritance.AbstractClasses\TypeWithBaseInCopiedAssembly.cs" />
+    <Compile Include="Inheritance.AbstractClasses\TypeWithBaseInCopiedAssembly2.cs" />
+    <Compile Include="Inheritance.AbstractClasses\TypeWithBaseInCopiedAssembly3.cs" />
+    <Compile Include="Inheritance.AbstractClasses\TypeWithBaseInCopiedAssembly4.cs" />
+    <Compile Include="Inheritance.AbstractClasses\TypeWithBaseInCopiedAssembly5.cs" />
+    <Compile Include="Inheritance.AbstractClasses\TypeWithBaseInCopiedAssembly6.cs" />
     <Compile Include="Inheritance.AbstractClasses\UnusedAbstractMethodRemoved.cs" />
     <Compile Include="Inheritance.AbstractClasses\UnusedVirtualMethodRemoved.cs" />
     <Compile Include="Inheritance.AbstractClasses\UsedOverrideOfAbstractMethodIsKept.cs" />
@@ -281,7 +298,10 @@
     <Compile Include="Inheritance.Interfaces\OnValueType\UnusedExplicitInterfaceIsRemoved.cs" />
     <Compile Include="Inheritance.Interfaces\OnValueType\UnusedInterfaceHasMethodPreservedViaXml.cs" />
     <Compile Include="Inheritance.Interfaces\OnValueType\UnusedInterfaceTypeIsRemoved.cs" />
+    <Compile Include="Inheritance.VirtualMethods\Dependencies\TypeWithBaseInCopiedAssembly_Base.cs" />
     <Compile Include="Inheritance.VirtualMethods\HarderToDetectUnusedVirtualMethodGetsRemoved.cs" />
+    <Compile Include="Inheritance.VirtualMethods\NotKeptCtor\NeverInstantiatedTypeWithBaseInCopiedAssembly.cs" />
+    <Compile Include="Inheritance.VirtualMethods\TypeWithBaseInCopiedAssembly.cs" />
     <Compile Include="Inheritance.VirtualMethods\UnusedTypeWithOverrideOfVirtualMethodIsRemoved.cs" />
     <Compile Include="Inheritance.VirtualMethods\UnusedVirtualMethodRemoved.cs" />
     <Compile Include="Inheritance.VirtualMethods\UsedOverrideOfVirtualMethodIsKept.cs" />


### PR DESCRIPTION
The test `NeverInstantiatedTypeWithBaseInCopiedAssembly` is the case that would hit an invalid IL bug.

Essentially what this PR does is 

* Establishes two variations of the old `IsVirtualAndHasPreservedParent`.
* Restores the call to `IsVirtualAndHasPreservedParent` that used to be in `MarkType`

`IsVirtualNeededByTypeDueToPreservedScope` is the new variation.  This is the one that will be called during `MarkType` like we used to do before never instantiated interface sweeping landed.  This variation is updated to play nice with never instantiated interface sweeping.

`IsVirtualNeededByInstantiatedTypeDueToPreservedScope` is a rename of `IsVirtualAndHasPreservedParent`

The bug fix is restoring the `MarkMethodsIf (type.Methods, IsVirtualNeededByTypeDueToPreservedScope);` in `MarkType`

And the two optimizations are adding 

```
				// Just because the type is marked does not mean we need interface methods.
				// if the type is never instantiated, interfaces will be removed
				if (@base.DeclaringType.IsInterface)
					continue;
```

and 

```
				// If the type is marked, we need to keep overrides of abstract members defined in assemblies
				// that are copied.  However, if the base method is virtual, then we don't need to keep the override
				// until the type could be instantiated
				if (!@base.IsAbstract)
					continue;
```

Into `IsVirtualNeededByTypeDueToPreservedScope `