### PR TITLE
Add Linux Mono build to Azure Pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,4 @@ bin/
 .packages
 artifacts
 
-monobuild/TestResults.xml
+test/Mono.Linker.Tests/TestResults.xml

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -81,6 +81,22 @@ jobs:
           MSBUILDENSURESTDOUTFORTASKPROCESSES: 1
         displayName: Build illink.sln $(_BuildConfig)
 
+    - job: Linux_Mono
+      pool:
+        name: Hosted Ubuntu 1604
+      steps:
+      - checkout: self
+        submodules: true
+      - script: |
+          mkdir -p artifacts/log/$(_BuildConfig)
+          mono --version | tee artifacts/log/$(_BuildConfig)/mono-version.txt
+          make -C monobuild CONFIGURATION=$(_BuildConfig)
+        displayName: Build and test
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFormat: 'NUnit'
+          testResultsFiles: 'test/Mono.Linker.Tests/TestResults.xml'
+
     - job: macOS
       pool:
         ${{ if eq(variables.officialBuild, 'false') }}:

--- a/monobuild/Makefile
+++ b/monobuild/Makefile
@@ -3,19 +3,11 @@ CONFIGURATION = Debug
 
 all: build check
 
-build: prepare
-	$(MSBUILD) ../monolinker.sln /p:Configuration=$(CONFIGURATION)
+build:
+	$(MSBUILD) ../monolinker.sln /restore /p:Configuration=$(CONFIGURATION)
 
 clean:
 	$(MSBUILD) ../monolinker.sln /t:clean
 
-prepare:
-	nuget help | head -1
-	nuget restore ../external/cecil/
-	nuget restore ../monolinker.sln
-	# The nunit runner used below seems to expect the old package layout.
-	# This could potentially be removed with an update to nunit.
-	nuget restore -PackagesDirectory ../packages ../test/Mono.Linker.Tests/packages.config
-
-check: prepare
-	mono ../packages/NUnit.ConsoleRunner.3.6.1/tools/nunit3-console.exe --result="TestResults.xml;format=nunit2" ../test/Mono.Linker.Tests/bin/$(CONFIGURATION)/net471/Mono.Linker.Tests.dll
+check:
+	$(MSBUILD) ../test/Mono.Linker.Tests/Mono.Linker.Tests.csproj /t:RunTestsOnMono

--- a/test/Mono.Linker.Tests/Mono.Linker.Tests.csproj
+++ b/test/Mono.Linker.Tests/Mono.Linker.Tests.csproj
@@ -68,9 +68,12 @@
   </Target>
 
   <ItemGroup Condition="!$(ILLinkBuild)">
-    <PackageReference Include="NUnit" Version="3.6.1" />
-    <PackageReference Include="NUnit.ConsoleRunner" Version="3.6.1" />
-    <PackageReference Include="NUnit.Extension.NUnitV2ResultWriter" Version="3.5.0" />
+    <PackageReference Include="NUnit" Version="3.10.0" />
+    <PackageReference Include="NUnit.ConsoleRunner" Version="3.10.0" />
   </ItemGroup>
+
+  <Target Name="RunTestsOnMono" Condition="!$(ILLinkBuild)">
+    <Exec Command="mono $(PkgNUnit_ConsoleRunner)/tools/nunit3-console.exe --result=TestResults.xml $(OutputPath)Mono.Linker.Tests.dll" />
+  </Target>
 
 </Project>

--- a/test/Mono.Linker.Tests/packages.config
+++ b/test/Mono.Linker.Tests/packages.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NUnit" version="3.6.1" targetFramework="net462" />
-  <package id="NUnit.ConsoleRunner" version="3.6.1" targetFramework="net462" />
-  <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.5.0" targetFramework="net462" />
-</packages>


### PR DESCRIPTION
We can easily replace the Jenkins build with one on Azure Pipelines now.