### PR TITLE
Sweep attributes on GenericParameters and InterfaceImplementations

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -3,9 +3,9 @@
   <ProductDependencies>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19263.3">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19264.13">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>e6712584bba6e2f0e35a3704793c459ff97c09af</Sha>
+      <Sha>670f6ee1a619a2a7c84cfdfe2a1c84fbe94e1c6b</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -3,9 +3,9 @@
   <ProductDependencies>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19264.13">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19266.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>670f6ee1a619a2a7c84cfdfe2a1c84fbe94e1c6b</Sha>
+      <Sha>37c11672ee11dc2b3365b95a29e0c012f44032be</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/common/PublishToPackageFeed.proj
+++ b/eng/common/PublishToPackageFeed.proj
@@ -53,6 +53,7 @@
       <TargetStaticFeed Condition="'$(ArtifactsCategory.ToUpper())' == 'TOOLSET'">https://dotnetfeed.blob.core.windows.net/dotnet-toolset/index.json</TargetStaticFeed>
       <TargetStaticFeed Condition="'$(ArtifactsCategory.ToUpper())' == 'WINDOWSDESKTOP'">https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json</TargetStaticFeed>
       <TargetStaticFeed Condition="'$(ArtifactsCategory.ToUpper())' == 'NUGETCLIENT'">https://dotnetfeed.blob.core.windows.net/nuget-nugetclient/index.json</TargetStaticFeed>
+      <TargetStaticFeed Condition="'$(ArtifactsCategory.ToUpper())' == 'ASPNETENTITYFRAMEWORK6'">https://dotnetfeed.blob.core.windows.net/aspnet-entityframework6/index.json</TargetStaticFeed>
     </PropertyGroup>
 
     <Error 

--- a/eng/common/cross/arm64/sources.list.buster
+++ b/eng/common/cross/arm64/sources.list.buster
@@ -1,0 +1,11 @@
+deb http://deb.debian.org/debian buster main
+deb-src http://deb.debian.org/debian buster main
+
+deb http://deb.debian.org/debian-security/ buster/updates main
+deb-src http://deb.debian.org/debian-security/ buster/updates main
+
+deb http://deb.debian.org/debian buster-updates main
+deb-src http://deb.debian.org/debian buster-updates main
+
+deb http://deb.debian.org/debian buster-backports main contrib non-free
+deb-src http://deb.debian.org/debian buster-backports main contrib non-free

--- a/eng/common/cross/arm64/sources.list.stretch
+++ b/eng/common/cross/arm64/sources.list.stretch
@@ -1,0 +1,12 @@
+deb http://deb.debian.org/debian stretch main
+deb-src http://deb.debian.org/debian stretch main
+
+deb http://deb.debian.org/debian-security/ stretch/updates main
+deb-src http://deb.debian.org/debian-security/ stretch/updates main
+
+deb http://deb.debian.org/debian stretch-updates main
+deb-src http://deb.debian.org/debian stretch-updates main
+
+deb http://deb.debian.org/debian stretch-backports main contrib non-free
+deb-src http://deb.debian.org/debian stretch-backports main contrib non-free
+

--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -2,7 +2,7 @@
 
 usage()
 {
-    echo "Usage: $0 [BuildArch] [LinuxCodeName] [lldbx.y] [--skipunmount] --rootfs <directory>]"
+    echo "Usage: $0 [BuildArch] [LinuxCodeName] [lldbx.y] [--skipunmount] --rootfsdir <directory>]"
     echo "BuildArch can be: arm(default), armel, arm64, x86"
     echo "LinuxCodeName - optional, Code name for Linux, can be: trusty, xenial(default), zesty, bionic, alpine. If BuildArch is armel, LinuxCodeName is jessie(default) or tizen."
     echo "lldbx.y - optional, LLDB version, can be: lldb3.9(default), lldb4.0, lldb5.0, lldb6.0 no-lldb. Ignored for alpine"
@@ -113,12 +113,12 @@ while :; do
                 __LinuxCodeName=trusty
             fi
             ;;
-        xenial) # Ubunry 16.04
+        xenial) # Ubuntu 16.04
             if [ "$__LinuxCodeName" != "jessie" ]; then
                 __LinuxCodeName=xenial
             fi
             ;;
