### PR TITLE
RemoveConditions+GetReachableInstructionsMap test

### DIFF
--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/ComplexConditions.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/ComplexConditions.cs
@@ -31,5 +31,29 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 		static void Reached_1 ()
 		{			
 		}
+		[Kept]
+		[ExpectBodyModified]
+		[ExpectedLocalsSequence(new string [] { "System.Boolean", "System.Int32", "System.Int32", "System.DivideByZeroException"})]
+		static void Test_2 ()
+		{
+			/* 
+			   Test for https://github.com/mono/linker/issues/950 
+			   This test needs to be runned in Debug mode to generate right IL instructions
+			*/
+			int zero;
+			/* Dummy if condition, only to trigger TryInlineBodyDependencies and not return early */
+			if (IsDynamicCodeSupported)
+				zero = 0;
+			/* Guid.Parse function in order to not be replaced by constants in TryInlineBodyDependencies */
+			if (Guid.Parse ("3F2504E0-4F89-11D3-9A0C-0305E82C3301") != Guid.Empty || Guid.Parse ("3F2504E0-4F89-11D3-9A0C-0305E82C3302") != Guid.Empty) {
+				throw new ArgumentException ();
+			}
+			try {
+				zero = 0;
+				int calc = 10 / zero;
+			} catch (DivideByZeroException e) {
+				throw e;
+			}
+		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/ComplexConditions.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/ComplexConditions.cs
@@ -34,7 +34,7 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 		}
 		[Kept]
 		[ExpectBodyModified]
-		[ExpectedLocalsSequence(new string [] { "System.Boolean", "System.Int32", "System.Int32", "System.DivideByZeroException"})]
+		[ExpectedLocalsSequence(new string [] { "System.Int32", "System.Boolean", "System.Boolean", "System.Int32", "System.DivideByZeroException"})]
 		static void Test_2 ()
 		{
 			/* 

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/ComplexConditions.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/ComplexConditions.cs
@@ -9,6 +9,7 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 		public static void Main()
 		{
 			Test_1 (null);
+			Test_2 ();
 		}
 
 		[Kept]
@@ -45,7 +46,7 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 			if (IsDynamicCodeSupported)
 				zero = 0;
 			/* Guid.Parse function in order to not be replaced by constants in TryInlineBodyDependencies */
-			if (Guid.Parse ("3F2504E0-4F89-11D3-9A0C-0305E82C3301") != Guid.Empty || Guid.Parse ("3F2504E0-4F89-11D3-9A0C-0305E82C3302") != Guid.Empty) {
+			if (Guid.Parse ("3F2504E0-4F89-11D3-9A0C-0305E82C3301") == Guid.Empty || Guid.Parse ("3F2504E0-4F89-11D3-9A0C-0305E82C3302") == Guid.Empty) {
 				throw new ArgumentException ();
 			}
 			try {


### PR DESCRIPTION
Added a new test that reproduces error stated in https://github.com/mono/linker/issues/950
At this moment test generates an assert 
```
Expected method `System.Void Mono.Linker.Tests.Cases.UnreachableBlock.ComplexConditions::Test_2() to have it's exception handlers unchanged, however, the exception handlers differ from the original
```
The code does remove an exception handler which is one of the problems stated in the github issue so the "Expected" flags cannot be tested and might need to be updated once the issue is solved