### PR TITLE
Mark dependencies of assemblies with the copy and save action

### DIFF
--- a/test/Mono.Linker.Tests.Cases/References/CopyWithLinkedWillHaveAttributeDepsKept.cs
+++ b/test/Mono.Linker.Tests.Cases/References/CopyWithLinkedWillHaveAttributeDepsKept.cs
@@ -1,0 +1,75 @@
+using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.References.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.References {
+	[SetupLinkerArgument ("--used-attrs-only", "true")]
+	[SetupLinkerAction ("copy", "test")]
+	[SetupCompileBefore ("linked.dll", new [] {typeof (WithLinked_Attrs)})]
+
+	[KeptMember (".ctor()")]
+	[KeptMemberInAssembly ("linked.dll", typeof (WithLinked_Attrs.TypeAttribute), ".ctor()")]
+	[KeptMemberInAssembly ("linked.dll", typeof (WithLinked_Attrs.FieldAttribute), ".ctor()")]
+	[KeptMemberInAssembly ("linked.dll", typeof (WithLinked_Attrs.PropertyAttribute), ".ctor()")]
+	[KeptMemberInAssembly ("linked.dll", typeof (WithLinked_Attrs.EventAttribute), ".ctor()")]
+	[KeptMemberInAssembly ("linked.dll", typeof (WithLinked_Attrs.MethodAttribute), ".ctor()")]
+	[KeptMemberInAssembly ("linked.dll", typeof (WithLinked_Attrs.ParameterAttribute), ".ctor()")]
+	[KeptTypeInAssembly ("linked.dll", typeof (WithLinked_Attrs.FooEnum))]
+	[KeptTypeInAssembly ("linked.dll", typeof (WithLinked_Attrs.MethodWithEnumValueAttribute))]
+	public class CopyWithLinkedWillHaveAttributeDepsKept {
+		public static void Main ()
+		{
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptAttributeAttribute (typeof (WithLinked_Attrs.TypeAttribute))]
+		[WithLinked_Attrs.Type]
+		class Foo {
+			[Kept]
+			[KeptAttributeAttribute (typeof (WithLinked_Attrs.FieldAttribute))]
+			[WithLinked_Attrs.Field]
+			private static int Field;
+
+			[Kept]
+			[KeptBackingField]
+			[KeptAttributeAttribute (typeof (WithLinked_Attrs.PropertyAttribute))]
+			[WithLinked_Attrs.Property]
+			private static int Property
+			{
+				[Kept]
+				get;
+				[Kept]
+				set;
+			}
+
+			[Kept]
+			[KeptAttributeAttribute (typeof (WithLinked_Attrs.EventAttribute))]
+			[KeptBackingField]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
+			[WithLinked_Attrs.Event]
+			public event EventHandler Event;
+
+			[Kept]
+			[KeptAttributeAttribute (typeof (WithLinked_Attrs.MethodAttribute))]
+			[WithLinked_Attrs.Method]
+			static void Method ()
+			{
+			}
+			
+			[Kept]
+			[KeptAttributeAttribute (typeof(WithLinked_Attrs.MethodWithEnumValueAttribute))]
+			[WithLinked_Attrs.MethodWithEnumValue (WithLinked_Attrs.FooEnum.Three, typeof (WithLinked_Attrs))]
+			static void MethodWithEnum ()
+			{
+			}
+			
+			[Kept]
+			static void MethodWithParameter([KeptAttributeAttribute (typeof (WithLinked_Attrs.ParameterAttribute))] [WithLinked_Attrs.Parameter] int arg)
+			{
+			}
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/References/CopyWithLinkedWillHaveMethodDepsKept.cs
+++ b/test/Mono.Linker.Tests.Cases/References/CopyWithLinkedWillHaveMethodDepsKept.cs
@@ -1,0 +1,37 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.References.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.References {
+	[SetupCSharpCompilerToUse ("csc")]
+	[SetupLinkerAction ("copy", "test")]
+	[SetupCompileBefore ("linked.dll", new [] {typeof (WithLinked_Methods)})]
+
+	[KeptMember (".ctor()")]
+	[KeptMemberInAssembly ("linked.dll", typeof (WithLinked_Methods), nameof (WithLinked_Methods.UsedByPublic) + "()")]
+	[KeptMemberInAssembly ("linked.dll", typeof (WithLinked_Methods), nameof (WithLinked_Methods.UsedByInternal) + "()")]
+	[KeptMemberInAssembly ("linked.dll", typeof (WithLinked_Methods), nameof (WithLinked_Methods.UsedByPrivate) + "()")]
+	public class CopyWithLinkedWillHaveMethodDepsKept {
+		public static void Main ()
+		{
+		}
+
+		[Kept]
+		public static void UnusedPublic ()
+		{
+			WithLinked_Methods.UsedByPublic ();
+		}
+		
+		[Kept]
+		internal static void UnusedInternal ()
+		{
+			WithLinked_Methods.UsedByInternal ();
+		}
+		
+		[Kept]
+		static void UnusedPrivate()
+		{
+			WithLinked_Methods.UsedByPrivate ();
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/References/Dependencies/WithLinked_Attrs.cs
+++ b/test/Mono.Linker.Tests.Cases/References/Dependencies/WithLinked_Attrs.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace Mono.Linker.Tests.Cases.References.Dependencies
+{
+	public class WithLinked_Attrs
+	{
+		public enum FooEnum
+		{
+			One,
+			Two,
+			Three
+		}
+		public class MethodAttribute : Attribute
+		{
+		}
+		
+		public class MethodWithEnumValueAttribute : Attribute
+		{
+			public MethodWithEnumValueAttribute(FooEnum value, Type t)
+			{
+			}
+		}
+		
+		public class FieldAttribute : Attribute
+		{
+		}
+		
+		public class EventAttribute : Attribute
+		{
+		}
+		
+		public class PropertyAttribute : Attribute
+		{
+		}
+		
+		public class TypeAttribute : Attribute
+		{
+		}
+		
+		public class ParameterAttribute : Attribute
+		{
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/References/Dependencies/WithLinked_Methods.cs
+++ b/test/Mono.Linker.Tests.Cases/References/Dependencies/WithLinked_Methods.cs
@@ -1,0 +1,17 @@
+namespace Mono.Linker.Tests.Cases.References.Dependencies
+{
+	public class WithLinked_Methods
+	{
+		public static void UsedByPublic()
+		{
+		}
+		
+		public static void UsedByInternal()
+		{
+		}
+		
+		public static void UsedByPrivate()
+		{
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/References/SavedWithLinkedWillHaveMethodDepsKept.cs
+++ b/test/Mono.Linker.Tests.Cases/References/SavedWithLinkedWillHaveMethodDepsKept.cs
@@ -1,0 +1,37 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.References.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.References {
+	[SetupCSharpCompilerToUse("csc")]
+	[SetupLinkerAction("save", "test")]
+	[SetupCompileBefore("linked.dll", new [] {typeof (WithLinked_Methods)})]
+
+	[KeptMember(".ctor()")]
+	[KeptMemberInAssembly ("linked.dll", typeof (WithLinked_Methods), nameof (WithLinked_Methods.UsedByPublic) + "()")]
+	[KeptMemberInAssembly ("linked.dll", typeof (WithLinked_Methods), nameof (WithLinked_Methods.UsedByInternal) + "()")]
+	[KeptMemberInAssembly ("linked.dll", typeof (WithLinked_Methods), nameof (WithLinked_Methods.UsedByPrivate) + "()")]
+	public class SavedWithLinkedWillHaveMethodDepsKept {
+		public static void Main()
+		{
+		}
+
+		[Kept]
+		public static void UnusedPublic ()
+		{
+			WithLinked_Methods.UsedByPublic ();
+		}
+
+		[Kept]
+		internal static void UnusedInternal ()
+		{
+			WithLinked_Methods.UsedByInternal ();
+		}
+		
+		[Kept]
+		static void UnusedPrivate()
+		{
+			WithLinked_Methods.UsedByPrivate ();
+		}
+	}
+}


### PR DESCRIPTION
When an assembly had the action Copy, a lot of it's dependencies could go unmarked.  Things like public methods were being marked, but private methods, attributes, events, properties were not.

With this change the MarkStep will visit everything in a copy or saved assembly and mark everything.

I did not address the *Used AssemblyActions.  These will still be vulnerable to invalid IL.  Additional logic would be needed to track the first marking of these assemblies and then call `ForceFullMarkingOfAssembly`.

I did not handle `AddBypassNGen` either.  The XML comment for this action states that `Keep all types, methods, and fields but add System.Runtime.BypassNGenAttribute to unmarked methods.`  I don't know how this action is used, if it will still strip out EventDefinitions and PropertyDefinitions then additional tweaks would be needed to avoid the calls to `ForceFullMarkingOfProperties` and `ForceFullMarkingOfEvents`.  If someone would like to handle these cases they could do so in a follow on PR.