### PR TITLE
Preserve wildcard

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -511,6 +511,11 @@ namespace Mono.Linker.Steps {
 				}
 			}
 
+			if (member == "*") {
+				MarkEntireType (td);
+				return;
+			}
+
 			if (MarkDependencyMethod (td, member, signature))
 				return;
 

--- a/test/Mono.Linker.Tests.Cases/PreserveDependencies/Dependencies/PreserveDependencyMethodInAssemblyLibrary.cs
+++ b/test/Mono.Linker.Tests.Cases/PreserveDependencies/Dependencies/PreserveDependencyMethodInAssemblyLibrary.cs
@@ -4,5 +4,9 @@ namespace Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies {
 		public PreserveDependencyMethodInAssemblyLibrary ()
 		{
 		}
+
+		private void Foo ()
+		{
+		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMemberSignatureWildcard.cs
+++ b/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMemberSignatureWildcard.cs
@@ -1,0 +1,22 @@
+﻿using System.Runtime.CompilerServices;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.PreserveDependencies
+{
+	[KeptMemberInAssembly ("library.dll", "Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies.PreserveDependencyMethodInAssemblyLibrary", ".ctor()")]
+	[SetupCompileBefore ("library.dll", new [] { "Dependencies/PreserveDependencyMethodInAssemblyLibrary.cs" })]
+	public class PreserveDependencyMemberSignatureWildcard
+	{
+		public static void Main ()
+		{
+			Dependency ();
+		}
+
+		[Kept]
+		[PreserveDependency ("*", "Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies.PreserveDependencyMethodInAssemblyLibrary", "library")]
+		static void Dependency ()
+		{
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMemberSignatureWildcard.cs
+++ b/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMemberSignatureWildcard.cs
@@ -5,6 +5,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.PreserveDependencies
 {
 	[KeptMemberInAssembly ("library.dll", "Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies.PreserveDependencyMethodInAssemblyLibrary", ".ctor()")]
+	[KeptMemberInAssembly ("library.dll", "Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies.PreserveDependencyMethodInAssemblyLibrary", "Foo()")]
 	[SetupCompileBefore ("library.dll", new [] { "Dependencies/PreserveDependencyMethodInAssemblyLibrary.cs" })]
 	public class PreserveDependencyMemberSignatureWildcard
 	{


### PR DESCRIPTION
Let's users use `'*'` for grabbing all members of a given type in a `PreserveDependencyAttribute`. See #799.