### PR TITLE
Handle types with interfaces added later

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -243,7 +243,11 @@ namespace Mono.Linker.Steps {
 		{
 			// We may mark an interface type later on.  Which means we need to reprocess any time with one or more interface implementations that have not been marked
 			// and if an interface type is found to be marked and implementation is not marked, then we need to mark that implementation
-			foreach (var type in _typesWithInterfaces) {
+
+			// copy the data to avoid modified while enumerating error potential, which can happen under certain conditions.
+			var typesWithInterfaces = _typesWithInterfaces.ToArray ();
+
+			foreach (var type in typesWithInterfaces) {
 				// Exception, types that have not been flagged as instantiated yet.  These types may not need their interfaces even if the
 				// interface type is marked
 				if (!Annotations.IsInstantiated (type))

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnValueType/StructWithNestedStructImplementingInterface.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnValueType/StructWithNestedStructImplementingInterface.cs
@@ -1,0 +1,82 @@
+using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnValueType {
+	/// <summary>
+	/// This is a specially crafted cases that was able to hit a 'Collection was modified; enumeration operation may not execute.' exception during
+	/// MarkStep.ProcessMarkedTypesWithInterfaces
+	/// </summary>
+	public class StructWithNestedStructImplementingInterface {
+		public static void Main ()
+		{
+			var type = typeof (IBuildable<>);
+			GC.KeepAlive (type);
+			var test = new Profile ();
+			test.Foo ();
+		}
+
+		[Kept]
+		public interface IRunner {
+		}
+
+		public interface IBuildable {
+		}
+
+		[Kept]
+		public interface IBuilder {
+			Result<IRunner> Build (Node node, Node root, World world);
+		}
+
+		[Kept]
+		public interface IBuildable<T> : IBuildable where T : IBuilder, new() {
+		}
+
+		public struct Result<T> : IResult {
+		}
+
+		public class Node {
+		}
+
+		public class World {
+		}
+
+		public interface IResult {
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IBuilder))]
+		[KeptMember (".ctor()")]
+		public abstract class Builder<T> : IBuilder where T : IRunner {
+			public abstract Result<T> Build (Node node, Node root, World world);
+
+			Result<IRunner> IBuilder.Build (Node node, Node root, World world)
+			{
+				return default (Result<IRunner>);
+			}
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IBuildable<Profile.Builder>))]
+		public struct Profile : IBuildable<Profile.Builder> {
+			[Kept]
+			public void Foo ()
+			{
+			}
+
+			[Kept]
+			[KeptInterface (typeof (IRunner))]
+			private sealed class Runner : IRunner {
+			}
+
+			[Kept]
+			[KeptBaseType (typeof(Builder<Runner>))]
+			[KeptMember (".ctor()")]
+			private sealed class Builder : Builder<Runner> {
+				public override Result<Runner> Build (Node node, Node root, World world)
+				{
+					return default (Result<Runner>);
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
The linker `MarkStep` can add new types with interfaces while processing
the existing types with interfaces. Make a copy of the collection to
avoid modifying it while it is being iterated.