### PR TITLE
Enable override of marking convert to throw exception

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1950,12 +1950,12 @@ namespace Mono.Linker.Steps {
 				break;
 
 			case MethodAction.ConvertToThrow:
-				MarkAndCacheNotSupportedCtorString ();
+				MarkAndCacheConvertToThrowExceptionCtor ();
 				break;
 			}
 		}
 
-		void MarkAndCacheNotSupportedCtorString ()
+		protected virtual void MarkAndCacheConvertToThrowExceptionCtor ()
 		{
 			if (_context.MarkedKnownMembers.NotSupportedExceptionCtorString != null)
 				return;
@@ -2124,7 +2124,7 @@ namespace Mono.Linker.Steps {
 		protected virtual void MarkMethodBody (MethodBody body)
 		{
 			if (_context.IsOptimizationEnabled (CodeOptimizations.UnreachableBodies) && IsUnreachableBody (body)) {
-				MarkAndCacheNotSupportedCtorString ();
+				MarkAndCacheConvertToThrowExceptionCtor ();
 				_unreachableBodies.Add (body);
 				return;
 			}


### PR DESCRIPTION
We have a class library profile that doesn't support exceptions.  In order for MethodAction.ConvertToThrow to work with this profile I will need to be able to override enough of the pieces so that I can inject Environment.FailFast instead of throw new exception.