### PR TITLE
Remove attributes from generic parameter constraints

### DIFF
--- a/src/tuner/Mono.Tuner/RemoveAttributesBase.cs
+++ b/src/tuner/Mono.Tuner/RemoveAttributesBase.cs
@@ -39,9 +39,7 @@ namespace Mono.Tuner {
 		public override void ProcessType (TypeDefinition type)
 		{
 			ProcessAttributeProvider (type);
-
-			if (type.HasGenericParameters)
-				ProcessAttributeProviderCollection (type.GenericParameters);
+			ProcessGenericParameterProvider (type);
 
 			if (type.HasInterfaces)
 				ProcessAttributeProviderCollection (type.Interfaces);
@@ -58,6 +56,22 @@ namespace Mono.Tuner {
 			ProcessAttributeProvider (field);
 		}
 
+		void ProcessGenericParameterProvider (IGenericParameterProvider provider)
+		{
+			if (!provider.HasGenericParameters)
+				return;
+
+			foreach (var parameter in provider.GenericParameters) {
+				ProcessAttributeProvider (parameter);
+
+				if (!parameter.HasConstraints)
+					continue;
+
+				foreach (var constraint in parameter.Constraints)
+					ProcessAttributeProvider (constraint);
+			}
+		}
+
 		public override void ProcessMethod (MethodDefinition method)
 		{
 			ProcessMethodAttributeProvider (method);
@@ -71,8 +85,7 @@ namespace Mono.Tuner {
 			if (method.HasParameters)
 				ProcessAttributeProviderCollection (method.Parameters);
 
-			if (method.HasGenericParameters)
-				ProcessAttributeProviderCollection (method.GenericParameters);
+			ProcessGenericParameterProvider (method);
 		}
 
 		public override void ProcessProperty (PropertyDefinition property)


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/4284

This change solves the remaining problems from the issue above. The
generic parameter constraint is an `ICustomAttributeProvider`.

It was not very clear, where the remaining attribute instances are
located as even `ikdasm` doesn't show them. Instead it shows the
attributes as unassigned at the end of disassembly output. In this
case like:

```
...
} // end of class '<PrivateImplementationDetails>'

// =============================================================

.custom (UNKNOWN_OWNER) instance void System.Runtime.CompilerServices.NullableAttribute::.ctor(uint8) = ( 01 00 01 00 00 )
.custom (UNKNOWN_OWNER) instance void System.Runtime.CompilerServices.NullableAttribute::.ctor(uint8) = ( 01 00 01 00 00 )
// *********** DISASSEMBLY COMPLETE ***********************
```

After this change, the `Java.Interop` assembly doesn't contain the
`System.Runtime.CompilerServices.NullableAttribute` and
`Microsoft.CodeAnalysis.EmbeddedAttribute` attributes anymore.