### PR TITLE
Move to new arcade publishing using yaml stages

### DIFF
--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -12,105 +12,118 @@ variables:
   value: Release
 - name: _BuildArgs
   value: /p:ArcadeBuild=true
+- name: _DotNetArtifactsCategory
+  value: .NETCore
 - ${{ if eq(variables.officialBuild, 'true') }}:
   - name: _BuildArgs
     value: ${{ format('{0} /p:OfficialBuildId=$(Build.BuildNumber)', variables['_BuildArgs']) }}
   # Provide HelixApiAccessToken for telemetry
   - group: DotNet-HelixApi-Access
 
-jobs:
-- template: /eng/common/templates/jobs/jobs.yml
-  parameters:
+stages:
+- stage: build
+  displayName: Build
+  jobs:
+  - template: /eng/common/templates/jobs/jobs.yml
+    parameters:
 
-    enableTelemetry: true # send helix telemetry
-    helixRepo: mono/linker
-    enablePublishBuildArtifacts: true # publish build logs to pipeline storage
-    # enablePublishTestResults
-    enablePublishBuildAssets: true # generate build manifests and publish to BAR in internal builds
-    enableMicrobuild: true # only affects internal builds
+      enableTelemetry: true # send helix telemetry
+      helixRepo: mono/linker
+      enablePublishUsingPipelines: true
+      enablePublishBuildArtifacts: true # publish build logs to pipeline storage
+      # enablePublishTestResults
+      enablePublishBuildAssets: true # generate build manifests and publish to BAR in internal builds
+      enableMicrobuild: true # only affects internal builds
 
-    jobs:
+      jobs:
 
-    - job: Windows_NT
-      pool:
-        ${{ if eq(variables.officialBuild, 'false') }}:
-          name: Hosted VS2017
-        ${{ if eq(variables.officialBuild, 'true') }}:
-          name: NetCoreInternal-Pool
-          queue: BuildPool.Windows.10.Amd64.VS2017
-      variables:
-        - ${{ if eq(variables.officialBuild, 'false') }}:
-          - _SignType: test
-          - _PublishArgs: ''
-        - ${{ if eq(variables.officialBuild, 'true') }}:
-          - group: DotNet-Blob-Feed
-          - _TeamName: .NET # required by microbuild install step
-          - _SignType: real # used in the arcade templates that install microbuild.
-          - _DotNetPublishToBlobFeed: true # used by arcade templates that gather build asset manifests
-          - _PublishArgs: /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
-                          /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
-                          /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
-        - DotNetSignType: ${{ format('{0}', variables._SignType) }} # DotNetSignType defaults to real if not specified
-      steps:
-      - checkout: self
-        submodules: true
-      - script: eng\common\cibuild.cmd -projects $(Build.SourcesDirectory)\illink.sln
-                -configuration $(_BuildConfig) $(_BuildArgs) $(_PublishArgs)
-                -warnAsError "$false"
-                -nodeReuse "$false" # https://github.com/Microsoft/vstest/issues/1503
-        env:
-          # https://github.com/Microsoft/vstest/issues/1503#issuecomment-410732193
-          MSBUILDENSURESTDOUTFORTASKPROCESSES: 1
-        ${{ if eq(variables.officialBuild, 'false') }}:
+      - job: Windows_NT
+        pool:
+          ${{ if eq(variables.officialBuild, 'false') }}:
+            name: Hosted VS2017
+          ${{ if eq(variables.officialBuild, 'true') }}:
+            name: NetCoreInternal-Pool
+            queue: BuildPool.Windows.10.Amd64.VS2017
+        variables:
+          - ${{ if eq(variables.officialBuild, 'false') }}:
+            - _SignType: test
+            - _PublishArgs: ''
+          - ${{ if eq(variables.officialBuild, 'true') }}:
+            - group: DotNet-Blob-Feed
+            - _TeamName: .NET # required by microbuild install step
+            - _SignType: real # used in the arcade templates that install microbuild.
+            - _DotNetPublishToBlobFeed: true # used by arcade templates that gather build asset manifests
+            - _PublishArgs: /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
+                            /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+                            /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
+                            /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
+                            /p:DotNetPublishUsingPipelines=true
+          - DotNetSignType: ${{ format('{0}', variables._SignType) }} # DotNetSignType defaults to real if not specified
+        steps:
+        - checkout: self
+          submodules: true
+        - script: eng\common\cibuild.cmd -projects $(Build.SourcesDirectory)\illink.sln
+                  -configuration $(_BuildConfig) $(_BuildArgs) $(_PublishArgs)
+                  -warnAsError "$false"
+                  -nodeReuse "$false" # https://github.com/Microsoft/vstest/issues/1503
+          env:
+            # https://github.com/Microsoft/vstest/issues/1503#issuecomment-410732193
+            MSBUILDENSURESTDOUTFORTASKPROCESSES: 1
+          ${{ if eq(variables.officialBuild, 'false') }}:
+            displayName: Build illink.sln $(_BuildConfig)
+          ${{ if eq(variables.officialBuild, 'true') }}:
+            displayName: Build and publish illink.sln $(_BuildConfig)
+
+      - job: Linux
+        pool:
+          name: Hosted Ubuntu 1604
+        steps:
+        - checkout: self
+          submodules: true
+        - script: eng/common/cibuild.sh --projects $(Build.SourcesDirectory)/illink.sln
+                  --configuration $(_BuildConfig) $(_BuildArgs)
+                  --warnAsError false
+                  --nodeReuse false # https://github.com/Microsoft/vstest/issues/1503
+          env:
+            # https://github.com/Microsoft/vstest/issues/1503#issuecomment-410732193
+            MSBUILDENSURESTDOUTFORTASKPROCESSES: 1
           displayName: Build illink.sln $(_BuildConfig)
