### PR TITLE
Add custom logic for reflection-emit to RemoveFeaturesStep.

### DIFF
--- a/src/linker/Linker.Steps/RemoveFeaturesStep.cs
+++ b/src/linker/Linker.Steps/RemoveFeaturesStep.cs
@@ -59,10 +59,12 @@ namespace Mono.Linker.Steps
 			}
 
 			if (FeatureSRE) {
-				if (type.FullName == "System.RuntimeType") {
+				if (type.Namespace == "System" && type.Name == "RuntimeType") {
 					foreach (var method in type.Methods) {
-						if (method.Name == "MakeTypeBuilderInstantiation")
+						if (method.Name == "MakeTypeBuilderInstantiation") {
 							Annotations.SetAction (method, MethodAction.ConvertToThrow);
+							break;
+						}
 					}
 				}
 			}

--- a/src/linker/Linker.Steps/RemoveFeaturesStep.cs
+++ b/src/linker/Linker.Steps/RemoveFeaturesStep.cs
@@ -12,6 +12,7 @@ namespace Mono.Linker.Steps
 
 		public bool FeatureCOM { get; set; }
 		public bool FeatureETW { get; set; }
+		public bool FeatureSRE { get; set; }
 
 		//
 		// Manually overrides System.Globalization.Invariant mode
@@ -55,6 +56,15 @@ namespace Mono.Linker.Steps
 					ExcludeEventSource (type);
 				else if (BCL.EventTracingForWindows.IsEventSourceImplementation (type))
 					ExcludeEventSourceImplementation (type);
+			}
+
+			if (FeatureSRE) {
+				if (type.FullName == "System.RuntimeType") {
+					foreach (var method in type.Methods) {
+						if (method.Name == "MakeTypeBuilderInstantiation")
+							Annotations.SetAction (method, MethodAction.ConvertToThrow);
+					}
+				}
 			}
 
 			if (RemoveCustomAttributes (type)) {

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -369,6 +369,7 @@ namespace Mono.Linker {
 					p.AddStepBefore (typeof (MarkStep), new RemoveFeaturesStep () {
 						FeatureCOM = excluded_features.Contains ("com"),
 						FeatureETW = excluded_features.Contains ("etw"),
+						FeatureSRE = excluded_features.Contains ("sre"),
 						FeatureGlobalization = excluded_features.Contains ("globalization")
 					});
 


### PR DESCRIPTION
When `--exclude-feature sre` is provided, then we rewrite the `System.RuntimeType.MakeTypeBuilderInstantiation` to throw.