### PR TITLE
Added a case statement for when AssemblyAction is Skip in MarkStep

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -88,6 +88,7 @@ namespace Mono.Linker.Steps {
 				case AssemblyAction.Link:
 				case AssemblyAction.AddBypassNGen:
 				case AssemblyAction.AddBypassNGenUsed:
+				case AssemblyAction.Skip:
 					MarkAssembly (assembly);
 
 					foreach (TypeDefinition type in assembly.MainModule.Types)


### PR DESCRIPTION
This fixes error in issue #913 by using the same behavior it had before #810 fix 