### PR TITLE
Allow overriding assembly action on root assemblies

### DIFF
--- a/src/linker/Linker.Steps/ResolveFromAssemblyStep.cs
+++ b/src/linker/Linker.Steps/ResolveFromAssemblyStep.cs
@@ -86,8 +86,10 @@ namespace Mono.Linker.Steps
 
 		public static void ProcessLibrary (LinkContext context, AssemblyDefinition assembly, RootVisibility rootVisibility = RootVisibility.Any)
 		{
-			var action = rootVisibility == RootVisibility.Any ? AssemblyAction.Copy : AssemblyAction.Link;
-			context.SetAction (assembly, action);
+			if (!context.Actions.Contains (assembly.Name.Name)) {
+				var action = rootVisibility == RootVisibility.Any ? AssemblyAction.Copy : AssemblyAction.Link;
+				context.SetAction (assembly, action);
+			}
 
 			context.Tracer.Push (assembly);
 
@@ -170,7 +172,8 @@ namespace Mono.Linker.Steps
 
 		void ProcessExecutable (AssemblyDefinition assembly)
 		{
-			Context.SetAction (assembly, AssemblyAction.Link);
+			if (!Context.Actions.Contains (assembly.Name.Name))
+				Context.SetAction (assembly, AssemblyAction.Link);
 
 			Tracer.Push (assembly);
 

--- a/src/linker/Linker.Steps/ResolveFromAssemblyStep.cs
+++ b/src/linker/Linker.Steps/ResolveFromAssemblyStep.cs
@@ -86,10 +86,8 @@ namespace Mono.Linker.Steps
 
 		public static void ProcessLibrary (LinkContext context, AssemblyDefinition assembly, RootVisibility rootVisibility = RootVisibility.Any)
 		{
-			if (!context.Actions.Contains (assembly.Name.Name)) {
-				var action = rootVisibility == RootVisibility.Any ? AssemblyAction.Copy : AssemblyAction.Link;
-				context.SetAction (assembly, action);
-			}
+			var action = rootVisibility == RootVisibility.Any ? AssemblyAction.Copy : AssemblyAction.Link;
+			context.SetAction (assembly, action);
 
 			context.Tracer.Push (assembly);
 
@@ -172,8 +170,7 @@ namespace Mono.Linker.Steps
 
 		void ProcessExecutable (AssemblyDefinition assembly)
 		{
-			if (!Context.Actions.Contains (assembly.Name.Name))
-				Context.SetAction (assembly, AssemblyAction.Link);
+			Context.SetAction (assembly, AssemblyAction.Link);
 
 			Tracer.Push (assembly);
 

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -295,9 +295,13 @@ namespace Mono.Linker {
 			return reference;
 		}
 		
-		public void SetAction(AssemblyDefinition assembly, AssemblyAction action)
+		public void SetAction (AssemblyDefinition assembly, AssemblyAction defaultAction)
 		{
 			RegisterAssembly (assembly);
+
+			if (!_actions.TryGetValue (assembly.Name.Name, out AssemblyAction action))
+				action = defaultAction;
+
 			Annotations.SetAction (assembly, action);
 		}
 


### PR DESCRIPTION
When rooting assemblies via '-a' or '-r', ResolveFromAssemblyStep sets a default action depending on whether the assembly is a library or exe. This default takes precedence over any assembly action passed for that assembly via the command line using '-p <action> <assemblyname>'.
This change makes it possible to override the default assembly action even for root assemblies.

This is useful especially in cases (like we want to do for .NET Core) where we'd like to choose a conservative default that keeps the entire app assembly, only trimming framework code.

@marek-safar PTAL
