### PR TITLE
Fix bug with interface sweeping when AssemblyAction is Save

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -117,6 +117,7 @@ namespace Mono.Linker.Steps {
 				return true;
 
 			switch (Annotations.GetAction (type.Module.Assembly)) {
+			case AssemblyAction.Save:
 			case AssemblyAction.Copy:
 			case AssemblyAction.CopyUsed:
 			case AssemblyAction.AddBypassNGen:

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/InterfaceTypeInOtherUsedOnlyBySavedAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/InterfaceTypeInOtherUsedOnlyBySavedAssembly.cs
@@ -1,0 +1,21 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Inheritance.Interfaces.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType {
+	[SetupCompileBefore ("linked.dll", new [] {typeof (InterfaceTypeInOtherUsedOnlyByCopiedAssembly_Link)})]
+	[SetupCompileBefore ("save.dll", new [] {typeof (InterfaceTypeInOtherUsedOnlyByCopiedAssembly_Copy)}, new [] {"linked.dll"})]
+
+	[SetupLinkerAction ("save", "save")]
+	[SetupLinkerArgument ("-a", "save")]
+	
+	[KeptTypeInAssembly ("linked.dll", typeof (InterfaceTypeInOtherUsedOnlyByCopiedAssembly_Link.IFoo))]
+	[KeptMemberInAssembly ("save.dll", typeof (InterfaceTypeInOtherUsedOnlyByCopiedAssembly_Copy.A), "Method()")]
+	[KeptInterfaceOnTypeInAssembly ("save.dll", typeof (InterfaceTypeInOtherUsedOnlyByCopiedAssembly_Copy.A), "linked.dll", typeof (InterfaceTypeInOtherUsedOnlyByCopiedAssembly_Link.IFoo))]
+	public class InterfaceTypeInOtherUsedOnlyBySavedAssembly {
+		public static void Main ()
+		{
+			InterfaceTypeInOtherUsedOnlyByCopiedAssembly_Copy.ToKeepReferenceAtCompileTime ();
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/InterfaceTypeInOtherUsedOnlyBySavedAssemblyExplicit.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/InterfaceTypeInOtherUsedOnlyBySavedAssemblyExplicit.cs
@@ -1,0 +1,21 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Inheritance.Interfaces.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType {
+	[SetupCompileBefore ("linked.dll", new [] {typeof (InterfaceTypeInOtherUsedOnlyByCopiedAssemblyExplicit_Link)})]
+	[SetupCompileBefore ("save.dll", new [] {typeof (InterfaceTypeInOtherUsedOnlyByCopiedAssemblyExplicit_Copy)}, new [] {"linked.dll"})]
+
+	[SetupLinkerAction ("save", "save")]
+	[SetupLinkerArgument ("-a", "save")]
+
+	[KeptMemberInAssembly ("linked.dll", typeof (InterfaceTypeInOtherUsedOnlyByCopiedAssemblyExplicit_Link.IFoo), "Method()")]
+	[KeptMemberInAssembly ("save.dll", typeof (InterfaceTypeInOtherUsedOnlyByCopiedAssemblyExplicit_Copy.A), "Mono.Linker.Tests.Cases.Inheritance.Interfaces.Dependencies.InterfaceTypeInOtherUsedOnlyByCopiedAssemblyExplicit_Link.IFoo.Method()")]
+	[KeptInterfaceOnTypeInAssembly ("save.dll", typeof (InterfaceTypeInOtherUsedOnlyByCopiedAssemblyExplicit_Copy.A), "linked.dll", typeof (InterfaceTypeInOtherUsedOnlyByCopiedAssemblyExplicit_Link.IFoo))]
+	public class InterfaceTypeInOtherUsedOnlyBySavedAssemblyExplicit {
+		public static void Main ()
+		{
+			InterfaceTypeInOtherUsedOnlyByCopiedAssemblyExplicit_Copy.ToKeepReferenceAtCompileTime ();
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/test/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -211,6 +211,8 @@
     <Compile Include="Inheritance.Interfaces\OnReferenceType\InterfaceMarkOrderingDoesNotMatter3.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\InterfaceTypeInOtherUsedOnlyByCopiedAssembly.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\InterfaceTypeInOtherUsedOnlyByCopiedAssemblyExplicit.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\InterfaceTypeInOtherUsedOnlyBySavedAssembly.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\InterfaceTypeInOtherUsedOnlyBySavedAssemblyExplicit.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\InterfaceUsedOnlyAsConstraintIsKept.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\InterfaceWithInterfaceFromOtherAssemblyWhenExplicitMethodUsed.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\InterfaceTypeOnlyUsedHasInterfacesRemoved.cs" />


### PR DESCRIPTION
This is similar to https://github.com/mono/linker/pull/430.
We hit the same issue when `AssemblyAction` is `Save` instead of `Copy` since this enum value was missing in `MarkStep.IsFullyPreserved()`.

Note that this needs #496 in order for the test to fail before the fix. @marek-safar suggested I split this in two PRs.