### PR TITLE
Update integration test infrastructure

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -7,4 +7,8 @@
     <MSBuild Projects="$(MSBuildProjectFile)" Targets="VSTest" />
   </Target>
 
+  <Target Name="VSTestIfTestProject">
+    <CallTarget Targets="VSTest" Condition="'$(IsTestProject)' == 'true'" />
+  </Target>
+
 </Project>

--- a/after.illink.sln.targets
+++ b/after.illink.sln.targets
@@ -1,0 +1,6 @@
+<Project>
+  <!-- Workaround for https://github.com/dotnet/corefx/issues/16322 -->
+  <Target Name="VSTest">
+    <MSBuild Projects="@(ProjectReference)" Targets="VSTestIfTestProject" />
+  </Target>
+</Project>

--- a/illink.sln
+++ b/illink.sln
@@ -22,6 +22,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mono.Linker.Tests.Cases", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mono.Linker.Tests.Cases.Expectations", "test\Mono.Linker.Tests.Cases.Expectations\Mono.Linker.Tests.Cases.Expectations.csproj", "{2C26601F-3E2F-45B9-A02F-58EE9296E19E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "test", "test\ILLink.Tasks.Tests\test.csproj", "{10249F19-1B72-4087-AF7F-C95B7672B204}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -143,6 +145,18 @@ Global
 		{2C26601F-3E2F-45B9-A02F-58EE9296E19E}.Release|x64.Build.0 = illink_Release|Any CPU
 		{2C26601F-3E2F-45B9-A02F-58EE9296E19E}.Release|x86.ActiveCfg = illink_Release|Any CPU
 		{2C26601F-3E2F-45B9-A02F-58EE9296E19E}.Release|x86.Build.0 = illink_Release|Any CPU
+		{10249F19-1B72-4087-AF7F-C95B7672B204}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{10249F19-1B72-4087-AF7F-C95B7672B204}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{10249F19-1B72-4087-AF7F-C95B7672B204}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{10249F19-1B72-4087-AF7F-C95B7672B204}.Debug|x64.Build.0 = Debug|Any CPU
+		{10249F19-1B72-4087-AF7F-C95B7672B204}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{10249F19-1B72-4087-AF7F-C95B7672B204}.Debug|x86.Build.0 = Debug|Any CPU
+		{10249F19-1B72-4087-AF7F-C95B7672B204}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{10249F19-1B72-4087-AF7F-C95B7672B204}.Release|Any CPU.Build.0 = Release|Any CPU
+		{10249F19-1B72-4087-AF7F-C95B7672B204}.Release|x64.ActiveCfg = Release|Any CPU
+		{10249F19-1B72-4087-AF7F-C95B7672B204}.Release|x64.Build.0 = Release|Any CPU
+		{10249F19-1B72-4087-AF7F-C95B7672B204}.Release|x86.ActiveCfg = Release|Any CPU
+		{10249F19-1B72-4087-AF7F-C95B7672B204}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -154,5 +168,6 @@ Global
 		{400A1561-B6B6-482D-9E4C-3DDAEDE5BD07} = {A879F5FC-D6C9-4ED4-BEAE-03B5CCE3C136}
 		{B6BEE6AA-ADA0-4E1D-9A17-FBF2936F82B5} = {A879F5FC-D6C9-4ED4-BEAE-03B5CCE3C136}
 		{2C26601F-3E2F-45B9-A02F-58EE9296E19E} = {A879F5FC-D6C9-4ED4-BEAE-03B5CCE3C136}
+		{10249F19-1B72-4087-AF7F-C95B7672B204} = {A879F5FC-D6C9-4ED4-BEAE-03B5CCE3C136}
 	EndGlobalSection
 EndGlobal

--- a/test/ILLink.Tasks.Tests/HelloWorldTest.cs
+++ b/test/ILLink.Tasks.Tests/HelloWorldTest.cs
@@ -69,7 +69,7 @@ namespace ILLink.Tests
 		{
 			int ret = RunApp(target, out string commandOutput, selfContained: selfContained);
 			Assert.True(ret == 0);
-			Assert.True(commandOutput.Contains("Hello World!"));
+			Assert.Contains("Hello World!", commandOutput);
 		}
 	}
 }

--- a/test/ILLink.Tasks.Tests/HelloWorldTest.cs
+++ b/test/ILLink.Tasks.Tests/HelloWorldTest.cs
@@ -2,15 +2,17 @@ using System;
 using System.IO;
 using Xunit;
 using Xunit.Abstractions;
