### PR TITLE
Fix a bug in the reflection pattern recorder usage

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2422,13 +2422,13 @@ namespace Mono.Linker.Steps {
 			public void RecordRecognizedPattern<T> (T accessedItem, Action mark)
 				where T : IMemberDefinition
 			{
+#if DEBUG
 				Debug.Assert (_patternAnalysisAttempted, "To correctly report all patterns, when starting to analyze a pattern the AnalyzingPattern must be called first.");
+				_patternReported = true;
+#endif
 
 				_context.Tracer.Push ($"Reflection-{accessedItem}");
 				try {
-#if DEBUG
-					_patternReported = true;
-#endif
 					mark ();
 					_context.ReflectionPatternRecorder.RecognizedReflectionAccessPattern (MethodCalling, MethodCalled, accessedItem);
 				} finally {
@@ -2438,17 +2438,19 @@ namespace Mono.Linker.Steps {
 
 			public void RecordUnrecognizedPattern (string message)
 			{
-				Debug.Assert (_patternAnalysisAttempted, "To correctly report all patterns, when starting to analyze a pattern the AnalyzingPattern must be called first.");
-
 #if DEBUG
+				Debug.Assert (_patternAnalysisAttempted, "To correctly report all patterns, when starting to analyze a pattern the AnalyzingPattern must be called first.");
 				_patternReported = true;
 #endif
+
 				_context.ReflectionPatternRecorder.UnrecognizedReflectionAccessPattern (MethodCalling, MethodCalled, message);
 			}
 
 			public void Dispose ()
 			{
+#if DEBUG
 				Debug.Assert(!_patternAnalysisAttempted || _patternReported, "A reflection pattern was analyzed, but no result was reported.");
+#endif
 			}
 		}
 

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2378,11 +2378,21 @@ namespace Mono.Linker.Steps {
 			}
 		}
 
+		/// <summary>
+		/// Helper struct to pass around context information about reflection pattern
+		/// as a single parameter (and have a way to extend this in the future if we need to easily).
+		/// Also implements a simple validation mechanism to check that the code does report patter recognition
+		/// results for all methods it works on.
+		/// The promise of the pattern recorder is that for a given reflection method, it will either not talk
+		/// about it ever, or it will always report recognized/unrecognized.
+		/// </summary>
 		struct ReflectionPatternContext : IDisposable
 		{
 			readonly LinkContext _context;
+#if DEBUG
 			bool _patternAnalysisAttempted;
 			bool _patternReported;
+#endif
 
 			public MethodDefinition MethodCalling { get; private set; }
 			public MethodDefinition MethodCalled { get; private set; }
@@ -2395,13 +2405,18 @@ namespace Mono.Linker.Steps {
 				MethodCalled = methodCalled;
 				InstructionIndex = instructionIndex;
 
+#if DEBUG
 				_patternAnalysisAttempted = false;
 				_patternReported = false;
+#endif
 			}
 
+			[Conditional("DEBUG")]
 			public void AnalyzingPattern ()
 			{
+#if DEBUG
 				_patternAnalysisAttempted = true;
+#endif
 			}
 
 			public void RecordRecognizedPattern<T> (T accessedItem, Action mark)
@@ -2411,7 +2426,9 @@ namespace Mono.Linker.Steps {
 
 				_context.Tracer.Push ($"Reflection-{accessedItem}");
 				try {
+#if DEBUG
 					_patternReported = true;
+#endif
 					mark ();
 					_context.ReflectionPatternRecorder.RecognizedReflectionAccessPattern (MethodCalling, MethodCalled, accessedItem);
 				} finally {
@@ -2423,15 +2440,15 @@ namespace Mono.Linker.Steps {
 			{
 				Debug.Assert (_patternAnalysisAttempted, "To correctly report all patterns, when starting to analyze a pattern the AnalyzingPattern must be called first.");
 
+#if DEBUG
 				_patternReported = true;
+#endif
 				_context.ReflectionPatternRecorder.UnrecognizedReflectionAccessPattern (MethodCalling, MethodCalled, message);
 			}
 
 			public void Dispose ()
 			{
-				if (_patternAnalysisAttempted && !_patternReported) {
-					Debug.Fail ("A reflection pattern was analyzed, but no result was reported.");
-				}
+				Debug.Assert(!_patternAnalysisAttempted || _patternReported, "A reflection pattern was analyzed, but no result was reported.");
 			}
 		}
 

--- a/src/linker/Mono.Linker.csproj
+++ b/src/linker/Mono.Linker.csproj
@@ -13,6 +13,7 @@
     <AssemblyName>illink</AssemblyName>
     <Description>IL Linker</Description>
     <DefineConstants>$(DefineConstants);FEATURE_ILLINK</DefineConstants>
+    <DefineConstants Condition="'$(Configuration)' == 'illink_Debug'">$(DefineConstants);DEBUG</DefineConstants>
     <!-- net46 build is disabled until cecil uses SDK-style projects. -->
     <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Core' And '$(OS)' != 'Windows_NT'">netcoreapp2.0</TargetFrameworks>

--- a/test/Mono.Linker.Tests.Cases.Expectations/Assertions/RecognizedReflectionAccessPatternAttribute.cs
+++ b/test/Mono.Linker.Tests.Cases.Expectations/Assertions/RecognizedReflectionAccessPatternAttribute.cs
@@ -20,5 +20,21 @@ namespace Mono.Linker.Tests.Cases.Expectations.Assertions
 			if (accessedItemName == null)
 				throw new ArgumentException ("Value cannot be null or empty.", nameof (accessedItemName));
 		}
+
+		public RecognizedReflectionAccessPatternAttribute (Type reflectionMethodType, string reflectionMethodName, Type [] reflectionMethodParameters,
+			Type accessedItemType, string accessedItemName, string [] accessedItemParameters)
+		{
+			if (reflectionMethodType == null)
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (reflectionMethodType));
+			if (reflectionMethodName == null)
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (reflectionMethodName));
+			if (reflectionMethodParameters == null)
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (reflectionMethodParameters));
+
+			if (accessedItemType == null)
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (accessedItemType));
+			if (accessedItemName == null)
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (accessedItemName));
+		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases.Expectations/Assertions/UnrecognizedReflectionAccessPatternAttribute.cs
+++ b/test/Mono.Linker.Tests.Cases.Expectations/Assertions/UnrecognizedReflectionAccessPatternAttribute.cs
@@ -18,5 +18,19 @@ namespace Mono.Linker.Tests.Cases.Expectations.Assertions
 			if (message == null)
 				throw new ArgumentException ("Value cannot be null or empty.", nameof (message));
 		}
