### PR TITLE
Use PackageLicenseExpression

### DIFF
--- a/src/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/src/ILLink.Tasks/ILLink.Tasks.csproj
@@ -42,6 +42,7 @@
          references from being marked as dependencies. -->
     <!-- TODO: Remove the custom .nuspec once the P2P PrivateAssets
          issue is fixed. -->
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <NuspecFileName>ILLink.Tasks.nuspec</NuspecFileName>
     <NuspecFile>$(BaseOutputPath)$(NuspecFileName)</NuspecFile>
     <NuspecProperties>id=$(AssemblyName);authors=$(AssemblyName);description=linker tasks;</NuspecProperties>

--- a/src/ILLink.Tasks/ILLink.Tasks.nuspec
+++ b/src/ILLink.Tasks/ILLink.Tasks.nuspec
@@ -5,6 +5,7 @@
     <version>$version$</version>
     <authors>$authors$</authors>
     <description>$description$</description>
+    <license type="expression">MIT</license>
   </metadata>
   <files>
     <file src="ILLink.Tasks.targets" target="build" />


### PR DESCRIPTION
Fixes build issue with arcade update (https://github.com/mono/linker/pull/523). Since we are still using our own
.nuspec (rather than letting the nuget targets generate one), we also
need to specify the license in our custom .nuspec.