### PR TITLE
Resolve interfaces when checking KeptInterface attribute so that generic interfaces can be marked.

### DIFF
--- a/test/Mono.Linker.Tests.Cases/Basic/UsedGenericInterfaceIsKept.cs
+++ b/test/Mono.Linker.Tests.Cases/Basic/UsedGenericInterfaceIsKept.cs
@@ -1,0 +1,25 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Basic
+{
+	class UsedGenericInterfaceIsKept
+	{
+		public static void Main ()
+		{
+			A<int> a = new A<int> ();
+			var t = typeof (I<>).ToString();
+		}
+
+		[Kept]
+		[KeptInterface (typeof (I<>))]
+		[KeptMember (".ctor()")]
+		class A<T> : I<T>
+		{
+		}
+
+		[Kept]
+		interface I<T>
+		{
+		}
+	}
+}

--- a/test/Mono.Linker.Tests/TestCasesRunner/AssemblyChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/AssemblyChecker.cs
@@ -171,8 +171,10 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			if (expectedInterfaces.Count == 0) {
 				Assert.IsFalse (linked.HasInterfaces, $"Type `{src}' has unexpected interfaces");
 			} else {
-				foreach (var iface in linked.Interfaces) {
-					Assert.IsTrue (expectedInterfaces.Remove (iface.InterfaceType.FullName), $"Type `{src}' interface `{iface.InterfaceType.FullName}' should have been removed");
+				foreach (var iface in linked.Interfaces) { 
+					if (!expectedInterfaces.Remove(iface.InterfaceType.FullName)) {
+						Assert.IsTrue (expectedInterfaces.Remove (iface.InterfaceType.Resolve().FullName), $"Type `{src}' interface `{iface.InterfaceType.Resolve().FullName}' should have been removed");
+					}
 				}
 
 				Assert.IsEmpty (expectedInterfaces, $"Unexpected interfaces on {src}");


### PR DESCRIPTION
Since `[RequiredInterface]` does not allow type parameters when passing a generic interface, we need to do type resolution on the interface when comparing for marking.