### PR TITLE
Fix tests

### DIFF
--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallString.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallString.cs
@@ -6,7 +6,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Reflection
 {
-	[SetupCompileArgument ("/r:System.Core.dll")]
+	[Reference ("System.Core.dll")]
 	public class ExpressionCallString
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallStringAndLocals.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallStringAndLocals.cs
@@ -4,7 +4,7 @@ using System;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Reflection {
-	[SetupCompileArgument ("/r:System.Core.dll")]
+	[Reference ("System.Core.dll")]
 	public class ExpressionCallStringAndLocals {
 		public static void Main ()
 		{

--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionFieldString.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionFieldString.cs
@@ -4,7 +4,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Reflection
 {
-	[SetupCompileArgument ("/r:System.Core.dll")]
+	[Reference ("System.Core.dll")]
 	public class ExpressionFieldString
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionPropertyString.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionPropertyString.cs
@@ -4,25 +4,34 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Reflection
 {
-	[SetupCompileArgument ("/r:System.Core.dll")]
+	// Explicitly use roslyn to try and get a compiler that supports defining `TestOnlyStatic2` without a setter
+	[SetupCSharpCompilerToUse ("csc")]
+	[Reference ("System.Core.dll")]
 	public class ExpressionPropertyString
 	{
 		public static void Main ()
 		{
-			var e1 = Expression.Property (null, typeof (ExpressionPropertyString), "TestOnlyStatic1");
-			var e2 = Expression.Property (null, typeof (ExpressionPropertyString), "TestOnlyStatic2");
+			// So that this test works with or without unreachable bodies
+			new Foo ();
+			
+			var e1 = Expression.Property (null, typeof (Foo), "TestOnlyStatic1");
+			var e2 = Expression.Property (null, typeof (Foo), "TestOnlyStatic2");
 
-			var e3 = Expression.Property (Expression.Parameter (typeof(int), "somename"), typeof (ExpressionPropertyString), "TestName1");
+			var e3 = Expression.Property (Expression.Parameter (typeof(int), "somename"), typeof (Foo), "TestName1");
 		}
 
-		[Kept]
-		[KeptBackingField]
-		private static int TestOnlyStatic1 { [Kept] get; [Kept] set; }
+		[KeptMember (".ctor()")]
+		class Foo
+		{
+			[Kept]
+			[KeptBackingField]
+			private static int TestOnlyStatic1 { [Kept] get; [Kept] set; }
 
-		private int TestOnlyStatic2 { get; }
+			private int TestOnlyStatic2 { get; }
 
-		[Kept]
-		[KeptBackingField]
-		private int TestName1 { [Kept] get; }
+			[Kept]
+			[KeptBackingField]
+			private int TestName1 { [Kept] get; }
+		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/Reflection/RuntimeReflectionExtensionsCalls.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/RuntimeReflectionExtensionsCalls.cs
@@ -8,6 +8,9 @@ namespace Mono.Linker.Tests.Cases.Reflection
 	{
 		public static void Main ()
 		{
+			// Create a foo so that this test gives the expected result when unreachable bodies is turned on
+			new Foo ();
+
 			TestGetRuntimeEvent ();
 			TestGetRuntimeField ();
 			TestGetRuntimeProperty ();
@@ -39,6 +42,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			typeof (Foo).GetRuntimeMethod ("Method1", Type.EmptyTypes);
 		}
 
+		[KeptMember (".ctor()")]
 		class Foo
 		{
 			[Kept]


### PR DESCRIPTION
Tests should use the [Reference] attribute to specify additional references.  This is the established pattern for doing this.  Not using it was causing problems with our test framework

ExpressionPropertyString needs to use Roslyn to compile.  Explicitly request roslyn so that the test works when ran on Windows w/ .NET framework where the built in CodeDomProvider doesn't allow for properties that only define `{get}`

Update `RuntimeReflectionExtensionsCalls` to work with or without unreachable bodies enabled.