-        zesty) # Ununtu 17.04
+        zesty) # Ubuntu 17.04
             if [ "$__LinuxCodeName" != "jessie" ]; then
                 __LinuxCodeName=zesty
             fi
@@ -132,7 +132,16 @@ while :; do
             __LinuxCodeName=jessie
             __UbuntuRepo="http://ftp.debian.org/debian/"
             ;;
-        # TBD Stretch -> Debian 9, Buster -> Debian 10
+        stretch) # Debian 9
+            __LinuxCodeName=stretch
+            __UbuntuRepo="http://ftp.debian.org/debian/"
+            __LLDB_Package="liblldb-6.0-dev"
+            ;;
+        buster) # Debian 10
+            __LinuxCodeName=buster
+            __UbuntuRepo="http://ftp.debian.org/debian/"
+            __LLDB_Package="liblldb-6.0-dev"
+            ;;
         tizen)
             if [ "$__BuildArch" != "armel" ]; then
                 echo "Tizen is available only for armel."

--- a/eng/common/darc-init.ps1
+++ b/eng/common/darc-init.ps1
@@ -1,5 +1,6 @@
 param (
-    $darcVersion = $null
+    $darcVersion = $null,
+    $versionEndpoint = "https://maestro-prod.westus2.cloudapp.azure.com/api/assets/darc-version?api-version=2019-01-16"
 )
 
 $verbosity = "m"
