### PR TITLE
Add ReferenceAssemblyPaths input to linker task

### DIFF
--- a/src/ILLink.Tasks/LinkTask.cs
+++ b/src/ILLink.Tasks/LinkTask.cs
@@ -137,8 +137,8 @@ namespace ILLink.Tasks
 				args.Append (" -a ").Append (assemblyItem.ItemSpec);
 			}
 
-			HashSet<string> directories = new HashSet<string> ();
-			HashSet<string> assemblyNames = new HashSet<string> ();
+			HashSet<string> directories = new HashSet<string> (StringComparer.OrdinalIgnoreCase);
+			HashSet<string> assemblyNames = new HashSet<string> (StringComparer.OrdinalIgnoreCase);
 			foreach (var assembly in AssemblyPaths) {
 				var assemblyPath = assembly.ItemSpec;
 				var assemblyName = Path.GetFileNameWithoutExtension (assemblyPath);


### PR DESCRIPTION
When publishing a framework-dependent .NET Core app, the framework
implementation is not available during publish, and is represented to
the compiler by reference assemblies. Conceptually, reference
assemblies only represent surface area for compilation. Their
implementations can vary depending on the platform where the app is
eventually run.

There's no good way to detect whether an assembly is a reference
assembly. "True" reference assemblies will have a
ReferenceAssemblyAttribute, but the SDK's ReferencePath ItemGroup will
often contain implementation assemblies that are passed to the
compiler as references.

Ideally the linker would be able to resolve types defined in reference
assemblies without looking at IL they contain. For now, we just pass
along any reference assemblies that aren't also part of the
implementation set given to the linker, specifying the "skip"
action. This will prevent them from being placed in the output, but
they may still be analyzed.

As long as any implementation dlls in ReferenceAssemblyPaths are also
present in AssemblyPaths, this should match the desired
behavior. Exceptions to this should be rare.

/cc @fadimounir @nguerrera