### PR TITLE
Improve Error Experience in the linker

### DIFF
--- a/src/ILLink.Tasks/LinkTask.cs
+++ b/src/ILLink.Tasks/LinkTask.cs
@@ -95,6 +95,8 @@ namespace ILLink.Tasks
 
 
 		/// ToolTask implementation
+		
+		protected override MessageImportance StandardErrorLoggingImportance => MessageImportance.High;
 
 		protected override string ToolName => Path.GetFileName (DotNetPath);
 

--- a/src/linker/Linker.Steps/ResolveFromXmlStep.cs
+++ b/src/linker/Linker.Steps/ResolveFromXmlStep.cs
@@ -104,7 +104,7 @@ namespace Mono.Linker.Steps {
 		{
 			while (iterator.MoveNext ()) {
 				AssemblyDefinition assembly = GetAssembly (context, GetAssemblyName (iterator.Current));
-				if(assembly != null)
+				if (assembly != null)
 					ProcessAssembly (assembly, iterator);
 			}
 		}

--- a/src/linker/Linker.Steps/ResolveFromXmlStep.cs
+++ b/src/linker/Linker.Steps/ResolveFromXmlStep.cs
@@ -104,7 +104,8 @@ namespace Mono.Linker.Steps {
 		{
 			while (iterator.MoveNext ()) {
 				AssemblyDefinition assembly = GetAssembly (context, GetAssemblyName (iterator.Current));
-				ProcessAssembly (assembly, iterator);
+				if(assembly != null)
+					ProcessAssembly (assembly, iterator);
 			}
 		}
 

--- a/src/linker/Linker/AssemblyResolver.cs
+++ b/src/linker/Linker/AssemblyResolver.cs
@@ -121,7 +121,7 @@ namespace Mono.Linker {
 				} catch (AssemblyResolutionException) {
 					if (!_ignoreUnresolved)
 						throw;
-					_context.LogMessage ($"warning: unresolved assembly {name.Name}, skipping this assembly");
+					_context.LogMessage ($"Ignoring unresolved assembly '{name.Name}'.");
 					if (_unresolvedAssemblies == null)
 						_unresolvedAssemblies = new HashSet<string> ();
 					_unresolvedAssemblies.Add (name.Name);

--- a/src/linker/Linker/AssemblyResolver.cs
+++ b/src/linker/Linker/AssemblyResolver.cs
@@ -121,7 +121,10 @@ namespace Mono.Linker {
 				} catch (AssemblyResolutionException) {
 					if (!_ignoreUnresolved)
 						throw;
-
+					
+					char[] invalidChars = { '\'', '/', ' ', ':', '!', '@', '#', '$', '^', '&', '*', '(', ')', '+', '=', '{', '}', '[', ']', ',', '<', '>', '?', '\\', '|', '`', '~', '°', '¬' };
+					if (name.Name.IndexOfAny(invalidChars) != -1)
+						_context.LogMessage($"warning: suspicious characters had been entered, verify your assembly name is correct");
 					_context.LogMessage ($"warning: unresolved assembly {name.Name}");
 					if (_unresolvedAssemblies == null)
 						_unresolvedAssemblies = new HashSet<string> ();

--- a/src/linker/Linker/AssemblyResolver.cs
+++ b/src/linker/Linker/AssemblyResolver.cs
@@ -121,11 +121,7 @@ namespace Mono.Linker {
 				} catch (AssemblyResolutionException) {
 					if (!_ignoreUnresolved)
 						throw;
-					
-					char[] invalidChars = { '\'', '/', ' ', ':', '!', '@', '#', '$', '^', '&', '*', '(', ')', '+', '=', '{', '}', '[', ']', ',', '<', '>', '?', '\\', '|', '`', '~', '°', '¬' };
-					if (name.Name.IndexOfAny(invalidChars) != -1)
-						_context.LogMessage($"warning: suspicious characters had been entered, verify your assembly name is correct");
-					_context.LogMessage ($"warning: unresolved assembly {name.Name}");
+					_context.LogMessage ($"warning: unresolved assembly {name.Name}, skipping this assembly");
 					if (_unresolvedAssemblies == null)
 						_unresolvedAssemblies = new HashSet<string> ();
 					_unresolvedAssemblies.Add (name.Name);

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -285,7 +285,7 @@ namespace Mono.Linker {
 		public virtual ICollection<AssemblyDefinition> ResolveReferences (AssemblyDefinition assembly)
 		{
 			List<AssemblyDefinition> references = new List<AssemblyDefinition> ();
-			if(assembly == null)
+			if (assembly == null)
 				return references;
 			foreach (AssemblyNameReference reference in assembly.MainModule.AssemblyReferences) {
 				AssemblyDefinition definition = Resolve (reference);

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -285,6 +285,8 @@ namespace Mono.Linker {
 		public virtual ICollection<AssemblyDefinition> ResolveReferences (AssemblyDefinition assembly)
 		{
 			List<AssemblyDefinition> references = new List<AssemblyDefinition> ();
+			if(assembly == null)
+				return references;
 			foreach (AssemblyNameReference reference in assembly.MainModule.AssemblyReferences) {
 				AssemblyDefinition definition = Resolve (reference);
 				if (definition != null)


### PR DESCRIPTION
src/ILLink.Tasks/LinkTask.cs – Increase Standard Error output logging importance so default verbosity is able to print it

src/linker/Linker/AssemblyResolver.cs – Include a warning message for
suspicious series of common punctuation characters in assembly names,
although supported they are likely typos in assembly names. Warning is
only printed upon failure.

src/linker/Linker/LinkContext.cs – skip assembly if it’s null (means is
an unresolved assembly and skip flag was used)
src/linker/Linker.Steps/ResolveFromXmlStep.cs – skip assembly if it’s
null (means is an unresolved assembly and skip flag was used)

See issue #653 for more information