### PR TITLE
Fix attribute sweep bug and enable more tests on .NET Core

### DIFF
--- a/src/linker/Linker.Steps/SweepStep.cs
+++ b/src/linker/Linker.Steps/SweepStep.cs
@@ -398,13 +398,13 @@ namespace Mono.Linker.Steps {
 				SweepDebugInfo (methods);
 
 			foreach (var method in methods) {
+				SweepCustomAttributes (method.MethodReturnType);
+
 				if (!method.HasParameters)
 					continue;
 
 				foreach (var parameter in method.Parameters)
 					SweepCustomAttributes (parameter);
-
-				SweepCustomAttributes (method.MethodReturnType);
 			}
 		}
 

--- a/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/CanLinkCoreLibrariesWithOnlyKeepUsedAttributes.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/CanLinkCoreLibrariesWithOnlyKeepUsedAttributes.cs
@@ -4,9 +4,6 @@ using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
-#if NETCOREAPP
-	[IgnoreTestCase ("Needs investigation")]
-#endif
 	[SetupLinkerCoreAction ("link")]
 	[SetupLinkerArgument ("--used-attrs-only", "true")]
 	[Reference ("System.dll")]

--- a/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/CoreLibraryUnusedAssemblyAttributesAreRemoved.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/CoreLibraryUnusedAssemblyAttributesAreRemoved.cs
@@ -4,9 +4,6 @@ using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
-#if NETCOREAPP
-	[IgnoreTestCase ("Needs investigation")]
-#endif
 	[Reference ("System.dll")]
 	[SetupLinkerCoreAction ("link")]
 	[SetupLinkerArgument ("--used-attrs-only", "true")]

--- a/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/CoreLibraryUsedAssemblyAttributesAreKept.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/CoreLibraryUsedAssemblyAttributesAreKept.cs
@@ -4,9 +4,6 @@ using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
-#if NETCOREAPP
-	[IgnoreTestCase ("Needs investigation")]
-#endif
 	[Reference ("System.dll")]
 	[SetupLinkerCoreAction ("link")]
 	[SetupLinkerArgument ("--used-attrs-only", "true")]

--- a/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/Dependencies/AssemblyWithUnusedAttributeOnReturnParameterDefinition.il
+++ b/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/Dependencies/AssemblyWithUnusedAttributeOnReturnParameterDefinition.il
@@ -45,7 +45,18 @@
     IL_0000:  ldc.i4.s 3 
     IL_0001:  ret 
     }
-    
+
+    .method public hidebysig 
+           instance default int32 MethodWithoutParametersNonNestedAttribute ()  cil managed 
+    {
+    .param [0]
+    	.custom instance void class Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed.Dependencies.BarAttribute::'.ctor'() =  (01 00 00 00 ) // ....
+
+    .maxstack 8
+    IL_0000:  ldc.i4.s 5
+    IL_0001:  ret 
+    }
+
   .class nested private auto ansi beforefieldinit FooAttribute
     extends [mscorlib]System.Attribute
   {
@@ -60,6 +71,21 @@
     }
 
   }
+  }
+
+  .class private auto ansi beforefieldinit BarAttribute
+    extends [mscorlib]System.Attribute
+  {
+
+    .method public hidebysig specialname rtspecialname 
+           instance default void '.ctor' ()  cil managed 
+    {
+    .maxstack 8
+    IL_0000:  ldarg.0 
+    IL_0001:  call instance void class [mscorlib]System.Attribute::'.ctor'()
+    IL_0006:  ret 
+    }
+
   }
 }
 

--- a/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/Dependencies/AssemblyWithUnusedAttributeOnReturnParameterDefinition.il
+++ b/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/Dependencies/AssemblyWithUnusedAttributeOnReturnParameterDefinition.il
@@ -34,6 +34,17 @@
     IL_0000:  ldarg.1 
     IL_0001:  ret 
     }
+
+    .method public hidebysig 
+           instance default int32 MethodWithoutParameters ()  cil managed 
+    {
+    .param [0]
+    	.custom instance void class Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed.Dependencies.AssemblyWithUnusedAttributeOnReturnParameterDefinition/FooAttribute::'.ctor'() =  (01 00 00 00 ) // ....
+
+    .maxstack 8
+    IL_0000:  ldc.i4.s 3 
+    IL_0001:  ret 
+    }
     
   .class nested private auto ansi beforefieldinit FooAttribute
     extends [mscorlib]System.Attribute

