### PR TITLE
Don't block usage of 1 char args

### DIFF
--- a/test/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupLinkerArgumentAttribute.cs
+++ b/test/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupLinkerArgumentAttribute.cs
@@ -14,12 +14,6 @@ namespace Mono.Linker.Tests.Cases.Expectations.Metadata {
 		{
 			if (string.IsNullOrEmpty (flag))
 				throw new ArgumentNullException (nameof (flag));
-
-			if (flag[0] == '-' && flag.Length == 2) {
-				string errorMessage = "Flag `" + flag + "` is short.";
-				errorMessage += "  Avoid using this attribute with command line flags that are to short to communicate their meaning.  Support a more descriptive flag or create a new attribute for tests to use similar to " + nameof (SetupLinkerCoreActionAttribute);
-				throw new ArgumentException (errorMessage);
-			}
 		}
 	}
 }


### PR DESCRIPTION
Some tests landed that do this (I wrote them :) ).  It's not great to throw from an attribute ctor anyways.  Some tools will cover it up, others won't.