### PR TITLE
Add attribute test that uses params

### DIFF
--- a/test/Mono.Linker.Tests.Cases/Attributes/TypeUsedInObjectArrayConstructorArgumentOnAttributeIsKept.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes/TypeUsedInObjectArrayConstructorArgumentOnAttributeIsKept.cs
@@ -1,0 +1,28 @@
+using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Attributes {
+	[Foo (EnumThatShouldBeKept.Two)]
+	[KeptAttributeAttribute (typeof (FooAttribute))]
+	public class TypeUsedInObjectArrayConstructorArgumentOnAttributeIsKept {
+		public static void Main () {
+		}
+	}
+
+	[KeptBaseType (typeof (System.Attribute))]
+	class FooAttribute : Attribute {
+		[Kept]
+		public FooAttribute ([KeptAttributeAttribute (typeof (ParamArrayAttribute))] params object[] parameters) {
+		}
+	}
+
+	[Kept]
+	[KeptMember ("value__")]
+	[KeptBaseType (typeof (Enum))]
+	enum EnumThatShouldBeKept {
+		[Kept]
+		One = 1,
+		[Kept]
+		Two = 2,
+	}
+}


### PR DESCRIPTION
It turns out we fixed the same issue as https://github.com/mono/linker/commit/0fd66c9d65da4f60be46d178070d347df296fe4e around the same time it was fixed upstream.  Our test in the UnityLinker code base was slightly different however.  It used params.  Since upstream doesn't have any tests that use params I figured it wouldn't hurt to upstream the test we had.