### PR TITLE
Add C# specific settings to .editorconfig.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,3 +3,11 @@ root = true
 
 [*.cs]
 indent_style = tab
+csharp_new_line_before_open_brace = types,methods
+csharp_new_line_before_else = false
+csharp_new_line_before_catch = false
+csharp_new_line_before_finally = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_declaration_name_and_open_parenthesis = true
+csharp_space_between_method_call_name_and_opening_parenthesis = true
+csharp_space_before_open_square_brackets = true


### PR DESCRIPTION
When using VS these new settings make VS automatically format the code the way the rest of the linker is written.

Note that linker itself is not always 100% consistent, but it's close.