@@ -16,10 +17,10 @@ function InstallDarcCli ($darcVersion) {
     Invoke-Expression "& `"$dotnet`" tool uninstall $darcCliPackageName -g"
   }
 
-  # Until we can anonymously query the BAR API for the latest arcade-services
-  # build applied to the PROD channel, this is hardcoded.
+  # If the user didn't explicitly specify the darc version,
+  # query the Maestro API for the correct version of darc to install.
   if (-not $darcVersion) {
-    $darcVersion = '1.1.0-beta.19258.3'
+    $darcVersion = $(Invoke-WebRequest -Uri $versionEndpoint -UseBasicParsing).Content
   }
   
   $arcadeServicesSource = 'https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json'

--- a/eng/common/darc-init.sh
+++ b/eng/common/darc-init.sh
@@ -1,13 +1,18 @@
 #!/usr/bin/env bash
 
 source="${BASH_SOURCE[0]}"
-darcVersion="1.1.0-beta.19258.3"
+darcVersion=''
+versionEndpoint="https://maestro-prod.westus2.cloudapp.azure.com/api/assets/darc-version?api-version=2019-01-16"
 
 while [[ $# > 0 ]]; do
   opt="$(echo "$1" | awk '{print tolower($0)}')"
   case "$opt" in
     --darcversion)
       darcVersion=$2
+      shift
+      ;;
+    --versionendpoint)
+      versionEndpoint=$2
       shift
       ;;
     *)
@@ -33,6 +38,10 @@ verbosity=m
 
 . "$scriptroot/tools.sh"
 
+if [ -z "$darcVersion" ]; then
+  darcVersion=$(curl -X GET "$versionEndpoint" -H "accept: text/plain")
+fi
+
 function InstallDarcCli {
   local darc_cli_package_name="microsoft.dotnet.darc"
 
@@ -47,7 +56,7 @@ function InstallDarcCli {
 
   local arcadeServicesSource="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json"
 
-  echo "Installing Darc CLI version $toolset_version..."
+  echo "Installing Darc CLI version $darcVersion..."
   echo "You may need to restart your command shell if this is the first dotnet tool you have installed."
   echo $($dotnet_root/dotnet tool install $darc_cli_package_name --version $darcVersion --add-source "$arcadeServicesSource" -v $verbosity -g)
 }

--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "tools": {
-    "dotnet": "3.0.100-preview-010184"
+    "dotnet": "3.0.100-preview5-011568"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19263.3",
+    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19264.13",
     "Microsoft.NET.Sdk.IL": "3.0.0-preview4-27520-71"
   }
 }

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "dotnet": "3.0.100-preview5-011568"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19264.13",
+    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19266.2",
     "Microsoft.NET.Sdk.IL": "3.0.0-preview4-27520-71"
   }
 }

--- a/src/linker/Linker.Steps/SweepStep.cs
+++ b/src/linker/Linker.Steps/SweepStep.cs
@@ -285,6 +285,9 @@ namespace Mono.Linker.Steps {
 			if (type.HasCustomAttributes)
 				SweepCustomAttributes (type);
 
+			if (type.HasGenericParameters)
+				SweepCustomAttributeCollection (type.GenericParameters);
+
 			if (type.HasProperties)
 				SweepCustomAttributeCollection (type.Properties);
 
@@ -312,8 +315,10 @@ namespace Mono.Linker.Steps {
 		{
 			for (int i = type.Interfaces.Count - 1; i >= 0; i--) {
 				var iface = type.Interfaces [i];
-				if (Annotations.IsMarked (iface))
+				if (Annotations.IsMarked (iface)) {
+					SweepCustomAttributes (iface);
 					continue;
+				}
 				InterfaceRemoved (type, iface);
 				type.Interfaces.RemoveAt (i);
 			}
@@ -398,6 +403,9 @@ namespace Mono.Linker.Steps {
 				SweepDebugInfo (methods);
 
 			foreach (var method in methods) {
+				if (method.HasGenericParameters)
+					SweepCustomAttributeCollection (method.GenericParameters);
+
 				SweepCustomAttributes (method.MethodReturnType);
 
 				if (!method.HasParameters)

--- a/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/Dependencies/AssemblyWithUnusedAttributeOnGenericParameter.il
+++ b/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/Dependencies/AssemblyWithUnusedAttributeOnGenericParameter.il
@@ -1,0 +1,82 @@
+.assembly extern mscorlib
+{
+}
+.assembly 'library'
+{
+  .hash algorithm 0x00008004
+  .ver  0:0:0:0
+}
+.module library.dll
+
+
+.namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed.Dependencies
+{
+
+  .class public auto ansi beforefieldinit FooAttribute
+    extends [mscorlib]System.Attribute
+  {
+
+    .method public hidebysig specialname rtspecialname
+           instance default void '.ctor' ()  cil managed
+    {
+    .maxstack 8
+    IL_0000:  ldarg.0
+    IL_0001:  call instance void class [mscorlib]System.Attribute::'.ctor'()
+    IL_0006:  ret
+    }
+
+  }
+
+  .class public auto ansi beforefieldinit GenericType`1<T>
+    extends [mscorlib]System.Object
+  {
+    .param type T
+    .custom instance void class Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed.Dependencies.FooAttribute::'.ctor'() =  (01 00 00 00 ) // ....
+
+    .field private !T input
+
+    .method public hidebysig specialname rtspecialname
+          instance default void '.ctor' (!T input)  cil managed
+    {
+    .maxstack 8
+    IL_0000:  ldarg.0
+    IL_0001:  call instance void class [mscorlib]System.Object::'.ctor'()
+    IL_0006:  ldarg.0
+    IL_0007:  ldarg.1
+    IL_000a:  stfld  !0 class Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed.Dependencies.GenericType`1<!T>::input
+    IL_000f:  ret
+    }
+
+    .method public hidebysig instance !T Method() cil managed
+    {
+    .maxstack 8
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld !0 class Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed.Dependencies.GenericType`1<!T>::input
+    IL_0006:  ret
+    }
+
+  }
+
+  .class public auto ansi beforefieldinit TypeWithGenericMethod
+    extends [mscorlib]System.Object
+  {
+    .method public hidebysig specialname rtspecialname
+            instance void '.ctor' () cil managed
+    {
+    .maxstack 8
+    IL_0000:  ldarg.0
+    IL_0001:  call instance void class [mscorlib]System.Object::'.ctor'()
+    IL_0006:  ret
+    }
+
+    .method public hidebysig instance !!T GenericMethod<T> (!!T input) cil managed
+    {
+    .param type T
+    .custom instance void class Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed.Dependencies.FooAttribute::'.ctor'() =  (01 00 00 00 ) // ....
+    .maxstack 8
+    IL_0000:  ldarg.1
+    IL_0001:  ret
+    }
+  }
+
+}

