### PR TITLE
Don't try to change scope of windows runtime projection

### DIFF
--- a/src/linker/Linker.Steps/SweepStep.cs
+++ b/src/linker/Linker.Steps/SweepStep.cs
@@ -414,6 +414,10 @@ namespace Mono.Linker.Steps {
 
 		static void UpdateTypeScope (TypeReference type, AssemblyDefinition assembly)
 		{
+			// Can't update the scope of windows runtime projections
+			if (type.IsWindowsRuntimeProjection)
+				return;
+
 			if (type is GenericInstanceType git && git.HasGenericArguments) {
 				UpdateTypeScope (git.ElementType, assembly);
 				foreach (var ga in git.GenericArguments)


### PR DESCRIPTION
Trying to change the scope of a projection results in a exception`System.InvalidOperationException : Projected type scope can't be changed`, so let's skip these.