### PR TITLE
Use "-reference" in LinkTask

### DIFF
--- a/src/ILLink.Tasks/LinkTask.cs
+++ b/src/ILLink.Tasks/LinkTask.cs
@@ -148,7 +148,7 @@ namespace ILLink.Tasks
 				if (!assemblyNames.Add (assemblyName))
 					continue;
 
-				args.Append ("--ref ").AppendLine (Quote (assemblyPath));
+				args.Append ("-reference ").AppendLine (Quote (assemblyPath));
 
 				string action = assembly.GetMetadata ("action");
 				if ((action != null) && (action.Length > 0)) {


### PR DESCRIPTION
Left-over from https://github.com/mono/linker/pull/567/files. I believe this is what's causing https://github.com/dotnet/coreclr/issues/24397#issuecomment-495720076. @marek-safar PTAL