### PR TITLE
Add tests for mvid options and symbol files

### DIFF
--- a/test/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/test/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Condition=" $(Configuration.StartsWith('illink')) ">
     <TargetFramework>netcoreapp3.0</TargetFramework>
@@ -333,6 +333,14 @@
     <Compile Include="Inheritance.VirtualMethods\UsedTypeWithOverrideOfVirtualMethodHasOverrideKept.cs" />
     <Compile Include="Inheritance.VirtualMethods\VirtualMethodGetsPerservedIfBaseMethodGetsInvoked.cs" />
     <Compile Include="Inheritance.VirtualMethods\VirtualMethodGetsStrippedIfImplementingMethodGetsInvokedDirectly.cs" />
+    <Compile Include="Symbols\ReferenceWithEmbeddedPdbAndSymbolLinkingEnabledAndDeterministicMvid.cs" />
+    <Compile Include="Symbols\ReferenceWithEmbeddedPdbAndSymbolLinkingEnabledAndNewMvid.cs" />
+    <Compile Include="Symbols\ReferenceWithMdbAndSymbolLinkingEnabledAndDeterministicMvid.cs" />
+    <Compile Include="Symbols\ReferenceWithMdbAndSymbolLinkingEnabledAndNewMvid.cs" />
+    <Compile Include="Symbols\ReferenceWithPdbAndSymbolLinkingEnabledAndDeterministicMvid.cs" />
+    <Compile Include="Symbols\ReferenceWithPdbAndSymbolLinkingEnabledAndNewMvid.cs" />
+    <Compile Include="Symbols\ReferenceWithPortablePdbAndSymbolLinkingEnabledAndDeterministicMvid.cs" />
+    <Compile Include="Symbols\ReferenceWithPortablePdbAndSymbolLinkingEnabledAndNewMvid.cs" />
     <Compile Include="UnreachableBody\BodyWithManyVariables.cs" />
     <Compile Include="UnreachableBody\BodyWithManyVariablesWithSymbols.cs" />
     <Compile Include="UnreachableBody\CanDisableLazyBodyMarking.cs" />

