### PR TITLE
Add callback for handling marking reflection calls

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2303,9 +2303,9 @@ namespace Mono.Linker.Steps {
 		}
 
 		//
-		// Callback for other mark steps to prevent normal reflection logic from running
+		// Extension point for reflection logic handling customization
 		//
-		protected virtual bool ShouldProcessReflectionDependencies (MethodBody body, Instruction instruction)
+		protected virtual bool ProcessReflectionDependency (MethodBody body, Instruction instruction)
 		{
 			return true;
 		}
@@ -2326,7 +2326,7 @@ namespace Mono.Linker.Steps {
 				if (instruction.OpCode != OpCodes.Call && instruction.OpCode != OpCodes.Callvirt)
 					continue;
 
-				if (!ShouldProcessReflectionDependencies (body, instruction))
+				if (!ProcessReflectionDependency (body, instruction))
 					continue;
 
 				var methodCalled = instruction.Operand as MethodReference;

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2307,7 +2307,7 @@ namespace Mono.Linker.Steps {
 		//
 		protected virtual bool ProcessReflectionDependency (MethodBody body, Instruction instruction)
 		{
-			return true;
+			return false;
 		}
 
 		//
@@ -2326,7 +2326,7 @@ namespace Mono.Linker.Steps {
 				if (instruction.OpCode != OpCodes.Call && instruction.OpCode != OpCodes.Callvirt)
 					continue;
 
-				if (!ProcessReflectionDependency (body, instruction))
+				if (ProcessReflectionDependency (body, instruction))
 					continue;
 
 				var methodCalled = instruction.Operand as MethodReference;

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2303,6 +2303,14 @@ namespace Mono.Linker.Steps {
 		}
 
 		//
+		// Callback for other mark steps to prevent normal reflection logic from running
+		//
+		protected virtual bool ShouldProcessReflectionDependencies (MethodBody body, Instruction instruction)
+		{
+			return true;
+		}
+
+		//
 		// Tries to mark additional dependencies used in reflection like calls (e.g. typeof (MyClass).GetField ("fname"))
 		//
 		protected virtual void MarkReflectionLikeDependencies (MethodBody body)
@@ -2316,6 +2324,9 @@ namespace Mono.Linker.Steps {
 				var instruction = instructions [i];
 
 				if (instruction.OpCode != OpCodes.Call && instruction.OpCode != OpCodes.Callvirt)
+					continue;
+
+				if (!ShouldProcessReflectionDependencies (body, instruction))
 					continue;
 
 				var methodCalled = instruction.Operand as MethodReference;


### PR DESCRIPTION
Added a callback that can be overridden so we can suppress warnings on instructions that have already been handled.

Also allows for checking reflection calls like `GetMethod()` and `GetConstructor()` that include parameter arrays, so we can mark only methods with matching parameters.