### PR TITLE
Explicitly enable optimization during test

### DIFF
--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/BodiesWithSubstitutions.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/BodiesWithSubstitutions.cs
@@ -6,6 +6,7 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 	[SetupLinkerSubstitutionFile ("BodiesWithSubstitutions.xml")]
 	[SetupCSharpCompilerToUse ("csc")]
 	[SetupCompileArgument ("/optimize+")]
+	[SetupLinkerArgument ("--enable-opt", "ipconstantpropagation")]
 	public class BodiesWithSubstitutions
 	{
 		static class ClassWithField

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/ComplexConditions.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/ComplexConditions.cs
@@ -6,6 +6,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.UnreachableBlock
 {
 	[SetupCompileArgument ("/optimize-")] // Relying on debug csc behaviour
+	[SetupLinkerArgument ("--enable-opt", "ipconstantpropagation")]
 	public class ComplexConditions
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/DeadVariables.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/DeadVariables.cs
@@ -6,6 +6,7 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 {
 	[SetupCSharpCompilerToUse ("csc")]
 	[SetupCompileArgument ("/optimize+")]
+	[SetupLinkerArgument ("--enable-opt", "ipconstantpropagation")]
 	public class DeadVariables
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/MultiStageRemoval.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/MultiStageRemoval.cs
@@ -5,6 +5,7 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 {
 	[SetupCSharpCompilerToUse ("csc")]
 	[SetupCompileArgument ("/optimize+")]
+	[SetupLinkerArgument ("--enable-opt", "ipconstantpropagation")]
 	public class MultiStageRemoval
 	{
 		public static void Main()

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/ReplacedReturns.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/ReplacedReturns.cs
@@ -6,6 +6,7 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 {
 	[SetupCSharpCompilerToUse ("csc")]
 	[SetupCompileArgument ("/optimize+")]
+	[SetupLinkerArgument ("--enable-opt", "ipconstantpropagation")]
 	public class ReplacedReturns
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/SimpleConditionalProperty.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/SimpleConditionalProperty.cs
@@ -6,6 +6,7 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 {
 //	[SetupCSharpCompilerToUse ("csc")]
 	[SetupCompileArgument ("/optimize+")]
+	[SetupLinkerArgument ("--enable-opt", "ipconstantpropagation")]
 	public class SimpleConditionalProperty
 	{
 		public static void Main()

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/SizeOfInConditions.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/SizeOfInConditions.cs
@@ -9,6 +9,7 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock {
 	[SetupLinkerSubstitutionFile ("SizeOfInConditions.net_4_x.xml")]
 #endif
 	[SetupCompileArgument ("/unsafe")]
+	[SetupLinkerArgument ("--enable-opt", "ipconstantpropagation")]
 	public unsafe class SizeOfInConditions {
 		public static void Main ()
 		{

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/TryFinallyBlocks.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/TryFinallyBlocks.cs
@@ -1,7 +1,9 @@
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.UnreachableBlock
 {
+	[SetupLinkerArgument ("--enable-opt", "ipconstantpropagation")]
 	public class TryFinallyBlocks
 	{
 		public static void Main ()


### PR DESCRIPTION
Explicitly enable `IPConstantPropagation` during the `UnreachableBlock` tests.  This gives implementors of a linker executable the freedom to pick which optimizations are enabled by default while also ensuring that they can pass all tests.

This is consistent with other optimizations such as unreachable bodies, used attrs only, etc.