### PR TITLE
Fix overriding assembly action in ResolveFromAssemblyStep.ProcessLibrary

### DIFF
--- a/src/linker/Linker.Steps/LoadI18nAssemblies.cs
+++ b/src/linker/Linker.Steps/LoadI18nAssemblies.cs
@@ -77,6 +77,7 @@ namespace Mono.Linker.Steps {
 		void LoadAssembly (AssemblyNameReference name)
 		{
 			AssemblyDefinition assembly = Context.Resolve (name);
+			Context.Annotations.SetAction (assembly, AssemblyAction.Copy);
 			ResolveFromAssemblyStep.ProcessLibrary (Context, assembly, ResolveFromAssemblyStep.RootVisibility.Any);
 		}
 

--- a/src/linker/Linker.Steps/ResolveFromAssemblyStep.cs
+++ b/src/linker/Linker.Steps/ResolveFromAssemblyStep.cs
@@ -79,11 +79,13 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		protected static void SetAction (LinkContext context, AssemblyDefinition assembly, AssemblyAction action)
+		protected static void TrySetAction (LinkContext context, AssemblyDefinition assembly, AssemblyAction action)
 		{
 			TryReadSymbols (context, assembly);
 
-			context.Annotations.SetAction (assembly, action);
+			if (!context.Annotations.HasAction (assembly)) {
+				context.Annotations.SetAction (assembly, action);
+			}
 		}
 
 		static void TryReadSymbols (LinkContext context, AssemblyDefinition assembly)
@@ -99,7 +101,7 @@ namespace Mono.Linker.Steps
 		public static void ProcessLibrary (LinkContext context, AssemblyDefinition assembly, RootVisibility rootVisibility = RootVisibility.Any)
 		{
 			var action = rootVisibility == RootVisibility.Any ? AssemblyAction.Copy : AssemblyAction.Link;
-			SetAction (context, assembly, action);
+			TrySetAction (context, assembly, action);
 
 			context.Tracer.Push (assembly);
 
@@ -182,7 +184,7 @@ namespace Mono.Linker.Steps
 
 		void ProcessExecutable (AssemblyDefinition assembly)
 		{
-			SetAction (Context, assembly, AssemblyAction.Link);
+			TrySetAction (Context, assembly, AssemblyAction.Link);
 
 			Tracer.Push (assembly);
 


### PR DESCRIPTION
When a custom link action for an assembly is passed to the linker on the commandline we'd override it with `Copy` in `ProcessLibrary`. Instead we now check whether we already have an assembly action before setting it.

`LoadI18nAssemblies` used this to force `Copy` on the I18N assemblies by calling `ProcessLibrary` with `RootVisibility.Any` so we need to set the assembly action explicitly to maintain that behavior.