### PR TITLE
Handle long paths in ILLink.Tasks LinkTask

### DIFF
--- a/src/ILLink.Tasks/LinkTask.cs
+++ b/src/ILLink.Tasks/LinkTask.cs
@@ -123,19 +123,24 @@ namespace ILLink.Tasks
 			set => _illinkPath = value;
 		}
 
+		private string Quote (string path)
+		{
+			return $"\"{path.TrimEnd('\\')}\"";
+		}
+
 		protected override string GenerateCommandLineCommands ()
 		{
 			var args = new StringBuilder ();
-			args.Append (ILLinkPath);
+			args.Append (Quote (ILLinkPath));
 
 			if (RootDescriptorFiles != null) {
 				foreach (var rootFile in RootDescriptorFiles) {
-					args.Append (" -x ").Append (rootFile.ItemSpec);
+					args.Append (" -x ").Append (Quote (rootFile.ItemSpec));
 				}
 			}
 
 			foreach (var assemblyItem in RootAssemblyNames) {
-				args.Append (" -a ").Append (assemblyItem.ItemSpec);
+				args.Append (" -a ").Append (Quote (assemblyItem.ItemSpec));
 			}
 
 			HashSet<string> directories = new HashSet<string> (StringComparer.OrdinalIgnoreCase);
@@ -149,14 +154,14 @@ namespace ILLink.Tasks
 				var dir = Path.GetDirectoryName (assemblyPath);
 				if (!directories.Contains (dir)) {
 					directories.Add (dir);
-					args.Append (" -d ").Append (dir);
+					args.Append (" -d ").Append (Quote (dir));
 				}
 
 				string action = assembly.GetMetadata ("action");
 				if ((action != null) && (action.Length > 0)) {
 					args.Append (" -p ");
 					args.Append (action);
-					args.Append (" ").Append (assemblyName);
+					args.Append (" ").Append (Quote (assemblyName));
 				}
 			}
 
@@ -172,17 +177,17 @@ namespace ILLink.Tasks
 				var dir = Path.GetDirectoryName (assemblyPath);
 				if (!directories.Contains (dir)) {
 					directories.Add (dir);
-					args.Append (" -d ").Append (dir);
+					args.Append (" -d ").Append (Quote (dir));
 				}
 
 				// Treat reference assemblies as "skip". Ideally we
 				// would not even look at the IL, but only use them to
 				// resolve surface area.
-				args.Append (" -p skip ").Append (assemblyName);
+				args.Append (" -p skip ").Append (Quote (assemblyName));
 			}
 
 			if (OutputDirectory != null) {
-				args.Append (" -out ").Append (OutputDirectory.ItemSpec);
+				args.Append (" -out ").Append (Quote (OutputDirectory.ItemSpec));
 			}
 
 			if (ClearInitLocals) {

--- a/src/ILLink.Tasks/LinkTask.cs
+++ b/src/ILLink.Tasks/LinkTask.cs
@@ -123,7 +123,7 @@ namespace ILLink.Tasks
 			set => _illinkPath = value;
 		}
 
-		private string Quote (string path)
+		private static string Quote (string path)
 		{
 			return $"\"{path.TrimEnd('\\')}\"";
 		}


### PR DESCRIPTION
LinkTask invocation involving long-paths (with spaces) failed because
the arguments to dotnet.exe Illink.dll are not within quotes.
This change fixes the problem.

Ideally, the LinkTask should use a response file, instead of the long
command line. However, dotnet.exe currently doesn't support response files.
https://github.com/dotnet/cli/issues/7657