+
+		public UnrecognizedReflectionAccessPatternAttribute (Type reflectionMethodType, string reflectionMethodName, string [] reflectionMethodParameters,
+		string message = null)
+		{
+			if (reflectionMethodType == null)
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (reflectionMethodType));
+			if (reflectionMethodName == null)
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (reflectionMethodName));
+			if (reflectionMethodParameters == null)
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (reflectionMethodParameters));
+
+			if (message == null)
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (message));
+		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases.Expectations/Assertions/VerifyAllReflectionAccessPatternsAreHandledAttribute.cs
+++ b/test/Mono.Linker.Tests.Cases.Expectations/Assertions/VerifyAllReflectionAccessPatternsAreHandledAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Assertions
+{
+	[AttributeUsage (AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+	public class VerifyAllReflectionAccessPatternsAreValidatedAttribute : BaseExpectedLinkedBehaviorAttribute
+	{
+		public VerifyAllReflectionAccessPatternsAreValidatedAttribute ()
+		{
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Reflection/ConstructorUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ConstructorUsedViaReflection.cs
@@ -7,8 +7,43 @@ namespace Mono.Linker.Tests.Cases.Reflection
 	public class ConstructorUsedViaReflection {
 		public static void Main ()
 		{
-			var constructor = typeof (OnlyUsedViaReflection).GetConstructor (BindingFlags.Public, GetNullValue ("some argument", 2, 3), new Type[]{}, new ParameterModifier[]{});
-			constructor.Invoke (null, new object[] { });
+			TestWithBindingFlags ();
+			TestNullType ();
+			TestDataFlowType ();
+		}
+
+		[RecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetConstructor), new Type [] { typeof (BindingFlags), typeof (Binder), typeof (Type[]), typeof (ParameterModifier []) },
+			typeof (OnlyUsedViaReflection), ".ctor", new Type [0])]
+		[Kept]
+		static void TestWithBindingFlags ()
+		{
+			var constructor = typeof (OnlyUsedViaReflection).GetConstructor (BindingFlags.Public, GetNullValue ("some argument", 2, 3), new Type [] { }, new ParameterModifier [] { });
+			constructor.Invoke (null, new object [] { });
+		}
+
+		[UnrecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetConstructor), new Type [] { typeof (Type []) })]
+		[Kept]
+		static void TestNullType ()
+		{
+			Type type = null;
+			var constructor = type.GetConstructor (new Type [] { });
+		}
+
+		[Kept]
+		static Type FindType ()
+		{
+			return null;
+		}
+
+		[UnrecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetConstructor), new Type [] { typeof (Type []) })]
+		[Kept]
+		static void TestDataFlowType ()
+		{
+			Type type = FindType ();
+			var constructor = type.GetConstructor (new Type [] { });
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/Reflection/EventUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/EventUsedViaReflection.cs
@@ -6,8 +6,71 @@ namespace Mono.Linker.Tests.Cases.Reflection {
 		public static void Main ()
 		{
 			new Foo (); // Needed to avoid lazy body marking stubbing
+
+			TestByName ();
+			TestNullName ();
+			TestEmptyName ();
+			TestNonExistingName ();
+			TestNullType ();
+			TestDataFlowType ();
+		}
+
+		[Kept]
+		[RecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetEvent), new Type [] { typeof (string) },
+			typeof (Foo), nameof (Foo.Event), (Type[]) null)]
+		static void TestByName ()
+		{
 			var eventInfo = typeof (Foo).GetEvent ("Event");
 			eventInfo.GetAddMethod (false);
+		}
+
+		[Kept]
+		[UnrecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetEvent), new Type [] { typeof (string) })]
+		static void TestNullName ()
+		{
+			var eventInfo = typeof (EventUsedViaReflection).GetEvent (null);
+		}
+
+		[Kept]
+		[UnrecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetEvent), new Type [] { typeof (string) })]
+		static void TestEmptyName ()
+		{
+			var eventInfo = typeof (EventUsedViaReflection).GetEvent (string.Empty);
+		}
+
+		[Kept]
+		[UnrecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetEvent), new Type [] { typeof (string) })]
+		static void TestNonExistingName ()
+		{
+			var eventInfo = typeof (EventUsedViaReflection).GetEvent ("NonExisting");
+		}
+
+		[Kept]
+		[UnrecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetEvent), new Type [] { typeof (string) })]
+		static void TestNullType ()
+		{
+			Type type = null;
+			var eventInfo = type.GetEvent ("Event");
+		}
+
+		[Kept]
+		static Type FindType ()
+		{
+			return typeof (Foo);
+		}
+
+		[Kept]
+		[UnrecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetEvent), new Type [] { typeof (string) })]
+		static void TestDataFlowType ()
+		{
+			Type type = FindType ();
+			var eventInfo = type.GetEvent ("Event");
 		}
 
 		[KeptMember (".ctor()")]