--- a/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeOnReturnTypeIsRemoved.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeOnReturnTypeIsRemoved.cs
@@ -9,12 +9,14 @@ namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
 	[Define ("IL_ASSEMBLY_AVAILABLE")]
 	[SetupCompileBefore ("library.dll", new [] { "Dependencies/AssemblyWithUnusedAttributeOnReturnParameterDefinition.il" })]
 	[RemovedTypeInAssembly ("library.dll", "Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed.Dependencies.AssemblyWithUnusedAttributeOnReturnParameterDefinition/FooAttribute")]
+	[RemovedTypeInAssembly ("library.dll", "Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed.Dependencies.BarAttribute")]
 	public class UnusedAttributeOnReturnTypeIsRemoved {
 		static void Main ()
 		{
 #if IL_ASSEMBLY_AVAILABLE
 			var tmp = new Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed.Dependencies.AssemblyWithUnusedAttributeOnReturnParameterDefinition ().Method (1);
 			var tmp2 = new Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed.Dependencies.AssemblyWithUnusedAttributeOnReturnParameterDefinition ().MethodWithoutParameters ();
+			var tmp3 = new Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed.Dependencies.AssemblyWithUnusedAttributeOnReturnParameterDefinition ().MethodWithoutParametersNonNestedAttribute ();
 #endif
 		}
 	}

--- a/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeOnReturnTypeIsRemoved.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeOnReturnTypeIsRemoved.cs
@@ -14,6 +14,7 @@ namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
 		{
 #if IL_ASSEMBLY_AVAILABLE
 			var tmp = new Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed.Dependencies.AssemblyWithUnusedAttributeOnReturnParameterDefinition ().Method (1);
+			var tmp2 = new Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed.Dependencies.AssemblyWithUnusedAttributeOnReturnParameterDefinition ().MethodWithoutParameters ();
 #endif
 		}
 	}

--- a/test/Mono.Linker.Tests.Cases/CoreLink/NoSecurityPlusOnlyKeepUsedRemovesAllSecurityAttributesFromCoreLibraries.cs
+++ b/test/Mono.Linker.Tests.Cases/CoreLink/NoSecurityPlusOnlyKeepUsedRemovesAllSecurityAttributesFromCoreLibraries.cs
@@ -5,9 +5,6 @@ using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.CoreLink {
-#if NETCOREAPP
-	[IgnoreTestCase ("Needs investigation")]
-#endif
 	[SetupLinkerCoreAction ("link")]
 	[SetupLinkerArgument ("--strip-security", "true")]
 	[SetupLinkerArgument ("--used-attrs-only", "true")]


### PR DESCRIPTION
The introduction of `MethodWithoutParameters()` in this test causes the linker to write invalid IL. When the linker sweeps this method, a bug causes it to keep the attribute on the return type parameter. However, the attribute type itself is removed (causing it to become detached from its declaring type).

https://jenkins.mono-project.com/job/test-linker-pull-request/759/console:
```
09:58:19 1) Failed : Mono.Linker.Tests.TestCases.All.OnlyKeepUsed.UnusedAttributeOnReturnTypeIsRemoved
09:58:19 Invalid IL detected in /tmp/linker_tests/output/library.dll
09:58:19 FAIL: Invalid CustomAttribute row 0 Type field 0x00000022
09:58:19 Error count: 1
09:58:19 at Mono.Linker.Tests.TestCasesRunner.PeVerifier.CheckAssembly (Mono.Linker.Tests.Extensions.NPath assemblyPath) [0x00099] in <0aac952fa2cb4e07af00f27b39783fd3>:0
09:58:19 at Mono.Linker.Tests.TestCasesRunner.PeVerifier.Check (Mono.Linker.Tests.TestCasesRunner.LinkedTestCaseResult linkResult, Mono.Cecil.AssemblyDefinition original) [0x00098] in <0aac952fa2cb4e07af00f27b39783fd3>:0
09:58:19 at Mono.Linker.Tests.TestCasesRunner.ResultChecker.Check (Mono.Linker.Tests.TestCasesRunner.LinkedTestCaseResult linkResult) [0x00095] in <0aac952fa2cb4e07af00f27b39783fd3>:0
09:58:19 at Mono.Linker.Tests.TestCases.All.Run (Mono.Linker.Tests.TestCases.TestCase testCase) [0x00019] in <0aac952fa2cb4e07af00f27b39783fd3>:0
09:58:19 at Mono.Linker.Tests.TestCases.All.AttributesTests (Mono.Linker.Tests.TestCases.TestCase testCase) [0x00001] in <0aac952fa2cb4e07af00f27b39783fd3>:0
```