### PR TITLE
Adjust how tests are asserted

### DIFF
--- a/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -49,19 +49,16 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			try
 			{
 				var original = ResolveOriginalsAssembly (linkResult.ExpectationsAssemblyPath.FileNameWithoutExtension);
+				var linked = ResolveLinkedAssembly (linkResult.OutputAssemblyPath.FileNameWithoutExtension);
+
+				InitialChecking (linkResult, original, linked);
+
 				PerformOutputAssemblyChecks (original, linkResult.OutputAssemblyPath.Parent);
 				PerformOutputSymbolChecks (original, linkResult.OutputAssemblyPath.Parent);
-
-				var linked = ResolveLinkedAssembly (linkResult.OutputAssemblyPath.FileNameWithoutExtension);
 
 				CreateAssemblyChecker (original, linked).Verify ();
 
 				VerifyLinkingOfOtherAssemblies (original);
-
-#if !NETCOREAPP
-				// the PE Verifier does not know how to resolve .NET Core assemblies.
-				_peVerifier.Check (linkResult, original);
-#endif
 
 				AdditionalChecking (linkResult, original, linked);
 			}
@@ -168,6 +165,14 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 
 		protected virtual void AdditionalChecking (LinkedTestCaseResult linkResult, AssemblyDefinition original, AssemblyDefinition linked)
 		{
+		}
+
+		protected virtual void InitialChecking (LinkedTestCaseResult linkResult, AssemblyDefinition original, AssemblyDefinition linked)
+		{
+#if !NETCOREAPP
+			// the PE Verifier does not know how to resolve .NET Core assemblies.
+			_peVerifier.Check (linkResult, original);
+#endif
 		}
 
 		void VerifyLinkingOfOtherAssemblies (AssemblyDefinition original)


### PR DESCRIPTION
We are hitting ever more complex scenarios in our linker.  I'm finding that I'd rather know that the IL was valid before worrying about getting all the types, methods, etc correctly annotated with [Kept] attributes.

In our linker test framework we have extra attributes to allow for the cases to be executed and the output asserted.  `InitialChecking` will be the place where we do that.  Again, I'd rather see these failures first before I invest the time correctly annotating the kept attributes.