-        ${{ if eq(variables.officialBuild, 'true') }}:
-          displayName: Build and publish illink.sln $(_BuildConfig)
 
-    - job: Linux
-      pool:
-        name: Hosted Ubuntu 1604
-      steps:
-      - checkout: self
-        submodules: true
-      - script: eng/common/cibuild.sh --projects $(Build.SourcesDirectory)/illink.sln
-                --configuration $(_BuildConfig) $(_BuildArgs)
-                --warnAsError false
-                --nodeReuse false # https://github.com/Microsoft/vstest/issues/1503
-        env:
-          # https://github.com/Microsoft/vstest/issues/1503#issuecomment-410732193
-          MSBUILDENSURESTDOUTFORTASKPROCESSES: 1
-        displayName: Build illink.sln $(_BuildConfig)
+      - job: Linux_Mono
+        pool:
+          name: Hosted Ubuntu 1604
+        steps:
+        - checkout: self
+          submodules: true
+        - script: |
+            mkdir -p artifacts/log/$(_BuildConfig)
+            mono --version | tee artifacts/log/$(_BuildConfig)/mono-version.txt
+            make -C monobuild CONFIGURATION=$(_BuildConfig)
+          displayName: Build and test
+        - task: PublishTestResults@2
+          inputs:
+            testResultsFormat: 'NUnit'
+            testResultsFiles: 'test/Mono.Linker.Tests/TestResults.xml'
 