@@ -16,7 +79,7 @@ namespace Mono.Linker.Tests.Cases.Reflection {
 			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
-			event EventHandler<EventArgs> Event;
+			internal event EventHandler<EventArgs> Event;
 		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallString.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallString.cs
@@ -11,11 +11,70 @@ namespace Mono.Linker.Tests.Cases.Reflection
 	{
 		public static void Main ()
 		{
+			TestByName ();
+			TestByNameWithParameters ();
+			TestNullName ();
+			TestNonExistingName ();
+			TestNullType ();
+			TestDataFlowType ();
+		}
+
+		[RecognizedReflectionAccessPattern (
+			typeof (Expression), nameof (Expression.Call), new Type [] { typeof (Type), typeof (string), typeof (Type[]), typeof (Expression []) },
+			typeof (ExpressionCallString), nameof (OnlyCalledViaExpression), new Type [0])]
+		[Kept]
+		static void TestByName ()
+		{
 			var expr = Expression.Call (typeof (ExpressionCallString), "OnlyCalledViaExpression", Type.EmptyTypes);
 			Console.WriteLine (expr.Method);
+		}
 
-            IQueryable source = null;
-            var e2 = Expression.Call (typeof (ExpressionCallString), "Count", new Type [] { source.ElementType }, source.Expression);
+		[RecognizedReflectionAccessPattern (
+			typeof (Expression), nameof (Expression.Call), new Type [] { typeof (Type), typeof (string), typeof (Type []), typeof (Expression []) },
+			typeof (ExpressionCallString), nameof (Count) + "<T>", new string [] { "T" } )]
+		[Kept]
+		static void TestByNameWithParameters ()
+		{
+			IQueryable source = null;
+			var e2 = Expression.Call (typeof (ExpressionCallString), "Count", new Type [] { source.ElementType }, source.Expression);
+		}
+
+		[UnrecognizedReflectionAccessPattern (
+			typeof (Expression), nameof (Expression.Call), new Type [] { typeof (Type), typeof (string), typeof (Type []), typeof (Expression []) })]
+		[Kept]
+		static void TestNullName ()
+		{
+			var expr = Expression.Call (typeof (ExpressionCallString), null, Type.EmptyTypes);
+		}
+
+		[UnrecognizedReflectionAccessPattern (
+			typeof (Expression), nameof (Expression.Call), new Type [] { typeof (Type), typeof (string), typeof (Type []), typeof (Expression []) })]
+		[Kept]
+		static void TestNonExistingName ()
+		{
+			var expr = Expression.Call (typeof (ExpressionCallString), "NonExisting", Type.EmptyTypes);
+		}
+
+		[UnrecognizedReflectionAccessPattern (
+			typeof (Expression), nameof (Expression.Call), new Type [] { typeof (Type), typeof (string), typeof (Type []), typeof (Expression []) })]
+		[Kept]
+		static void TestNullType ()
+		{
+			var expr = Expression.Call ((Type)null, "OnlyCalledViaExpression", Type.EmptyTypes);
+		}
+
+		[Kept]
+		static Type FindType ()
+		{
+			return typeof (ExpressionCallString);
+		}
+
+		[UnrecognizedReflectionAccessPattern (
+			typeof (Expression), nameof (Expression.Call), new Type [] { typeof (Type), typeof (string), typeof (Type []), typeof (Expression []) })]
+		[Kept]
+		static void TestDataFlowType ()
+		{
+			var expr = Expression.Call (FindType (), "OnlyCalledViaExpression", Type.EmptyTypes);
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/Reflection/FieldUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/FieldUsedViaReflection.cs
@@ -1,13 +1,77 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Reflection {
 	public class FieldUsedViaReflection {
 		public static void Main ()
 		{
+			TestByName ();
+			TestNullName ();
+			TestEmptyName ();
+			TestNonExistingName ();
+			TestNullType ();
+			TestDataFlowType ();
+		}
+
+		[Kept]
+		[RecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetField), new Type [] { typeof (string) },
+			typeof (FieldUsedViaReflection), nameof (FieldUsedViaReflection.field), (Type[]) null)]
+		static void TestByName ()
+		{
 			var field = typeof (FieldUsedViaReflection).GetField ("field");
 			field.GetValue (null);
 		}
+
+		[Kept]
+		[UnrecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetField), new Type [] { typeof (string) })]
+		static void TestNullName ()
+		{
+			var field = typeof (FieldUsedViaReflection).GetField (null);
+		}
+
+		[Kept]
+		[UnrecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetField), new Type [] { typeof (string) })]
+		static void TestEmptyName ()
+		{
+			var field = typeof (FieldUsedViaReflection).GetField (string.Empty);
+		}
+
+		[Kept]
+		[UnrecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetField), new Type [] { typeof (string) })]
+		static void TestNonExistingName ()
+		{
+			var field = typeof (FieldUsedViaReflection).GetField ("NonExisting");
+		}
+
+		[Kept]
+		[UnrecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetField), new Type [] { typeof (string) })]
+		static void TestNullType ()
+		{
+			Type type = null;
+			var field = type.GetField ("field");
+		}
+
+		[Kept]
+		static Type FindType ()
+		{
+			return typeof (FieldUsedViaReflection);
+		}
+
+		[Kept]
+		[UnrecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetField), new Type [] { typeof (string) })]
+		static void TestDataFlowType ()
+		{
+			Type type = FindType ();
+			var field = type.GetField ("field");
+		}
+
 
 		[Kept]
 		static int field;

