### PR TITLE
Add abstraction between the linker and the dependency tracing/recording.

### DIFF
--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -72,14 +72,13 @@ namespace Mono.Linker {
 		[Obsolete ("Use Tracer in LinkContext directly")]
 		public void PrepareDependenciesDump ()
 		{
-			Tracer.Start ();
+			Tracer.AddRecorder (new XmlDependencyRecorder (context));
 		}
 
 		[Obsolete ("Use Tracer in LinkContext directly")]
 		public void PrepareDependenciesDump (string filename)
 		{
-			Tracer.DependenciesFileName = filename;
-			Tracer.Start ();
+			Tracer.AddRecorder (new XmlDependencyRecorder (context, filename));
 		}
 
 		public ICollection<AssemblyDefinition> GetAssemblies ()

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -29,7 +29,6 @@
 using System;
 using System.IO;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Xml.XPath;
 
@@ -443,6 +442,8 @@ namespace Mono.Linker {
 				if (context.IsOptimizationEnabled (CodeOptimizations.ClearInitLocals))
 					p.AddStepBefore (typeof (OutputStep), new ClearInitLocalsStep ());
 
+				CustomizeContext (context);
+
 				PreProcessPipeline (p);
 
 				try {
@@ -456,6 +457,10 @@ namespace Mono.Linker {
 		}
 
 		partial void PreProcessPipeline (Pipeline pipeline);
+
+		protected virtual void CustomizeContext(LinkContext context)
+		{
+		}
 
 		protected static void AddCustomStep (Pipeline pipeline, string arg)
 		{

--- a/src/linker/Linker/IDependencyResolver.cs
+++ b/src/linker/Linker/IDependencyResolver.cs
@@ -1,0 +1,44 @@
+﻿//
+// IDependencyRecorder.cs
+//
+// Copyright (C) 2017 Microsoft Corporation (http://www.microsoft.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+namespace Mono.Linker
+{
+	/// <summary>
+	/// Abstraction exposed by the linker (mostly MarkStep, but not only) - it will call this interface
+	/// every time it finds a dependency between two parts of the dependency graph.
+	/// </summary>
+	public interface IDependencyRecorder
+	{
+		/// <summary>
+		/// Reports a dependency detected by the linker.
+		/// </summary>
+		/// <param name="source">The source of the dependency (for example the caller method).</param>
+		/// <param name="target">The target of the dependency (for example the callee method).</param>
+		/// <param name="marked">true if the target is also marked by the MarkStep.</param>
+		/// <remarks>The source and target are typically Cecil metadata objects (MethodDefinition, TypeDefinition, ...)
+		/// but they can also be the linker steps or really any other object.</remarks>
+		void RecordDependency (object source, object target, bool marked);
+	}
+}

--- a/src/linker/Linker/Tracer.cs
+++ b/src/linker/Linker/Tracer.cs
@@ -28,72 +28,62 @@
 
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
-using System.Xml;
-using Mono.Cecil;
-using Mono.Linker.Steps;
 
 namespace Mono.Linker
 {
-	public class Tracer {
+	public class Tracer
+	{
 		public const string DefaultDependenciesFileName = "linker-dependencies.xml.gz";
 
 		public string DependenciesFileName { get; set; } = DefaultDependenciesFileName;
 
 		protected readonly LinkContext context;
 
-		Stack<object> dependency_stack;
-		System.Xml.XmlWriter writer;
-		Stream stream;
+		private XmlDependencyRecorder xmlDependencyRecorder;
 
-		public Tracer (LinkContext context) => this.context = context;
+		Stack<object> dependency_stack;
+		List<IDependencyRecorder> recorders;
+
+		public Tracer (LinkContext context)
+		{
+			this.context = context;
+			dependency_stack = new Stack<object> ();
+		}
 
 		public void Start ()
 		{
-			dependency_stack = new Stack<object> ();
-			System.Xml.XmlWriterSettings settings = new System.Xml.XmlWriterSettings {
-				Indent = true,
-				IndentChars = "\t"
-			};
-
 			if (string.IsNullOrEmpty (Path.GetDirectoryName (DependenciesFileName)) && !string.IsNullOrEmpty (context.OutputDirectory)) {
 				DependenciesFileName = Path.Combine (context.OutputDirectory, DependenciesFileName);
 				Directory.CreateDirectory (context.OutputDirectory);
 			}
 
-			var depsFile = File.OpenWrite (DependenciesFileName);
-
-			if (Path.GetExtension (DependenciesFileName) == ".xml")
-				stream = depsFile;
-			else
-				stream = new GZipStream (depsFile, CompressionMode.Compress);
-
-			writer = System.Xml.XmlWriter.Create (stream, settings);
-			writer.WriteStartDocument ();
-			writer.WriteStartElement ("dependencies");
-			writer.WriteStartAttribute ("version");
-			writer.WriteString ("1.2");
-			writer.WriteEndAttribute ();
+			xmlDependencyRecorder = new XmlDependencyRecorder (DependenciesFileName, context);
+			AddRecorder (xmlDependencyRecorder);
 		}
 
 		public void Finish ()
 		{
-			if (writer == null)
-				return;
-
-			writer.WriteEndElement ();
-			writer.WriteEndDocument ();
-			writer.Flush ();
-			writer.Dispose ();
-			stream.Dispose ();
-			writer = null;
-			stream = null;
 			dependency_stack = null;
+			recorders = null;
+
+			if (xmlDependencyRecorder != null) {
+				xmlDependencyRecorder.Dispose ();
+				xmlDependencyRecorder = null;
+			}
+		}
+
+		public void AddRecorder (IDependencyRecorder recorder)
+		{
+			if (recorders == null) {
+				recorders = new List<IDependencyRecorder> ();
+			}
+
+			recorders.Add (recorder);
 		}
 
 		public void Push (object o, bool addDependency = true)
 		{
-			if (writer == null)
+			if (!IsRecordingEnabled ())
 				return;
 
 			if (addDependency && dependency_stack.Count > 0)
@@ -104,149 +94,37 @@ namespace Mono.Linker
 
 		public void Pop ()
 		{
-			if (writer == null)
+			if (!IsRecordingEnabled ())
 				return;
 
 			dependency_stack.Pop ();
 		}
 
-		static bool IsAssemblyBound (TypeDefinition td)
+		bool IsRecordingEnabled ()
 		{
-			do {
-				if (td.IsNestedPrivate || td.IsNestedAssembly || td.IsNestedFamilyAndAssembly)
-					return true;
-
-				td = td.DeclaringType;
-			} while (td != null);
-
-			return false;
-		}
-
-		string TokenString (object o)
-		{
-			if (o == null)
-				return "N:null";
-
-			if (o is TypeReference t) {
-				bool addAssembly = true;
-				var td = t as TypeDefinition ?? t.Resolve ();
-
-				if (td != null) {
-					addAssembly = td.IsNotPublic || IsAssemblyBound (td);
-					t = td;
-				}
-
-				var addition = addAssembly ? $":{t.Module}" : "";
-
-				return $"{(o as IMetadataTokenProvider).MetadataToken.TokenType}:{o}{addition}";
-			}
-
-			if (o is IMetadataTokenProvider)
-				return (o as IMetadataTokenProvider).MetadataToken.TokenType + ":" + o;
-
-			return "Other:" + o;
+			return recorders != null;
 		}
 
 		public void AddDirectDependency (object b, object e)
 		{
-			if (writer == null)
-				return;
-
-			writer.WriteStartElement ("edge");
-			writer.WriteAttributeString ("b", TokenString (b));
-			writer.WriteAttributeString ("e", TokenString (e));
-			writer.WriteEndElement ();
+			ReportDependency (b, e, false);
 		}
 
 		public void AddDependency (object o, bool marked = false)
 		{
-			if (writer == null)
+			if (!IsRecordingEnabled ())
 				return;
 
-			KeyValuePair<object, object> pair = new KeyValuePair<object, object> (dependency_stack.Count > 0 ? dependency_stack.Peek () : null, o);
-
-			if (!ShouldRecord (pair.Key) && !ShouldRecord (pair.Value))
-				return;
-
-			// This is a hack to work around a quirk of MarkStep that results in outputting ~6k edges even with the above ShouldRecord checks.
-			// What happens is that due to the method queueing in MarkStep, the dependency chain is broken in many cases.  And in these cases
-			// we end up adding an edge for MarkStep -> <queued Method>
-			// This isn't particularly useful information since it's incomplete, but it's especially not useful in ReducedTracing mode when there is one of these for
-			// every class library method that was queued.
-			if (context.EnableReducedTracing && pair.Key is MarkStep && !ShouldRecord (pair.Value))
-				return;
-
-			// This is another hack to prevent useless information from being logged.  With the introduction of interface sweeping there are a lot of edges such as
-			// `e="InterfaceImpl:Mono.Cecil.InterfaceImplementation"` which are useless information.  Ideally we would format the interface implementation into a meaningful format
-			// however I don't think that is worth the effort at the moment.
-			if (pair.Value is InterfaceImplementation)
-				return;
-
-			if (pair.Key != pair.Value) {
-				writer.WriteStartElement ("edge");
-				if (marked)
-					writer.WriteAttributeString ("mark", "1");
-				writer.WriteAttributeString ("b", TokenString (pair.Key));
-				writer.WriteAttributeString ("e", TokenString (pair.Value));
-				writer.WriteEndElement ();
-			}
+			ReportDependency (dependency_stack.Count > 0 ? dependency_stack.Peek () : null, o, marked);
 		}
 
-		bool WillAssemblyBeModified (AssemblyDefinition assembly)
+		private void ReportDependency (object source, object target, bool marked)
 		{
-			switch (context.Annotations.GetAction (assembly)) {
-				case AssemblyAction.Link:
-				case AssemblyAction.AddBypassNGen:
-				case AssemblyAction.AddBypassNGenUsed:
-					return true;
-				default:
-					return false;
+			if (IsRecordingEnabled ()) {
+				foreach (IDependencyRecorder recorder in recorders) {
+					recorder.RecordDependency (source, target, marked);
+				}
 			}
-		}
-
-		bool ShouldRecord (object o)
-		{
-			if (!context.EnableReducedTracing)
-				return true;
-
-			if (o is TypeDefinition t)
-				return WillAssemblyBeModified (t.Module.Assembly);
-
-			if (o is IMemberDefinition m)
-				return WillAssemblyBeModified (m.DeclaringType.Module.Assembly);
-
-			if (o is TypeReference typeRef) {
-				var resolved = typeRef.Resolve ();
-
-				// Err on the side of caution if we can't resolve
-				if (resolved == null)
-					return true;
-
-				return WillAssemblyBeModified (resolved.Module.Assembly);
-			}
-
-			if (o is MemberReference mRef) {
-				var resolved = mRef.Resolve ();
-
-				// Err on the side of caution if we can't resolve
-				if (resolved == null)
-					return true;
-
-				return WillAssemblyBeModified (resolved.DeclaringType.Module.Assembly);
-			}
-
-			if (o is ModuleDefinition module)
-				return WillAssemblyBeModified (module.Assembly);
-
-			if (o is AssemblyDefinition assembly)
-				return WillAssemblyBeModified (assembly);
-
-			if (o is ParameterDefinition parameter) {
-				if (parameter.Method is MethodDefinition parameterMethodDefinition)
-					return WillAssemblyBeModified (parameterMethodDefinition.DeclaringType.Module.Assembly);
-			}
-
-			return true;
 		}
 	}
 }

--- a/src/linker/Linker/XmlDependencyRecorder.cs
+++ b/src/linker/Linker/XmlDependencyRecorder.cs
@@ -1,0 +1,205 @@
+﻿//
+// Tracer.cs
+//
+// Copyright (C) 2017 Microsoft Corporation (http://www.microsoft.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using Mono.Cecil;
+using Mono.Linker.Steps;
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Xml;
+
+namespace Mono.Linker
+{
+	/// <summary>
+	/// Class which implements IDependencyRecorder and writes the dependencies into an XML file.
+	/// </summary>
+	class XmlDependencyRecorder : IDependencyRecorder, IDisposable
+	{
+		private readonly LinkContext context;
+		private XmlWriter writer;
+		private Stream stream;
+
+		public XmlDependencyRecorder (string fileName, LinkContext context)
+		{
+			this.context = context;
+
+			XmlWriterSettings settings = new XmlWriterSettings {
+				Indent = true,
+				IndentChars = "\t"
+			};
+
+			var depsFile = File.OpenWrite (fileName);
+
+			if (Path.GetExtension (fileName) == ".xml")
+				stream = depsFile;
+			else
+				stream = new GZipStream (depsFile, CompressionMode.Compress);
+
+			writer = XmlWriter.Create (stream, settings);
+			writer.WriteStartDocument ();
+			writer.WriteStartElement ("dependencies");
+			writer.WriteStartAttribute ("version");
+			writer.WriteString ("1.2");
+			writer.WriteEndAttribute ();
+		}
+
+		public void Dispose ()
+		{
+			if (writer == null)
+				return;
+
+			writer.WriteEndElement ();
+			writer.WriteEndDocument ();
+			writer.Flush ();
+			writer.Dispose ();
+			stream.Dispose ();
+			writer = null;
+			stream = null;
+		}
+
+		public void RecordDependency (object source, object target, bool marked)
+		{
+			if (!ShouldRecord (source) && !ShouldRecord (target))
+				return;
+
+			// This is a hack to work around a quirk of MarkStep that results in outputting ~6k edges even with the above ShouldRecord checks.
+			// What happens is that due to the method queueing in MarkStep, the dependency chain is broken in many cases.  And in these cases
+			// we end up adding an edge for MarkStep -> <queued Method>
+			// This isn't particularly useful information since it's incomplete, but it's especially not useful in ReducedTracing mode when there is one of these for
+			// every class library method that was queued.
+			if (context.EnableReducedTracing && source is MarkStep && !ShouldRecord (target))
+				return;
+
+			// This is another hack to prevent useless information from being logged.  With the introduction of interface sweeping there are a lot of edges such as
+			// `e="InterfaceImpl:Mono.Cecil.InterfaceImplementation"` which are useless information.  Ideally we would format the interface implementation into a meaningful format
+			// however I don't think that is worth the effort at the moment.
+			if (target is InterfaceImplementation)
+				return;
+
+			if (source != target) {
+				writer.WriteStartElement ("edge");
+				if (marked)
+					writer.WriteAttributeString ("mark", "1");
+				writer.WriteAttributeString ("b", TokenString (source));
+				writer.WriteAttributeString ("e", TokenString (target));
+				writer.WriteEndElement ();
+			}
+		}
+
+		static bool IsAssemblyBound (TypeDefinition td)
+		{
+			do {
+				if (td.IsNestedPrivate || td.IsNestedAssembly || td.IsNestedFamilyAndAssembly)
+					return true;
+
+				td = td.DeclaringType;
+			} while (td != null);
+
+			return false;
+		}
+
+		string TokenString (object o)
+		{
+			if (o == null)
+				return "N:null";
+
+			if (o is TypeReference t) {
+				bool addAssembly = true;
+				var td = t as TypeDefinition ?? t.Resolve ();
+
+				if (td != null) {
+					addAssembly = td.IsNotPublic || IsAssemblyBound (td);
+					t = td;
+				}
+
+				var addition = addAssembly ? $":{t.Module}" : "";
+
+				return $"{(o as IMetadataTokenProvider).MetadataToken.TokenType}:{o}{addition}";
+			}
+
+			if (o is IMetadataTokenProvider)
+				return (o as IMetadataTokenProvider).MetadataToken.TokenType + ":" + o;
+
+			return "Other:" + o;
+		}
+
+		bool WillAssemblyBeModified (AssemblyDefinition assembly)
+		{
+			switch (context.Annotations.GetAction (assembly)) {
+				case AssemblyAction.Link:
+				case AssemblyAction.AddBypassNGen:
+				case AssemblyAction.AddBypassNGenUsed:
+					return true;
+				default:
+					return false;
+			}
+		}
+
+		bool ShouldRecord (object o)
+		{
+			if (!context.EnableReducedTracing)
+				return true;
+
+			if (o is TypeDefinition t)
+				return WillAssemblyBeModified (t.Module.Assembly);
+
+			if (o is IMemberDefinition m)
+				return WillAssemblyBeModified (m.DeclaringType.Module.Assembly);
+
+			if (o is TypeReference typeRef) {
+				var resolved = typeRef.Resolve ();
+
+				// Err on the side of caution if we can't resolve
+				if (resolved == null)
+					return true;
+
+				return WillAssemblyBeModified (resolved.Module.Assembly);
+			}
+
+			if (o is MemberReference mRef) {
+				var resolved = mRef.Resolve ();
+
+				// Err on the side of caution if we can't resolve
+				if (resolved == null)
+					return true;
+
+				return WillAssemblyBeModified (resolved.DeclaringType.Module.Assembly);
+			}
+
+			if (o is ModuleDefinition module)
+				return WillAssemblyBeModified (module.Assembly);
+
+			if (o is AssemblyDefinition assembly)
+				return WillAssemblyBeModified (assembly);
+
+			if (o is ParameterDefinition parameter) {
+				if (parameter.Method is MethodDefinition parameterMethodDefinition)
+					return WillAssemblyBeModified (parameterMethodDefinition.DeclaringType.Module.Assembly);
+			}
+
+			return true;
+		}
+	}
+}

--- a/src/linker/Linker/XmlDependencyRecorder.cs
+++ b/src/linker/Linker/XmlDependencyRecorder.cs
@@ -35,13 +35,15 @@ namespace Mono.Linker
 	/// <summary>
 	/// Class which implements IDependencyRecorder and writes the dependencies into an XML file.
 	/// </summary>
-	class XmlDependencyRecorder : IDependencyRecorder, IDisposable
+	public class XmlDependencyRecorder : IDependencyRecorder, IDisposable
 	{
+		public const string DefaultDependenciesFileName = "linker-dependencies.xml.gz";
+
 		private readonly LinkContext context;
 		private XmlWriter writer;
 		private Stream stream;
 
-		public XmlDependencyRecorder (string fileName, LinkContext context)
+		public XmlDependencyRecorder (LinkContext context, string fileName = null)
 		{
 			this.context = context;
 
@@ -49,6 +51,14 @@ namespace Mono.Linker
 				Indent = true,
 				IndentChars = "\t"
 			};
+
+			if (fileName == null)
+				fileName = DefaultDependenciesFileName;
+
+			if (string.IsNullOrEmpty (Path.GetDirectoryName (fileName)) && !string.IsNullOrEmpty (context.OutputDirectory)) {
+				fileName = Path.Combine (context.OutputDirectory, fileName);
+				Directory.CreateDirectory (context.OutputDirectory);
+			}
 
 			var depsFile = File.OpenWrite (fileName);
 

--- a/test/Mono.Linker.Tests.Cases.Expectations/Assertions/DependencyRecordedAttribute.cs
+++ b/test/Mono.Linker.Tests.Cases.Expectations/Assertions/DependencyRecordedAttribute.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Assertions
+{
+	[AttributeUsage (AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+	public class DependencyRecordedAttribute : BaseExpectedLinkedBehaviorAttribute
+	{
+		public DependencyRecordedAttribute(string source, string target, string marked = null)
+		{
+			if (string.IsNullOrEmpty (source))
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (source));
+
+			if (string.IsNullOrEmpty (target))
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (target));
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Tracing/DependencyRecorder/BasicDependencies.cs
+++ b/test/Mono.Linker.Tests.Cases/Tracing/DependencyRecorder/BasicDependencies.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Tracing.DependencyRecorder
+{
+	[DependencyRecorded("System.Void Mono.Linker.Tests.Cases.Tracing.DependencyRecorder.BasicDependencies::Main()", "Mono.Linker.Tests.Cases.Tracing.DependencyRecorder.UsedType")]
+	[DependencyRecorded ("System.Void Mono.Linker.Tests.Cases.Tracing.DependencyRecorder.BasicDependencies::Main()", "System.Void Mono.Linker.Tests.Cases.Tracing.DependencyRecorder.UsedType::.ctor()")]
+	[DependencyRecorded ("System.Void Mono.Linker.Tests.Cases.Tracing.DependencyRecorder.BasicDependencies::Main()", "System.Void Mono.Linker.Tests.Cases.Tracing.DependencyRecorder.UsedType::UsedMethod()")]
+	public class BasicDependencies
+	{
+		public static void Main()
+		{
+			UsedType ut = new UsedType ();
+			ut.UsedMethod ();
+		}
+	}
+
+	[Kept]
+	class UsedType
+	{
+		[Kept]
+		public UsedType()
+		{
+		}
+
+		[Kept]
+		public void UsedMethod()
+		{
+		}
+	}
+}

--- a/test/Mono.Linker.Tests/TestCases/IndividualTests.cs
+++ b/test/Mono.Linker.Tests/TestCases/IndividualTests.cs
@@ -1,12 +1,10 @@
 ﻿using System;
-using System.IO;
 using System.Xml;
 using Mono.Cecil;
 using Mono.Linker.Tests.Cases.CommandLine.Mvid;
 using Mono.Linker.Tests.Cases.References.Individual;
 using Mono.Linker.Tests.Cases.Tracing.Individual;
 using Mono.Linker.Tests.Extensions;
-using Mono.Linker.Tests.TestCases;
 using Mono.Linker.Tests.TestCasesRunner;
 using NUnit.Framework;
 
@@ -34,7 +32,7 @@ namespace Mono.Linker.Tests.TestCases
 			var testcase = CreateIndividualCase (typeof (CanEnableDependenciesDump));
 			var result = Run (testcase);
 
-			var outputPath = result.OutputAssemblyPath.Parent.Combine (Tracer.DefaultDependenciesFileName);
+			var outputPath = result.OutputAssemblyPath.Parent.Combine (XmlDependencyRecorder.DefaultDependenciesFileName);
 			if (!outputPath.Exists ())
 				Assert.Fail ($"The dependency dump file is missing.  Expected it to exist at {outputPath}");
 		}

--- a/test/Mono.Linker.Tests/TestCases/TestDatabase.cs
+++ b/test/Mono.Linker.Tests/TestCases/TestDatabase.cs
@@ -151,6 +151,11 @@ namespace Mono.Linker.Tests.TestCases
 			return NUnitCasesBySuiteName ("Substitutions");
 		}
 
+		public static IEnumerable<TestCaseData> TracingTests ()
+		{
+			return NUnitCasesBySuiteName ("Tracing");
+		}
+
 		public static TestCaseCollector CreateCollector ()
 		{
 			string rootSourceDirectory;

--- a/test/Mono.Linker.Tests/TestCases/TestSuites.cs
+++ b/test/Mono.Linker.Tests/TestCases/TestSuites.cs
@@ -181,6 +181,12 @@ namespace Mono.Linker.Tests.TestCases
 			Run (testCase);
 		}
 
+		[TestCaseSource (typeof (TestDatabase), nameof (TestDatabase.TracingTests))]
+		public void TracingTests (TestCase testCase)
+		{
+			Run (testCase);
+		}
+
 		protected virtual void Run (TestCase testCase)
 		{
 			var runner = new TestRunner (new ObjectFactory ());

--- a/test/Mono.Linker.Tests/TestCasesRunner/LinkedTestCaseResult.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/LinkedTestCaseResult.cs
@@ -11,8 +11,9 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 		public readonly TestCaseMetadaProvider MetadataProvider;
 		public readonly ManagedCompilationResult CompilationResult;
 		public readonly LinkerTestLogger Logger;
+		public readonly LinkerCustomizations Customizations;
 
-		public LinkedTestCaseResult (TestCase testCase, NPath inputAssemblyPath, NPath outputAssemblyPath, NPath expectationsAssemblyPath, TestCaseSandbox sandbox, TestCaseMetadaProvider metadaProvider, ManagedCompilationResult compilationResult, LinkerTestLogger logger)
+		public LinkedTestCaseResult (TestCase testCase, NPath inputAssemblyPath, NPath outputAssemblyPath, NPath expectationsAssemblyPath, TestCaseSandbox sandbox, TestCaseMetadaProvider metadaProvider, ManagedCompilationResult compilationResult, LinkerTestLogger logger, LinkerCustomizations customizations)
 		{
 			TestCase = testCase;
 			InputAssemblyPath = inputAssemblyPath;
@@ -22,6 +23,7 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			MetadataProvider = metadaProvider;
 			CompilationResult = compilationResult;
 			Logger = logger;
+			Customizations = customizations;
 		}
 	}
 }

--- a/test/Mono.Linker.Tests/TestCasesRunner/LinkerCustomizations.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/LinkerCustomizations.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Mono.Linker.Tests.TestCasesRunner
+{
+	/// <summary>
+	/// Stores various customizations which can be added to the linker at runtime,
+	/// for example test implementations of certain interfaces.
+	/// </summary>
+	public class LinkerCustomizations
+	{
+		public TestDependencyRecorder DependencyRecorder { get; set; }
+
+		public event Action<LinkContext> CustomizeContext;
+
+		public void CustomizeLinkContext(LinkContext context)
+		{
+			CustomizeContext (context);
+		}
+	}
+}

--- a/test/Mono.Linker.Tests/TestCasesRunner/LinkerCustomizations.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/LinkerCustomizations.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Mono.Linker.Tests.TestCasesRunner
 {
@@ -16,7 +14,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 		public void CustomizeLinkContext(LinkContext context)
 		{
-			CustomizeContext (context);
+			CustomizeContext?.Invoke (context);
 		}
 	}
 }

--- a/test/Mono.Linker.Tests/TestCasesRunner/LinkerDriver.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/LinkerDriver.cs
@@ -1,8 +1,25 @@
 ﻿﻿namespace Mono.Linker.Tests.TestCasesRunner {
 	public class LinkerDriver {
-		public virtual void Link (string [] args, ILogger logger)
+		protected class TestDriver : Driver
 		{
-			new Driver (args).Run (logger);
+			LinkerCustomizations _customization;
+
+			public TestDriver(string[] args, LinkerCustomizations customizations) : base(args)
+			{
+				_customization = customizations;
+			}
+
+			protected override void CustomizeContext (LinkContext context)
+			{
+				base.CustomizeContext (context);
+
+				_customization.CustomizeLinkContext (context);
+			}
+		}
+
+		public virtual void Link (string [] args, LinkerCustomizations customizations, ILogger logger)
+		{
+			new TestDriver (args, customizations).Run (logger);
 		}
 	}
 }

--- a/test/Mono.Linker.Tests/TestCasesRunner/LinkerDriver.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/LinkerDriver.cs
@@ -9,11 +9,11 @@
 				_customization = customizations;
 			}
 
-			protected override void CustomizeContext (LinkContext context)
+			protected override LinkContext GetDefaultContext (Pipeline pipeline)
 			{
-				base.CustomizeContext (context);
-
+				LinkContext context = base.GetDefaultContext (pipeline);
 				_customization.CustomizeLinkContext (context);
+				return context;
 			}
 		}
 

--- a/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -167,6 +167,7 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 		protected virtual void AdditionalChecking (LinkedTestCaseResult linkResult, AssemblyDefinition original, AssemblyDefinition linked)
 		{
 			VerifyLoggedMessages(original, linkResult.Logger);
+			VerifyRecordedDependencies (original, linkResult.Customizations.DependencyRecorder);
 		}
 
 		protected virtual void InitialChecking (LinkedTestCaseResult linkResult, AssemblyDefinition original, AssemblyDefinition linked)
@@ -610,6 +611,48 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 						}
 					}
 				}
+			}
+		}
+
+		void VerifyRecordedDependencies (AssemblyDefinition original, TestDependencyRecorder dependencyRecorder)
+		{
+			foreach (var typeWithRemoveInAssembly in original.AllDefinedTypes ()) {
+				foreach (var attr in typeWithRemoveInAssembly.CustomAttributes) {
+					if (attr.AttributeType.Resolve ().Name == nameof (DependencyRecordedAttribute)) {
+						var expectedSource = (string)attr.ConstructorArguments [0].Value;
+						var expectedTarget = (string)attr.ConstructorArguments [1].Value;
+						var expectedMarked = (string)attr.ConstructorArguments [2].Value;
+
+						if (!dependencyRecorder.Dependencies.Any (dependency => {
+								if (dependency.Source != expectedSource)
+									return false;
+
+								if (dependency.Target != expectedTarget)
+									return false;
+
+								return expectedMarked == null || dependency.Marked.ToString () == expectedMarked;
+							})) {
+
+							string targetCandidates = string.Join(Environment.NewLine, dependencyRecorder.Dependencies
+								.Where (d => d.Target.Contains (expectedTarget, StringComparison.OrdinalIgnoreCase))
+								.Select (d => "\t" + DependencyToString (d)));
+							string sourceCandidates = string.Join (Environment.NewLine, dependencyRecorder.Dependencies
+								.Where (d => d.Source.Contains (expectedSource, StringComparison.OrdinalIgnoreCase))
+								.Select (d => "\t" + DependencyToString (d)));
+
+							Assert.Fail (
+								$"Expected to find recorded dependency '{expectedSource} -> {expectedTarget} {expectedMarked ?? string.Empty}'{Environment.NewLine}" +
+								$"Potential dependencies matching the target: {Environment.NewLine}{targetCandidates}{Environment.NewLine}" +
+								$"Potential dependencies matching the source: {Environment.NewLine}{sourceCandidates}{Environment.NewLine}" +
+								$"If there's no matches, try to specify just a part of the source/target name and rerun the test.");
+						}
+					}
+				}
+			}
+
+			string DependencyToString(TestDependencyRecorder.Dependency dependency)
+			{
+				return $"{dependency.Source} -> {dependency.Target} Marked: {dependency.Marked}";
 			}
 		}
 

