### PR TITLE
Add mvid tests

### DIFF
--- a/test/Mono.Linker.Tests.Cases/CommandLine/Mvid/DefaultMvidBehavior.cs
+++ b/test/Mono.Linker.Tests.Cases/CommandLine/Mvid/DefaultMvidBehavior.cs
@@ -1,0 +1,15 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.CommandLine.Mvid {
+	public class DefaultMvidBehavior {
+		public static void Main ()
+		{
+			Method ();
+		}
+
+		[Kept]
+		static void Method ()
+		{
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/CommandLine/Mvid/DeterministicMvidWorks.cs
+++ b/test/Mono.Linker.Tests.Cases/CommandLine/Mvid/DeterministicMvidWorks.cs
@@ -1,0 +1,17 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.CommandLine.Mvid {
+	[SetupLinkerArgument ("--deterministic")]
+	public class DeterministicMvidWorks {
+		public static void Main ()
+		{
+			Method ();
+		}
+
+		[Kept]
+		static void Method ()
+		{
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/CommandLine/Mvid/NewMvidWorks.cs
+++ b/test/Mono.Linker.Tests.Cases/CommandLine/Mvid/NewMvidWorks.cs
@@ -1,0 +1,17 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.CommandLine.Mvid {
+	[SetupLinkerArgument ("--new-mvid", "true")]
+	public class NewMvidWorks {
+		public static void Main ()
+		{
+			Method ();
+		}
+
+		[Kept]
+		static void Method ()
+		{
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/CommandLine/Mvid/RetainMvid.cs
+++ b/test/Mono.Linker.Tests.Cases/CommandLine/Mvid/RetainMvid.cs
@@ -1,0 +1,18 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.CommandLine.Mvid {
+	[SetupLinkerArgument ("--new-mvid", "false")]
+	public class RetainMvid
+	{
+		public static void Main ()
+		{
+			Method ();
+		}
+
+		[Kept]
+		static void Method ()
+		{
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/test/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Condition=" $(Configuration.StartsWith('illink')) ">
     <TargetFramework>netcoreapp3.0</TargetFramework>
@@ -155,6 +155,10 @@
     <Compile Include="BCLFeatures\ETW\BaseRemovedEventSourceEmptyBody.cs" />
     <Compile Include="BCLFeatures\ETW\LocalsOfModifiedMethodAreRemoved.cs" />
     <Compile Include="BCLFeatures\ETW\StubbedMethodWithExceptionHandlers.cs" />
+    <Compile Include="CommandLine\Mvid\DefaultMvidBehavior.cs" />
+    <Compile Include="CommandLine\Mvid\DeterministicMvidWorks.cs" />
+    <Compile Include="CommandLine\Mvid\NewMvidWorks.cs" />
+    <Compile Include="CommandLine\Mvid\RetainMvid.cs" />
     <Compile Include="CommandLine\ResponseFilesWork.cs" />
     <Compile Include="CoreLink\CanIncludeI18nAssemblies.cs" />
     <Compile Include="CoreLink\DelegateAndMulticastDelegateKeepInstantiatedReqs.cs" />

--- a/test/Mono.Linker.Tests/TestCasesRunner/LinkedTestCaseResult.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/LinkedTestCaseResult.cs
@@ -7,13 +7,19 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 		public readonly NPath InputAssemblyPath;
 		public readonly NPath OutputAssemblyPath;
 		public readonly NPath ExpectationsAssemblyPath;
+		public readonly TestCaseSandbox Sandbox;
+		public readonly TestCaseMetadaProvider MetadataProvider;
+		public readonly ManagedCompilationResult CompilationResult;
 
-		public LinkedTestCaseResult (TestCase testCase, NPath inputAssemblyPath, NPath outputAssemblyPath, NPath expectationsAssemblyPath)
+		public LinkedTestCaseResult (TestCase testCase, NPath inputAssemblyPath, NPath outputAssemblyPath, NPath expectationsAssemblyPath, TestCaseSandbox sandbox, TestCaseMetadaProvider metadaProvider, ManagedCompilationResult compilationResult)
 		{
 			TestCase = testCase;
 			InputAssemblyPath = inputAssemblyPath;
 			OutputAssemblyPath = outputAssemblyPath;
 			ExpectationsAssemblyPath = expectationsAssemblyPath;
+			Sandbox = sandbox;
+			MetadataProvider = metadaProvider;
+			CompilationResult = compilationResult;
 		}
 	}
 }

--- a/test/Mono.Linker.Tests/TestCasesRunner/TestRunner.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestRunner.cs
@@ -31,6 +31,12 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			}
 		}
 
+		public virtual LinkedTestCaseResult Relink (LinkedTestCaseResult result)
+		{
+			PrepForLink (result.Sandbox, result.CompilationResult);
+			return Link (result.TestCase, result.Sandbox, result.CompilationResult, result.MetadataProvider);
+		}
+
 		private TestCaseSandbox Sandbox (TestCase testCase, TestCaseMetadaProvider metadataProvider)
 		{
 			var sandbox = _factory.CreateSandbox (testCase);
@@ -92,7 +98,7 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 
 			linker.Link (builder.ToArgs ());
 
-			return new LinkedTestCaseResult (testCase, compilationResult.InputAssemblyPath, sandbox.OutputDirectory.Combine (compilationResult.InputAssemblyPath.FileName), compilationResult.ExpectationsAssemblyPath);
+			return new LinkedTestCaseResult (testCase, compilationResult.InputAssemblyPath, sandbox.OutputDirectory.Combine (compilationResult.InputAssemblyPath.FileName), compilationResult.ExpectationsAssemblyPath, sandbox, metadataProvider, compilationResult);
 		}
 
 		protected virtual void AddLinkOptions (TestCaseSandbox sandbox, ManagedCompilationResult compilationResult, LinkerArgumentBuilder builder, TestCaseMetadaProvider metadataProvider)


### PR DESCRIPTION
A number of changes to command line options related to assembly mvid's have been made recently and no tests were added.  This PR adds tests and also makes it easier to write tests for changes such as https://github.com/mono/linker/pull/583