### PR TITLE
Run full mark logic on copy and copy-used assemblies

### DIFF
--- a/test/Mono.Linker.Tests.Cases/References/CopyUsedAreKeptFully.cs
+++ b/test/Mono.Linker.Tests.Cases/References/CopyUsedAreKeptFully.cs
@@ -1,0 +1,23 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.References.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.References {
+	// Actions:
+	// link - This assembly
+	// copyused - library1.dll
+	[SetupLinkerUserAction ("copyused")]
+
+	[SetupCompileBefore ("library1.dll", new [] { "Dependencies/UserAssembliesAreLinkedByDefault_Library1.cs" })]
+
+	[KeptAssembly ("library1.dll")]
+	[KeptMemberInAssembly ("library1.dll", typeof (UserAssembliesAreLinkedByDefault_Library1), "UsedMethod()")]
+	[KeptMemberInAssembly ("library1.dll", typeof (UserAssembliesAreLinkedByDefault_Library1), "UnusedMethod()")]
+	class CopyUsedAreKeptFully
+	{
+		public static void Main ()
+		{
+			new UserAssembliesAreLinkedByDefault_Library1 ().UsedMethod ();
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/References/CopyWithLinkedWillHaveAttributeDepsKept.cs
+++ b/test/Mono.Linker.Tests.Cases/References/CopyWithLinkedWillHaveAttributeDepsKept.cs
@@ -1,0 +1,75 @@
+using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.References.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.References {
+	[SetupLinkerArgument ("--used-attrs-only", "true")]
+	[SetupLinkerAction ("copy", "test")]
+	[SetupCompileBefore ("linked.dll", new [] {typeof (WithLinked_Attrs)})]
+
+	[KeptMember (".ctor()")]
+	[KeptMemberInAssembly ("linked.dll", typeof (WithLinked_Attrs.TypeAttribute), ".ctor()")]
+	[KeptMemberInAssembly ("linked.dll", typeof (WithLinked_Attrs.FieldAttribute), ".ctor()")]
+	[KeptMemberInAssembly ("linked.dll", typeof (WithLinked_Attrs.PropertyAttribute), ".ctor()")]
+	[KeptMemberInAssembly ("linked.dll", typeof (WithLinked_Attrs.EventAttribute), ".ctor()")]
+	[KeptMemberInAssembly ("linked.dll", typeof (WithLinked_Attrs.MethodAttribute), ".ctor()")]
+	[KeptMemberInAssembly ("linked.dll", typeof (WithLinked_Attrs.ParameterAttribute), ".ctor()")]
+	[KeptTypeInAssembly ("linked.dll", typeof (WithLinked_Attrs.FooEnum))]
+	[KeptTypeInAssembly ("linked.dll", typeof (WithLinked_Attrs.MethodWithEnumValueAttribute))]
+	public class CopyWithLinkedWillHaveAttributeDepsKept {
+		public static void Main ()
+		{
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptAttributeAttribute (typeof (WithLinked_Attrs.TypeAttribute))]
+		[WithLinked_Attrs.Type]
+		class Foo {
+			[Kept]
+			[KeptAttributeAttribute (typeof (WithLinked_Attrs.FieldAttribute))]
+			[WithLinked_Attrs.Field]
+			private static int Field;
+
+			[Kept]
+			[KeptBackingField]
+			[KeptAttributeAttribute (typeof (WithLinked_Attrs.PropertyAttribute))]
+			[WithLinked_Attrs.Property]
+			private static int Property
+			{
+				[Kept]
+				get;
+				[Kept]
+				set;
+			}
+
+			[Kept]
+			[KeptAttributeAttribute (typeof (WithLinked_Attrs.EventAttribute))]
+			[KeptBackingField]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
+			[WithLinked_Attrs.Event]
+			public event EventHandler Event;
+
+			[Kept]
+			[KeptAttributeAttribute (typeof (WithLinked_Attrs.MethodAttribute))]
+			[WithLinked_Attrs.Method]
+			static void Method ()
+			{
+			}
+			
+			[Kept]
+			[KeptAttributeAttribute (typeof(WithLinked_Attrs.MethodWithEnumValueAttribute))]
+			[WithLinked_Attrs.MethodWithEnumValue (WithLinked_Attrs.FooEnum.Three, typeof (WithLinked_Attrs))]
+			static void MethodWithEnum ()
+			{
+			}
+			
+			[Kept]
+			static void MethodWithParameter([KeptAttributeAttribute (typeof (WithLinked_Attrs.ParameterAttribute))] [WithLinked_Attrs.Parameter] int arg)
+			{
+			}
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/References/CopyWithLinkedWillHaveMethodDepsKept.cs
+++ b/test/Mono.Linker.Tests.Cases/References/CopyWithLinkedWillHaveMethodDepsKept.cs
@@ -1,0 +1,37 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.References.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.References {
+	[SetupCSharpCompilerToUse ("csc")]
+	[SetupLinkerAction ("copy", "test")]
+	[SetupCompileBefore ("linked.dll", new [] {typeof (WithLinked_Methods)})]
+
+	[KeptMember (".ctor()")]
+	[KeptMemberInAssembly ("linked.dll", typeof (WithLinked_Methods), nameof (WithLinked_Methods.UsedByPublic) + "()")]
+	[KeptMemberInAssembly ("linked.dll", typeof (WithLinked_Methods), nameof (WithLinked_Methods.UsedByInternal) + "()")]
+	[KeptMemberInAssembly ("linked.dll", typeof (WithLinked_Methods), nameof (WithLinked_Methods.UsedByPrivate) + "()")]
+	public class CopyWithLinkedWillHaveMethodDepsKept {
+		public static void Main ()
+		{
+		}
+
+		[Kept]
+		public static void UnusedPublic ()
+		{
+			WithLinked_Methods.UsedByPublic ();
+		}
+		
+		[Kept]
+		internal static void UnusedInternal ()
+		{
+			WithLinked_Methods.UsedByInternal ();
+		}
+		
+		[Kept]
+		static void UnusedPrivate()
+		{
+			WithLinked_Methods.UsedByPrivate ();
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/References/Dependencies/WithLinked_Attrs.cs
+++ b/test/Mono.Linker.Tests.Cases/References/Dependencies/WithLinked_Attrs.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace Mono.Linker.Tests.Cases.References.Dependencies
+{
+	public class WithLinked_Attrs
+	{
+		public enum FooEnum
+		{
+			One,
+			Two,
+			Three
+		}
+		public class MethodAttribute : Attribute
+		{
+		}
+		
+		public class MethodWithEnumValueAttribute : Attribute
+		{
+			public MethodWithEnumValueAttribute(FooEnum value, Type t)
+			{
+			}
+		}
+		
+		public class FieldAttribute : Attribute
+		{
+		}
+		
+		public class EventAttribute : Attribute
+		{
+		}
+		
+		public class PropertyAttribute : Attribute
+		{
+		}
+		
+		public class TypeAttribute : Attribute
+		{
+		}
+		
+		public class ParameterAttribute : Attribute
+		{
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/References/Dependencies/WithLinked_Methods.cs
+++ b/test/Mono.Linker.Tests.Cases/References/Dependencies/WithLinked_Methods.cs
@@ -1,0 +1,17 @@
+namespace Mono.Linker.Tests.Cases.References.Dependencies
+{
+	public class WithLinked_Methods
+	{
+		public static void UsedByPublic()
+		{
+		}
+		
+		public static void UsedByInternal()
+		{
+		}
+		
+		public static void UsedByPrivate()
+		{
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/References/SavedWithLinkedWillHaveMethodDepsKept.cs
+++ b/test/Mono.Linker.Tests.Cases/References/SavedWithLinkedWillHaveMethodDepsKept.cs
@@ -1,0 +1,37 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.References.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.References {
+	[SetupCSharpCompilerToUse("csc")]
+	[SetupLinkerAction("save", "test")]
+	[SetupCompileBefore("linked.dll", new [] {typeof (WithLinked_Methods)})]
+
+	[KeptMember(".ctor()")]
+	[KeptMemberInAssembly ("linked.dll", typeof (WithLinked_Methods), nameof (WithLinked_Methods.UsedByPublic) + "()")]
+	[KeptMemberInAssembly ("linked.dll", typeof (WithLinked_Methods), nameof (WithLinked_Methods.UsedByInternal) + "()")]
+	[KeptMemberInAssembly ("linked.dll", typeof (WithLinked_Methods), nameof (WithLinked_Methods.UsedByPrivate) + "()")]
+	public class SavedWithLinkedWillHaveMethodDepsKept {
+		public static void Main()
+		{
+		}
+
+		[Kept]
+		public static void UnusedPublic ()
+		{
+			WithLinked_Methods.UsedByPublic ();
+		}
+
+		[Kept]
+		internal static void UnusedInternal ()
+		{
+			WithLinked_Methods.UsedByInternal ();
+		}
+		
+		[Kept]
+		static void UnusedPrivate()
+		{
+			WithLinked_Methods.UsedByPrivate ();
+		}
+	}
+}


### PR DESCRIPTION
Improved #796 which used more of the existing code