### PR TITLE
Produce packages during dotnet build

### DIFF
--- a/src/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/src/ILLink.Tasks/ILLink.Tasks.csproj
@@ -23,6 +23,8 @@
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_LayoutPackage</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
+  <Target Name="PackDuringBuild" AfterTargets="Build" DependsOnTargets="Pack" />
+
   <ItemGroup>
     <Compile Include="LinkTask.cs" />
     <Compile Include="CheckEmbeddedRootDescriptor.cs" />


### PR DESCRIPTION
This way the integration tests won't fail due to a missing nupkg folder. @mateoatr PTAL