### PR TITLE
Allow derived mark steps to change required methods

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1953,7 +1953,7 @@ namespace Mono.Linker.Steps {
 
 			MarkInterfaceImplementations (type);
 
-			foreach (var method in CollectRequiredMethodsForInstantiatedType (type))
+			foreach (var method in GetRequiredMethodsForInstantiatedType (type))
 				MarkMethod (method);
 
 			DoAdditionalInstantiatedTypeProcessing (type);
@@ -1966,7 +1966,7 @@ namespace Mono.Linker.Steps {
 		/// </summary>
 		/// <param name="type"></param>
 		/// <returns></returns>
-		protected virtual IEnumerable<MethodDefinition> CollectRequiredMethodsForInstantiatedType (TypeDefinition type)
+		protected virtual IEnumerable<MethodDefinition> GetRequiredMethodsForInstantiatedType (TypeDefinition type)
 		{
 			foreach (var method in type.Methods) {
 				if (method.IsFinalizer () || IsVirtualNeededByInstantiatedTypeDueToPreservedScope (method))

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1953,14 +1953,25 @@ namespace Mono.Linker.Steps {
 
 			MarkInterfaceImplementations (type);
 
-			foreach (var method in type.Methods) {
-				if (method.IsFinalizer ())
-					MarkMethod (method);
-				else if (IsVirtualNeededByInstantiatedTypeDueToPreservedScope (method))
-					MarkMethod (method);
-			}
+			foreach (var method in CollectRequiredMethodsForInstantiatedType (type))
+				MarkMethod (method);
 
 			DoAdditionalInstantiatedTypeProcessing (type);
+		}
+
+		/// <summary>
+		/// Collect methods that must be marked once a type is determined to be instantiated.
+		///
+		/// This method is virtual in order to give derived mark steps an opportunity to modify the collection of methods that are needed 
+		/// </summary>
+		/// <param name="type"></param>
+		/// <returns></returns>
+		protected virtual IEnumerable<MethodDefinition> CollectRequiredMethodsForInstantiatedType (TypeDefinition type)
+		{
+			foreach (var method in type.Methods) {
+				if (method.IsFinalizer () || IsVirtualNeededByInstantiatedTypeDueToPreservedScope (method))
+					yield return method;
+			}
 		}
 
 		void MarkExplicitInterfaceImplementation (MethodDefinition method, MethodReference ov)


### PR DESCRIPTION
We have a use case where we want to disable the explicit marking of of finalize methods.  I thought a general purpose hook to allow for modifying the collection of methods that are required on types that are instantiated would be a good way to go about this.