### PR TITLE
Fix warnings in arcade build

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -4,6 +4,5 @@
     <FileSignInfo Include="Mono.Cecil.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Mono.Cecil.Mdb.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Mono.Cecil.Pdb.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="illink.dll" CertificateName="3PartySHA2" />
   </ItemGroup>
 </Project>

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -94,23 +94,6 @@ stages:
             displayName: Build illink.sln $(_BuildConfig)
 
       - ${{ if eq(variables.officialBuild, 'false') }}:
-        - job: Linux_Mono
-          pool:
-            name: Hosted Ubuntu 1604
-          steps:
-          - checkout: self
-            submodules: true
-          - script: |
-              mkdir -p artifacts/log/$(_BuildConfig)
-              mono --version | tee artifacts/log/$(_BuildConfig)/mono-version.txt
-              make -C monobuild CONFIGURATION=$(_BuildConfig)
-            displayName: Build and test
-          - task: PublishTestResults@2
-            inputs:
-              testResultsFormat: 'NUnit'
-              testResultsFiles: 'test/Mono.Linker.Tests/TestResults.xml'
-
-      - ${{ if eq(variables.officialBuild, 'false') }}:
         - job: macOS
           pool:
               name: Hosted MacOS
@@ -126,6 +109,22 @@ stages:
               # https://github.com/Microsoft/vstest/issues/1503#issuecomment-410732193
               MSBUILDENSURESTDOUTFORTASKPROCESSES: 1
             displayName: Build illink.sln $(_BuildConfig)
+
+  - ${{ if eq(variables.officialBuild, 'false') }}:
+    - job: Linux_Mono
+      pool:
+        name: Hosted Ubuntu 1604
+      steps:
+      - checkout: self
+        submodules: true
+      - script: |
+          mono --version
+          make -C monobuild CONFIGURATION=$(_BuildConfig)
+        displayName: Build and test
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFormat: 'NUnit'
+          testResultsFiles: 'test/Mono.Linker.Tests/TestResults.xml'
 
 # Post-Build Arcade logic
 - ${{ if eq(variables.officialBuild, 'true') }}:

--- a/src/linker/Mono.Linker.csproj
+++ b/src/linker/Mono.Linker.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>Mono</RootNamespace>
-    <Copyright>(C) 2006, Jb Evain</Copyright>
     <Version>0.2.0.0</Version>
     <Configurations>Debug;Release</Configurations>
     <LangVersion>latest</LangVersion>
@@ -20,6 +19,7 @@
     <AssemblyName>monolinker</AssemblyName>
     <AssemblyTitle>Mono.Linker</AssemblyTitle>
     <Description>Mono CIL Linker</Description>
+    <Copyright>(C) 2006, Jb Evain</Copyright>
     <TargetFrameworks>net471</TargetFrameworks>
   </PropertyGroup>
 


### PR DESCRIPTION
- Move Mono build out of common arcade template to get rid of missing xunit test results warning.
- Use Microsoft copyright for Mono.Linker.csproj, it is [required by arcade](https://github.com/dotnet/arcade/blob/e8c75ece0ff35ae1f3cf4103db9873467be7690a/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.targets#L49-L55).