### PR TITLE
Revert "Disable mcs tests by excluding from compilation"

### DIFF
--- a/test/Mono.Linker.Tests.Cases/Attributes/Mcs/OnlyTypeUsedInAssemblyIsTypeOnAttributeCtorOnAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes/Mcs/OnlyTypeUsedInAssemblyIsTypeOnAttributeCtorOnAssembly.cs
@@ -9,6 +9,9 @@ namespace Mono.Linker.Tests.Cases.Attributes.Mcs {
 	/// In the case of attributes on assemblies, we expect both assemblies to be removed because we don't keep assembly level attributes
 	/// when that is the only type marked in the assembly
 	/// </summary>
+#if NETCOREAPP
+	[IgnoreTestCase ("Don't try to compile with mcs on .NET Core")]
+#endif
 	[SetupCSharpCompilerToUse ("mcs")]
 	[SetupCompileBefore ("LibraryWithType.dll", new [] { typeof(TypeDefinedInReference) })]
 	[SetupCompileBefore ("LibraryWithAttribute.dll", new [] { typeof(AttributeDefinedInReference) })]

--- a/test/Mono.Linker.Tests.Cases/Attributes/Mcs/OnlyTypeUsedInAssemblyIsTypeOnAttributeFieldOnAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes/Mcs/OnlyTypeUsedInAssemblyIsTypeOnAttributeFieldOnAssembly.cs
@@ -9,6 +9,9 @@ namespace Mono.Linker.Tests.Cases.Attributes.Mcs {
 	/// In the case of attributes on assemblies, we expect both assemblies to be removed because we don't keep assembly level attributes
 	/// when that is the only type marked in the assembly
 	/// </summary>
+#if NETCOREAPP
+	[IgnoreTestCase ("Don't try to compile with mcs on .NET Core")]
+#endif
 	[SetupCSharpCompilerToUse ("mcs")]
 	[SetupCompileBefore ("LibraryWithType.dll", new [] { typeof(TypeDefinedInReference) })]
 	[SetupCompileBefore ("LibraryWithAttribute.dll", new [] { typeof(AttributeDefinedInReference) })]

--- a/test/Mono.Linker.Tests.Cases/Attributes/Mcs/OnlyTypeUsedInAssemblyIsTypeOnAttributePropertyOnAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes/Mcs/OnlyTypeUsedInAssemblyIsTypeOnAttributePropertyOnAssembly.cs
@@ -9,6 +9,9 @@ namespace Mono.Linker.Tests.Cases.Attributes.Mcs {
 	/// In the case of attributes on assemblies, we expect both assemblies to be removed because we don't keep assembly level attributes
 	/// when that is the only type marked in the assembly
 	/// </summary>
+#if NETCOREAPP
+	[IgnoreTestCase ("Don't try to compile with mcs on .NET Core")]
+#endif
 	[SetupCSharpCompilerToUse ("mcs")]
 	[SetupCompileBefore ("LibraryWithType.dll", new [] { typeof(TypeDefinedInReference) })]
 	[SetupCompileBefore ("LibraryWithAttribute.dll", new [] { typeof(AttributeDefinedInReference) })]

--- a/test/Mono.Linker.Tests.Cases/CoreLink/CanIncludeI18nAssemblies.cs
+++ b/test/Mono.Linker.Tests.Cases/CoreLink/CanIncludeI18nAssemblies.cs
@@ -2,6 +2,9 @@
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.CoreLink {
+#if NETCOREAPP
+	[IgnoreTestCase ("Don't try to compile with mcs on .NET Core")]
+#endif
 	[SetupLinkerCoreAction ("link")]
 	[Il8n ("all")]
 	

--- a/test/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/test/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -103,6 +103,24 @@
     <Compile Include="Attributes\Dependencies\TypeDefinedInReference2.cs" />
     <Compile Include="Attributes\Dependencies\TypeDefinedInReferenceWithReference.cs" />
     <Compile Include="Attributes\FixedLengthArrayAttributesArePreserved.cs" />
+    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeArrayOnAttributeCtorOnType.cs" />
+    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeOnAttributeCtorOnAssembly.cs" />
+    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeOnAttributeCtorOnAssemblyOtherTypesInAttributeAssemblyUsed.cs" />
+    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeOnAttributeCtorOnEvent.cs" />
+    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeOnAttributeCtorOnMethod.cs" />
+    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeOnAttributeCtorOnProperty.cs" />
+    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeOnAttributeCtorOnType.cs" />
+    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeOnAttributeFieldOnAssembly.cs" />
+    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeOnAttributeFieldOnEvent.cs" />
+    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeOnAttributeFieldOnMethod.cs" />
+    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeOnAttributeFieldOnProperty.cs" />
+    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeOnAttributeFieldOnType.cs" />
+    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeOnAttributePropertyOnAssembly.cs" />
+    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeOnAttributePropertyOnEvent.cs" />
+    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeOnAttributePropertyOnMethod.cs" />
+    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeOnAttributePropertyOnProperty.cs" />
+    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeOnAttributePropertyOnType.cs" />
+    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyWithReferenceIsTypeOnAttributeCtorOnType.cs" />
     <Compile Include="Attributes\NoSecurity\SecurityAttributesOnUsedMethodAreRemoved.cs" />
     <Compile Include="Attributes\NoSecurity\SecurityAttributesOnUsedTypeAreRemoved.cs" />
     <Compile Include="Attributes\NoSecurity\CoreLibrarySecurityAttributeTypesAreRemoved.cs" />
@@ -164,6 +182,7 @@
     <Compile Include="BCLFeatures\ETW\LocalsOfModifiedMethodAreRemoved.cs" />
     <Compile Include="BCLFeatures\ETW\StubbedMethodWithExceptionHandlers.cs" />
     <Compile Include="CommandLine\ResponseFilesWork.cs" />
+    <Compile Include="CoreLink\CanIncludeI18nAssemblies.cs" />
     <Compile Include="CoreLink\DelegateAndMulticastDelegateKeepInstantiatedReqs.cs" />
     <Compile Include="CoreLink\InstantiatedStructWithOverridesFromObject.cs" />
     <Compile Include="CoreLink\NeverInstantiatedTypeWithOverridesFromObject.cs" />
@@ -335,6 +354,7 @@
     <Compile Include="PreserveDependencies\PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithEmbeddedXml.cs" />
     <Compile Include="References\AssemblyOnlyUsedByUsingWithCsc.cs" />
     <Compile Include="References\AssemblyOnlyUsedByUsingWithCscWithKeepFacades.cs" />
+    <Compile Include="References\AssemblyOnlyUsedByUsingWithMcs.cs" />
     <Compile Include="References\Dependencies\AssemblyOnlyUsedByUsing_Copied.cs" />
     <Compile Include="References\Dependencies\AssemblyOnlyUsedByUsing_Lib.cs" />
     <Compile Include="References\Individual\CanSkipUnresolved.cs" />
@@ -407,14 +427,17 @@
     <Compile Include="TestFramework\CanCompileReferencesUsingTypes.cs" />
     <Compile Include="TestFramework\CanCompileReferencesWithResources.cs" />
     <Compile Include="TestFramework\CanCompileReferencesWithResourcesWithCsc.cs" />
+    <Compile Include="TestFramework\CanCompileReferencesWithResourcesWithMcs.cs" />
     <Compile Include="TestFramework\CanCompileTestCaseWithDebugPdbs.cs" />
     <Compile Include="TestFramework\CanCompileTestCaseWithCsc.cs" />
+    <Compile Include="TestFramework\CanCompileTestCaseWithMcs.cs" />
     <Compile Include="TestFramework\CanSandboxDependenciesUsingType.cs" />
     <Compile Include="TestFramework\CanVerifyInterfacesOnTypesInAssembly.cs" />
     <Compile Include="TestFramework\Dependencies\CanCompileReferencesUsingTypes_LibSource1.cs" />
     <Compile Include="TestFramework\Dependencies\CanCompileReferencesUsingTypes_LibSource2.cs" />
     <Compile Include="TestFramework\Dependencies\CanCompileReferencesWithResources_Lib1.cs" />
     <Compile Include="TestFramework\Dependencies\CanCompileTestCaseWithCsc_Lib.cs" />
+    <Compile Include="TestFramework\Dependencies\CanCompileTestCaseWithMcs_Lib.cs" />
     <Compile Include="TestFramework\Dependencies\CanSandboxDependenciesUsingType_Source1.cs" />
     <Compile Include="TestFramework\Dependencies\CanSandboxDependenciesUsingType_Source2.cs" />
     <Compile Include="TestFramework\Dependencies\CanVerifyInterfacesOnTypesInAssembly_Lib.cs" />
@@ -585,37 +608,11 @@
     <Content Include="TestFramework\Dependencies\CanCompileReferencesWithResources_Lib1.txt" />
     <Content Include="TestFramework\Dependencies\CanCompileReferencesWithResources_Lib1.log" />
     <Content Include="TestFramework\Dependencies\CanCompileTestCaseWithCsc.txt" />
+    <Content Include="TestFramework\Dependencies\CanCompileTestCaseWithMcs.txt" />
     <Content Include="TestFramework\Dependencies\VerifyResourceInAssemblyAttributesBehavior.txt" />
     <Content Include="LinkXml\PreserveBackingFieldWhenPropertyIsKept.xml" />
     <Content Include="TypeForwarding\TypeForwarderOnlyAssemblyCanBePreservedViaLinkXml.xml" />
     <Content Include="LinkXml\UnusedTypeDeclarationPreservedByLinkXmlIsKept.xml" />
-  </ItemGroup>
-  <ItemGroup Condition=" ! $(ILLinkBuild) ">
-    <!-- Mcs tests -->
-    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeArrayOnAttributeCtorOnType.cs" />
-    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeOnAttributeCtorOnAssembly.cs" />
-    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeOnAttributeCtorOnAssemblyOtherTypesInAttributeAssemblyUsed.cs" />
-    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeOnAttributeCtorOnEvent.cs" />
-    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeOnAttributeCtorOnMethod.cs" />
-    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeOnAttributeCtorOnProperty.cs" />
-    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeOnAttributeCtorOnType.cs" />
-    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeOnAttributeFieldOnAssembly.cs" />
-    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeOnAttributeFieldOnEvent.cs" />
-    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeOnAttributeFieldOnMethod.cs" />
-    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeOnAttributeFieldOnProperty.cs" />
-    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeOnAttributeFieldOnType.cs" />
-    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeOnAttributePropertyOnAssembly.cs" />
-    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeOnAttributePropertyOnEvent.cs" />
-    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeOnAttributePropertyOnMethod.cs" />
-    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeOnAttributePropertyOnProperty.cs" />
-    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyIsTypeOnAttributePropertyOnType.cs" />
-    <Compile Include="Attributes\Mcs\OnlyTypeUsedInAssemblyWithReferenceIsTypeOnAttributeCtorOnType.cs" />
-    <Compile Include="CoreLink\CanIncludeI18nAssemblies.cs" />
-    <Compile Include="References\AssemblyOnlyUsedByUsingWithMcs.cs" />
-    <Compile Include="TestFramework\CanCompileReferencesWithResourcesWithMcs.cs" />
-    <Compile Include="TestFramework\CanCompileTestCaseWithMcs.cs" />
-    <Compile Include="TestFramework\Dependencies\CanCompileTestCaseWithMcs_Lib.cs" />
-    <Content Include="TestFramework\Dependencies\CanCompileTestCaseWithMcs.txt" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Mono.Linker.Tests.Cases.Expectations\Mono.Linker.Tests.Cases.Expectations.csproj">

--- a/test/Mono.Linker.Tests.Cases/References/AssemblyOnlyUsedByUsingWithMcs.cs
+++ b/test/Mono.Linker.Tests.Cases/References/AssemblyOnlyUsedByUsingWithMcs.cs
@@ -3,6 +3,9 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.References.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.References {
+#if NETCOREAPP
+	[IgnoreTestCase ("Don't try to compile with mcs on .NET Core")]
+#endif
 	[SetupLinkerAction ("copy", "copied")]
 	[SetupCompileBefore ("library.dll", new [] {"Dependencies/AssemblyOnlyUsedByUsing_Lib.cs"})]
 

--- a/test/Mono.Linker.Tests.Cases/TestFramework/CanCompileReferencesWithResourcesWithMcs.cs
+++ b/test/Mono.Linker.Tests.Cases/TestFramework/CanCompileReferencesWithResourcesWithMcs.cs
@@ -3,6 +3,9 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.TestFramework.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.TestFramework {
+#if NETCOREAPP
+	[IgnoreTestCase ("Don't try to compile with mcs on .NET Core")]
+#endif
 	[SetupCompileBefore ("library.dll",
 		new [] { "Dependencies/CanCompileReferencesWithResources_Lib1.cs" },
 		resources: new [] { "Dependencies/CanCompileReferencesWithResources_Lib1.txt" },

--- a/test/Mono.Linker.Tests.Cases/TestFramework/CanCompileTestCaseWithMcs.cs
+++ b/test/Mono.Linker.Tests.Cases/TestFramework/CanCompileTestCaseWithMcs.cs
@@ -4,6 +4,9 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.TestFramework.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.TestFramework {
+#if NETCOREAPP
+	[IgnoreTestCase ("Don't try to compile with mcs on .NET Core.")]
+#endif
 	[SetupCSharpCompilerToUse ("mcs")]
 
 	// Use all of the compiler setup attributes so that we can verify they all work


### PR DESCRIPTION
Excluding mcs tests from compilation on .NET Core results in messages like
```
Could not find the matching type for test case /Users/sven/src/dotnet/linker/test/Mono.Linker.Tests.Cases/Attributes/Mcs/OnlyTypeUsedInAssemblyIsTypeOnAttributePropertyOnType.cs.  Ensure the file name and class name match
```
From @mrvoorhe in https://github.com/mono/linker/pull/489#discussion_r268153440:
> 
> 
> That output is to help identify when a test case is named incorrectly. So we really do not want to introduce these.
> 
> I would recommend we leave it how you had it originally. Add the #if NETCOREAPP w/ ignores and let's worry about this later if it becomes an annoyance. @marek-safar Are you OK with that?
> 

See also the discussion at https://github.com/mono/linker/pull/493.

This reverts commit e239b64768549537cff339b617ba689d0deeda75.