--- a/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithEmbeddedPdbAndSymbolLinkingEnabledAndDeterministicMvid.cs
+++ b/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithEmbeddedPdbAndSymbolLinkingEnabledAndDeterministicMvid.cs
@@ -1,0 +1,20 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Symbols.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.Symbols {
+	[SetupCompileBefore ("LibraryWithEmbeddedPdbSymbols.dll", new[] { "Dependencies/LibraryWithEmbeddedPdbSymbols.cs" }, additionalArguments: "/debug:embedded", compilerToUse: "csc")]
+	[SetupLinkerLinkSymbols ("true")]
+	[SetupLinkerArgument ("--deterministic")]
+
+	[KeptSymbols ("LibraryWithEmbeddedPdbSymbols.dll")]
+
+	[KeptMemberInAssembly ("LibraryWithEmbeddedPdbSymbols.dll", typeof (LibraryWithEmbeddedPdbSymbols), "SomeMethod()")]
+	[RemovedMemberInAssembly ("LibraryWithEmbeddedPdbSymbols.dll", typeof (LibraryWithEmbeddedPdbSymbols), "NotUsed()")]
+	public class ReferenceWithEmbeddedPdbAndSymbolLinkingEnabledAndDeterministicMvid {
+		static void Main ()
+		{
+			LibraryWithEmbeddedPdbSymbols.SomeMethod ();
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithEmbeddedPdbAndSymbolLinkingEnabledAndNewMvid.cs
+++ b/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithEmbeddedPdbAndSymbolLinkingEnabledAndNewMvid.cs
@@ -1,0 +1,20 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Symbols.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.Symbols {
+	[SetupCompileBefore ("LibraryWithEmbeddedPdbSymbols.dll", new[] { "Dependencies/LibraryWithEmbeddedPdbSymbols.cs" }, additionalArguments: "/debug:embedded", compilerToUse: "csc")]
+	[SetupLinkerLinkSymbols ("true")]
+	[SetupLinkerArgument ("--deterministic")]
+
+	[KeptSymbols ("LibraryWithEmbeddedPdbSymbols.dll")]
+
+	[KeptMemberInAssembly ("LibraryWithEmbeddedPdbSymbols.dll", typeof (LibraryWithEmbeddedPdbSymbols), "SomeMethod()")]
+	[RemovedMemberInAssembly ("LibraryWithEmbeddedPdbSymbols.dll", typeof (LibraryWithEmbeddedPdbSymbols), "NotUsed()")]
+	public class ReferenceWithEmbeddedPdbAndSymbolLinkingEnabledAndNewMvid {
+		static void Main ()
+		{
+			LibraryWithEmbeddedPdbSymbols.SomeMethod ();
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdbAndSymbolLinkingEnabledAndDeterministicMvid.cs
+++ b/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdbAndSymbolLinkingEnabledAndDeterministicMvid.cs
@@ -1,0 +1,34 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Symbols.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.Symbols {
+	[IgnoreTestCase ("Requires cecil updated with fix for https://github.com/jbevain/cecil/issues/583")]
+	[Reference ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll")]
+	[ReferenceDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb")]
+	[SetupLinkerLinkSymbols ("true")]
+	[SetupLinkerArgument ("--deterministic")]
+
+	[KeptSymbols ("LibraryWithMdb.dll")]
+
+	[KeptMemberInAssembly ("LibraryWithMdb.dll", typeof (LibraryWithMdb), "SomeMethod()")]
+	[RemovedMemberInAssembly ("LibraryWithMdb.dll", typeof (LibraryWithMdb), "NotUsed()")]
+	public class ReferenceWithMdbAndSymbolLinkingEnabledAndDeterministicMvid {
+		static void Main ()
+		{
+			// Use some stuff so that we can verify that the linker output correct results
+			SomeMethod ();
+
+			LibraryWithMdb.SomeMethod ();
+		}
+
+		[Kept]
+		static void SomeMethod ()
+		{
+		}
+
+		static void NotUsed ()
+		{
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdbAndSymbolLinkingEnabledAndNewMvid.cs
+++ b/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdbAndSymbolLinkingEnabledAndNewMvid.cs
@@ -1,0 +1,33 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Symbols.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.Symbols {
+	[Reference ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll")]
+	[ReferenceDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb")]
+	[SetupLinkerLinkSymbols ("true")]
+	[SetupLinkerArgument ("--new-mvid", "true")]
+
+	[KeptSymbols ("LibraryWithMdb.dll")]
+
+	[KeptMemberInAssembly ("LibraryWithMdb.dll", typeof (LibraryWithMdb), "SomeMethod()")]
+	[RemovedMemberInAssembly ("LibraryWithMdb.dll", typeof (LibraryWithMdb), "NotUsed()")]
+	public class ReferenceWithMdbAndSymbolLinkingEnabledAndNewMvid {
+		static void Main ()
+		{
+			// Use some stuff so that we can verify that the linker output correct results
+			SomeMethod ();
+
+			LibraryWithMdb.SomeMethod ();
+		}
+
+		[Kept]
+		static void SomeMethod ()
+		{
+		}
+
+		static void NotUsed ()
+		{
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbAndSymbolLinkingEnabledAndDeterministicMvid.cs
+++ b/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbAndSymbolLinkingEnabledAndDeterministicMvid.cs
@@ -1,0 +1,35 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Symbols.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.Symbols {
+	[Reference ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll")]
+	[ReferenceDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb")]
+	[SetupLinkerLinkSymbols( "true")]
+	[SetupLinkerArgument ("--deterministic")]
+
+#if WIN32
+	[KeptSymbols ("LibraryWithPdb.dll")]
+#else
+	[RemovedSymbols ("LibraryWithPdb.dll")]
+#endif
+	[KeptMemberInAssembly ("LibraryWithPdb.dll", typeof (LibraryWithPdb), "SomeMethod()")]
+	[RemovedMemberInAssembly ("LibraryWithPdb.dll", typeof (LibraryWithPdb), "NotUsed()")]
+	public class ReferenceWithPdbAndSymbolLinkingEnabledAndDeterministicMvid {
+		static void Main ()
+		{
+			// Use some stuff so that we can verify that the linker output correct results
+			SomeMethod();
+			LibraryWithPdb.SomeMethod ();
+		}
+
+		[Kept]
+		static void SomeMethod ()
+		{
+		}
+
+		static void NotUsed ()
+		{
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbAndSymbolLinkingEnabledAndNewMvid.cs
+++ b/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbAndSymbolLinkingEnabledAndNewMvid.cs
@@ -1,0 +1,35 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Symbols.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.Symbols {
+	[Reference ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll")]
+	[ReferenceDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb")]
+	[SetupLinkerLinkSymbols( "true")]
+	[SetupLinkerArgument ("--new-mvid", "true")]
+
+#if WIN32
+	[KeptSymbols ("LibraryWithPdb.dll")]
+#else
+	[RemovedSymbols ("LibraryWithPdb.dll")]
+#endif
+	[KeptMemberInAssembly ("LibraryWithPdb.dll", typeof (LibraryWithPdb), "SomeMethod()")]
+	[RemovedMemberInAssembly ("LibraryWithPdb.dll", typeof (LibraryWithPdb), "NotUsed()")]
+	public class ReferenceWithPdbAndSymbolLinkingEnabledAndNewMvid {
+		static void Main ()
+		{
+			// Use some stuff so that we can verify that the linker output correct results
+			SomeMethod();
+			LibraryWithPdb.SomeMethod ();
+		}
+
+		[Kept]
+		static void SomeMethod ()
+		{
+		}
+
+		static void NotUsed ()
+		{
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPortablePdbAndSymbolLinkingEnabledAndDeterministicMvid.cs
+++ b/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPortablePdbAndSymbolLinkingEnabledAndDeterministicMvid.cs
@@ -1,0 +1,21 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Symbols.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.Symbols {
+	[IgnoreTestCase ("Requires cecil updated with fix for https://github.com/jbevain/cecil/issues/583")]
+	[SetupCompileBefore ("LibraryWithPortablePdbSymbols.dll", new[] { "Dependencies/LibraryWithPortablePdbSymbols.cs" }, additionalArguments: "/debug:portable", compilerToUse: "csc")]
+	[SetupLinkerLinkSymbols ("true")]
+	[SetupLinkerArgument ("--deterministic")]
+
+	[KeptSymbols ("LibraryWithPortablePdbSymbols.dll")]
+
+	[KeptMemberInAssembly ("LibraryWithPortablePdbSymbols.dll", typeof (LibraryWithPortablePdbSymbols), "SomeMethod()")]
+	[RemovedMemberInAssembly ("LibraryWithPortablePdbSymbols.dll", typeof (LibraryWithPortablePdbSymbols), "NotUsed()")]
+	public class ReferenceWithPortablePdbAndSymbolLinkingEnabledAndDeterministicMvid {
+		static void Main()
+		{
+			LibraryWithPortablePdbSymbols.SomeMethod ();
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPortablePdbAndSymbolLinkingEnabledAndNewMvid.cs
+++ b/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPortablePdbAndSymbolLinkingEnabledAndNewMvid.cs
@@ -1,0 +1,20 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Symbols.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.Symbols {
+	[SetupCompileBefore ("LibraryWithPortablePdbSymbols.dll", new[] { "Dependencies/LibraryWithPortablePdbSymbols.cs" }, additionalArguments: "/debug:portable", compilerToUse: "csc")]
+	[SetupLinkerLinkSymbols ("true")]
+	[SetupLinkerArgument ("--new-mvid", "true")]
+
+	[KeptSymbols ("LibraryWithPortablePdbSymbols.dll")]
+
+	[KeptMemberInAssembly ("LibraryWithPortablePdbSymbols.dll", typeof (LibraryWithPortablePdbSymbols), "SomeMethod()")]
+	[RemovedMemberInAssembly ("LibraryWithPortablePdbSymbols.dll", typeof (LibraryWithPortablePdbSymbols), "NotUsed()")]
+	public class ReferenceWithPortablePdbAndSymbolLinkingEnabledAndNewMvid {
+		static void Main()
+		{
+			LibraryWithPortablePdbSymbols.SomeMethod ();
+		}
+	}
+}


### PR DESCRIPTION
The test for mdb + deterministic mvid and portable pdb + deterministic mvid had to be ignored because they encounter https://github.com/jbevain/cecil/issues/583