### PR TITLE
Add a couple new test

### DIFF
--- a/test/Mono.Linker.Tests.Cases/Inheritance.Complex/NoKeptCtor/OverrideOfAbstractAndInterfaceMethodWhenInterfaceRemoved.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Complex/NoKeptCtor/OverrideOfAbstractAndInterfaceMethodWhenInterfaceRemoved.cs
@@ -1,0 +1,54 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Complex.NoKeptCtor {
+	public class OverrideOfAbstractAndInterfaceMethodWhenInterfaceRemoved {
+		public static void Main ()
+		{
+			Foo b = HelperToMarkFooAndRequireBase ();
+			// Use IBar in another method so that IBar can be removed from Foo
+			HelperToMarkIBar ();
+		}
+
+		[Kept]
+		static Foo HelperToMarkFooAndRequireBase ()
+		{
+			return null;
+		}
+
+		[Kept]
+		static void HelperToMarkIBar()
+		{
+			GetAnIBar().Method();
+		}
+
+		[Kept]
+		static IBar GetAnIBar()
+		{
+			return null;
+		}
+
+		[Kept]
+		abstract class Base {
+			public abstract void Method ();
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (Base))]
+		class Foo : Base, IBar {
+			public override void Method ()
+			{
+				UsedByOverride ();
+			}
+
+			void UsedByOverride ()
+			{
+			}
+		}
+
+		[Kept]
+		interface IBar {
+			[Kept]
+			void Method ();
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Complex/NoKeptCtor/OverrideOfAbstractAndInterfaceMethodWhenInterfaceRemoved2.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Complex/NoKeptCtor/OverrideOfAbstractAndInterfaceMethodWhenInterfaceRemoved2.cs
@@ -1,0 +1,54 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Complex.NoKeptCtor {
+	public class OverrideOfAbstractAndInterfaceMethodWhenInterfaceRemoved2 {
+		public static void Main ()
+		{
+			Foo b = null;
+			HelperToKeepLocalAtCompileTime (b);
+			// Use IBar in another method so that IBar can be removed from Foo
+			HelperToMarkIBar ();
+		}
+
+		[Kept]
+		static void HelperToKeepLocalAtCompileTime (Foo f)
+		{
+		}
+
+		[Kept]
+		static void HelperToMarkIBar()
+		{
+			GetAnIBar().Method();
+		}
+
+		[Kept]
+		static IBar GetAnIBar()
+		{
+			return null;
+		}
+
+		[Kept]
+		abstract class Base {
+			public abstract void Method ();
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (Base))]
+		class Foo : Base, IBar {
+			public override void Method ()
+			{
+				UsedByOverride ();
+			}
+
+			void UsedByOverride ()
+			{
+			}
+		}
+
+		[Kept]
+		interface IBar {
+			[Kept]
+			void Method ();
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/test/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -191,6 +191,8 @@
     <Compile Include="Inheritance.AbstractClasses\UnusedVirtualMethodRemoved.cs" />
     <Compile Include="Inheritance.AbstractClasses\UsedOverrideOfAbstractMethodIsKept.cs" />
     <Compile Include="Inheritance.AbstractClasses\UsedOverrideOfVirtualMethodIsKept.cs" />
+    <Compile Include="Inheritance.Complex\NoKeptCtor\OverrideOfAbstractAndInterfaceMethodWhenInterfaceRemoved.cs" />
+    <Compile Include="Inheritance.Complex\NoKeptCtor\OverrideOfAbstractAndInterfaceMethodWhenInterfaceRemoved2.cs" />
     <Compile Include="Inheritance.Interfaces\Dependencies\InterfaceTypeInOtherUsedOnlyByCopiedAssemblyExplicit_Copy.cs" />
     <Compile Include="Inheritance.Interfaces\Dependencies\InterfaceTypeInOtherUsedOnlyByCopiedAssemblyExplicit_Link.cs" />
     <Compile Include="Inheritance.Interfaces\Dependencies\InterfaceTypeInOtherUsedOnlyByCopiedAssembly_Copy.cs" />
@@ -609,7 +611,6 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Attributes.StructLayout\" />
-    <Folder Include="Inheritance.Complex" />
     <Folder Include="Reflection\Dependencies\" />
     <Folder Include="BCLFeatures\" />
     <Folder Include="BCLFeatures\ETW\" />


### PR DESCRIPTION
Add a few complicated tests with interface sweeping and abstract classes involved.  These tests are green on master.  These tests are setup to come close to triggering a new feature I'm working on `lazy body marking`.

I'm also tired of seeing the `Inheritance.Complex` tests showing up in the Solution Explorer as missing.  Adding these tests provides something to run for that set of tests.