### PR TITLE
Clean up SetAction a little

### DIFF
--- a/src/linker/Linker.Steps/ResolveFromAssemblyStep.cs
+++ b/src/linker/Linker.Steps/ResolveFromAssemblyStep.cs
@@ -81,16 +81,9 @@ namespace Mono.Linker.Steps
 
 		protected static void TrySetAction (LinkContext context, AssemblyDefinition assembly, AssemblyAction action)
 		{
-			TryReadSymbols (context, assembly);
-
 			if (!context.Annotations.HasAction (assembly)) {
-				context.Annotations.SetAction (assembly, action);
+				context.SetAction (assembly, action);
 			}
-		}
-
-		static void TryReadSymbols (LinkContext context, AssemblyDefinition assembly)
-		{
-			context.SafeReadSymbols (assembly);
 		}
 
 		protected virtual void ProcessLibrary (AssemblyDefinition assembly)

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -233,7 +233,7 @@ namespace Mono.Linker {
 		{
 			if (SeenFirstTime (assembly)) {
 				SafeReadSymbols (assembly);
-				SetAction (assembly);
+				SetDefaultAction (assembly);
 			}
 		}
 
@@ -292,8 +292,14 @@ namespace Mono.Linker {
 
 			return reference;
 		}
+		
+		public void SetAction(AssemblyDefinition assembly, AssemblyAction action)
+		{
+			RegisterAssembly(assembly);
+			Annotations.SetAction(assembly, action);
+		}
 
-		protected void SetAction (AssemblyDefinition assembly)
+		protected void SetDefaultAction (AssemblyDefinition assembly)
 		{
 			AssemblyAction action;
 

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -295,8 +295,8 @@ namespace Mono.Linker {
 		
 		public void SetAction(AssemblyDefinition assembly, AssemblyAction action)
 		{
-			RegisterAssembly(assembly);
-			Annotations.SetAction(assembly, action);
+			RegisterAssembly (assembly);
+			Annotations.SetAction (assembly, action);
 		}
 
 		protected void SetDefaultAction (AssemblyDefinition assembly)


### PR DESCRIPTION
* Rename `LinkContext.SetAction` to `LinkContext.SetActionToDefault` since that's what it is actually doing.  Setting the action to the specified user or core action.

* Add a new `LinkContext.SetAction` that will ensure the assembly is registered and has SafeReadSymbols called.  I hit an issue in our linker where I had early phase steps calling `context.Annotations.SetAction`.  If you call that directly you can get into a situation where `RegisterAssembly` does not call `SafeReadSymbols` because `SeenFirstTime` is returning true.  And when that happens, you end up breaking symbol linking for that assembly.  My hope is that this new `LinkContext.SetAction` is a slightly less error prone way of setting the action on assembly in a step that runs before `LoadReferenceStep`