### PR TITLE
Support "type granularity" option

### DIFF
--- a/src/ILLink.Tasks/LinkTask.cs
+++ b/src/ILLink.Tasks/LinkTask.cs
@@ -158,6 +158,13 @@ namespace ILLink.Tasks
 					args.Append (action);
 					args.Append (" ").AppendLine (Quote (assemblyName));
 				}
+
+				string actionflag = assembly.GetMetadata ("actionflag");
+				if ((actionflag != null) && (actionflag.Length > 0)) {
+					args.Append ("-f ");
+					args.Append (actionflag);
+					args.Append (" ").AppendLine (Quote (assemblyName));
+				}
 			}
 
 			if (ReferenceAssemblyPaths != null) {

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1699,6 +1699,10 @@ namespace Mono.Linker.Steps {
 		{
 			ApplyPreserveMethods (type);
 
+			if (_context.HasActionFlag(type.Module.Assembly, AssemblyActionFlag.TypeGranularity)) {
+				Annotations.SetPreserve (type, TypePreserve.All);
+			}
+
 			if (!Annotations.TryGetPreserve (type, out TypePreserve preserve))
 				return;
 

--- a/src/linker/Linker/AssemblyActionFlag.cs
+++ b/src/linker/Linker/AssemblyActionFlag.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Mono.Linker {
+	[Flags]
+	public enum AssemblyActionFlag : int {
+		// If there is any reference to a type, preserve all members in that type
+		TypeGranularity = 1,
+	}
+}

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -309,6 +309,13 @@ namespace Mono.Linker {
 						AssemblyAction action = ParseAssemblyAction (GetParam ());
 						context.Actions [GetParam ()] = action;
 						break;
+					case 'f':
+						AssemblyActionFlag newFlag = ParseAssemblyActionFlag (GetParam ());
+						string flagTargetName = GetParam ();
+						context.ActionFlags [flagTargetName] = context.ActionFlags.TryGetValue (flagTargetName, out AssemblyActionFlag existingFlag)
+							? existingFlag | newFlag
+							: newFlag;
+						break;
 					case 't':
 						context.KeepTypeForwarderOnlyAssemblies = true;
 						break;
@@ -535,6 +542,11 @@ namespace Mono.Linker {
 			return assemblyAction;
 		}
 
+		AssemblyActionFlag ParseAssemblyActionFlag (string s)
+		{
+			return (AssemblyActionFlag)Enum.Parse (typeof (AssemblyActionFlag), s, true);
+		}
+
 		string GetParam ()
 		{
 			if (_queue.Count == 0)
@@ -591,6 +603,8 @@ namespace Mono.Linker {
 			Console.WriteLine ("                        addbypassngenused: Same as addbypassngen but unused assemblies are removed");
 			Console.WriteLine ("  -u <action>         Action on the user assemblies. Defaults to 'link'");
 			Console.WriteLine ("  -p <action> <name>  Overrides the default action for an assembly");
+			Console.WriteLine ("  -f <flag> <name>    Adds a linker action flag for an assembly");
+			Console.WriteLine ("                        typegranularity: If there is any reference to a type, preserve the whole type");
 
 			Console.WriteLine ();
 			Console.WriteLine ("Advanced");

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -47,6 +47,7 @@ namespace Mono.Linker {
 		AssemblyAction _userAction;
 		Dictionary<string, AssemblyAction> _actions;
 		string _outputDirectory;
+		readonly Dictionary<string, AssemblyActionFlag> _actionFlags;
 		readonly Dictionary<string, string> _parameters;
 		bool _linkSymbols;
 		bool _keepTypeForwarderOnlyAssemblies;
@@ -123,6 +124,10 @@ namespace Mono.Linker {
 			get { return _actions; }
 		}
 
+		public IDictionary<string, AssemblyActionFlag> ActionFlags {
+			get { return _actionFlags; }
+		}
+
 		public AssemblyResolver Resolver {
 			get { return _resolver; }
 		}
@@ -178,6 +183,7 @@ namespace Mono.Linker {
 			_resolver = resolver;
 			_resolver.Context = this;
 			_actions = new Dictionary<string, AssemblyAction> ();
+			_actionFlags = new Dictionary<string, AssemblyActionFlag> ();
 			_parameters = new Dictionary<string, string> ();
 			_readerParameters = readerParameters;
 			

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -406,6 +406,12 @@ namespace Mono.Linker {
 			return val;
 		}
 
+		public bool HasActionFlag (AssemblyDefinition assembly, AssemblyActionFlag flag)
+		{
+			return ActionFlags.TryGetValue (assembly.Name.Name, out AssemblyActionFlag foundFlags)
+				&& foundFlags.HasFlag (flag);
+		}
+
 		public void Dispose ()
 		{
 			_resolver.Dispose ();

--- a/test/Mono.Linker.Tests.Cases/TypeGranularity/UsedTypeKeepsAllMembersWithTypeGranularity.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeGranularity/UsedTypeKeepsAllMembersWithTypeGranularity.cs
@@ -1,0 +1,34 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using System;
+
+namespace Mono.Linker.Tests.Cases.TypeGranularity
+{
+	[SetupLinkerArgument ("-f", "typegranularity", "test")]
+	static class UsedTypeKeepsAllMembersWithTypeGranularity {
+		public static void Main() {
+			GC.KeepAlive (typeof(ReferencedClass));
+		}
+
+		[KeptMember (".ctor()")]
+		class ReferencedClass {
+			[Kept]
+			[KeptBackingField]
+			public int Prop { [Kept] get; [Kept] set; }
+
+			[Kept]
+			public void SomeMethod() {
+				Console.WriteLine (typeof (KeptNestedClass));
+			}
+
+			[KeptMember (".ctor()")]
+			class KeptNestedClass { }
+
+			// Unkept because nested types are not members. Type-level granularity doesn't
+			// preserve nested classes unless there is a reference to them.
+			class UnkeptNestedClass {
+				public string unkeptField;
+			}
+		}
+	}
+}

--- a/test/Mono.Linker.Tests/TestCases/TestDatabase.cs
+++ b/test/Mono.Linker.Tests/TestCases/TestDatabase.cs
@@ -91,6 +91,11 @@ namespace Mono.Linker.Tests.TestCases
 			return NUnitCasesBySuiteName ("PreserveDependencies");
 		}
 		
+		public static IEnumerable<TestCaseData> TypeGranularityTests ()
+		{
+			return NUnitCasesBySuiteName ("TypeGranularity");
+		}
+		
 		public static IEnumerable<TestCaseData> LibrariesTests ()
 		{
 			return NUnitCasesBySuiteName ("Libraries");

--- a/test/Mono.Linker.Tests/TestCases/TestSuites.cs
+++ b/test/Mono.Linker.Tests/TestCases/TestSuites.cs
@@ -103,6 +103,12 @@ namespace Mono.Linker.Tests.TestCases
 			Run (testCase);
 		}
 		
+		[TestCaseSource (typeof (TestDatabase), nameof (TestDatabase.TypeGranularityTests))]
+		public void TypeGranularityTests (TestCase testCase)
+		{
+			Run (testCase);
+		}
+
 		[TestCaseSource (typeof (TestDatabase), nameof (TestDatabase.SymbolsTests))]
 		public void SymbolsTests (TestCase testCase)
 		{


### PR DESCRIPTION
@lewing @marek-safar @rynowak Following our discussions this week, I've tried two different approaches to linking more from the `Microsoft.AspNetCore.*` assemblies in Blazor apps.

### Approach 1: Use XML configs

I created some new build tooling inside the aspnetcore repo that generates and embeds linker XML config files based on known patterns for Blazor. Its rules are:

  * preserve all `IComponent` types completely, since their constructors and property-setters are used through reflection only
  * preserve all `[JSinterop]` methods, since they are called through reflection only
  * preserve all DI service types, since their constructors are called through reflection only
  * preserve all `EventArgs` subclasses, since their property setters are called through reflection only

This does work, and allows us to enable linking for `Microsoft.AspNetCore.*` assemblies. It doesn't require any new linker features. However, it has two main drawbacks:

 * Creating, maintaining, and reasoning about these XML config files is going to be expensive. For example, we have to use `Mono.Cecil` and hard-code duplicate copies of some logic from the linker to generate method signature strings in exactly the same format as the linker expects. It also complicates our build process somewhat.
 * The actual size gains aren't as substantial as we hoped.
    * The core problem is that the XML rules aren't expressive enough to cover a requirement like "preserve `IComponent` types completely, but only if there is a reference to the type somewhere in user code". Since we have no choice but to just preserve all `IComponent` types completely, we end up with sizeable chains of references.
    * For example, the default app ends up including the `Microsoft.AspNetCore.Components.Forms` assembly even though it contains no forms components, simply because one of the types in that assembly is referenced by a component in `Microsoft.AspNetCore.Components.Web` that is not actually being used by default.

### Approach 2: Define a new "type-level granularity" option

This is implemented by this PR, and [the core logic](https://github.com/mono/linker/pull/854/commits/63a9491325481f34e5fe4e3bad9d6ed9db56b3e1) is very simple. It's a per-assembly flag that means "if a type in this assembly is referenced at all, preserve that type completely". This is a perfect fit for common patterns in ASP.NET and Blazor applications, because for things like `IComponent` types and DI services, you will have a rooted reference to the type itself (e.g., in DI config) and not to any members in that type, but you do need to preserve those members.

When enabling this for the `Microsoft.AspNetCore.*` assemblies, we get two major benefits compared with the XML approach:

  * Virtually nothing to maintain. It needs no XML config files, and the resulting applications just work.
  * Better size reductions. See table below.
     * For example, in the scenario described above, it *does* manage to drop the `Microsoft.AspNetCore.Components.Forms` assembly completely.

Based on this, I consider the "type-level granularity" option to be preferable.

### Size comparisons

These numbers are for the [Blazor StandaloneApp test case in the ASP.NET Core repo](https://github.com/aspnet/AspNetCore/tree/blazor-wasm/src/Components/Blazor/testassets/StandaloneApp), which is pretty much identical to a File->New Blazor WebAssembly app, built in Release configuration.

| Scenario | Total app transferred size (compressed) |
| ------------- | ------------- |
| Before any changes (i.e., HEAD of `blazor-wasm` branch) | 2.17 MB |
| Approach 1 (XML configs) | 2.11 MB |
| Approach 2 (type-level granularity) | 1.98 MB |

Note that for all of these, 0.95 MB of the compressed transferred data is things *other* than .NET dlls, so the percentage gains are higher if you only consider .dlls.

# PR review notes

I know we didn't make a specific plan to add this feature to the linker. If you feel it's not an appropriate feature, or something is wrong with the implementation, I've very happy to discuss other options!

In particular, I tracked the "per-assembly granularity" option in a general-purpose dictionary of per-assembly flags, just to avoid over-specializing for this one feature. For example, on the command line you can pass `-f typegranularity MyApp.SomeAssembly`.

This might be useful for other per-assembly flags in the future. However if you disagree and think it's over-generalized, I'm happy to take the `ActionFlags` concept out and reduce it to a specialized option like `-usetypegranularity MyApp.SomeAssembly`.