### PR TITLE
Add another link xml test

### DIFF
--- a/test/Mono.Linker.Tests.Cases/LinkXml/UnusedMethodPreservedByLinkXmlIsKept.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/UnusedMethodPreservedByLinkXmlIsKept.cs
@@ -32,6 +32,11 @@ namespace Mono.Linker.Tests.Cases.LinkXml {
 			private void NotPreservedMethod ()
 			{
 			}
+
+			[Kept]
+			private void PreservedMethod5<T>(T arg)
+			{
+			}
 		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/LinkXml/UnusedMethodPreservedByLinkXmlIsKept.xml
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/UnusedMethodPreservedByLinkXmlIsKept.xml
@@ -5,6 +5,7 @@
       <method signature="System.Void PreservedMethod2(System.Int32,System.String)" />
       <method name="PreservedMethod3" />
       <method signature="System.Void PreservedMethod4(System.Collections.Generic.List`1&lt;System.Int32&gt;)" />
+      <method signature="System.Void PreservedMethod5(T)" />
     </type>
   </assembly>
 </linker>


### PR DESCRIPTION
Add a link xml test that preserves a method with a generic parameter.  Adding mostly as an example of the string to put in the `signature` xml attribute