### PR TITLE
Resolve assemblies from specific paths

### DIFF
--- a/src/ILLink.Tasks/LinkTask.cs
+++ b/src/ILLink.Tasks/LinkTask.cs
@@ -133,11 +133,11 @@ namespace ILLink.Tasks
 
 			if (RootDescriptorFiles != null) {
 				foreach (var rootFile in RootDescriptorFiles)
-					args.Append (" -x ").Append (Quote (rootFile.ItemSpec));
+					args.Append ("-x ").AppendLine (Quote (rootFile.ItemSpec));
 			}
 
 			foreach (var assemblyItem in RootAssemblyNames)
-				args.Append (" -a ").Append (Quote (assemblyItem.ItemSpec));
+				args.Append ("-a ").AppendLine (Quote (assemblyItem.ItemSpec));
 
 			HashSet<string> assemblyNames = new HashSet<string> (StringComparer.OrdinalIgnoreCase);
 			foreach (var assembly in AssemblyPaths) {
@@ -148,13 +148,13 @@ namespace ILLink.Tasks
 				if (!assemblyNames.Add (assemblyName))
 					continue;
 
-				args.Append (" --ref ").Append (Quote (assemblyPath));
+				args.Append ("--ref ").AppendLine (Quote (assemblyPath));
 
 				string action = assembly.GetMetadata ("action");
 				if ((action != null) && (action.Length > 0)) {
-					args.Append (" -p ");
+					args.Append ("-p ");
 					args.Append (action);
-					args.Append (" ").Append (Quote (assemblyName));
+					args.Append (" ").AppendLine (Quote (assemblyName));
 				}
 			}
 
@@ -168,33 +168,33 @@ namespace ILLink.Tasks
 					if (assemblyNames.Contains (assemblyName))
 						continue;
 
-					args.Append (" --ref ").Append (Quote (assemblyPath));
+					args.Append ("--ref ").AppendLine (Quote (assemblyPath));
 
 					// Treat reference assemblies as "skip". Ideally we
 					// would not even look at the IL, but only use them to
 					// resolve surface area.
-					args.Append (" -p skip ").Append (Quote (assemblyName));
+					args.Append ("-p skip ").AppendLine (Quote (assemblyName));
 				}
 			}
 
 			if (OutputDirectory != null)
-				args.Append (" -out ").Append (Quote (OutputDirectory.ItemSpec));
+				args.Append ("-out ").AppendLine (Quote (OutputDirectory.ItemSpec));
 
 			if (ClearInitLocals) {
-				args.Append (" -s ");
+				args.Append ("-s ");
 				// Version of ILLink.CustomSteps is passed as a workaround for msbuild issue #3016
-				args.Append ("LLink.CustomSteps.ClearInitLocalsStep,ILLink.CustomSteps,Version=0.0.0.0:OutputStep");
+				args.AppendLine ("ILLink.CustomSteps.ClearInitLocalsStep,ILLink.CustomSteps,Version=0.0.0.0:OutputStep");
 				if ((ClearInitLocalsAssemblies != null) && (ClearInitLocalsAssemblies.Length > 0)) {
-					args.Append (" -m ClearInitLocalsAssemblies ");
-					args.Append (ClearInitLocalsAssemblies);
+					args.Append ("-m ClearInitLocalsAssemblies ");
+					args.AppendLine (ClearInitLocalsAssemblies);
 				}
 			}
 
 			if (ExtraArgs != null)
-				args.Append (" ").Append (ExtraArgs);
+				args.AppendLine (ExtraArgs);
 
 			if (DumpDependencies)
-				args.Append (" --dump-dependencies");
+				args.AppendLine ("--dump-dependencies");
 
 			return args.ToString ();
 		}

--- a/src/ILLink.Tasks/LinkTask.cs
+++ b/src/ILLink.Tasks/LinkTask.cs
@@ -168,7 +168,7 @@ namespace ILLink.Tasks
 					if (assemblyNames.Contains (assemblyName))
 						continue;
 
-					args.Append ("--ref ").AppendLine (Quote (assemblyPath));
+					args.Append ("-reference ").AppendLine (Quote (assemblyPath));
 
 					// Treat reference assemblies as "skip". Ideally we
 					// would not even look at the IL, but only use them to

--- a/src/linker/Linker/AssemblyResolver.cs
+++ b/src/linker/Linker/AssemblyResolver.cs
@@ -83,7 +83,7 @@ namespace Mono.Linker {
 		}
 #endif
 
