### PR TITLE
Fix logging of unrecognized reflection patterns

### DIFF
--- a/src/linker/Linker.Steps/BlacklistStep.cs
+++ b/src/linker/Linker.Steps/BlacklistStep.cs
@@ -46,11 +46,11 @@ namespace Mono.Linker.Steps {
 					continue;
 
 				try {
-					Context.LogMessage ("Processing resource linker descriptor: {0}", name);
+					Context.LogMessage ($"Processing resource linker descriptor: {name}");
 					AddToPipeline (GetResolveStep (name));
 				} catch (XmlException ex) {
 					/* This could happen if some broken XML file is included. */
-					Context.LogMessage ("Error processing {0}: {1}", name, ex);
+					Context.LogMessage ($"Error processing {name}: {ex}");
 				}
 			}
 
@@ -62,12 +62,12 @@ namespace Mono.Linker.Steps {
 									.Where (res => ShouldProcessAssemblyResource (GetAssemblyName (res.Name)))
 									.Cast<EmbeddedResource> ()) {
 					try {
-						Context.LogMessage ("Processing embedded resource linker descriptor: {0}", rsc.Name);
+						Context.LogMessage ($"Processing embedded resource linker descriptor: {rsc.Name}");
 
 						AddToPipeline (GetExternalResolveStep (rsc, asm));
 					} catch (XmlException ex) {
 						/* This could happen if some broken XML file is embedded. */
-						Context.LogMessage ("Error processing {0}: {1}", rsc.Name, ex);
+						Context.LogMessage ($"Error processing {rsc.Name}: {ex}");
 					}
 				}
 			}

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -477,7 +477,7 @@ namespace Mono.Linker.Steps {
 			var args = ca.ConstructorArguments;
 			if (args.Count >= 3 && args [2].Value is string assemblyName) {
 				if (!_context.Resolver.AssemblyCache.TryGetValue (assemblyName, out assembly)) {
-					_context.Logger.LogMessage (MessageImportance.Low, $"Could not resolve '{assemblyName}' assembly dependency");
+					_context.LogMessage (MessageImportance.Low, $"Could not resolve '{assemblyName}' assembly dependency");
 					return;
 				}
 			} else {
@@ -489,7 +489,7 @@ namespace Mono.Linker.Steps {
 				td = FindType (assembly ?? context.Module.Assembly, typeName);
 
 				if (td == null) {
-					_context.Logger.LogMessage (MessageImportance.Low, $"Could not resolve '{typeName}' type dependency");
+					_context.LogMessage (MessageImportance.Low, $"Could not resolve '{typeName}' type dependency");
 					return;
 				}
 			} else {
@@ -522,7 +522,7 @@ namespace Mono.Linker.Steps {
 			if (MarkDependencyField (td, member))
 				return;
 
-			_context.Logger.LogMessage (MessageImportance.High, $"Could not resolve dependency member '{member}' declared in type '{td.FullName}'");
+			_context.LogMessage (MessageImportance.High, $"Could not resolve dependency member '{member}' declared in type '{td.FullName}'");
 		}
 
 		static TypeDefinition FindType (AssemblyDefinition assembly, string fullName)

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -418,15 +418,15 @@ namespace Mono.Linker {
 			return (DisabledOptimizations & optimization) == 0;
 		}
 
-		public void LogMessage (string message, params object[] values)
+		public void LogMessage (string message)
 		{
-			LogMessage (MessageImportance.Normal, message, values);
+			LogMessage (MessageImportance.Normal, message);
 		}
 
-		public void LogMessage (MessageImportance importance, string message, params object [] values)
+		public void LogMessage (MessageImportance importance, string message)
 		{
 			if (LogMessages && Logger != null)
-				Logger.LogMessage (importance, message, values);
+				Logger.LogMessage (importance, "{0}", message);
 		}
 	}
 

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -143,7 +143,7 @@ namespace Mono.Linker {
 
 		public bool LogMessages { get; set; }
 
-		public ILogger Logger { get; set; } = new ConsoleLogger ();
+		public ILogger Logger { private get; set; } = new ConsoleLogger ();
 
 		public MarkingHelpers MarkingHelpers { get; private set; }
 

--- a/src/linker/Linker/LoggingReflectionPatternRecorder.cs
+++ b/src/linker/Linker/LoggingReflectionPatternRecorder.cs
@@ -43,7 +43,7 @@ namespace Mono.Linker
 
 		public void UnrecognizedReflectionAccessPattern (MethodDefinition sourceMethod, MethodDefinition reflectionMethod, string message)
 		{
-			_context.LogMessage (MessageImportance.Low, message);
+			_context.LogMessage (MessageImportance.Low, "{0}", message);
 		}
 	}
 }

--- a/src/linker/Linker/LoggingReflectionPatternRecorder.cs
+++ b/src/linker/Linker/LoggingReflectionPatternRecorder.cs
@@ -43,7 +43,7 @@ namespace Mono.Linker
 
 		public void UnrecognizedReflectionAccessPattern (MethodDefinition sourceMethod, MethodDefinition reflectionMethod, string message)
 		{
-			_context.LogMessage (MessageImportance.Low, "{0}", message);
+			_context.LogMessage (MessageImportance.Low, message);
 		}
 	}
 }


### PR DESCRIPTION
LinkContext.LogMessage is behaving like string.Format, so if it gets a single parameter which has `{` in it, it will break.

Fixes #945 