### PR TITLE
Don't crash on unresolved assembly

### DIFF
--- a/src/linker/Linker.Steps/SweepStep.cs
+++ b/src/linker/Linker.Steps/SweepStep.cs
@@ -281,7 +281,14 @@ namespace Mono.Linker.Steps {
 				if (tr.IsWindowsRuntimeProjection)
 					continue;
 
-				var td = tr.Resolve ();
+				TypeDefinition td;
+				try {
+					td = tr.Resolve ();
+				} catch (AssemblyResolutionException) {
+					// Don't crash on unresolved assembly
+					continue;
+				}
+
 				// at this stage reference might include things that can't be resolved
 				// and if it is (resolved) it needs to be kept only if marked (#16213)
 				if (td == null || !Annotations.IsMarked (td))


### PR DESCRIPTION
We have tests that use nunit, which leads to System.Windows.Forms being processed which leads to an attempt at resolving some type that is in `WindowsBase`.  I don't think it matters that we failed to resolve these types here.  Just ignore and continue.