### PR TITLE
Always consider ValueType instantiated

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1436,6 +1436,8 @@ namespace Mono.Linker.Steps {
 				// could exist
 				case "Delegate":
 				case "MulticastDelegate":
+				case "ValueType":
+				case "Enum":
 					return td.Namespace == "System";
 			}
 

--- a/test/Mono.Linker.Tests.Cases/CoreLink/InstantiatedStructWithOverridesFromObject.cs
+++ b/test/Mono.Linker.Tests.Cases/CoreLink/InstantiatedStructWithOverridesFromObject.cs
@@ -1,0 +1,50 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.CoreLink {
+	[SetupLinkerCoreAction ("link")]
+	// Need to skip due to `Runtime critical type System.Reflection.CustomAttributeData not found` failure
+	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
+	public class InstantiatedStructWithOverridesFromObject {
+		public static void Main ()
+		{
+			HelperToUseFoo (new Foo ());
+			HelperToUseMethodsOnObject ();
+		}
+
+		[Kept]
+		static void HelperToUseFoo (Foo f)
+		{
+		}
+
+		[Kept]
+		static void HelperToUseMethodsOnObject ()
+		{
+			var o = new object ();
+			var e = o.Equals (null);
+			var s = o.ToString ();
+			var c = o.GetHashCode ();
+		}
+
+		[Kept]
+		struct Foo {
+			[Kept]
+			public override bool Equals (object obj)
+			{
+				return false;
+			}
+
+			[Kept]
+			public override string ToString ()
+			{
+				return null;
+			}
+
+			[Kept]
+			public override int GetHashCode ()
+			{
+				return 0;
+			}
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/test/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -176,6 +176,7 @@
     <Compile Include="CommandLine\ResponseFilesWork.cs" />
     <Compile Include="CoreLink\CanIncludeI18nAssemblies.cs" />
     <Compile Include="CoreLink\DelegateAndMulticastDelegateKeepInstantiatedReqs.cs" />
+    <Compile Include="CoreLink\InstantiatedStructWithOverridesFromObject.cs" />
     <Compile Include="CoreLink\NeverInstantiatedTypeWithOverridesFromObject.cs" />
     <Compile Include="CoreLink\NoSecurityPlusOnlyKeepUsedRemovesAllSecurityAttributesFromCoreLibraries.cs" />
     <Compile Include="CoreLink\InstantiatedTypeWithOverridesFromObject.cs" />


### PR DESCRIPTION
This wasn't causing any issues today.  ValueType is Serializable and that leads to `MarkStep.MarkSerializable` being called, which ensures `ValueType::.ctor()` is marked, which ensures `ValueType` is marked as instantiated.

However, at Unity we have a smaller class library profile that does not have the serializable code.  As a result `ValueType` is not marked as instantiated.  This leads to struct overrides of object members being removed.

Having so much hinge on `ValueType` being Serializable seems fragile.  So rather than depend on that, let's also consider `ValueType` one of the things that should always be marked instantiated if it appears.