### PR TITLE
Fix build definition

### DIFF
--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -7,7 +7,7 @@ variables:
   value: /p:ArcadeBuild=true
 - ${{ if eq(variables.officialBuild, 'true') }}:
   - name: _BuildArgs
-    value: ${{ format('{0} /p:OfficialBuildId={1}', variables['_BuildArgs'], variables['Build.BuildNumber']) }}
+    value: ${{ format('{0} /p:OfficialBuildId=$(Build.BuildNumber)', variables['_BuildArgs']) }}
   # Provide HelixApiAccessToken for telemetry
   - group: DotNet-HelixApi-Access
 

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -88,3 +88,4 @@ jobs:
         env:
           # https://github.com/Microsoft/vstest/issues/1503#issuecomment-410732193
           MSBUILDENSURESTDOUTFORTASKPROCESSES: 1
+        displayName: Build illink.sln $(_BuildConfig)


### PR DESCRIPTION
This fixes an issue with the official build definition.
The build number was not being set correctly because `variables['Build.BuildNumber']` is not available during the early phase of pipeline processing.

Also adds a missing displayName for the macOS job.

Fixes https://github.com/mono/linker/issues/503.