### PR TITLE
Overwrite when copying satellite assemblies

### DIFF
--- a/src/linker/Linker.Steps/OutputStep.cs
+++ b/src/linker/Linker.Steps/OutputStep.cs
@@ -201,7 +201,7 @@ namespace Mono.Linker.Steps {
 				string culturePath = Path.Combine (directory, cultureName);
 
 				Directory.CreateDirectory (culturePath);
-				File.Copy (satelliteAssembly, Path.Combine (culturePath, resourceFile));
+				File.Copy (satelliteAssembly, Path.Combine (culturePath, resourceFile), true);
 			}
 		}
 


### PR DESCRIPTION
This fixes a failure on Xamarin.Android