+using Xunit.Sdk;
 
 namespace ILLink.Tests
 {
-	public class HelloWorldTest : IntegrationTestBase
+	public class HelloWorldFixture : ProjectFixture
 	{
-		private string csproj;
+		public string csproj;
 
-		public HelloWorldTest(ITestOutputHelper output) : base(output) {
-			csproj = SetupProject();
+		public HelloWorldFixture (IMessageSink diagnosticMessageSink) : base (diagnosticMessageSink)
+		{
+			csproj = SetupProject ();
 		}
 
 		public string SetupProject()
@@ -19,7 +21,7 @@ namespace ILLink.Tests
 			string csproj = Path.Combine(projectRoot, $"{projectRoot}.csproj");
 
 			if (File.Exists(csproj)) {
-				output.WriteLine($"using existing project {csproj}");
+				LogMessage ($"using existing project {csproj}");
 				return csproj;
 			}
 
@@ -28,9 +30,9 @@ namespace ILLink.Tests
 			}
 
 			Directory.CreateDirectory(projectRoot);
-			int ret = Dotnet("new console", projectRoot);
+			int ret = CommandHelper.Dotnet("new console", projectRoot);
 			if (ret != 0) {
-				output.WriteLine("dotnet new failed");
+				LogMessage ("dotnet new failed");
 				Assert.True(false);
 			}
 
@@ -39,17 +41,27 @@ namespace ILLink.Tests
 			return csproj;
 		}
 
+	}
+
+	public class HelloWorldTest : IntegrationTestBase, IClassFixture<HelloWorldFixture>
+	{
+		HelloWorldFixture fixture;
+
+		public HelloWorldTest(HelloWorldFixture fixture, ITestOutputHelper helper) : base(helper) {
+			this.fixture = fixture;
+		}
+
 		[Fact]
 		public void RunHelloWorldStandalone()
 		{
-			string executablePath = BuildAndLink(csproj, selfContained: true);
+			string executablePath = BuildAndLink(fixture.csproj, selfContained: true);
 			CheckOutput(executablePath, selfContained: true);
 		}
 
 		[Fact]
 		public void RunHelloWorldPortable()
 		{
-			string target = BuildAndLink(csproj, selfContained: false);
+			string target = BuildAndLink(fixture.csproj, selfContained: false);
 			CheckOutput(target, selfContained: false);
 		}
 

--- a/test/ILLink.Tasks.Tests/Loggers.cs
+++ b/test/ILLink.Tasks.Tests/Loggers.cs
@@ -1,0 +1,36 @@
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace ILLink.Tests
+{
+	public interface ILogger
+	{
+		void LogMessage (string message);
+	}
+
+	public class TestLogger : ILogger
+	{
+		private ITestOutputHelper output;
+		public TestLogger (ITestOutputHelper output)
+		{
+			this.output = output;
+		}
+		public void LogMessage (string message)
+		{
+			output.WriteLine (message);
+		}
+	}
+
+	public class FixtureLogger : ILogger
+	{
+		private IMessageSink messageSink;
+		public FixtureLogger (IMessageSink messageSink)
+		{
+			this.messageSink = messageSink;
+		}
+		public void LogMessage (string message)
+		{
+			messageSink.OnMessage (new DiagnosticMessage (message));
+		}
+	}
+}

--- a/test/ILLink.Tasks.Tests/MusicStoreTest.cs
+++ b/test/ILLink.Tasks.Tests/MusicStoreTest.cs
@@ -18,15 +18,15 @@ namespace ILLink.Tests
 		// Revision can also be a branch name. We generally
 		// want to ensure that we are able to link the latest
 		// MusicStore from the dev branch.
-		private static string gitRevision = "536f89ac6178246e58125401480b0a3b6406efe8";
+		private static string gitRevision = "ac314bd68294ae0f91bd16df20cf5ebd4b8ef5b5";
 
 		// The version of Microsoft.NETCore.App that
 		// musicstore will run on (and deploy with, for
 		// self-contained deployments).
-		private static string runtimeVersion = "2.1.0-preview1-25915-01";
+		private static string runtimeVersion = "3.0.0-preview-27324-5";
 
 		// The version of the SDK used to build and link
-		// musicstore.
+		// musicstore, if a specific version is desired.
 		private static string sdkVersion = "2.2.0-preview1-007525";
 
 		// The version of Microsoft.AspNetCore.All to publish with.
@@ -51,10 +51,10 @@ namespace ILLink.Tests
 		public MusicStoreTest(ITestOutputHelper output) : base(output) {
 			csproj = SetupProject();
 
-			// MusicStore targets .NET Core 2.1, so it must be built
-			// using an SDK that can target 2.1. We obtain that SDK
-			// here.
-			context.DotnetToolPath = ObtainSDK(context.TestBin, repoName);
+			// MusicStore has been updated to target netcoreapp3.0, so
+			// we should be able to run on the SDK used to build this
+			// repo.
+			// context.DotnetToolPath = ObtainSDK(context.TestBin, repoName);
 		}
 
 		[Fact]
@@ -128,7 +128,9 @@ namespace ILLink.Tests
 
 			AddLinkerReference(csproj);
 
-			AddGlobalJson(repoName);
+			// We no longer need a custom global.json, because we are
+			// using the same SDK used in the repo.
+			// AddGlobalJson(repoName);
 
 			return csproj;
 		}

