### PR TITLE
Move CustomAttributes scope updating to sweep step to update only needed ones

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -770,7 +770,7 @@ namespace Mono.Linker.Steps {
 				switch (at.Name) {
 				case "Type":
 					MarkType (argument.Type);
-					MarkWithResolvedScope ((TypeReference)argument.Value);
+					MarkType ((TypeReference)argument.Value);
 					return;
 
 				case "Object":
@@ -780,34 +780,6 @@ namespace Mono.Linker.Steps {
 					return;
 				}
 			}
-		}
-
-		// custom attributes encoding means it's possible to have a scope that will point into a PCL facade
-		// even if we (just before saving) will resolve all type references (bug #26752)
-		void MarkWithResolvedScope (TypeReference type)
-		{
-			if (type == null)
-				return;
-
-			// a GenericInstanceType can could contains generic arguments with scope that
-			// needs to be updated out of the PCL facade (bug #28823)
-			var git = (type as GenericInstanceType);
-			if ((git != null) && git.HasGenericArguments) {
-				foreach (var ga in git.GenericArguments)
-					MarkWithResolvedScope (ga);
-			}
-			// we cannot set the Scope of a TypeSpecification but it's element type can be set
-			// e.g. System.String[] -> System.String
-			var ts = (type as TypeSpecification);
-			if (ts != null) {
-				MarkWithResolvedScope (ts.ElementType);
-				return;
-			}
-
-			var td = type.Resolve ();
-			if (td != null)
-				type.Scope = td.Scope;
-			MarkType (type);
 		}
 
 		protected bool CheckProcessed (IMetadataTokenProvider provider)

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/AttributeArgumentForwarded.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/AttributeArgumentForwarded.cs
@@ -1,0 +1,100 @@
+using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.TypeForwarding.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.TypeForwarding
+{
+	// Actions:
+	// link - This assembly, Forwarder.dll and Implementation.dll
+	[SetupLinkerUserAction ("link")]
+	[KeepTypeForwarderOnlyAssemblies ("false")]
+
+	[SetupCompileBefore ("Forwarder.dll", new[] { "Dependencies/ReferenceImplementationLibrary.cs" }, defines: new[] { "INCLUDE_REFERENCE_IMPL" })]
+
+	// After compiling the test case we then replace the reference impl with implementation + type forwarder
+	[SetupCompileAfter ("Implementation.dll", new[] { "Dependencies/ImplementationLibrary.cs" })]
+	[SetupCompileAfter ("Forwarder.dll", new[] { "Dependencies/ForwarderLibrary.cs" }, references: new[] { "Implementation.dll" })]
+
+	[RemovedAssembly ("Forwarder.dll")]
+	[KeptMemberInAssembly ("Implementation.dll", typeof (ImplementationLibrary))]
+	class AttributeArgumentForwarded
+	{
+		static void Main()
+		{
+			Test_1 ();
+			Test_1b ();
+			Test_1c ();
+			Test_2 ();
+			Test_3 ();
+			Test_3a ();
+		}
+
+		[Kept]
+		[KeptAttributeAttribute (typeof (TestTypeAttribute))]
+		[TestType (typeof (ImplementationLibrary))]
+		public static void Test_1 ()
+		{
+		}
+
+		[Kept]
+		[KeptAttributeAttribute (typeof (TestTypeAttribute))]
+		[TestType (typeof (ImplementationLibrary[,][]))]
+		public static void Test_1b ()
+		{
+		}
+
+		[Kept]
+		[KeptAttributeAttribute (typeof (TestTypeAttribute))]
+		[TestType (typeof (ImplementationLibrary [,] []))]
+		public static void Test_1c ()
+		{
+		}
+
+		[Kept]
+		[KeptAttributeAttribute (typeof (TestTypeAttribute))]
+		[TestType (TestProperty = new object [] { typeof (ImplementationLibrary) })]
+		public static void Test_2 ()
+		{
+		}
+
+		[Kept]
+		[KeptAttributeAttribute (typeof (TestTypeAttribute))]
+		[TestType (TestField = typeof (SomeGenericType<ImplementationLibrary[]>))]
+		public static void Test_3 ()
+		{
+		}
+
+
+		[Kept]
+		[KeptAttributeAttribute (typeof (TestTypeAttribute))]
+		[TestType (TestField = typeof (SomeGenericType<>))]
+		public static void Test_3a ()
+		{
+		}
+	}
+
+	[KeptBaseType (typeof (Attribute))]
+	public class TestTypeAttribute : Attribute {
+		[Kept]
+		public TestTypeAttribute ()
+		{
+		}
+
+		[Kept]
+		public TestTypeAttribute (Type arg)
+		{
+		}
+
+		[KeptBackingField]
+		[Kept]
+		public object TestProperty { get; [Kept] set; }
+
+		[Kept]
+		public object TestField;
+	}
+
+	[Kept]
+	public class SomeGenericType<T> {
+	}
+}


### PR DESCRIPTION
Adds traversing of all CA values. Fixes #737