-		private AssemblyDefinition ResolveFromReferences (AssemblyNameReference name, Collection<string> references, ReaderParameters parameters)
+		AssemblyDefinition ResolveFromReferences (AssemblyNameReference name, Collection<string> references, ReaderParameters parameters)
 		{
 			var fileName = name.Name + ".dll";
 			foreach (var reference in references) {
@@ -110,7 +110,7 @@ namespace Mono.Linker {
 			AssemblyDefinition asm = null;
 			if (!_assemblies.TryGetValue (name.Name, out asm) && (_unresolvedAssemblies == null || !_unresolvedAssemblies.Contains (name.Name))) {
 				try {
-					// Try the new resolution behavior. This can't live in the cecil-owned base class.
+					// Any full path explicit reference takes precedence over other look up logic
 					asm = ResolveFromReferences (name, _references, parameters);
 
 					// Fall back to the base class resolution logic

--- a/src/linker/Linker/DirectoryAssemblyResolver.cs
+++ b/src/linker/Linker/DirectoryAssemblyResolver.cs
@@ -11,16 +11,10 @@ namespace Mono.Linker {
 	public abstract class DirectoryAssemblyResolver : IAssemblyResolver {
 
 		readonly Collection<string> directories;
-		readonly Collection<string> assemblyPaths;
 
 		public void AddSearchDirectory (string directory)
 		{
 			directories.Add (directory);
-		}
-
-		public void AddAssemblyPath (string assemblyPath)
-		{
-			assemblyPaths.Add (assemblyPath);
 		}
 
 		public void RemoveSearchDirectory (string directory)
@@ -36,10 +30,9 @@ namespace Mono.Linker {
 		protected DirectoryAssemblyResolver ()
 		{
 			directories = new Collection<string> (2) { "." };
-			assemblyPaths = new Collection<string> (10) { };
 		}
 
-		AssemblyDefinition GetAssembly (string file, ReaderParameters parameters)
+		protected AssemblyDefinition GetAssembly (string file, ReaderParameters parameters)
 		{
 			if (parameters.AssemblyResolver == null)
 				parameters.AssemblyResolver = this;
@@ -57,32 +50,13 @@ namespace Mono.Linker {
 			if (name == null)
 				throw new ArgumentNullException ("name");
 			if (parameters == null)
-				parameters = new ReaderParameters ();
+				throw new ArgumentNullException ("parameters");
 
-			var assembly = SearchAssemblyPaths (name, assemblyPaths, parameters);
-			if (assembly != null)
-				return assembly;
-
-			assembly = SearchDirectory (name, directories, parameters);
+			var assembly = SearchDirectory (name, directories, parameters);
 			if (assembly != null)
 				return assembly;
 
 			throw new AssemblyResolutionException (name);
-		}
-
-		AssemblyDefinition SearchAssemblyPaths (AssemblyNameReference name, IEnumerable<string> assemblyPaths, ReaderParameters parameters)
-		{
-			foreach (var assemblyPath in assemblyPaths) {
-				if (Path.GetFileName (assemblyPath) != name.Name + ".dll")
-					continue;
-				try {
-					return GetAssembly (assemblyPath, parameters);
-				} catch (System.BadImageFormatException) {
-					continue;
-				}
-			}
-
-			return null;
 		}
 
 		AssemblyDefinition SearchDirectory (AssemblyNameReference name, IEnumerable<string> directories, ReaderParameters parameters)

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -240,6 +240,10 @@ namespace Mono.Linker {
 								disabled_optimizations.Add (opt);
 
 							continue;
+
+						case "--ref":
+							context.Resolver.AddAssemblyPath (GetParam ());
+							continue;
 						}
 
 						switch (token [2]) {
@@ -504,6 +508,7 @@ namespace Mono.Linker {
 			Console.WriteLine ("  -r                  Link from a list of assemblies using roots visible outside of the assembly");
 			Console.WriteLine ("  -x                  Link from XML descriptor");
 			Console.WriteLine ("  -d <path>           Specify additional directories to search in for references");
+			Console.WriteLine ("  --ref <path>        Specify additional assemblies to use as references");
 			Console.WriteLine ("  -b                  Update debug symbols for each linked module. Defaults to false");
 			Console.WriteLine ("  -v                  Keep members and types used by debugger. Defaults to false");
 			Console.WriteLine ("  -l <name>,<name>    List of i18n assemblies to copy to the output directory. Defaults to 'all'");

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -241,7 +241,7 @@ namespace Mono.Linker {
 
 							continue;
 
-						case "--reference":
+						case "-reference":
 							context.Resolver.AddReferenceAssembly (GetParam ());
 							continue;
 						}

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -508,16 +508,15 @@ namespace Mono.Linker {
 			Console.WriteLine ("  -r                  Link from a list of assemblies using roots visible outside of the assembly");
 			Console.WriteLine ("  -x                  Link from XML descriptor");
 			Console.WriteLine ("  -d <path>           Specify additional directories to search in for references");
-			Console.WriteLine ("  --reference <file>  Specify additional assemblies to use as references");
+			Console.WriteLine ("  -reference <file>   Specify additional assemblies to use as references");
 			Console.WriteLine ("  -b                  Update debug symbols for each linked module. Defaults to false");
 			Console.WriteLine ("  -v                  Keep members and types used by debugger. Defaults to false");
 			Console.WriteLine ("  -l <name>,<name>    List of i18n assemblies to copy to the output directory. Defaults to 'all'");
 			Console.WriteLine ("                        Valid names are 'none', 'all', 'cjk', 'mideast', 'other', 'rare', 'west'");
+			Console.WriteLine ("  -out <path>         Specify the output directory. Defaults to 'output'");
 			Console.WriteLine ("  --about             About the {0}", _linker);
 			Console.WriteLine ("  --verbose           Log messages indicating progress and warnings");
 			Console.WriteLine ("  --version           Print the version number of the {0}", _linker);
-			Console.WriteLine ("  --skip-unresolved   Ignore unresolved types, methods, and assemblies. Defaults to false");
-			Console.WriteLine ("  -out <path>         Specify the output directory. Defaults to 'output'");
 
 			Console.WriteLine ();
 			Console.WriteLine ("Actions");
@@ -547,6 +546,7 @@ namespace Mono.Linker {
 			Console.WriteLine ("  --ignore-descriptors      Skips reading embedded descriptors (short -z). Defaults to false");
 			Console.WriteLine ("  --keep-facades            Keep assemblies with type-forwarders (short -t). Defaults to false");
 			Console.WriteLine ("  --new-mvid                Generate a new guid for each linked assembly (short -g). Defaults to true");
+			Console.WriteLine ("  --skip-unresolved         Ignore unresolved types, methods, and assemblies. Defaults to false");			
 			Console.WriteLine ("  --strip-resources         Remove XML descriptor resources for linked assemblies. Defaults to true");
 			Console.WriteLine ("  --strip-security          Remove metadata and code related to Code Access Security. Defaults to true");
 			Console.WriteLine ("  --used-attrs-only         Any attribute is removed if the attribute type is not used. Defaults to false");

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -241,8 +241,8 @@ namespace Mono.Linker {
 
 							continue;
 
-						case "--ref":
-							context.Resolver.AddAssemblyPath (GetParam ());
+						case "--reference":
+							context.Resolver.AddReferenceAssembly (GetParam ());
 							continue;
 						}
 
@@ -508,7 +508,7 @@ namespace Mono.Linker {
 			Console.WriteLine ("  -r                  Link from a list of assemblies using roots visible outside of the assembly");
 			Console.WriteLine ("  -x                  Link from XML descriptor");
 			Console.WriteLine ("  -d <path>           Specify additional directories to search in for references");
-			Console.WriteLine ("  --ref <path>        Specify additional assemblies to use as references");
+			Console.WriteLine ("  --reference <file>  Specify additional assemblies to use as references");
 			Console.WriteLine ("  -b                  Update debug symbols for each linked module. Defaults to false");
 			Console.WriteLine ("  -v                  Keep members and types used by debugger. Defaults to false");
 			Console.WriteLine ("  -l <name>,<name>    List of i18n assemblies to copy to the output directory. Defaults to 'all'");


### PR DESCRIPTION
This introduces a command-line option, "-reference <file>", which makes it possible to give the linker full assembly paths to resolve.

LinkTask now uses "-reference" instead of "-d", to prevent the directory resolution behavior from finding dependencies next to inputs. Now it takes an explicit list of inputs, which will be the only files it resolves.

When passing along full paths to each file, the command-line becomes substantially longer. To prevent hitting command length limits, arguments are now passed via a response file (using ToolTask's GenerateResponseFileCommands).

This fixes issues like that mentioned in https://github.com/dotnet/coreclr/issues/24397#issuecomment-490807112 when trying to link WPF apps, which have a `WindowsBase.dll` in the core framework directory and also in the WPF runtime pack:
```
Unhandled Exception: System.ArgumentNullException: Value cannot be null.
         Parameter name: declaringType
            at Mono.Cecil.Mixin.CheckType(Object type, Argument argument)
            at Mono.Cecil.MethodReference..ctor(String name, TypeReference returnType, TypeReference declaringType)
            at Mono.Linker.Steps.TypeMapStep.CreateGenericInstanceCandidate(GenericContext context, TypeDefinition candidateType, MethodDefinition interfaceMethod)
            at Mono.Linker.Steps.TypeMapStep.GetBaseInflatedInterfaceMethodInTypeHierarchy(GenericContext context, TypeDefinition type, MethodDefinition interfaceMethod)
            at Mono.Linker.Steps.TypeMapStep.MapInterfaceMethodsInTypeHierarchy(TypeDefinition type)
            at Mono.Linker.Steps.TypeMapStep.MapType(TypeDefinition type)
            at Mono.Linker.Steps.TypeMapStep.ProcessAssembly(AssemblyDefinition assembly)
            at Mono.Linker.Steps.BaseStep.Process(LinkContext context)
            at Mono.Linker.Pipeline.ProcessStep(LinkContext context, IStep step)
            at Mono.Linker.Pipeline.Process(LinkContext context)
            at Mono.Linker.Driver.Run(ILogger customLogger)
            at Mono.Linker.Driver.Execute(String[] args, ILogger customLogger)
            at Mono.Linker.Driver.Main(String[] args)
```