--- a/test/ILLink.Tasks.Tests/MusicStoreTest.cs
+++ b/test/ILLink.Tasks.Tests/MusicStoreTest.cs
@@ -231,9 +231,9 @@ namespace ILLink.Tests
 		{
 			int ret = RunApp(target, out string commandOutput, selfContained: selfContained);
 
-			Assert.True(commandOutput.Contains("Starting request to http://localhost:5000"));
-			Assert.True(commandOutput.Contains("Response: OK"));
-			Assert.True(commandOutput.Contains("Running 100 requests"));
+			Assert.Contains("starting request to http://localhost:5000", commandOutput);
+			Assert.Contains("Response: OK", commandOutput);
+			Assert.Contains("Running 100 requests", commandOutput);
 			Assert.True(ret == 0);
 		}
 

--- a/test/ILLink.Tasks.Tests/MusicStoreTest.cs
+++ b/test/ILLink.Tasks.Tests/MusicStoreTest.cs
@@ -57,14 +57,14 @@ namespace ILLink.Tests
 			// context.DotnetToolPath = ObtainSDK(context.TestBin, repoName);
 		}
 
-		[Fact]
+		// [Fact]
 		public void RunMusicStoreStandalone()
 		{
 			string executablePath = BuildAndLink(csproj, rootFiles, VersionPublishArgs, selfContained: true);
 			CheckOutput(executablePath, selfContained: true);
 		}
 
