### PR TITLE
Add warning before Log message

### DIFF
--- a/src/linker/Linker/AssemblyResolver.cs
+++ b/src/linker/Linker/AssemblyResolver.cs
@@ -121,7 +121,7 @@ namespace Mono.Linker {
 				} catch (AssemblyResolutionException) {
 					if (!_ignoreUnresolved)
 						throw;
-					_context.LogMessage ($"Ignoring unresolved assembly '{name.Name}'.");
+					_context.LogMessage ($"warning: Ignoring unresolved assembly '{name.Name}'.");
 					if (_unresolvedAssemblies == null)
 						_unresolvedAssemblies = new HashSet<string> ();
 					_unresolvedAssemblies.Add (name.Name);


### PR DESCRIPTION
I added the word Ignoring to the unresolved assembly log message for PR https://github.com/mono/linker/pull/719, but I also delete the warning word section which is useful since it can be printed using the --verbose flag in the linker options, adding it again.