### PR TITLE
Revert changes from https://github.com/mono/linker/pull/496

### DIFF
--- a/src/linker/Linker.Steps/ResolveFromAssemblyStep.cs
+++ b/src/linker/Linker.Steps/ResolveFromAssemblyStep.cs
@@ -79,13 +79,6 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		protected static void TrySetAction (LinkContext context, AssemblyDefinition assembly, AssemblyAction action)
-		{
-			if (!context.Annotations.HasAction (assembly)) {
-				context.SetAction (assembly, action);
-			}
-		}
-
 		protected virtual void ProcessLibrary (AssemblyDefinition assembly)
 		{
 			ProcessLibrary (Context, assembly, _rootVisibility);
@@ -94,7 +87,7 @@ namespace Mono.Linker.Steps
 		public static void ProcessLibrary (LinkContext context, AssemblyDefinition assembly, RootVisibility rootVisibility = RootVisibility.Any)
 		{
 			var action = rootVisibility == RootVisibility.Any ? AssemblyAction.Copy : AssemblyAction.Link;
-			TrySetAction (context, assembly, action);
+			context.SetAction (assembly, action);
 
 			context.Tracer.Push (assembly);
 
@@ -177,7 +170,7 @@ namespace Mono.Linker.Steps
 
 		void ProcessExecutable (AssemblyDefinition assembly)
 		{
-			TrySetAction (Context, assembly, AssemblyAction.Link);
+			Context.SetAction (assembly, AssemblyAction.Link);
 
 			Tracer.Push (assembly);
 


### PR DESCRIPTION
For some reason the linker logic in Xamarin.iOS relies on  `ResolveFromAssemblyStep.ProcessLibrary()` to overwrite the assembly action. If we don't do that it'd link an assembly that should really be copied.

I couldn't yet figure out how to fix this so best to revert this change (it was mostly needed to write a test for https://github.com/mono/linker/pull/497 but I didn't get to that yet).

Partially reverts 9b26a0973a5439ab79135ba826c539768ed7455c.