-		[Fact]
+		// [Fact]
 		public void RunMusicStorePortable()
 		{
 			Dictionary<string, string> extraPublishArgs = new Dictionary<string, string>(VersionPublishArgs);

--- a/test/ILLink.Tasks.Tests/MusicStoreTest.cs
+++ b/test/ILLink.Tasks.Tests/MusicStoreTest.cs
@@ -8,9 +8,9 @@ using Xunit.Abstractions; // ITestOutputHelper
 
 namespace ILLink.Tests
 {
-	public class MusicStoreTest : IntegrationTestBase
+	public class MusicStoreFixture : ProjectFixture
 	{
-		private static List<string> rootFiles = new List<string> { "MusicStoreReflection.xml" };
+		public static List<string> rootFiles = new List<string> { "MusicStoreReflection.xml" };
 
 		private static string gitRepo = "http://github.com/aspnet/JitBench";
 		private static string repoName = "JitBench";
@@ -32,8 +32,8 @@ namespace ILLink.Tests
 		// The version of Microsoft.AspNetCore.All to publish with.
 		private static string aspNetVersion = "2.1.0-preview1-27654";
 
-		private static Dictionary<string, string> versionPublishArgs;
-		private static Dictionary<string, string> VersionPublishArgs
+		public static Dictionary<string, string> versionPublishArgs;
+		public static Dictionary<string, string> VersionPublishArgs
 		{
 			get {
 				if (versionPublishArgs != null) {
@@ -46,41 +46,11 @@ namespace ILLink.Tests
 			}
 		}
 
-		private static string csproj;
+		public static string csproj;
 
-		public MusicStoreTest(ITestOutputHelper output) : base(output) {
+		public MusicStoreFixture(IMessageSink diagnosticMessageSink) : base(diagnosticMessageSink)
+		{
 			csproj = SetupProject();
-
-			// MusicStore has been updated to target netcoreapp3.0, so
-			// we should be able to run on the SDK used to build this
-			// repo.
-			// context.DotnetToolPath = ObtainSDK(context.TestBin, repoName);
-		}
-
-		// [Fact]
-		public void RunMusicStoreStandalone()
-		{
-			string executablePath = BuildAndLink(csproj, rootFiles, VersionPublishArgs, selfContained: true);
-			CheckOutput(executablePath, selfContained: true);
-		}
-
-		// [Fact]
-		public void RunMusicStorePortable()
-		{
-			Dictionary<string, string> extraPublishArgs = new Dictionary<string, string>(VersionPublishArgs);
-			extraPublishArgs.Add("PublishWithAspNetCoreTargetManifest", "false");
-			string target = BuildAndLink(csproj, null, extraPublishArgs, selfContained: false);
-			CheckOutput(target, selfContained: false);
-		}
-
-		void CheckOutput(string target, bool selfContained = false)
-		{
-			int ret = RunApp(target, out string commandOutput, selfContained: selfContained);
-
-			Assert.True(commandOutput.Contains("Starting request to http://localhost:5000"));
-			Assert.True(commandOutput.Contains("Response: OK"));
-			Assert.True(commandOutput.Contains("Running 100 requests"));
-			Assert.True(ret == 0);
 		}
 
 		// returns path to .csproj project file
@@ -91,7 +61,7 @@ namespace ILLink.Tests
 			string csproj = Path.Combine(demoRoot, "MusicStore.csproj");
 
 			if (File.Exists(csproj)) {
-				output.WriteLine($"using existing project {csproj}");
+				LogMessage($"using existing project {csproj}");
 				return csproj;
 			}
 
@@ -99,20 +69,20 @@ namespace ILLink.Tests
 				Directory.Delete(repoName, true);
 			}
 
-			ret = RunCommand("git", $"clone {gitRepo} {repoName}");
+			ret = CommandHelper.RunCommand("git", $"clone {gitRepo} {repoName}");
 			if (ret != 0) {
-				output.WriteLine("git failed");
+				LogMessage("git failed");
 				Assert.True(false);
 			}
 
 			if (!Directory.Exists(demoRoot)) {
-				output.WriteLine($"{demoRoot} does not exist");
+				LogMessage($"{demoRoot} does not exist");
 				Assert.True(false);
 			}
 
-			ret = RunCommand("git", $"checkout {gitRevision}", demoRoot);
+			ret = CommandHelper.RunCommand("git", $"checkout {gitRevision}", demoRoot);
 			if (ret != 0) {
-				output.WriteLine($"problem checking out revision {gitRevision}");
+				LogMessage($"problem checking out revision {gitRevision}");
 				Assert.True(false);
 			}
 
@@ -142,7 +112,6 @@ namespace ILLink.Tests
 			File.WriteAllText(globalJson, globalJsonContents);
 		}
 
-
 		string GetDotnetToolPath(string dotnetDir)
 		{
 			string dotnetToolName = Directory.GetFiles(dotnetDir)
@@ -152,7 +121,7 @@ namespace ILLink.Tests
 			string dotnetToolPath = Path.Combine(dotnetDir, dotnetToolName);
 
 			if (!File.Exists(dotnetToolPath)) {
-				output.WriteLine("repo-local dotnet tool does not exist.");
+				LogMessage("repo-local dotnet tool does not exist.");
 				Assert.True(false);
 			}
 
@@ -169,36 +138,36 @@ namespace ILLink.Tests
 			}
 
 			string dotnetInstall = Path.Combine(Path.GetFullPath(repoDir), "dotnet-install");
-			if (context.RuntimeIdentifier.Contains("win")) {
+			if (TestContext.RuntimeIdentifier.Contains("win")) {
 				dotnetInstall += ".ps1";
 			} else {
 				dotnetInstall += ".sh";
 			}
 			if (!File.Exists(dotnetInstall)) {
-				output.WriteLine($"missing dotnet-install script at {dotnetInstall}");
+				LogMessage($"missing dotnet-install script at {dotnetInstall}");
 				Assert.True(false);
 			}
 
-			if (context.RuntimeIdentifier.Contains("win")) {
-				ret = RunCommand("powershell", $"{dotnetInstall} -SharedRuntime -InstallDir {dotnetDirName} -Channel master -Architecture x64 -Version {runtimeVersion}", rootDir);
+			if (TestContext.RuntimeIdentifier.Contains("win")) {
+				ret = CommandHelper.RunCommand("powershell", $"{dotnetInstall} -SharedRuntime -InstallDir {dotnetDirName} -Channel master -Architecture x64 -Version {runtimeVersion}", rootDir);
 				if (ret != 0) {
-					output.WriteLine("failed to retrieve shared runtime");
+					LogMessage("failed to retrieve shared runtime");
 					Assert.True(false);
 				}
-				ret = RunCommand("powershell", $"{dotnetInstall} -InstallDir {dotnetDirName} -Channel master -Architecture x64 -Version {sdkVersion}", rootDir);
+				ret = CommandHelper.RunCommand("powershell", $"{dotnetInstall} -InstallDir {dotnetDirName} -Channel master -Architecture x64 -Version {sdkVersion}", rootDir);
 				if (ret != 0) {
-					output.WriteLine("failed to retrieve sdk");
+					LogMessage("failed to retrieve sdk");
 					Assert.True(false);
 				}
 			} else {
-				ret = RunCommand(dotnetInstall, $"-sharedruntime -runtimeid {context.RuntimeIdentifier} -installdir {dotnetDirName} -channel master -architecture x64 -version {runtimeVersion}", rootDir);
+				ret = CommandHelper.RunCommand(dotnetInstall, $"-sharedruntime -runtimeid {TestContext.RuntimeIdentifier} -installdir {dotnetDirName} -channel master -architecture x64 -version {runtimeVersion}", rootDir);
 				if (ret != 0) {
-					output.WriteLine("failed to retrieve shared runtime");
+					LogMessage("failed to retrieve shared runtime");
 					Assert.True(false);
 				}
-				ret = RunCommand(dotnetInstall, $"-installdir {dotnetDirName} -channel master -architecture x64 -version {sdkVersion}", rootDir);
+				ret = CommandHelper.RunCommand(dotnetInstall, $"-installdir {dotnetDirName} -channel master -architecture x64 -version {sdkVersion}", rootDir);
 				if (ret != 0) {
-					output.WriteLine("failed to retrieve sdk");
+					LogMessage("failed to retrieve sdk");
 					Assert.True(false);
 				}
 			}
@@ -215,7 +184,7 @@ namespace ILLink.Tests
 
 		private void AddLocalNugetFeedAfterClear(string nugetConfig)
 		{
-			string localPackagePath = Path.GetFullPath(context.PackageSource);
+			string localPackagePath = Path.GetFullPath(TestContext.PackageSource);
 			var xdoc = XDocument.Load(nugetConfig);
 			var ns = xdoc.Root.GetDefaultNamespace();
 			var clear = xdoc.Root.Element(ns+"packageSources").Element(ns+"clear");
@@ -227,5 +196,46 @@ namespace ILLink.Tests
 				xdoc.Save(fs);
 			}
 		}
+	}
+
+	public class MusicStoreTest : IntegrationTestBase, IClassFixture<MusicStoreFixture>
+	{
+
+		MusicStoreFixture fixture;
+
+		public MusicStoreTest(MusicStoreFixture fixture, ITestOutputHelper output) : base(output) {
+			this.fixture = fixture;
+			// MusicStore has been updated to target netcoreapp3.0, so
+			// we should be able to run on the SDK used to build this
+			// repo.
+			// context.DotnetToolPath = ObtainSDK(context.TestBin, repoName);
+		}
+
+		[Fact]
+		public void RunMusicStoreStandalone()
+		{
+			string executablePath = BuildAndLink(MusicStoreFixture.csproj, MusicStoreFixture.rootFiles, MusicStoreFixture.VersionPublishArgs, selfContained: true);
+			CheckOutput(executablePath, selfContained: true);
+		}
+
+		[Fact]
+		public void RunMusicStorePortable()
+		{
+			Dictionary<string, string> extraPublishArgs = new Dictionary<string, string>(MusicStoreFixture.VersionPublishArgs);
+			extraPublishArgs.Add("PublishWithAspNetCoreTargetManifest", "false");
+			string target = BuildAndLink(MusicStoreFixture.csproj, null, extraPublishArgs, selfContained: false);
+			CheckOutput(target, selfContained: false);
+		}
+
+		void CheckOutput(string target, bool selfContained = false)
+		{
+			int ret = RunApp(target, out string commandOutput, selfContained: selfContained);
+
+			Assert.True(commandOutput.Contains("Starting request to http://localhost:5000"));
+			Assert.True(commandOutput.Contains("Response: OK"));
+			Assert.True(commandOutput.Contains("Running 100 requests"));
+			Assert.True(ret == 0);
+		}
+
 	}
 }

--- a/test/ILLink.Tasks.Tests/TestContext.cs
+++ b/test/ILLink.Tasks.Tests/TestContext.cs
@@ -5,50 +5,55 @@ using Microsoft.DotNet.PlatformAbstractions;
 
 namespace ILLink.Tests
 {
-	public class TestContext
+	public static class TestContext
 	{
 		/// <summary>
 		///   The name of the tasks package to add to the integration
 		///   projects.
 		/// </summary>
-		public string TasksPackageName { get; private set; }
+		public static string TasksPackageName { get; private set; }
 
 		/// <summary>
 		///   The version of the tasks package to add to the
 		///   integration projects.
 		/// </summary>
-		public string TasksPackageVersion { get; private set; }
+		public static string TasksPackageVersion { get; private set; }
 
 		/// <summary>
 		///   The path of the directory from which to get the linker
 		///   package.
 		/// </summary>
-		public string PackageSource { get; private set; }
+		public static string PackageSource { get; private set; }
 
 		/// <summary>
 		///   The path to the dotnet tool to use to run the
 		///   integration tests.
 		/// </summary>
-		public string DotnetToolPath { get; set; }
+		public static string DotnetToolPath { get; set; }
 
 		/// <summary>
 		///   The RID to use when restoring, building, and linking the
 		///   integration test projects.
 		/// </summary>
-		public string RuntimeIdentifier { get; private set; }
+		public static string RuntimeIdentifier { get; private set; }
 
 		/// <summary>
 		///   The configuration to use to build the integration test
 		///   projects.
 		/// </summary>
-		public string Configuration { get; private set; }
+		public static string Configuration { get; private set; }
 
 		/// <summary>
 		///   The root testbin directory. Used to install test
 		///   assets that don't depend on the configuration or
 		///   target framework.
 		/// </summary>
-		public string TestBin { get; private set; }
+		public static string TestBin { get; private set; }
+
+		static TestContext()
+		{
+			SetupDefaultContext();
+		}
 
 		/// <summary>
 		///   This is the context from which tests will be run in the
@@ -58,7 +63,7 @@ namespace ILLink.Tests
 		///   one version of the package is present, and uses it to
 		///   unambiguously determine which pacakge to use in the tests.
 		/// </summary>
-		public static TestContext CreateDefaultContext()
+		public static void SetupDefaultContext()
 		{
 			// test working directory is test project's <baseoutputpath>/<config>/<tfm>
 			var testBin = Path.Combine(Environment.CurrentDirectory, "..", "..");
@@ -92,24 +97,23 @@ namespace ILLink.Tests
 				.Single();
 			var dotnetToolPath = Path.Combine(dotnetDir, dotnetToolName);
 
-			var context = new TestContext();
-			context.PackageSource = packageSource;
-			context.TasksPackageName = packageName;
-			context.TasksPackageVersion = version;
-			context.DotnetToolPath = dotnetToolPath;
+			// Initialize static members
+			PackageSource = packageSource;
+			TasksPackageName = packageName;
+			TasksPackageVersion = version;
+			DotnetToolPath = dotnetToolPath;
 			// This sets the RID to the RID of the currently-executing system.
-			context.RuntimeIdentifier = RuntimeEnvironment.GetRuntimeIdentifier();
+			RuntimeIdentifier = RuntimeEnvironment.GetRuntimeIdentifier();
 			// workaround: the osx.10.13-x64 RID doesn't exist yet.
 			// see https://github.com/NuGet/Home/issues/5862
-			if (context.RuntimeIdentifier == "osx.10.14-x64")
+			if (RuntimeIdentifier == "osx.10.14-x64")
 			{
-				context.RuntimeIdentifier = "osx.10.13-x64";
+				RuntimeIdentifier = "osx.10.13-x64";
 			}
 			// We want to build and link integration projects in the
 			// release configuration.
-			context.Configuration = "Release";
-			context.TestBin = testBin;
-			return context;
+			Configuration = "Release";
+			TestBin = testBin;
 		}
 	}
 }

--- a/test/ILLink.Tasks.Tests/TestContext.cs
+++ b/test/ILLink.Tasks.Tests/TestContext.cs
@@ -60,10 +60,12 @@ namespace ILLink.Tests
 		/// </summary>
 		public static TestContext CreateDefaultContext()
 		{
-			var packageName = "ILLink.Tasks";
 			// test working directory is test project's <baseoutputpath>/<config>/<tfm>
-			var testBin = "../../";
-			var repoRoot = Path.Combine(testBin, "..", "..", "..");
+			var testBin = Path.Combine(Environment.CurrentDirectory, "..", "..");
+			var repoRoot = Path.GetFullPath(Path.Combine(testBin, "..", "..", ".."));
+
+			// Locate task package
+			var packageName = "ILLink.Tasks";
 			var packageSource = Path.Combine(repoRoot, "src", "ILLink.Tasks", "bin", "nupkgs");
 			var tasksPackages = Directory.GetFiles(packageSource)
 				.Where(p => Path.GetExtension(p) == ".nupkg")
@@ -77,17 +79,13 @@ namespace ILLink.Tests
 			}
 			var tasksPackage = tasksPackages.Single();
 			var version = tasksPackage.Remove(0, packageName.Length + 1);
-			var dotnetDir = Path.Combine(repoRoot, "corebuild", "Tools", "dotnetcli");
-			var dotnetToolNames = Directory.GetFiles(dotnetDir)
+
+			// Locate dotnet host
+			var dotnetDir = Path.Combine(repoRoot, ".dotnet");
+			var dotnetToolName = Directory.GetFiles(dotnetDir)
 				.Select(p => Path.GetFileName(p))
-				.Where(p => p.Contains("dotnet"));
-			var nTools = dotnetToolNames.Count();
-			if (nTools > 1) {
-				throw new Exception($"multiple dotnet tools in {dotnetDir}");
-			} else if (nTools == 0) {
-				throw new Exception($"no dotnet tool found in {dotnetDir}");
-			}
-			var dotnetToolName = dotnetToolNames.Single();
+				.Where(p => p.StartsWith("dotnet"))
+				.First();
 			var dotnetToolPath = Path.Combine(dotnetDir, dotnetToolName);
 
 			var context = new TestContext();

--- a/test/ILLink.Tasks.Tests/TestContext.cs
+++ b/test/ILLink.Tasks.Tests/TestContext.cs
@@ -96,10 +96,10 @@ namespace ILLink.Tests
 			// This sets the RID to the RID of the currently-executing system.
 			context.RuntimeIdentifier = RuntimeEnvironment.GetRuntimeIdentifier();
 			// workaround: the osx.10.13-x64 RID doesn't exist yet.
-			// see https://github.com/dotnet/core-setup/issues/3301
-			if (context.RuntimeIdentifier == "osx.10.13-x64")
+			// see https://github.com/NuGet/Home/issues/5862
+			if (context.RuntimeIdentifier == "osx.10.14-x64")
 			{
-				context.RuntimeIdentifier = "osx.10.12-x64";
+				context.RuntimeIdentifier = "osx.10.13-x64";
 			}
 			// We want to build and link integration projects in the
 			// release configuration.

--- a/test/ILLink.Tasks.Tests/TestContext.cs
+++ b/test/ILLink.Tasks.Tests/TestContext.cs
@@ -85,7 +85,11 @@ namespace ILLink.Tests
 			var dotnetToolName = Directory.GetFiles(dotnetDir)
 				.Select(p => Path.GetFileName(p))
 				.Where(p => p.StartsWith("dotnet"))
-				.First();
+				.Where(p => {
+					var ext = Path.GetExtension(p);
+					return ext == "" || ext == ".exe";
+				})
+				.Single();
 			var dotnetToolPath = Path.Combine(dotnetDir, dotnetToolName);
 
 			var context = new TestContext();

--- a/test/ILLink.Tasks.Tests/WebApiTest.cs
+++ b/test/ILLink.Tasks.Tests/WebApiTest.cs
@@ -77,9 +77,9 @@ namespace ILLink.Tests
 
 		void CheckOutput(string target, bool selfContained = false)
 		{
-			string terminatingOutput = "Now listening on: http://localhost:5000";
+			string terminatingOutput = "Application started. Press Ctrl+C to shut down.";
 			int ret = RunApp(target, out string commandOutput, 60000, terminatingOutput, selfContained: selfContained);
-			Assert.True(commandOutput.Contains("Application started. Press Ctrl+C to shut down."));
+			Assert.True(commandOutput.Contains("Now listening on: http://localhost:5000"));
 			Assert.True(commandOutput.Contains(terminatingOutput));
 		}
 	}

--- a/test/ILLink.Tasks.Tests/WebApiTest.cs
+++ b/test/ILLink.Tasks.Tests/WebApiTest.cs
@@ -89,8 +89,8 @@ namespace ILLink.Tests
 		{
 			string terminatingOutput = "Application started. Press Ctrl+C to shut down.";
 			int ret = RunApp(target, out string commandOutput, 60000, terminatingOutput, selfContained: selfContained);
-			Assert.True(commandOutput.Contains("Now listening on: http://localhost:5000"));
-			Assert.True(commandOutput.Contains(terminatingOutput));
+			Assert.Contains("Now listening on: http://localhost:5000", commandOutput);
+			Assert.Contains(terminatingOutput, commandOutput);
 		}
 	}
 }

