### PR TITLE
Another pass on arguments parsing clean up

### DIFF
--- a/test/Mono.Linker.Tests/TestCasesRunner/LinkerDriver.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/LinkerDriver.cs
@@ -1,10 +1,12 @@
-﻿﻿namespace Mono.Linker.Tests.TestCasesRunner {
+﻿using System.Collections.Generic;
+
+﻿namespace Mono.Linker.Tests.TestCasesRunner {
 	public class LinkerDriver {
 		protected class TestDriver : Driver
 		{
 			LinkerCustomizations _customization;
 
-			public TestDriver(string[] args, LinkerCustomizations customizations) : base(args)
+			public TestDriver(Queue<string> args, LinkerCustomizations customizations) : base(args)
 			{
 				_customization = customizations;
 			}
@@ -19,7 +21,8 @@
 
 		public virtual void Link (string [] args, LinkerCustomizations customizations, ILogger logger)
 		{
-			new TestDriver (args, customizations).Run (logger);
+			Driver.ProcessResponseFile (args, out var queue);
+			new TestDriver (queue, customizations).Run (logger);
 		}
 	}
 }


### PR DESCRIPTION
- Remove Environment.Exit usage as it breaks linker as library hosting
- Add missing documentation entries
- Move custom steps insertion to the end to be deterministic
- Error out on invalid arguments with a reasonable message
- Allow omitting true value for bool like options
- Separate new_mvid and deterministic options