### PR TITLE
Respect embedded xml files from copy assemblies

### DIFF
--- a/src/linker/Linker.Steps/BlacklistStep.cs
+++ b/src/linker/Linker.Steps/BlacklistStep.cs
@@ -93,6 +93,7 @@ namespace Mono.Linker.Steps {
 			case AssemblyAction.Link:
 			case AssemblyAction.AddBypassNGen:
 			case AssemblyAction.AddBypassNGenUsed:
+			case AssemblyAction.Copy:
 				return true;
 			default:
 				return false;

--- a/test/Mono.Linker.Tests.Cases/LinkXml/Dependencies/EmbeddedLinkXmlFromCopyAssemblyIsProcessed/CopyLibrary.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/Dependencies/EmbeddedLinkXmlFromCopyAssemblyIsProcessed/CopyLibrary.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Mono.Linker.Tests.Cases.LinkXml.Dependencies.EmbeddedLinkXmlFromCopyAssemblyIsProcessed
+{
+	public class CopyLibrary {
+		public void Method ()
+		{
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/LinkXml/Dependencies/EmbeddedLinkXmlFromCopyAssemblyIsProcessed/CopyLibrary.xml
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/Dependencies/EmbeddedLinkXmlFromCopyAssemblyIsProcessed/CopyLibrary.xml
@@ -1,0 +1,3 @@
+<linker>
+    <assembly fullname="Library" />
+</linker>

--- a/test/Mono.Linker.Tests.Cases/LinkXml/Dependencies/EmbeddedLinkXmlFromCopyAssemblyIsProcessed/OtherLibrary.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/Dependencies/EmbeddedLinkXmlFromCopyAssemblyIsProcessed/OtherLibrary.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Mono.Linker.Tests.Cases.LinkXml.Dependencies.EmbeddedLinkXmlFromCopyAssemblyIsProcessed
+{
+	public class OtherLibrary {
+		public void Method ()
+		{
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/LinkXml/EmbeddedLinkXmlFromCopyAssemblyIsProcessed.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/EmbeddedLinkXmlFromCopyAssemblyIsProcessed.cs
@@ -7,7 +7,6 @@ namespace Mono.Linker.Tests.Cases.LinkXml {
 		new [] { "Dependencies/EmbeddedLinkXmlFromCopyAssemblyIsProcessed/OtherLibrary.cs" })]
 	[SetupCompileBefore ("CopyLibrary.dll",
 		new [] { "Dependencies/EmbeddedLinkXmlFromCopyAssemblyIsProcessed/CopyLibrary.cs" },
-		new [] { "Library.dll" },
 		resources: new [] { "Dependencies/EmbeddedLinkXmlFromCopyAssemblyIsProcessed/CopyLibrary.xml"})]
 	[IncludeBlacklistStep (true)]
 	[SetupLinkerAction ("copy", "CopyLibrary")]

--- a/test/Mono.Linker.Tests.Cases/LinkXml/EmbeddedLinkXmlFromCopyAssemblyIsProcessed.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/EmbeddedLinkXmlFromCopyAssemblyIsProcessed.cs
@@ -1,0 +1,24 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.LinkXml.Dependencies.EmbeddedLinkXmlFromCopyAssemblyIsProcessed;
+
+namespace Mono.Linker.Tests.Cases.LinkXml {
+	[SetupCompileBefore ("Library.dll",
+		new [] { "Dependencies/EmbeddedLinkXmlFromCopyAssemblyIsProcessed/OtherLibrary.cs" })]
+	[SetupCompileBefore ("CopyLibrary.dll",
+		new [] { "Dependencies/EmbeddedLinkXmlFromCopyAssemblyIsProcessed/CopyLibrary.cs" },
+		new [] { "Library.dll" },
+		resources: new [] { "Dependencies/EmbeddedLinkXmlFromCopyAssemblyIsProcessed/CopyLibrary.xml"})]
+	[IncludeBlacklistStep (true)]
+	[SetupLinkerAction ("copy", "CopyLibrary")]
+
+	[KeptTypeInAssembly ("CopyLibrary.dll", typeof (CopyLibrary))]
+	[KeptTypeInAssembly ("Library.dll", typeof (OtherLibrary))]
+	public class EmbeddedLinkXmlFromCopyAssemblyIsProcessed {
+		public static void Main ()
+		{
+			var tmp = new CopyLibrary ();
+			tmp.Method ();
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/test/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -63,6 +63,7 @@
     <Content Include="LinkXml\CanPreserveAnExportedType.xml" />
     <Content Include="LinkXml\CanPreserveExportedTypesUsingRegex.xml" />
     <Content Include="LinkXml\Dependencies\EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod\Library1.xml" />
+    <Content Include="LinkXml\Dependencies\EmbeddedLinkXmlFromCopyAssemblyIsProcessed\CopyLibrary.xml" />
     <Content Include="LinkXml\FeatureExclude\OnAssembly.xml" />
     <Content Include="LinkXml\FeatureExclude\OnEvent.xml" />
     <Content Include="LinkXml\FeatureExclude\OnField.xml" />


### PR DESCRIPTION
The embedded xml files should be respected from copy assemblies the same way they are for link assemblies. I'm actually not sure why we respect them for AddBypassNGenUsed - I would expect that for assemblies that do not end up being used (even if they have action CopyUsed or AddBypassNGenUsed), we don't add roots from xml.

Necessary to make https://github.com/dotnet/wpf/pull/1387 work. We're adding roots to WPF assemblies to work around the linker's inability to process C++/CLI assemblies (https://github.com/mono/linker/pull/658).

@marek-safar PTAL.