--- a/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -634,10 +634,10 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 							})) {
 
 							string targetCandidates = string.Join(Environment.NewLine, dependencyRecorder.Dependencies
-								.Where (d => d.Target.Contains (expectedTarget, StringComparison.OrdinalIgnoreCase))
+								.Where (d => d.Target.ToLowerInvariant().Contains (expectedTarget.ToLowerInvariant()))
 								.Select (d => "\t" + DependencyToString (d)));
 							string sourceCandidates = string.Join (Environment.NewLine, dependencyRecorder.Dependencies
-								.Where (d => d.Source.Contains (expectedSource, StringComparison.OrdinalIgnoreCase))
+								.Where (d => d.Source.ToLowerInvariant().Contains (expectedSource.ToLowerInvariant()))
 								.Select (d => "\t" + DependencyToString (d)));
 
 							Assert.Fail (

--- a/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadaProvider.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadaProvider.cs
@@ -66,6 +66,17 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			return tclo;
 		}
 
+		public virtual void CustomizeLinker (LinkerDriver linker, LinkerCustomizations customizations)
+		{
+			if (_testCaseTypeDefinition.CustomAttributes.Any (attr =>
+				attr.AttributeType.Name == nameof (DependencyRecordedAttribute))) {
+				customizations.DependencyRecorder = new TestDependencyRecorder ();
+				customizations.CustomizeContext += context => {
+					context.Tracer.AddRecorder (customizations.DependencyRecorder);
+				};
+			}
+		}
+
 #if NETCOREAPP
 		public static IEnumerable<string> GetTrustedPlatformAssemblies ()
 		{

--- a/test/Mono.Linker.Tests/TestCasesRunner/TestDependencyRecorder.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestDependencyRecorder.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+
+namespace Mono.Linker.Tests.TestCasesRunner
+{
+	public class TestDependencyRecorder : IDependencyRecorder
+	{
+		public struct Dependency
+		{
+			public string Source;
+			public string Target;
+			public bool Marked;
+		}
+
+		public List<Dependency> Dependencies = new List<Dependency> ();
+
+		public void RecordDependency (object source, object target, bool marked)
+		{
+			Dependencies.Add (new Dependency () {
+				Source = source.ToString (),
+				Target = target.ToString (),
+				Marked = marked
+			});
+		}
+	}
+}

--- a/test/Mono.Linker.Tests/TestCasesRunner/TestRunner.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestRunner.cs
@@ -92,14 +92,16 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 		private LinkedTestCaseResult Link (TestCase testCase, TestCaseSandbox sandbox, ManagedCompilationResult compilationResult, TestCaseMetadaProvider metadataProvider)
 		{
 			var linker = _factory.CreateLinker ();
+			var linkerCustomizations = CustomizeLinker (linker, metadataProvider);
+
 			var builder = _factory.CreateLinkerArgumentBuilder (metadataProvider);
 
 			AddLinkOptions (sandbox, compilationResult, builder, metadataProvider);
 
 			LinkerTestLogger logger = new LinkerTestLogger();
-			linker.Link (builder.ToArgs (), logger);
+			linker.Link (builder.ToArgs (), linkerCustomizations, logger);
 
-			return new LinkedTestCaseResult (testCase, compilationResult.InputAssemblyPath, sandbox.OutputDirectory.Combine (compilationResult.InputAssemblyPath.FileName), compilationResult.ExpectationsAssemblyPath, sandbox, metadataProvider, compilationResult, logger);
+			return new LinkedTestCaseResult (testCase, compilationResult.InputAssemblyPath, sandbox.OutputDirectory.Combine (compilationResult.InputAssemblyPath.FileName), compilationResult.ExpectationsAssemblyPath, sandbox, metadataProvider, compilationResult, logger, linkerCustomizations);
 		}
 
 		protected virtual void AddLinkOptions (TestCaseSandbox sandbox, ManagedCompilationResult compilationResult, LinkerArgumentBuilder builder, TestCaseMetadaProvider metadataProvider)
@@ -120,6 +122,15 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			builder.ProcessOptions (caseDefinedOptions);
 
 			builder.ProcessTestInputAssembly (compilationResult.InputAssemblyPath);
+		}
+
+		protected virtual LinkerCustomizations CustomizeLinker(LinkerDriver linker, TestCaseMetadaProvider metadataProvider)
+		{
+			LinkerCustomizations customizations = new LinkerCustomizations ();
+
+			metadataProvider.CustomizeLinker (linker, customizations);
+
+			return customizations;
 		}
 
 		private T GetResultOfTaskThatMakesNUnitAssertions<T> (Task<T> task)


### PR DESCRIPTION
Adds ;IDependencyRecorder; which separates the linker/tracer from the actual implementation which stores the dependencies.
Implements the default XML writer for the dependencies (should produce exactly the same output as before the change).
Adds test infra to test the dependency recorder directly (as a test mock) and a simple test.

Motivation: Future analyzers need to have visibility into the dependency analysis (MarkStep basically) to report what caused a given method/type to be included. We already expose this information through the dependency XML, this just adds an API to do this programatically.