### PR TITLE
Change fatal error messages

### DIFF
--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -68,7 +68,8 @@ namespace Mono.Linker {
 					return 1;
 
 			} catch {
-				Console.Error.WriteLine ("Fatal error in {0}", _linker);
+				String source = e.TargetSite.DeclaringType.FullName + "." + e.TargetSite.Name;
+				Console.Error.WriteLine ("{0} : Fatal error: At {1}. {2}", _linker, source, e.Message);
 				throw;
 			}
 

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -67,7 +67,7 @@ namespace Mono.Linker {
 				if (!driver.Run (customLogger))
 					return 1;
 
-			} catch {
+			} catch (Exception e) {
 				String source = e.TargetSite.DeclaringType.FullName + "." + e.TargetSite.Name;
 				Console.Error.WriteLine ("{0} : Fatal error: At {1}. {2}", _linker, source, e.Message);
 				throw;


### PR DESCRIPTION
A small change in case of a fatal error message, this is compliant with MSBuild error messages and provide a better experience to the user