### PR TITLE
Fix IL Compilation tests on .NET Core

### DIFF
--- a/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeOnReturnTypeIsRemoved.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeOnReturnTypeIsRemoved.cs
@@ -2,9 +2,6 @@
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
-#if NETCOREAPP
-	[IgnoreTestCase ("Needs investigation")]
-#endif
 	[SetupLinkerArgument ("--used-attrs-only", "true")]
 	[Define ("IL_ASSEMBLY_AVAILABLE")]
 	[SetupCompileBefore ("library.dll", new [] { "Dependencies/AssemblyWithUnusedAttributeOnReturnParameterDefinition.il" })]

--- a/test/Mono.Linker.Tests.Cases/TestFramework/CanCompileILAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/TestFramework/CanCompileILAssembly.cs
@@ -3,9 +3,6 @@ using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.TestFramework {
-#if NETCOREAPP
-	[IgnoreTestCase ("Needs investigation")]
-#endif
 	[Define ("IL_ASSEMBLY_AVAILABLE")]
 	[SetupCompileBefore ("ILAssembly.dll", new [] { "Dependencies/ILAssemblySample.il" })]
 	[KeptMemberInAssembly ("ILAssembly.dll", "Mono.Linker.Tests.Cases.TestFramework.Dependencies.ILAssemblySample", "GiveMeAValue()")]

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/MissingTargetReference.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/MissingTargetReference.cs
@@ -3,9 +3,6 @@ using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.TypeForwarding {
-#if NETCOREAPP
-	[IgnoreTestCase ("Needs investigation")]
-#endif
 	[SkipUnresolved (true)]
 	[Define ("IL_ASSEMBLY_AVAILABLE")]
 	[SetupCompileBefore ("TypeForwarderMissingReference.dll", new [] { "Dependencies/TypeForwarderMissingReference.il" })]

--- a/test/Mono.Linker.Tests/TestCasesRunner/TestCaseCompiler.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestCaseCompiler.cs
@@ -203,7 +203,8 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 		{
 			var parseOptions = new CSharpParseOptions (preprocessorSymbols: options.Defines);
 			var compilationOptions = new CSharpCompilationOptions (
-				outputKind: options.OutputPath.FileName.EndsWith (".exe") ? OutputKind.ConsoleApplication : OutputKind.DynamicallyLinkedLibrary
+				outputKind: options.OutputPath.FileName.EndsWith (".exe") ? OutputKind.ConsoleApplication : OutputKind.DynamicallyLinkedLibrary,
+				assemblyIdentityComparer: DesktopAssemblyIdentityComparer.Default
 			);
 			// Default debug info format for the current platform.
 			DebugInformationFormat debugType = RuntimeInformation.IsOSPlatform (OSPlatform.Windows) ? DebugInformationFormat.Pdb : DebugInformationFormat.PortablePdb;


### PR DESCRIPTION
These tests were failing because the .il files depend
on mscorlib without a version, and roslyn was looking for Object in
mscorlib, Version=0.0.0.0 as a result. This doesn't happen when using
csc from the command line because csc uses a different assembly
identity comparer by default: DesktopAssemblyIdentityComparer (even on
.NET Core).

```
Failed   MissingTargetReference
Error Message:
 System.AggregateException : One or more errors occurred. (Roslyn compilation errors: (19,4): error CS0012: The type 'Object' is defined in an assembly that is not referenced. You must add a reference to assembly 'mscorlib, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
)
  ----> System.Exception : Roslyn compilation errors: (19,4): error CS0012: The type 'Object' is defined in an assembly that is not referenced. You must add a reference to assembly 'mscorlib, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.

Stack Trace:
   at System.Threading.Tasks.Task`1.GetResultCore(Boolean waitCompletionNotification)
   at System.Threading.Tasks.Task`1.get_Result()
   at Mono.Linker.Tests.TestCasesRunner.TestRunner.GetResultOfTaskThatMakesNUnitAssertions[T](Task`1 task) in /Users/sven/src/dotnet/linker/test/Mono.Linker.Tests/TestCasesRunner/TestRunner.cs:line 121
   at Mono.Linker.Tests.TestCasesRunner.TestRunner.Compile(TestCaseSandbox sandbox, TestCaseMetadaProvider metadataProvider) in /Users/sven/src/dotnet/linker/test/Mono.Linker.Tests/TestCasesRunner/TestRunner.cs:line 63
   at Mono.Linker.Tests.TestCasesRunner.TestRunner.Run(TestCase testCase) in /Users/sven/src/dotnet/linker/test/Mono.Linker.Tests/TestCasesRunner/TestRunner.cs:line 28
   at Mono.Linker.Tests.TestCases.All.Run(TestCase testCase) in /Users/sven/src/dotnet/linker/test/Mono.Linker.Tests/TestCases/TestSuites.cs:line 150
   at Mono.Linker.Tests.TestCases.All.TypeForwardingTests(TestCase testCase) in /Users/sven/src/dotnet/linker/test/Mono.Linker.Tests/TestCases/TestSuites.cs:line 78
--Exception
   at Mono.Linker.Tests.TestCasesRunner.TestCaseCompiler.CompileCSharpAssemblyWithRoslyn(CompilerOptions options) in /Users/sven/src/dotnet/linker/test/Mono.Linker.Tests/TestCasesRunner/TestCaseCompiler.cs:line 280
   at Mono.Linker.Tests.TestCasesRunner.TestCaseCompiler.CompileCSharpAssemblyWithDefaultCompiler(CompilerOptions options) in /Users/sven/src/dotnet/linker/test/Mono.Linker.Tests/TestCasesRunner/TestCaseCompiler.cs:line 195
   at Mono.Linker.Tests.TestCasesRunner.TestCaseCompiler.CompileCSharpAssembly(CompilerOptions options) in /Users/sven/src/dotnet/linker/test/Mono.Linker.Tests/TestCasesRunner/TestCaseCompiler.cs:line 419
   at Mono.Linker.Tests.TestCasesRunner.TestCaseCompiler.CompileAssembly(CompilerOptions options) in /Users/sven/src/dotnet/linker/test/Mono.Linker.Tests/TestCasesRunner/TestCaseCompiler.cs:line 184
   at Mono.Linker.Tests.TestCasesRunner.TestCaseCompiler.CompileTestIn(NPath outputDirectory, String outputName, IEnumerable`1 sourceFiles, String[] commonReferences, String[] mainAssemblyReferences, IEnumerable`1 defines, NPath[] resources, String[] additionalArguments) in /Users/sven/src/dotnet/linker/test/Mono.Linker.Tests/TestCasesRunner/TestCaseCompiler.cs:line 56
   at Mono.Linker.Tests.TestCasesRunner.TestRunner.<>c__DisplayClass4_0.<Compile>b__1() in /Users/sven/src/dotnet/linker/test/Mono.Linker.Tests/TestCasesRunner/TestRunner.cs:line 57
   at System.Threading.Tasks.Task`1.InnerInvoke()
   at System.Threading.Tasks.Task.<>c.<.cctor>b__278_1(Object obj)
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location where exception was thrown ---
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
```