### PR TITLE
Try to fix codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 # the default owners for everything in the repo.
 * @marek-safar
 
-/src/analyzer @radekdoulik
-/src/ILLink.Tasks @sbomer
-/src/linker @marek-safar @mrvoorhe
-/test @marek-safar @mrvoorhe
+/src/analyzer/ @radekdoulik
+/src/ILLink.Tasks/ @sbomer
+/src/linker/ @marek-safar @mrvoorhe
+/test/ @marek-safar @mrvoorhe


### PR DESCRIPTION
I think the reason the codeowners hasn't been working is because the directory paths need to end with a `/`