### PR TITLE
Test fixes

### DIFF
--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/AttributeArgumentForwarded.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/AttributeArgumentForwarded.cs
@@ -5,6 +5,10 @@ using Mono.Linker.Tests.Cases.TypeForwarding.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.TypeForwarding
 {
+	// On .NET FW the built in compiler will drop the reference to the forwarder assembly when compiling the test assembly.
+	// Use roslyn to give consistent behavior across platforms
+	[SetupCSharpCompilerToUse ("csc")]
+
 	// Actions:
 	// link - This assembly, Forwarder.dll and Implementation.dll
 	[SetupLinkerUserAction ("link")]

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/AttributeArgumentForwardedWithCopyAction.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/AttributeArgumentForwardedWithCopyAction.cs
@@ -5,6 +5,10 @@ using Mono.Linker.Tests.Cases.TypeForwarding.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.TypeForwarding
 {
+	// On .NET FW the built in compiler will drop the reference to the forwarder assembly when compiling the test assembly.
+	// Use roslyn to give consistent behavior across platforms
+	[SetupCSharpCompilerToUse ("csc")]
+
 	// Actions:
 	// link - Forwarder.dll and Implementation.dll
 	// copy - this (test.dll) assembly


### PR DESCRIPTION
Fix two type forwarding tests.  On .NET FW the built in compiler will drop the reference to the forwarder assembly when compiling the test assembly.  Use roslyn to give consistent behavior across platforms