### PR TITLE
Add separate step for marking public surface of libraries

### DIFF
--- a/src/linker/Linker.Steps/LoadI18nAssemblies.cs
+++ b/src/linker/Linker.Steps/LoadI18nAssemblies.cs
@@ -78,7 +78,7 @@ namespace Mono.Linker.Steps {
 		{
 			AssemblyDefinition assembly = Context.Resolve (name);
 			Context.Annotations.SetAction (assembly, AssemblyAction.Copy);
-			ResolveFromAssemblyStep.ProcessLibrary (Context, assembly, ResolveFromAssemblyStep.RootVisibility.Any);
+			ResolveFromAssemblyStep.ProcessLibrary (Context, assembly);
 		}
 
 		AssemblyNameReference GetAssemblyName (I18nAssemblies assembly)

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -310,12 +310,13 @@ namespace Mono.Linker {
 						resolver = true;
 						break;
 					case 'r':
-					case 'a':
-						var rootVisibility = (token [1] == 'r')
-							? ResolveFromAssemblyStep.RootVisibility.PublicAndFamily
-							: ResolveFromAssemblyStep.RootVisibility.Any;
 						foreach (string file in GetFiles (GetParam ()))
-							p.PrependStep (new ResolveFromAssemblyStep (file, rootVisibility));
+							p.PrependStep (new MarkPublicFromAssemblyStep (file));
+						resolver = true;
+						break;
+					case 'a':
+						foreach (string file in GetFiles (GetParam ()))
+							p.PrependStep (new ResolveFromAssemblyStep (file));
 						resolver = true;
 						break;
 					case 'i':

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -46,6 +46,7 @@ namespace Mono.Linker {
 		AssemblyAction _coreAction;
 		AssemblyAction _userAction;
 		Dictionary<string, AssemblyAction> _actions;
+		HashSet<string> _publicAssemblies;
 		string _outputDirectory;
 		readonly Dictionary<string, string> _parameters;
 		bool _linkSymbols;
@@ -174,6 +175,7 @@ namespace Mono.Linker {
 			_resolver = resolver;
 			_resolver.Context = this;
 			_actions = new Dictionary<string, AssemblyAction> ();
+			_publicAssemblies = new HashSet<string> ();
 			_parameters = new Dictionary<string, string> ();
 			_readerParameters = readerParameters;
 			
@@ -333,6 +335,17 @@ namespace Mono.Linker {
 			}
 
 			_annotations.SetAction (assembly, action);
+		}
+
+		public void SetPublicAssembly (AssemblyDefinition assembly)
+		{
+			AssemblyNameDefinition name = assembly.Name;
+			_publicAssemblies.Add (name.Name);
+		}
+
+		public bool IsPublicAssembly (AssemblyDefinition assembly)
+		{
+			return _publicAssemblies.Contains(assembly.Name.Name);
 		}
 
 		public static bool IsCore (AssemblyNameReference name)


### PR DESCRIPTION
@marek-safar I'm investigating the approach we discussed of creating a new step to replace ResolveFromAssemblyStep and MarkStep, and wanted to share what it looks like so far.

- ResolveFromAssemblyStep no longer deals with visibility
- '-r' instead uses MarkPublicFromAssemblyStep
- '-r' assemblies are tracked as public in the LinkContext, and they
  aren't optimized in MarkStep.
- Currently if the same assembly is passed via '-r' and '-a', it will
  still be considered a public assembly by MarkStep and not
  optimized. This probably shouldn't be a valid combination of
  parameters in the first place.
- MarkPublicFromAssemblyStep does a combination of what
  ResolveFromAssemblyStep and MarkStep used to do. It was created by
  copying over sources from those two steps, and unifying some of the
  overlapping logic (for example the Initialize* logic from MarkStep
  and the Mark* logic from ResolveFromAssemblyStep). It hasn't yet
  been pruned, so still has unnecessary optimizations from MarkStep.