### PR TITLE
Remove custom attributes from interface implementations

### DIFF
--- a/src/tuner/Mono.Tuner/RemoveAttributesBase.cs
+++ b/src/tuner/Mono.Tuner/RemoveAttributesBase.cs
@@ -42,6 +42,9 @@ namespace Mono.Tuner {
 
 			if (type.HasGenericParameters)
 				ProcessAttributeProviderCollection (type.GenericParameters);
+
+			if (type.HasInterfaces)
+				ProcessAttributeProviderCollection (type.Interfaces);
 		}
 
 		void ProcessAttributeProviderCollection (IList list)


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/4284

We were not removing custom attributes from the interface
implementations in type definitions.

The above mentioned issue is partially fixed by this change.

Example IL:
```
.class interface public abstract auto ansi Java.Interop.IJavaPeerable
       implements [mscorlib]System.IDisposable
{
  .custom instance void System.Runtime.CompilerServices.NullableContextAttribute::.ctor(uint8) = ( 01 00 01 00 00 ) 
  .interfaceimpl type [mscorlib]System.IDisposable
  .custom instance void System.Runtime.CompilerServices.NullableAttribute::.ctor(uint8) = ( 01 00 00 00 00 ) 
...
```

Before we were removing only `NullableContextAttribute`, after we remove `NullableAttribute` as well, in the above example.