### PR TITLE
Match sdk versions

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,6 +6,10 @@
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftNetCoreIlasmPackageVersion>3.0.0-preview4-27520-71</MicrosoftNetCoreIlasmPackageVersion>
+    <!-- These should match the SDK version at https://github.com/dotnet/sdk/blob/master/eng/Versions.props -->
+    <SystemReflectionMetadataVersion>1.5.0</SystemReflectionMetadataVersion>
+    <MicrosoftBuildFrameworkVersion>15.4.8</MicrosoftBuildFrameworkVersion>
+    <MicrosoftBuildUtilitiesCoreVersion>15.4.8</MicrosoftBuildUtilitiesCoreVersion>
   </PropertyGroup>
   <PropertyGroup>
     <RestoreSources>

--- a/src/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/src/ILLink.Tasks/ILLink.Tasks.csproj
@@ -71,10 +71,7 @@
 
     <MSBuild Projects="@(ProjectsToPublish)" Targets="Publish" />
     <ItemGroup>
-      <TfmSpecificPackageFile Include="$(PublishDir)/ILLink.*.dll" PackagePath="tools\$(TargetFramework)" />
-      <TfmSpecificPackageFile Include="$(PublishDir)/Mono.Cecil*.dll" PackagePath="tools\$(TargetFramework)" />
-      <TfmSpecificPackageFile Include="$(PublishDir)/illink.dll" PackagePath="tools\$(TargetFramework)"
-                              Condition=" '$(TargetFramework)' == 'netcoreapp2.0' " />
+      <TfmSpecificPackageFile Include="$(PublishDir)/*.dll" PackagePath="tools\$(TargetFramework)" />
       <TfmSpecificPackageFile Include="$(PublishDir)/*.json" PackagePath="tools\$(TargetFramework)" />
     </ItemGroup>
 
@@ -138,6 +135,7 @@
                       PrivateAssets="All" />
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)"
                       Condition=" '$(TargetFramework)' == 'net472' "
-                      PrivateAssets="All" />
+                      PrivateAssets="All"
+                      Publish="True" />
   </ItemGroup>
 </Project>

--- a/src/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/src/ILLink.Tasks/ILLink.Tasks.csproj
@@ -132,11 +132,12 @@
     <!-- We use private assets for the Microsoft.Build packages to
          prevent them from being published with the tasks dll, because
          these are already a part of the SDK. -->
-    <PackageReference Include="Microsoft.Build.Framework" Version="15.1.1012"
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)"
                       PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.1012"
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)"
                       PrivateAssets="All" />
-    <PackageReference Include="System.Reflection.Metadata" Version="1.3.0"
+    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)"
+                      Condition=" '$(TargetFramework)' == 'net472' "
                       PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/src/ILLink.Tasks/ILLink.Tasks.csproj
@@ -139,5 +139,14 @@
                       Condition=" '$(TargetFramework)' == 'net472' "
                       PrivateAssets="All"
                       Publish="True" />
+
+    <!-- Publishing cecil (targeting netstandard1.3) for net472
+         results in an extra dll being published (see
+         https://github.com/dotnet/sdk/issues/3194). Work around this
+         by excluding assets from that particular package. -->
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.3.0"
+                      Condition=" '$(TargetFramework)' == 'net472' "
+                      ExcludeAssets="All" />
+
   </ItemGroup>
 </Project>

--- a/src/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/src/ILLink.Tasks/ILLink.Tasks.csproj
@@ -130,9 +130,11 @@
          prevent them from being published with the tasks dll, because
          these are already a part of the SDK. -->
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)"
-                      PrivateAssets="All" />
+                      PrivateAssets="All"
+                      ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)"
-                      PrivateAssets="All" />
+                      PrivateAssets="All"
+                      ExcludeAssets="Runtime" />
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)"
                       Condition=" '$(TargetFramework)' == 'net472' "
                       PrivateAssets="All"


### PR DESCRIPTION
This updates ILLink.Tasks to reference the same version of `System.Reflection.Metadata` and msbuild packages as the SDK, and includes SRM in the package for desktop, the same way that `Microsoft.NET.Build.Tasks` does it.
@nguerrera PTAL.