### PR TITLE
Fix invalid IL bug with interface sweeping due to parameters

### DIFF
--- a/src/linker/Linker/MethodBodyScanner.cs
+++ b/src/linker/Linker/MethodBodyScanner.cs
@@ -47,6 +47,9 @@ namespace Mono.Linker {
 			foreach (VariableDefinition var in body.Variables)
 				AddIfResolved (types, var.VariableType);
 
+			foreach(var parameter in body.Method.Parameters)
+				AddIfResolved (types, parameter.ParameterType);
+
 			foreach (ExceptionHandler eh in body.ExceptionHandlers) {
 				if (eh.HandlerType == ExceptionHandlerType.Catch) {
 					AddIfResolved (types, eh.CatchType);

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtorButInterfaceNeeded/ParameterAndLocal.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtorButInterfaceNeeded/ParameterAndLocal.cs
@@ -1,0 +1,32 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoKeptCtorButInterfaceNeeded {
+	public class ParameterAndLocal {
+		public static void Main ()
+		{
+			Helper (null);
+		}
+
+		[Kept]
+		static void Helper (Foo f)
+		{
+			IFoo i = f;
+			i.Method ();
+		}
+
+		[Kept]
+		interface IFoo {
+			[Kept]
+			void Method ();
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IFoo))]
+		class Foo : IFoo {
+			[Kept]
+			public void Method ()
+			{
+			}
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtorButInterfaceNeeded/ParameterOutAndLocal.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtorButInterfaceNeeded/ParameterOutAndLocal.cs
@@ -1,0 +1,34 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoKeptCtorButInterfaceNeeded {
+	public class ParameterOutAndLocal {
+		public static void Main ()
+		{
+			Foo f;
+			Helper (out f);
+		}
+
+		[Kept]
+		static void Helper (out Foo f)
+		{
+			f = null;
+			IFoo i = f;
+			i.Method ();
+		}
+
+		[Kept]
+		interface IFoo {
+			[Kept]
+			void Method ();
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IFoo))]
+		class Foo : IFoo {
+			[Kept]
+			public void Method ()
+			{
+			}
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtorButInterfaceNeeded/ParameterRefAndLocal.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtorButInterfaceNeeded/ParameterRefAndLocal.cs
@@ -1,0 +1,33 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoKeptCtorButInterfaceNeeded {
+	public class ParameterRefAndLocal {
+		public static void Main ()
+		{
+			Foo f = null;
+			Helper (ref f);
+		}
+
+		[Kept]
+		static void Helper (ref Foo f)
+		{
+			IFoo i = f;
+			i.Method ();
+		}
+
+		[Kept]
+		interface IFoo {
+			[Kept]
+			void Method ();
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IFoo))]
+		class Foo : IFoo {
+			[Kept]
+			public void Method ()
+			{
+			}
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/test/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -239,6 +239,9 @@
     <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtorButInterfaceNeeded\NestedInterfaces3.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtorButInterfaceNeeded\NestedInterfacesWithExplicit1.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtorButInterfaceNeeded\NestedInterfacesWithExplicitAndNormal1.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtorButInterfaceNeeded\ParameterAndLocal.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtorButInterfaceNeeded\ParameterOutAndLocal.cs" />
+    <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtorButInterfaceNeeded\ParameterRefAndLocal.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtorButInterfaceNeeded\ReturnValueDowncastedToInterface.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtorButInterfaceNeeded\GenericTypeWithConstraint.cs" />
     <Compile Include="Inheritance.Interfaces\OnReferenceType\NoKeptCtor\ComInterfaceTypeRemovedWhenOnlyUsedByClassWithOnlyStaticMethod.cs" />


### PR DESCRIPTION
Fix a bug caused by parameter types not being taken into account in `AllPossibleStackTypes`