### PR TITLE
Allow overriding of MarkTypeConverterLikeDependency

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1208,7 +1208,7 @@ namespace Mono.Linker.Steps {
 			MarkNamedMethod (type, method_name);
 		}
 
-		void MarkTypeConverterLikeDependency (CustomAttribute attribute, Func<MethodDefinition, bool> predicate)
+		protected virtual void MarkTypeConverterLikeDependency (CustomAttribute attribute, Func<MethodDefinition, bool> predicate)
 		{
 			var args = attribute.ConstructorArguments;
 			if (args.Count < 1)


### PR DESCRIPTION
We don't care about these type converter like dependencies.  Exposing this method for overriding is an easy way for us to disable the behavior