--- a/test/ILLink.Tasks.Tests/WebApiTest.cs
+++ b/test/ILLink.Tasks.Tests/WebApiTest.cs
@@ -6,11 +6,11 @@ using Xunit.Abstractions;
 
 namespace ILLink.Tests
 {
-	public class WebApiTest : IntegrationTestBase
+	public class WebApiFixture : ProjectFixture
 	{
-		private string csproj;
+		public string csproj;
 
-		public WebApiTest(ITestOutputHelper output) : base(output) {
+		public WebApiFixture(IMessageSink diagnosticMessageSink) : base(diagnosticMessageSink) {
 			csproj = SetupProject();
 		}
 
@@ -20,7 +20,7 @@ namespace ILLink.Tests
 			string csproj = Path.Combine(projectRoot, $"{projectRoot}.csproj");
 
 			if (File.Exists(csproj)) {
-				output.WriteLine($"using existing project {csproj}");
+				LogMessage($"using existing project {csproj}");
 				return csproj;
 			}
 
@@ -29,9 +29,9 @@ namespace ILLink.Tests
 			}
 
 			Directory.CreateDirectory(projectRoot);
-			int ret = Dotnet("new webapi", projectRoot);
+			int ret = CommandHelper.Dotnet("new webapi", projectRoot);
 			if (ret != 0) {
-				output.WriteLine("dotnet new failed");
+				LogMessage("dotnet new failed");
 				Assert.True(false);
 			}
 
@@ -52,7 +52,7 @@ namespace ILLink.Tests
 
 			var propertygroup = xdoc.Root.Element(ns + "PropertyGroup");
 
-			output.WriteLine("setting PublishWithAspNetCoreTargetManifest=false");
+			LogMessage("setting PublishWithAspNetCoreTargetManifest=false");
 			propertygroup.Add(new XElement(ns + "PublishWithAspNetCoreTargetManifest",
 										   "false"));
 
@@ -60,18 +60,28 @@ namespace ILLink.Tests
 				xdoc.Save(fs);
 			}
 		}
