### PR TITLE
Allow some Globalization code to be dynamically removed.

### DIFF
--- a/src/linker/Linker.Steps/RemoveFeaturesStep.cs
+++ b/src/linker/Linker.Steps/RemoveFeaturesStep.cs
@@ -69,6 +69,9 @@ namespace Mono.Linker.Steps
 				}
 			}
 
+			if (FeatureGlobalization)
+				ExcludeGlobalization (type);
+
 			if (RemoveCustomAttributes (type)) {
 				if (FeatureCOM && type.IsImport) {
 					type.IsImport = false;
@@ -86,6 +89,66 @@ namespace Mono.Linker.Steps
 
 			foreach (var nested in type.NestedTypes)
 				ProcessType (nested);
+		}
+
+		void ExcludeGlobalization (TypeDefinition type)
+		{
+			switch (type.Namespace) {
+			case "System.Globalization":
+				switch (type.Name) {
+				case "CalendarData":
+					foreach (var method in type.Methods) {
+						switch (method.Name) {
+						case "GetJapaneseEraNames":
+						case "GetJapaneseEnglishEraNames":
+							Annotations.SetAction (method, MethodAction.ConvertToThrow);
+							break;
+						}
+					}
+					break;
+				case "DateTimeFormatInfo":
+					foreach (var method in type.Methods) {
+						switch (method.Name) {
+						case "PopulateSpecialTokenHashTable":
+						case "GetJapaneseCalendarDTFI":
+						case "GetTaiwanCalendarDTFI":
+						case "IsJapaneseCalendar":
+						case "TryParseHebrewNumber":
+							Annotations.SetAction (method, MethodAction.ConvertToThrow);
+							break;
+						}
+					}
+					break;
+				}
+				break;
+			case "System":
+				switch (type.Name) {
+				case "DateTimeFormat":
+					foreach (var method in type.Methods) {
+						switch (method.Name) {
+						case "HebrewFormatDigits":
+						case "FormatHebrewMonthName":
+							Annotations.SetAction (method, MethodAction.ConvertToThrow);
+							break;
+						}
+					}
+					break;
+				case "DateTimeParse":
+					foreach (var method in type.Methods) {
+						switch (method.Name) {
+						case "GetJapaneseCalendarDefaultInstance":
+						case "GetTaiwanCalendarDefaultInstance":
+						case "ProcessHebrewTerminalState":
+						case "GetHebrewDayOfNM":
+						case "MatchHebrewDigits":
+							Annotations.SetAction (method, MethodAction.ConvertToThrow);
+							break;
+						}
+					}
+					break;
+				}
+				break;
+			}
 		}
 
 		void ExcludeEventSource (TypeDefinition type)


### PR DESCRIPTION
Rationale: allow dynamic removal (as it without rebuilding corlib) of some of the globalization code when `--exclude-feature globalization` is provided.

Currently removes the Japanese, Taiwan and Hebrew calendars as well as Hebrew numbers.

This requires https://github.com/mono/corefx/pull/298 and https://github.com/mono/mono/pull/14825.

We are using the same techinique as previously employed in https://github.com/mono/linker/pull/590 to dynamically remove the `System.Reflection.Emit` code.

Since the linker does not currently support dead code elimination, it cannot break down any conditionals inside method bodies.  One trick that we use to work around this is to move those conditional pieces into separate methods; then we can give the linker a list of those methods and tell it to replace their bodies with exceptions.

After this has been done in the BCL, we need to explicitly tell the linker to turn those method bodies into stubs when `--exclude-feature globalization`.

Ideally, we would want to use `MethodAction.ConvertToStub` instead of `ConvertToThrow` here, but we'd have to extend the code rewriter first to support methods with arbitrary return types and parameters.