### PR TITLE
Revert "Make sure _needAddBypassNGenStep is false if the assembly act…

### DIFF
--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -466,6 +466,9 @@ namespace Mono.Linker {
 		AssemblyAction ParseAssemblyAction (string s)
 		{
 			var assemblyAction = (AssemblyAction)Enum.Parse(typeof(AssemblyAction), s, true);
+			// The AddBypassNGenStep is necessary if any actions (default or per-assembly) are AddBypassNGen(Used).
+			// We enable this step as soon as we see such an action. Even if subsequent steps change an action we have
+			// already seen, the step will only operate on assemblies with a final action AddBypassNGen(Used).
 			if ((assemblyAction == AssemblyAction.AddBypassNGen) || (assemblyAction == AssemblyAction.AddBypassNGenUsed)) {
 				_needAddBypassNGenStep = true;
 			}

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -467,7 +467,7 @@ namespace Mono.Linker {
 		{
 			var assemblyAction = (AssemblyAction)Enum.Parse(typeof(AssemblyAction), s, true);
 			// The AddBypassNGenStep is necessary if any actions (default or per-assembly) are AddBypassNGen(Used).
-			// We enable this step as soon as we see such an action. Even if subsequent steps change an action we have
+			// We enable this step as soon as we see such an action. Even if subsequent parameters change an action we have
 			// already seen, the step will only operate on assemblies with a final action AddBypassNGen(Used).
 			if ((assemblyAction == AssemblyAction.AddBypassNGen) || (assemblyAction == AssemblyAction.AddBypassNGenUsed)) {
 				_needAddBypassNGenStep = true;

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -466,7 +466,9 @@ namespace Mono.Linker {
 		AssemblyAction ParseAssemblyAction (string s)
 		{
 			var assemblyAction = (AssemblyAction)Enum.Parse(typeof(AssemblyAction), s, true);
-			_needAddBypassNGenStep = ((assemblyAction == AssemblyAction.AddBypassNGen) || (assemblyAction == AssemblyAction.AddBypassNGenUsed));
+			if ((assemblyAction == AssemblyAction.AddBypassNGen) || (assemblyAction == AssemblyAction.AddBypassNGenUsed)) {
+				_needAddBypassNGenStep = true;
+			}
 			return assemblyAction;
 		}
 


### PR DESCRIPTION
…ion is overridden by specifying more than once"

This reverts commit 7dce9327c11798b4811d2b376a8fcbc2fc399f2e.

The logic was originally changed so that parameters like `-c addbypassngen -c copy` would not result in an unnecessary AddBypassNGen step being added to the linker pipeline. However, we need to support cases like `-c addbypassngen -p copy MyAssembly`, where one assembly gets a different action from the default. In this case, we still need the addbypassngen step.

Reverting this commit will reintroduce the unnecessary AddBypassNGen step that the original change was designed to prevent for cases like `-c addbypassngen -c copy`. However, because the step itself checks the assembly action, the unnecessary step doesn't change the linker behavior.

@cshung PTAL