### PR TITLE
Rethrow exceptions in Resolve as AssemblyResolutionException 

### DIFF
--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -208,8 +208,12 @@ namespace Mono.Linker {
 		public AssemblyDefinition Resolve (string name)
 		{
 			if (File.Exists (name)) {
-				AssemblyDefinition assembly = AssemblyDefinition.ReadAssembly (name, _readerParameters);
-				return _resolver.CacheAssembly (assembly);
+				try {
+					AssemblyDefinition assembly = AssemblyDefinition.ReadAssembly (name, _readerParameters);
+					return _resolver.CacheAssembly (assembly);
+				} catch (Exception e) {
+					throw new AssemblyResolutionException (new AssemblyNameReference (name, new Version ()), e);
+				}
 			}
 
 			return Resolve (new AssemblyNameReference (name, new Version ()));


### PR DESCRIPTION
Cecil throws a BadImageFormatException when trying to read assemblies with no CIL section.  This turns that exception into a AssemblyResolutionException and includes the assembly name in the information in the exception.


```
Unhandled Exception: Mono.Cecil.AssemblyResolutionException: Failed to resolve assembly: '/Users/lewing/.nuget/packages/runtime.win-x86.runtime.native.system.data.sqlclient.sni/4.4.0/runtimes/win-x86/native/sni.dll, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' ---> System.BadImageFormatException: Format of the executable (.exe) or library (.dll) is invalid.
   at Mono.Cecil.PE.ImageReader.ReadOptionalHeaders(UInt16& subsystem, UInt16& dll_characteristics) in /Users/lewing/Source/linker/external/cecil/Mono.Cecil.PE/ImageReader.cs:line 199
   at Mono.Cecil.PE.ImageReader.ReadImage() in /Users/lewing/Source/linker/external/cecil/Mono.Cecil.PE/ImageReader.cs:line 85
   at Mono.Cecil.PE.ImageReader.ReadImage(Disposable`1 stream, String file_name) in /Users/lewing/Source/linker/external/cecil/Mono.Cecil.PE/ImageReader.cs:line 763
   at Mono.Cecil.ModuleDefinition.ReadModule(Disposable`1 stream, String fileName, ReaderParameters parameters) in /Users/lewing/Source/linker/external/cecil/Mono.Cecil/ModuleDefinition.cs:line 1128
   at Mono.Cecil.ModuleDefinition.ReadModule(String fileName, ReaderParameters parameters) in /Users/lewing/Source/linker/external/cecil/Mono.Cecil/ModuleDefinition.cs:line 1097
   at Mono.Cecil.AssemblyDefinition.ReadAssembly(String fileName, ReaderParameters parameters) in /Users/lewing/Source/linker/external/cecil/Mono.Cecil/AssemblyDefinition.cs:line 131
   at Mono.Linker.LinkContext.Resolve(String name) in /Users/lewing/Source/linker/src/linker/Linker/LinkContext.cs:line 212
   --- End of inner exception stack trace ---
   at Mono.Linker.LinkContext.Resolve(String name) in /Users/lewing/Source/linker/src/linker/Linker/LinkContext.cs:line 215
   at Mono.Linker.Steps.ResolveFromAssemblyStep.Process() in /Users/lewing/Source/linker/src/linker/Linker.Steps/ResolveFromAssemblyStep.cs:line 66
   at Mono.Linker.Steps.BaseStep.Process(LinkContext context) in /Users/lewing/Source/linker/src/linker/Linker.Steps/BaseStep.cs:line 58
   at Mono.Linker.Pipeline.ProcessStep(LinkContext context, IStep step) in /Users/lewing/Source/linker/src/linker/Linker/Pipeline.cs:line 134
   at Mono.Linker.Pipeline.Process(LinkContext context) in /Users/lewing/Source/linker/src/linker/Linker/Pipeline.cs:line 126
   at Mono.Linker.Driver.Run(ILogger customLogger) in /Users/lewing/Source/linker/src/linker/Linker/Driver.cs:line 383
   at Mono.Linker.Driver.Execute(String[] args, ILogger customLogger) in /Users/lewing/Source/linker/src/linker/Linker/Driver.cs:line 61
   at Mono.Linker.Driver.Main(String[] args) in /Users/lewing/Source/linker/src/linker/Linker/Driver.cs:line 50
Abort trap: 6
```
instead of
```
xamlewing-good:output lewing$ monolinker -u link -a  ~/.nuget/packages/runtime.win-x86.runtime.native.system.data.sqlclient.sni/4.4.0/runtimes/win-x86/native/sni.dll
Fatal error in Mono CIL Linker
System.BadImageFormatException: Format of the executable (.exe) or library (.dll) is invalid.
  at Mono.Cecil.PE.ImageReader.ReadOptionalHeaders (System.UInt16& subsystem, System.UInt16& dll_characteristics, System.UInt16& linker) [0x00088] in <e1647306bd4645429d49b6efbfd41f4f>:0 
  at Mono.Cecil.PE.ImageReader.ReadImage () [0x0008b] in <e1647306bd4645429d49b6efbfd41f4f>:0 
  at Mono.Cecil.PE.ImageReader.ReadImage (Mono.Disposable`1[T] stream, System.String file_name) [0x00007] in <e1647306bd4645429d49b6efbfd41f4f>:0 
  at Mono.Cecil.ModuleDefinition.ReadModule (Mono.Disposable`1[T] stream, System.String fileName, Mono.Cecil.ReaderParameters parameters) [0x00006] in <e1647306bd4645429d49b6efbfd41f4f>:0 
  at Mono.Cecil.ModuleDefinition.ReadModule (System.String fileName, Mono.Cecil.ReaderParameters parameters) [0x0006c] in <e1647306bd4645429d49b6efbfd41f4f>:0 
  at Mono.Cecil.AssemblyDefinition.ReadAssembly (System.String fileName, Mono.Cecil.ReaderParameters parameters) [0x00000] in <e1647306bd4645429d49b6efbfd41f4f>:0 
  at Mono.Linker.LinkContext.Resolve (System.String name) [0x00008] in <8282cf85e935442184eceabb1951fa77>:0 
  at Mono.Linker.Steps.ResolveFromAssemblyStep.Process () [0x0002f] in <8282cf85e935442184eceabb1951fa77>:0 
  at Mono.Linker.Steps.BaseStep.Process (Mono.Linker.LinkContext context) [0x00010] in <8282cf85e935442184eceabb1951fa77>:0 
  at Mono.Linker.Pipeline.Process (Mono.Linker.LinkContext context) [0x0001c] in <8282cf85e935442184eceabb1951fa77>:0 
  at Mono.Linker.Driver.Run (Mono.Linker.ILogger customLogger) [0x005a0] in <8282cf85e935442184eceabb1951fa77>:0 
  at Mono.Linker.Driver.Execute (System.String[] args, Mono.Linker.ILogger customLogger) [0x00015] in <8282cf85e935442184eceabb1951fa77>:0
```
As part of the work for https://github.com/mono/mono/issues/12916