### PR TITLE
Fix integration test configuration

### DIFF
--- a/test/ILLink.Tasks.IntegrationTests/TestContext.cs
+++ b/test/ILLink.Tasks.IntegrationTests/TestContext.cs
@@ -74,9 +74,15 @@ namespace ILLink.Tests
 			Configuration = "Release";
 			TestBin = testBin;
 
+#if DEBUG
+			var illinkConfiguration = "Debug";
+#else
+			var illinkConfiguration = "Release";
+#endif
+
 			// Locate task package
 			var packageName = "ILLink.Tasks";
-			var packageSource = Path.Combine(repoRoot, "artifacts", "packages", Configuration, "Shipping");
+			var packageSource = Path.Combine(repoRoot, "artifacts", "packages", illinkConfiguration, "Shipping");
 			var tasksPackages = Directory.GetFiles(packageSource)
 				.Where(p => Path.GetExtension(p) == ".nupkg")
 				.Select(p => Path.GetFileNameWithoutExtension(p))


### PR DESCRIPTION
Look for ILLink.Tasks package matching the configuration used
for "dotnet test". @vitek-karas PTAL.