--- a/test/Mono.Linker.Tests.Cases/Reflection/MethodUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/MethodUsedViaReflection.cs
@@ -4,6 +4,7 @@ using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Reflection {
 
+	[VerifyAllReflectionAccessPatternsAreValidated]
 	public class MethodUsedViaReflection {
 		[RecognizedReflectionAccessPattern (
 			typeof (Type), nameof (Type.GetMethod), new Type [] { typeof(string), typeof(BindingFlags) },

--- a/test/Mono.Linker.Tests.Cases/Reflection/MethodUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/MethodUsedViaReflection.cs
@@ -6,13 +6,72 @@ namespace Mono.Linker.Tests.Cases.Reflection {
 
 	[VerifyAllReflectionAccessPatternsAreValidated]
 	public class MethodUsedViaReflection {
-		[RecognizedReflectionAccessPattern (
-			typeof (Type), nameof (Type.GetMethod), new Type [] { typeof(string), typeof(BindingFlags) },
-			typeof (MethodUsedViaReflection), nameof (MethodUsedViaReflection.OnlyCalledViaReflection), new Type [0])]
 		public static void Main ()
 		{
+			TestNameAndExplicitBindingFlags ();
+			TestNullName ();
+			TestEmptyName ();
+			TestNonExistingName ();
+			TestNullType ();
+			TestDataFlowType ();
+		}
+
+		[Kept]
+		[RecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetMethod), new Type [] { typeof (string), typeof (BindingFlags) },
+			typeof (MethodUsedViaReflection), nameof (MethodUsedViaReflection.OnlyCalledViaReflection), new Type [0])]
+		static void TestNameAndExplicitBindingFlags ()
+		{
 			var method = typeof (MethodUsedViaReflection).GetMethod ("OnlyCalledViaReflection", BindingFlags.Static | BindingFlags.NonPublic);
-			method.Invoke (null, new object[] { });
+			method.Invoke (null, new object [] { });
+		}
+
+		[Kept]
+		[UnrecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetMethod), new Type [] { typeof (string) })]
+		static void TestNullName ()
+		{
+			var method = typeof (MethodUsedViaReflection).GetMethod (null);
+		}
+
+		[Kept]
+		[UnrecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetMethod), new Type [] { typeof (string) })]
+		static void TestEmptyName ()
+		{
+			var method = typeof (MethodUsedViaReflection).GetMethod (string.Empty);
+		}
+
+		[Kept]
+		[UnrecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetMethod), new Type [] { typeof (string) })]
+		static void TestNonExistingName ()
+		{
+			var method = typeof (MethodUsedViaReflection).GetMethod ("NonExisting");
+		}
+
+		[Kept]
+		[UnrecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetMethod), new Type [] { typeof (string), typeof (BindingFlags) })]
+		static void TestNullType ()
+		{
+			Type type = null;
+			var method = type.GetMethod ("OnlyCalledViaReflection", BindingFlags.Static | BindingFlags.NonPublic);
+		}
+
+		[Kept]
+		static Type FindType ()
+		{
+			return typeof (MethodUsedViaReflection);
+		}
+
+		[Kept]
+		[UnrecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetMethod), new Type [] { typeof (string), typeof (BindingFlags) })]
+		static void TestDataFlowType ()
+		{
+			Type type = FindType ();
+			var method = type.GetMethod ("OnlyCalledViaReflection", BindingFlags.Static | BindingFlags.NonPublic);
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/Reflection/PropertyUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/PropertyUsedViaReflection.cs
@@ -1,17 +1,96 @@
 ﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using System;
 
 namespace Mono.Linker.Tests.Cases.Reflection {
 	public class PropertyUsedViaReflection {
 		public static void Main ()
 		{
+			TestGetterAndSetter ();
+			TestSetterOnly ();
+			TestGetterOnly ();
+			TestNullName ();
+			TestEmptyName ();
+			TestNonExistingName ();
+			TestNullType ();
+			TestDataFlowType ();
+		}
+
+		[Kept]
+		[RecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetProperty), new Type [] { typeof (string) },
+			typeof (PropertyUsedViaReflection), nameof (PropertyUsedViaReflection.OnlyUsedViaReflection), (Type[]) null)]
+		static void TestGetterAndSetter ()
+		{
 			var property = typeof (PropertyUsedViaReflection).GetProperty ("OnlyUsedViaReflection");
-			property.GetValue (null, new object[] { });
+			property.GetValue (null, new object [] { });
+		}
 
-			property = typeof (PropertyUsedViaReflection).GetProperty ("SetterOnly");
-			property.SetValue (null, 42, new object[] { });
+		[Kept]
+		[RecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetProperty), new Type [] { typeof (string) },
+			typeof (PropertyUsedViaReflection), nameof (PropertyUsedViaReflection.SetterOnly), (Type []) null)]
+		static void TestSetterOnly ()
+		{
+			var property = typeof (PropertyUsedViaReflection).GetProperty ("SetterOnly");
+			property.SetValue (null, 42, new object [] { });
+		}
 
