### PR TITLE
Skip C++/CLI assemblies

### DIFF
--- a/src/ILLink.Tasks/Utils.cs
+++ b/src/ILLink.Tasks/Utils.cs
@@ -1,5 +1,6 @@
 using System;
 using Mono.Cecil;
+using System.Linq;
 
 public static class Utils
 {
@@ -7,9 +8,16 @@ public static class Utils
 	{
 		try {
 			ModuleDefinition module = ModuleDefinition.ReadModule (fileName);
-			return true;
+			return !IsCPPCLIAssembly (module);
 		} catch (BadImageFormatException) {
 			return false;
 		}
+	}
+
+	private static bool IsCPPCLIAssembly (ModuleDefinition module)
+	{
+		return module.Types.Any(t =>
+			t.Namespace == "<CppImplementationDetails>" ||
+			t.Namespace == "<CrtImplementationDetails>");
 	}
 }


### PR DESCRIPTION
This will skip linking of C++/CLI assemblies. See https://github.com/mono/linker/issues/651 for context.

There are potentially some issues with skipping the C++/CLI assembly entirely - any calls that the assembly makes to .NET dlls will no longer be analyzed. This may result in some required dependencies being dropped, though I don't know how likely that is in practice. The ideal fix would be to address https://github.com/mono/linker/issues/639 (or to preserve the ordering of the relevant C++/CLI data when linking as mentioned in https://github.com/mono/linker/issues/651#issuecomment-510689413), which would still result in the assembly being analyzed.

I marked this do not merge until we have some more confidence that this is the right fix.