-    - job: Linux_Mono
-      pool:
-        name: Hosted Ubuntu 1604
-      steps:
-      - checkout: self
-        submodules: true
-      - script: |
-          mkdir -p artifacts/log/$(_BuildConfig)
-          mono --version | tee artifacts/log/$(_BuildConfig)/mono-version.txt
-          make -C monobuild CONFIGURATION=$(_BuildConfig)
-        displayName: Build and test
-      - task: PublishTestResults@2
-        inputs:
-          testResultsFormat: 'NUnit'
-          testResultsFiles: 'test/Mono.Linker.Tests/TestResults.xml'
+      - job: macOS
+        pool:
+          ${{ if eq(variables.officialBuild, 'false') }}:
+            name: Hosted MacOS
+          ${{ if eq(variables.officialBuild, 'true') }}:
+            name: Hosted Mac Internal
+        steps:
+        - checkout: self
+          submodules: true
+        - script: eng/common/cibuild.sh --projects $(Build.SourcesDirectory)/illink.sln
+                  --configuration $(_BuildConfig) $(_BuildArgs)
+                  --warnAsError false
+                  --nodeReuse false # https://github.com/Microsoft/vstest/issues/1503
+          env:
+            # https://github.com/Microsoft/vstest/issues/1503#issuecomment-410732193
+            MSBUILDENSURESTDOUTFORTASKPROCESSES: 1
+          displayName: Build illink.sln $(_BuildConfig)
 
-    - job: macOS
-      pool:
-        ${{ if eq(variables.officialBuild, 'false') }}:
-          name: Hosted MacOS
-        ${{ if eq(variables.officialBuild, 'true') }}:
-          name: Hosted Mac Internal
-      steps:
-      - checkout: self
-        submodules: true
-      - script: eng/common/cibuild.sh --projects $(Build.SourcesDirectory)/illink.sln
-                --configuration $(_BuildConfig) $(_BuildArgs)
-                --warnAsError false
-                --nodeReuse false # https://github.com/Microsoft/vstest/issues/1503
-        env:
-          # https://github.com/Microsoft/vstest/issues/1503#issuecomment-410732193
-          MSBUILDENSURESTDOUTFORTASKPROCESSES: 1
-        displayName: Build illink.sln $(_BuildConfig)
+# Post-Build Arcade logic
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - template: /eng/common/templates/post-build/post-build.yml
+

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -16,7 +16,7 @@ variables:
   value: .NETCore
 - ${{ if eq(variables.officialBuild, 'true') }}:
   - name: _BuildArgs
-    value: ${{ format('{0} /p:OfficialBuildId=$(Build.BuildNumber)', variables['_BuildArgs']) }}
+    value: ${{ format('{0} /p:OfficialBuildId=$(Build.BuildNumber) /p:Test=false', variables['_BuildArgs']) }}
   # Provide HelixApiAccessToken for telemetry
   - group: DotNet-HelixApi-Access
 

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -74,56 +74,57 @@ stages:
           ${{ if eq(variables.officialBuild, 'true') }}:
             displayName: Build and publish illink.sln $(_BuildConfig)
 
-      - job: Linux
-        pool:
-          name: Hosted Ubuntu 1604
-        steps:
-        - checkout: self
-          submodules: true
-        - script: eng/common/cibuild.sh --projects $(Build.SourcesDirectory)/illink.sln
-                  --configuration $(_BuildConfig) $(_BuildArgs)
-                  --warnAsError false
-                  --nodeReuse false # https://github.com/Microsoft/vstest/issues/1503
-          env:
-            # https://github.com/Microsoft/vstest/issues/1503#issuecomment-410732193
-            MSBUILDENSURESTDOUTFORTASKPROCESSES: 1
-          displayName: Build illink.sln $(_BuildConfig)
+      - ${{ if eq(variables.officialBuild, 'false') }}:
+        - job: Linux
+          condition: eq(variables.officialBuild, 'false')
+          pool:
+            name: Hosted Ubuntu 1604
+          steps:
+          - checkout: self
+            submodules: true
+          - script: eng/common/cibuild.sh --projects $(Build.SourcesDirectory)/illink.sln
+                    --configuration $(_BuildConfig) $(_BuildArgs)
+                    --warnAsError false
+                    --nodeReuse false # https://github.com/Microsoft/vstest/issues/1503
+            env:
+              # https://github.com/Microsoft/vstest/issues/1503#issuecomment-410732193
+              MSBUILDENSURESTDOUTFORTASKPROCESSES: 1
+            displayName: Build illink.sln $(_BuildConfig)
 