--- a/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeOnGenericParameterIsRemoved.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeOnGenericParameterIsRemoved.cs
@@ -1,0 +1,18 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
+	[SetupLinkerArgument ("--used-attrs-only", "true")]
+	[Define ("IL_ASSEMBLY_AVAILABLE")]
+	[SetupCompileBefore ("library.dll", new [] { "Dependencies/AssemblyWithUnusedAttributeOnGenericParameter.il" })]
+	[RemovedTypeInAssembly ("library.dll", "Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed.Dependencies.FooAttribute")]
+	public class UnusedAttributeOnGenericParameterIsRemoved {
+		static void Main ()
+		{
+#if IL_ASSEMBLY_AVAILABLE
+			var tmp = new Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed.Dependencies.GenericType<int> (8).Method ();
+			var tmp2 = new Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed.Dependencies.TypeWithGenericMethod ().GenericMethod<int> (9);
+#endif
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/test/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -107,6 +107,7 @@
     <Compile Include="Attributes\OnlyKeepUsed\ThreadStaticIsPreservedOnField.cs" />
     <Compile Include="Attributes\OnlyKeepUsed\CoreLibraryUnusedAssemblyAttributesAreRemoved.cs" />
     <Compile Include="Attributes\OnlyKeepUsed\UnusedAttributeOnReturnTypeIsRemoved.cs" />
+    <Compile Include="Attributes\OnlyKeepUsed\UnusedAttributeOnGenericParameterIsRemoved.cs" />
     <Compile Include="Attributes\OnlyKeepUsed\UnusedAttributeTypeOnModuleIsRemoved.cs" />
     <Compile Include="Attributes\OnlyKeepUsed\UnusedAttributeWithTypeForwarderIsRemoved.cs" />
     <Compile Include="Attributes\OnlyKeepUsed\CanLinkCoreLibrariesWithOnlyKeepUsedAttributes.cs" />
@@ -597,6 +598,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Attributes\OnlyKeepUsed\Dependencies\AssemblyWithUnusedAttributeOnReturnParameterDefinition.il" />
+    <Content Include="Attributes\OnlyKeepUsed\Dependencies\AssemblyWithUnusedAttributeOnGenericParameter.il" />
     <Content Include="Attributes\OnlyKeepUsed\UnusedAttributePreservedViaLinkXmlIsKept.xml" />
     <Content Include="CommandLine\Dependencies\ResponseFilesWork.rsp" />
     <Content Include="Inheritance.AbstractClasses\NoKeptCtor\OverrideRemoval\PreservesOverriddenMethodOverrideOfUsedVirtualStillRemoved.xml" />

--- a/test/Mono.Linker.Tests/TestCases/IndividualTests.cs
+++ b/test/Mono.Linker.Tests/TestCases/IndividualTests.cs
@@ -73,8 +73,9 @@ namespace Mono.Linker.Tests.TestCases
 			var lineCount = outputPath.ReadAllLines ().Length;
 
 			// When reduced tracing is not enabled there are around 16k of lines in the output file.
-			// With reduced tracing there should be less than 65, but to be safe, we'll check for less than 100.
-			const int expectedMaxLines = 100;
+			// With reduced tracing there should be less than 65, but to be safe, we'll check for less than 200.
+			// Reduced tracing on System.Private.CoreLib.dll produces about 130 lines just for NullableAttribute usages.
+			const int expectedMaxLines = 200;
 			Assert.That (lineCount, Is.LessThan (expectedMaxLines), $"There were `{lineCount}` lines in the dump file.  This is more than expected max of {expectedMaxLines} and likely indicates reduced tracing was not enabled.  Dump file can be found at: {outputPath}");
 		}
 


### PR DESCRIPTION
This fixes test failures that show up due to NullableAttribute with recent versions of .NET Core (see the failures in https://github.com/mono/linker/pull/570). This should unblock the dependency uptake.