### PR TITLE
Ignore missing .ctor or .cctor in PreserveDependency attribute

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -516,6 +516,10 @@ namespace Mono.Linker.Steps {
 			if (MarkDependencyField (td, member))
 				return;
 
+			// Don't report missing .ctor() or .cctor() as those can be compiler generated and thus hard to control their existence of
+			if (((member == ".ctor") || (member == ".cctor")) && signature.Length == 0)
+				return;
+
 			_context.LogMessage (MessageImportance.High, $"Could not resolve dependency member '{member}' declared in type '{td.FullName}'");
 		}
 

--- a/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethod.cs
+++ b/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethod.cs
@@ -2,6 +2,13 @@
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.PreserveDependencies {
+	
+	[LogContains("Could not resolve 'Mono.Linker.Tests.Cases.PreserveDependencies.MissingType' type dependency")]
+	[LogContains("Could not resolve dependency member 'MissingMethod' declared in type 'Mono.Linker.Tests.Cases.PreserveDependencies.C'")]
+	[LogContains("Could not resolve dependency member 'Dependency2`1' declared in type 'Mono.Linker.Tests.Cases.PreserveDependencies.C'")]
+	[LogContains("Could not resolve dependency member '' declared in type 'Mono.Linker.Tests.Cases.PreserveDependencies.PreserveDependencyMethod/B'")]
+	[LogDoesNotContain("Could not resolve dependency member '.ctor' declared in type 'Mono.Linker.Tests.Cases.PreserveDependencies.PreserveDependencyMethod/NestedStruct'")]
+	[LogDoesNotContain("Could not resolve dependency member '.cctor' declared in type 'Mono.Linker.Tests.Cases.PreserveDependencies.C'")]
 	class PreserveDependencyMethod {
 		public static void Main ()
 		{
@@ -31,7 +38,8 @@ namespace Mono.Linker.Tests.Cases.PreserveDependencies {
 			[PreserveDependency (".ctor()", "Mono.Linker.Tests.Cases.PreserveDependencies.C")] // To avoid lazy body marking stubbing
 			[PreserveDependency ("field", "Mono.Linker.Tests.Cases.PreserveDependencies.C")]
 			[PreserveDependency ("NextOne (Mono.Linker.Tests.Cases.PreserveDependencies.PreserveDependencyMethod+Nested&)", "Mono.Linker.Tests.Cases.PreserveDependencies.PreserveDependencyMethod+Nested")]
-			[PreserveDependency ("Property", "Mono.Linker.Tests.Cases.PreserveDependencies.C")]
+			[PreserveDependency (".cctor()", "Mono.Linker.Tests.Cases.PreserveDependencies.PreserveDependencyMethod+Nested")]
+			// Dependency on a property itself should be expressed as a dependency one or both accessor methods
 			[PreserveDependency ("get_Property()", "Mono.Linker.Tests.Cases.PreserveDependencies.C")]
 			public static void Method ()
 			{
@@ -45,15 +53,18 @@ namespace Mono.Linker.Tests.Cases.PreserveDependencies {
 			}
 
 			[Kept]
-			[PreserveDependency ("Missing", "Mono.Linker.Tests.Cases.Advanced.C")]
-			[PreserveDependency ("Dependency2`1 (T, System.Int32, System.Object)", "Mono.Linker.Tests.Cases.Advanced.C")]
+			[PreserveDependency ("MissingType", "Mono.Linker.Tests.Cases.PreserveDependencies.MissingType")]
+			[PreserveDependency ("MissingMethod", "Mono.Linker.Tests.Cases.PreserveDependencies.C")]
+			[PreserveDependency ("Dependency2`1 (T, System.Int32, System.Object)", "Mono.Linker.Tests.Cases.PreserveDependencies.C")]
 			[PreserveDependency ("")]
+			[PreserveDependency (".ctor()", "Mono.Linker.Tests.Cases.PreserveDependencies.PreserveDependencyMethod+NestedStruct")] // Should not report a warning
+			[PreserveDependency (".cctor()", "Mono.Linker.Tests.Cases.PreserveDependencies.C")] // Should not report a warning
 			public static void Broken ()
 			{
 			}
 
 			[Kept]
-			[PreserveDependency ("ConditionalTest()", "Mono.Linker.Tests.Cases.Advanced.C", Condition = "don't have it")]
+			[PreserveDependency ("ConditionalTest()", "Mono.Linker.Tests.Cases.PreserveDependencies.C", Condition = "don't have it")]
 			public static void Conditional ()
 			{
 			}
@@ -64,6 +75,22 @@ namespace Mono.Linker.Tests.Cases.PreserveDependencies {
 			[Kept]
 			private static void NextOne (ref Nested arg1)
 			{
+			}
+
+			[Kept]
+			static Nested()
+			{
+
+			}
+		}
+
+		struct NestedStruct
+		{
+			public string Name;
+
+			public NestedStruct (string name)
+			{
+				Name = name;
 			}
 		}
 	}


### PR DESCRIPTION
Currently linker issues a warning if the member referenced in PreserveDependency attribute doesn't exist. This makes perfect sense for most cases, but in case of .ctor and .cctor it's a bit tricky. Default constructor as well as static constructor are often compiler generated and otherwise unrelated changes to the code (or potentially even the compiler) may add or remove these. The PreserveDependency attribute should express intent, in this case dependency on being able to instantiate the target type or be able to use static fields on it. The fact that the compiler/implementation may or may not have the default .ctor/static .cctor is secondary.

This change will skip emitting the warning if the dependency is for default .ctor or static .cctor.

Fixed couple of small problems in the existing tests and added the new cases.

Fixes #966