+	}
+
+	public class WebApiTest : IntegrationTestBase, IClassFixture<WebApiFixture>
+	{
+		private WebApiFixture fixture;
+
+		public WebApiTest(WebApiFixture fixture, ITestOutputHelper output) : base(output)
+		{
+			this.fixture = fixture;
+		}
 
 		[Fact]
 		public void RunWebApiStandalone()
 		{
-			string executablePath = BuildAndLink(csproj, selfContained: true);
+			string executablePath = BuildAndLink(fixture.csproj, selfContained: true);
 			CheckOutput(executablePath, selfContained: true);
 		}
 
 		[Fact]
 		public void RunWebApiPortable()
 		{
-			string target = BuildAndLink(csproj, selfContained: false);
+			string target = BuildAndLink(fixture.csproj, selfContained: false);
 			CheckOutput(target, selfContained: false);
 		}
 

--- a/test/ILLink.Tasks.Tests/nuget/NuGet.config
+++ b/test/ILLink.Tasks.Tests/nuget/NuGet.config
@@ -6,6 +6,6 @@
          this NuGet.config should be read to find the local package
          directory. The path is relative to the test <baseoutputpath>/<config>/<tfm>
          directory. -->
-    <add key="local linker packages" value="../../../../src/ILLink.Tasks/bin/nupkgs" />
+    <add key="local linker packages" value="../../../../../src/ILLink.Tasks/bin/nupkgs" />
   </packageSources>
 </configuration>

--- a/test/ILLink.Tasks.Tests/test.csproj
+++ b/test/ILLink.Tasks.Tests/test.csproj
@@ -29,6 +29,9 @@
     <Compile Include="HelloWorldTest.cs" />
     <Compile Include="WebApiTest.cs" />
     <Compile Include="MusicStoreTest.cs" />
+
+    <!-- tell xunit to log diagnostic messages -->
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/ILLink.Tasks.Tests/test.csproj
+++ b/test/ILLink.Tasks.Tests/test.csproj
@@ -24,17 +24,17 @@
   <ItemGroup>
     <Compile Include="CommandRunner.cs" />
     <Compile Include="IntegrationTestBase.cs" />
+    <Compile Include="Loggers.cs" />
     <Compile Include="TestContext.cs" />
-    <Compile Include="MusicStoreTest.cs" />
     <Compile Include="HelloWorldTest.cs" />
     <Compile Include="WebApiTest.cs" />
+    <Compile Include="MusicStoreTest.cs" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
-    <PackageReference Include="xunit" Version="2.3.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
 
 </Project>

--- a/test/ILLink.Tasks.Tests/xunit.runner.json
+++ b/test/ILLink.Tasks.Tests/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+    "diagnosticMessages": true
+}


### PR DESCRIPTION
This moves to using the arcade-restored dotnet in our integration tests, and reacts to changes in the directory layout. The project setup logic has been moved into xunit fixtures (see the commit message in https://github.com/mono/linker/commit/01e638038516f29c3aff3390fdb5df91f993cf04).

This does not attempt to address test failures due to SDK changes. These tests won't run in ci (yet).