-			property = typeof (PropertyUsedViaReflection).GetProperty ("GetterOnly");
-			property.GetValue (null, new object[] { });
+		[Kept]
+		[RecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetProperty), new Type [] { typeof (string) },
+			typeof (PropertyUsedViaReflection), nameof (PropertyUsedViaReflection.GetterOnly), (Type []) null)]
+		static void TestGetterOnly ()
+		{
+			var property = typeof (PropertyUsedViaReflection).GetProperty ("GetterOnly");
+			property.GetValue (null, new object [] { });
+		}
+
+		[Kept]
+		[UnrecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetProperty), new Type [] { typeof (string) })]
+		static void TestNullName ()
+		{
+			var property = typeof (PropertyUsedViaReflection).GetProperty (null);
+		}
+
+		[Kept]
+		[UnrecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetProperty), new Type [] { typeof (string) })]
+		static void TestEmptyName ()
+		{
+			var property = typeof (PropertyUsedViaReflection).GetProperty (string.Empty);
+		}
+
+		[Kept]
+		[UnrecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetProperty), new Type [] { typeof (string) })]
+		static void TestNonExistingName ()
+		{
+			var property = typeof (PropertyUsedViaReflection).GetProperty ("NonExisting");
+		}
+
+		[Kept]
+		[UnrecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetProperty), new Type [] { typeof (string) })]
+		static void TestNullType ()
+		{
+			Type type = null;
+			var property = type.GetProperty ("GetterOnly");
+		}
+
+		[Kept]
+		static Type FindType ()
+		{
+			return typeof (PropertyUsedViaReflection);
+		}
+
+		[Kept]
+		[UnrecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetProperty), new Type [] { typeof (string) })]
+		static void TestDataFlowType ()
+		{
+			Type type = FindType ();
+			var property = type.GetProperty ("GetterOnly");
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflection.cs
@@ -33,6 +33,8 @@ namespace Mono.Linker.Tests.Cases.Reflection {
 		}
 
 		[Kept]
+		[UnrecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetType), new Type [] { typeof (string), typeof (bool) })]
 		public static void TestEmptyString ()
 		{
 			const string reflectionTypeKeptString = "";
@@ -85,7 +87,7 @@ namespace Mono.Linker.Tests.Cases.Reflection {
 		[Kept]
 		[RecognizedReflectionAccessPattern (
 			typeof (Type), nameof (Type.GetType), new Type[] { typeof (string), typeof (bool) },
-			typeof (AType), null, null)]
+			typeof (AType), null, (Type []) null)]
 		public static void TestType ()
 		{
 			const string reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+AType";

--- a/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflectionTypeDoesntExist.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflectionTypeDoesntExist.cs
@@ -1,7 +1,11 @@
-﻿using System;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using System;
 
 namespace Mono.Linker.Tests.Cases.Reflection {
+	[VerifyAllReflectionAccessPatternsAreValidated]
 	public class TypeUsedViaReflectionTypeDoesntExist {
+		[UnrecognizedReflectionAccessPatternAttribute (
+			typeof (Type), nameof (Type.GetType), new Type [] { typeof (string), typeof (bool) })]
 		public static void Main ()
 		{
 			var typeName = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflectionTypeDoesntExist+Full, DoesntExist";

--- a/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadaProvider.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadaProvider.cs
@@ -76,9 +76,11 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 				};
 			}
 
-			if (_testCaseTypeDefinition.AllMethods().Any(method => method.CustomAttributes.Any (attr =>
-				attr.AttributeType.Name == nameof (RecognizedReflectionAccessPatternAttribute) ||
-				attr.AttributeType.Name == nameof (UnrecognizedReflectionAccessPatternAttribute)))) {
+			if (_testCaseTypeDefinition.CustomAttributes.Any (attr =>
+					attr.AttributeType.Name == nameof (VerifyAllReflectionAccessPatternsAreValidatedAttribute))
+				|| _testCaseTypeDefinition.AllMethods ().Any (method => method.CustomAttributes.Any (attr =>
+					attr.AttributeType.Name == nameof (RecognizedReflectionAccessPatternAttribute) ||
+					attr.AttributeType.Name == nameof (UnrecognizedReflectionAccessPatternAttribute)))) {
 				customizations.ReflectionPatternRecorder = new TestReflectionPatternRecorder ();
 				customizations.CustomizeContext += context => {
 					context.ReflectionPatternRecorder = customizations.ReflectionPatternRecorder;


### PR DESCRIPTION
The code was written such that it would report almost all calls it didn't consider (or try to analyze) as unrecognized patterns.

This change adds the test infra to validate that no extra reflection patterns are recorded on a given test. It then uses this on two tests to validate the functionality.

The fix adds a boolean which tracks if the code is trying to analyze a given reflection pattern or not. It only reports unrecognized pattern if it did try to analyze a pattern, but didn't report any result explicitly.

Also unified the code in reflection pattern matching to always `break` (the `returns` were left-overs from previous attempts at this functionality).