### PR TITLE
Add a test with an unmanaged constraint

### DIFF
--- a/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/MethodWithUnmanagedConstraint.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/MethodWithUnmanagedConstraint.cs
@@ -1,0 +1,25 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed {
+	[SetupCSharpCompilerToUse ("csc")]
+	[SetupCompileArgument ("/langversion:7.3")]
+	[SetupLinkerArgument ("--used-attrs-only", "true")]
+	public class MethodWithUnmanagedConstraint {
+		public static void Main ()
+		{
+			Method<int> ();
+		}
+
+		/// <summary>
+		/// The compiler will generate a CustomAttribute that is of type IsUnmanagedAttribute.  By not annotating the attribute
+		/// as being kept we are asserting that the IsUnmanagedAttribute is removed, which is expected because the attribute is
+		/// only needed at compile time
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		[Kept]
+		static void Method<T> () where T : unmanaged
+		{
+		}
+	}
+}

--- a/test/Mono.Linker.Tests/TestCasesRunner/TestCaseCompiler.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestCaseCompiler.cs
@@ -201,7 +201,7 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 #if NETCOREAPP
 		protected virtual NPath CompileCSharpAssemblyWithRoslyn (CompilerOptions options)
 		{
-			var parseOptions = new CSharpParseOptions (preprocessorSymbols: options.Defines);
+			var languageVersion = LanguageVersion.Default;
 			var compilationOptions = new CSharpCompilationOptions (
 				outputKind: options.OutputPath.FileName.EndsWith (".exe") ? OutputKind.ConsoleApplication : OutputKind.DynamicallyLinkedLibrary,
 				assemblyIdentityComparer: DesktopAssemblyIdentityComparer.Default
@@ -231,9 +231,14 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 							emitPdb = true;
 							debugType = DebugInformationFormat.Embedded;
 							break;
+						case "/langversion:7.3":
+							languageVersion = LanguageVersion.CSharp7_3;
+							break;
+							
 					}
 				}
 			}
+			var parseOptions = new CSharpParseOptions (preprocessorSymbols: options.Defines, languageVersion: languageVersion);
 			var emitOptions = new EmitOptions (debugInformationFormat: debugType);
 			var pdbPath = (!emitPdb || debugType == DebugInformationFormat.Embedded) ? null : options.OutputPath.ChangeExtension (".pdb").ToString ();
 


### PR DESCRIPTION
Only added a test for when used-attrs-only is used for 2 reasons
1) That's the more interesting scenario
2) Annotating all of the compiler generated types that would survive without used-attrs-only is not possible with the current test framework abilities