### PR TITLE
Enable native PDB copy on Windows for .NET Core

### DIFF
--- a/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbCopyActionAndSymbolLinkingEnabled.cs
+++ b/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbCopyActionAndSymbolLinkingEnabled.cs
@@ -3,8 +3,12 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Symbols {
-#if NETCOREAPP
-	[IgnoreTestCase ("Needs investigation")]
+#if NETCOREAPP && !WIN32
+	// .NET Core type forwarders cause the assembly action to be
+	// changed from "copy" to "save" (to remove references to removed
+	// typeforwarders). However, saving the native PDB is only
+	// supported on windows.
+	[IgnoreTestCase ("Only supported on Windows on .NET Core.")]
 #endif
 	[Reference ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll")]
 	[ReferenceDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb")]


### PR DESCRIPTION
The test was failing on non-windows, because it was trying and failing to save native PDBs.

```
Failed   ReferenceWithPdbCopyActionAndSymbolLinkingEnabled
Error Message:
 Missing symbols for assembly `/var/folders/1g/pkblpwxd49g9gg1x80g1gddm0000gn/T/linker_tests/output/LibraryWithPdb.dll`
Stack Trace:
   at Mono.Linker.Tests.TestCasesRunner.ResultChecker.VerifyKeptSymbols(CustomAttribute symbolsAttribute) in /Users/sven/src/dotnet/linker/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs:line 140
   at Mono.Linker.Tests.TestCasesRunner.ResultChecker.PerformOutputSymbolChecks(AssemblyDefinition original, NPath outputDirectory) in /Users/sven/src/dotnet/linker/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs:line 127
   at Mono.Linker.Tests.TestCasesRunner.ResultChecker.Check(LinkedTestCaseResult linkResult) in /Users/sven/src/dotnet/linker/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs:line 53
   at Mono.Linker.Tests.TestCases.All.Run(TestCase testCase) in /Users/sven/src/dotnet/linker/test/Mono.Linker.Tests/TestCases/TestSuites.cs:line 151
   at Mono.Linker.Tests.TestCases.All.SymbolsTests(TestCase testCase) in /Users/sven/src/dotnet/linker/test/Mono.Linker.Tests/TestCases/TestSuites.cs:line 102
```