-      - job: Linux_Mono
-        pool:
-          name: Hosted Ubuntu 1604
-        steps:
-        - checkout: self
-          submodules: true
-        - script: |
-            mkdir -p artifacts/log/$(_BuildConfig)
-            mono --version | tee artifacts/log/$(_BuildConfig)/mono-version.txt
-            make -C monobuild CONFIGURATION=$(_BuildConfig)
-          displayName: Build and test
-        - task: PublishTestResults@2
-          inputs:
-            testResultsFormat: 'NUnit'
-            testResultsFiles: 'test/Mono.Linker.Tests/TestResults.xml'
+      - ${{ if eq(variables.officialBuild, 'false') }}:
+        - job: Linux_Mono
+          pool:
+            name: Hosted Ubuntu 1604
+          steps:
+          - checkout: self
+            submodules: true
+          - script: |
+              mkdir -p artifacts/log/$(_BuildConfig)
+              mono --version | tee artifacts/log/$(_BuildConfig)/mono-version.txt
+              make -C monobuild CONFIGURATION=$(_BuildConfig)
+            displayName: Build and test
+          - task: PublishTestResults@2
+            inputs:
+              testResultsFormat: 'NUnit'
+              testResultsFiles: 'test/Mono.Linker.Tests/TestResults.xml'
 
-      - job: macOS
-        pool:
-          ${{ if eq(variables.officialBuild, 'false') }}:
-            name: Hosted MacOS
-          ${{ if eq(variables.officialBuild, 'true') }}:
-            name: Hosted Mac Internal
-        steps:
-        - checkout: self
-          submodules: true
-        - script: eng/common/cibuild.sh --projects $(Build.SourcesDirectory)/illink.sln
-                  --configuration $(_BuildConfig) $(_BuildArgs)
-                  --warnAsError false
-                  --nodeReuse false # https://github.com/Microsoft/vstest/issues/1503
-          env:
-            # https://github.com/Microsoft/vstest/issues/1503#issuecomment-410732193
-            MSBUILDENSURESTDOUTFORTASKPROCESSES: 1
-          displayName: Build illink.sln $(_BuildConfig)
+      - ${{ if eq(variables.officialBuild, 'false') }}:
+        - job: macOS
+          pool:
+              name: Hosted MacOS
+          steps:
+          - checkout: self
+            submodules: true
+          - script: eng/common/cibuild.sh --projects $(Build.SourcesDirectory)/illink.sln
+                    --configuration $(_BuildConfig) $(_BuildArgs)
+                    --warnAsError false
+                    --nodeReuse false # https://github.com/Microsoft/vstest/issues/1503
+            env:
+              # https://github.com/Microsoft/vstest/issues/1503#issuecomment-410732193
+              MSBUILDENSURESTDOUTFORTASKPROCESSES: 1
+            displayName: Build illink.sln $(_BuildConfig)
 
 # Post-Build Arcade logic
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+- ${{ if eq(variables.officialBuild, 'true') }}:
   - template: /eng/common/templates/post-build/post-build.yml
 

--- a/src/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/src/ILLink.Tasks/ILLink.Tasks.csproj
@@ -9,7 +9,6 @@
     <IsPackable>true</IsPackable>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Description>MSBuild tasks for running the IL Linker</Description>
-    <Authors>$(AssemblyName)</Authors>
     <!-- Don't include the build output. Instead, we want to include
          the TargetFramework-specific publish output. -->
     <IncludeBuildOutput>false</IncludeBuildOutput>


### PR DESCRIPTION
Following https://github.com/dotnet/arcade/pull/4556

I ran an internal build with these changes here: https://dev.azure.com/dnceng/internal/_build/results?buildId=463049&view=results