### PR TITLE
Link global attributes only when both declaration and reference are linked

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -205,12 +205,6 @@ namespace Mono.Linker.Steps {
 
 		void Process ()
 		{
-			//
-			// This can happen when linker is called on facade with all references skipped
-			//
-			if (QueueIsEmpty ())
-				return;
-
 			while (ProcessPrimaryQueue () || ProcessLazyAttributes () || ProcessLateMarkedAttributes ())
 
 			// deal with [TypeForwardedTo] pseudo-attributes
@@ -677,7 +671,9 @@ namespace Mono.Linker.Steps {
 
 			// If an attribute's module has not been marked after processing all types in all assemblies and the attribute itself has not been marked,
 			// then surely nothing is using this attribute and there is no need to mark it
-			if (!Annotations.IsMarked (resolvedConstructor.Module) && !Annotations.IsMarked (ca.AttributeType))
+			if (!Annotations.IsMarked (resolvedConstructor.Module) &&
+				!Annotations.IsMarked (ca.AttributeType) &&
+				Annotations.GetAction (resolvedConstructor.Module.Assembly) == AssemblyAction.Link)
 				return false;
 
 			if (ca.Constructor.DeclaringType.Namespace == "System.Diagnostics") {

--- a/test/Mono.Linker.Tests.Cases/Attributes/AttributeOnAssemblyIsKeptIfDeclarationIsSkipped.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes/AttributeOnAssemblyIsKeptIfDeclarationIsSkipped.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Attributes;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+#if REFERENCE_INCLUDED
+[assembly: Mono.Linker.Tests.Cases.Attributes.Dependencies.AttributeDefinedInReference]
+#endif
+[assembly: KeptAttributeAttribute ("Mono.Linker.Tests.Cases.Attributes.Dependencies.AttributeDefinedInReference")]
+
+namespace Mono.Linker.Tests.Cases.Attributes
+{
+	[SkipPeVerify]
+	[Define ("REFERENCE_INCLUDED")]
+	[SetupCompileBefore ("library.dll", new [] { "Dependencies/AttributeDefinedInReference.cs" })]
+	[SetupLinkerAction ("skip", "library")]
+	class AttributeOnAssemblyIsKeptIfDeclarationIsSkipped {
+		static void Main ()
+		{
+		}
+	}
+}


### PR DESCRIPTION
This avoids issues with too aggressive linking when only reference assembly
is linked and declaration assembly is for example skipped.