### PR TITLE
Resolve custom steps from external assemblies

### DIFF
--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -816,24 +816,6 @@ namespace Mono.Linker {
 			return false;
 		}
 
-		bool GetCustomStepParams (string token, Action<string> action)
-		{
-			if (arguments.Count < 1) {
-				ErrorMissingArgument (token);
-				return false;
-			}
-
-			while (arguments.Count > 0 && !string.IsNullOrEmpty (arguments.Peek())) {
-				var step_or_assembly = arguments.Peek ();
-				if (step_or_assembly.StartsWith ("-") && !step_or_assembly.EndsWith (".dll"))
-					break;
-				action (step_or_assembly);
-				arguments.Dequeue ();
-			}
-
-			return true;
-		}
-
 		string GetNextStringValue ()
 		{
 			if (arguments.Count < 1)

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -589,27 +589,25 @@ namespace Mono.Linker {
 
 		partial void PreProcessPipeline (Pipeline pipeline);
 
-		protected static Assembly GetCustomAssembly (string arg) {
-			Assembly custom_assembly = null;
+		private static Assembly GetCustomAssembly (string arg) {
 			if (Path.IsPathRooted (arg)) {
 				var assemblyPath = Path.GetFullPath (arg);
 				if (File.Exists (assemblyPath))
 					return Assembly.Load (File.ReadAllBytes (assemblyPath));
-				else
-					Console.WriteLine ($"The assembly '{arg}' specified for '--custom-step' option could not be found");
+				Console.WriteLine ($"The assembly '{arg}' specified for '--custom-step' option could not be found");
 			}
 			else
-				Console.WriteLine ($"The path to the assembly '{arg}' specified for '--custom-step' must be rooted");
+				Console.WriteLine ($"The path to the assembly '{arg}' specified for '--custom-step' must be fully qualified");
 
-			return custom_assembly;
+			return null;
 		}
 
 		protected static bool AddCustomStep (Pipeline pipeline, string arg)
 		{
 			Assembly custom_assembly = null;
-			int pos = arg.IndexOf (",,");
+			int pos = arg.IndexOf (",");
 			if (pos != -1) {
-				custom_assembly = GetCustomAssembly (arg.Substring (pos + 2));
+				custom_assembly = GetCustomAssembly (arg.Substring (pos + 1));
 				if (custom_assembly == null)
 					return false;
 				arg = arg.Substring (0, pos);
@@ -670,10 +668,7 @@ namespace Mono.Linker {
 
 		static IStep ResolveStep (string type, Assembly assembly)
 		{
-			Type step = Type.GetType (type, false);
-			if (step == null) {
-				step = assembly.GetType (type);
-			}
+			Type step = assembly != null ? assembly.GetType(type) : Type.GetType (type, false);
 
 			if (step == null) {
 				Console.WriteLine ($"Custom step '{type}' could not be found");

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -866,9 +866,9 @@ namespace Mono.Linker {
 			Console.WriteLine ("Advanced");
 			Console.WriteLine ("  --custom-step CFG         Add a custom step <config> to the existing pipeline");
 			Console.WriteLine ("                            Step can use one of following configurations");
-			Console.WriteLine ("                            TYPE,,PATH_TO_ASSEMBLY: Add user defined type as last step to the pipeline");
-			Console.WriteLine ("                            +NAME:TYPE,,PATH_TO_ASSEMBLY: Inserts step type before existing step with name");
-			Console.WriteLine ("                            -NAME:TYPE,,PATH_TO_ASSEMBLY: Add step type after existing step");
+			Console.WriteLine ("                            TYPE,PATH_TO_ASSEMBLY: Add user defined type as last step to the pipeline");
+			Console.WriteLine ("                            +NAME:TYPE,PATH_TO_ASSEMBLY: Inserts step type before existing step with name");
+			Console.WriteLine ("                            -NAME:TYPE,PATH_TO_ASSEMBLY: Add step type after existing step");
 			Console.WriteLine ("  --ignore-descriptors      Skips reading embedded descriptors (short -z). Defaults to false");
 			Console.WriteLine ("  --keep-facades            Keep assemblies with type-forwarders (short -t). Defaults to false");
 			Console.WriteLine ("  --skip-unresolved         Ignore unresolved types, methods, and assemblies. Defaults to false");

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -579,7 +579,7 @@ namespace Mono.Linker {
 
 				List<Assembly> custom_step_assemblies = new List<Assembly> ();
 				foreach (string custom_assembly in custom_assemblies) {
-					var assembly = GetCustomAssembly (custom_assembly, context.Resolver.GetSearchDirectories ());
+					var assembly = GetCustomAssembly (custom_assembly);
 					if (assembly == null)
 						return false;
 					custom_step_assemblies.Add (assembly);
@@ -604,24 +604,18 @@ namespace Mono.Linker {
 
 		partial void PreProcessPipeline (Pipeline pipeline);
 
-		protected static Assembly GetCustomAssembly (string arg, string[] search_directories) {
+		protected static Assembly GetCustomAssembly (string arg) {
 			Assembly custom_assembly = null;
 			if (Path.IsPathRooted (arg)) {
 				var assemblyPath = Path.GetFullPath (arg);
 				if (File.Exists (assemblyPath))
 					return Assembly.LoadFrom (assemblyPath);
 				else
-					Console.WriteLine ($"Invalid assembly path '{arg}' specified for '--custom-step' option");
+					Console.WriteLine ($"The assembly '{arg}' specified for '--custom-assembly' option could not be found");
 			}
-			else {
-				foreach (var directory in search_directories) {
-					var assemblyPath = Path.Combine (directory, arg);
-					if (File.Exists (assemblyPath))
-						return Assembly.LoadFrom (assemblyPath);
-				}
-			}
+			else
+				Console.WriteLine ($"The path to the assembly '{arg}' specified for '--custom-assembly' must be rooted");
 
-			Console.WriteLine ($"The assembly '{arg}' specified for '--custom-step' option could not be found");
 			return custom_assembly;
 		}
 

--- a/src/linker/README.md
+++ b/src/linker/README.md
@@ -123,21 +123,21 @@ namespace Foo {
 
 That is compiled against the linker to `Foo.dll` assembly.
 
-You can let the linker know where this assembly is located by passing it's full path:
+To tell the linker where this assembly is located, you have to append its full path after two commas that separate the custom step's name from the custom assembly's path:
 
-`--custom-assembly D:\Bar\Foo.dll`
+`--custom-step [custom step],,[custom assembly]`
 
 You can now ask the linker to add the custom step at the end of the pipeline:
 
-`illinker --custom-step Foo.FooStep --custom-assembly D:\Bar\Foo.dll -a program.exe`
+`illinker --custom-step Foo.FooStep,,D:\Bar\Foo.dll`
 
 Or you can ask the linker to add it after a specific step:
 
-`illinker --custom-step MarkStep:Foo.FooStep --custom-assembly D:\Bar\Foo.dll -a program.exe`
+`illinker --custom-step +MarkStep:Foo.FooStep,,D:\Bar\Foo.dll -a program.exe`
 
 Or before a specific step:
 
-`illinker --custom-step Foo.FooStep:MarkStep --custom-assembly D:\Bar\Foo.dll -a program.exe`
+`illinker --custom-step -MarkStep:Foo.FooStep,,D:\Bar\Foo.dll -a program.exe`
 
 ## Mono specific options
 

--- a/src/linker/README.md
+++ b/src/linker/README.md
@@ -125,19 +125,19 @@ That is compiled against the linker to `Foo.dll` assembly.
 
 To tell the linker where this assembly is located, you have to append its full path after two commas that separate the custom step's name from the custom assembly's path:
 
-`--custom-step [custom step],,[custom assembly]`
+`--custom-step [custom step],[custom assembly]`
 
 You can now ask the linker to add the custom step at the end of the pipeline:
 
-`illinker --custom-step Foo.FooStep,,D:\Bar\Foo.dll`
+`illinker --custom-step Foo.FooStep,D:\Bar\Foo.dll`
 
 Or you can ask the linker to add it after a specific step:
 
-`illinker --custom-step +MarkStep:Foo.FooStep,,D:\Bar\Foo.dll -a program.exe`
+`illinker --custom-step +MarkStep:Foo.FooStep,D:\Bar\Foo.dll -a program.exe`
 
 Or before a specific step:
 
-`illinker --custom-step -MarkStep:Foo.FooStep,,D:\Bar\Foo.dll -a program.exe`
+`illinker --custom-step -MarkStep:Foo.FooStep,D:\Bar\Foo.dll -a program.exe`
 
 ## Mono specific options
 

--- a/src/linker/README.md
+++ b/src/linker/README.md
@@ -123,13 +123,9 @@ namespace Foo {
 
 That is compiled against the linker to `Foo.dll` assembly.
 
-You can let the linker know where this assembly is located either by passing it's full path:
+You can let the linker know where this assembly is located by passing it's full path:
 
 `--custom-assembly D:\Bar\Foo.dll`
-
-Or by specifying an additional directory to search for references together with the assembly file name:
-
-`-d D:\Bar --custom-assembly Foo.dll`
 
 You can now ask the linker to add the custom step at the end of the pipeline:
 

--- a/src/linker/README.md
+++ b/src/linker/README.md
@@ -123,17 +123,25 @@ namespace Foo {
 
 That is compiled against the linker to `Foo.dll` assembly.
 
-You can ask the linker to add it at the end of the pipeline:
+You can let the linker know where this assembly is located either by passing it's full path:
 
-`illinker -s Foo.FooStep,Foo -a program.exe`
+`--custom-assembly D:\Bar\Foo.dll`
+
+Or by specifying an additional directory to search for references together with the assembly file name:
+
+`-d D:\Bar --custom-assembly Foo.dll`
+
+You can now ask the linker to add the custom step at the end of the pipeline:
+
+`illinker --custom-step Foo.FooStep --custom-assembly D:\Bar\Foo.dll -a program.exe`
 
 Or you can ask the linker to add it after a specific step:
 
-`illinker -s MarkStep:Foo.FooStep,Foo -a program.exe`
+`illinker --custom-step MarkStep:Foo.FooStep --custom-assembly D:\Bar\Foo.dll -a program.exe`
 
 Or before a specific step:
 
-`illinker -s Foo.FooStep,Foo:MarkStep`
+`illinker --custom-step Foo.FooStep:MarkStep --custom-assembly D:\Bar\Foo.dll -a program.exe`
 
 ## Mono specific options
 

--- a/test/Mono.Linker.Tests.Cases/CommandLine/AddCustomStep.cs
+++ b/test/Mono.Linker.Tests.Cases/CommandLine/AddCustomStep.cs
@@ -5,8 +5,9 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.CommandLine
 {
 	[SetupCompileBefore ("CustomStep.dll", new [] { "Dependencies/CustomStepDummy.cs" })]
-	[SetupLinkerArgument ("--custom-step", "CustomStep.CustomStepDummy")]
-	[SetupLinkerArgument ("--custom-assembly", "CustomStep.dll")]
+	[SetupLinkerArgument ("--custom-step", "CustomStep.CustomStepDummy,,CustomStep.dll")]
+	[SetupLinkerArgument ("--custom-step", "-CleanStep:CustomStep.CustomStepDummy,,CustomStep.dll")]
+	[SetupLinkerArgument ("--custom-step", "+CleanStep:CustomStep.CustomStepDummy,,CustomStep.dll")]
 	[LogContains("Custom step added")]
 	public class AddCustomStep
 	{

--- a/test/Mono.Linker.Tests.Cases/CommandLine/AddCustomStep.cs
+++ b/test/Mono.Linker.Tests.Cases/CommandLine/AddCustomStep.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.CommandLine
+{
+	[SetupCompileBefore ("CustomStep.dll", new [] { "Dependencies/CustomStepDummy.cs" })]
+	[SetupLinkerArgument ("--custom-step", "CustomStep.CustomStepDummy", "CustomStep.dll")]
+	[LogContains("Custom step added")]
+	public class AddCustomStep
+	{
+		public static void Main ()
+		{
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/CommandLine/AddCustomStep.cs
+++ b/test/Mono.Linker.Tests.Cases/CommandLine/AddCustomStep.cs
@@ -4,7 +4,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.CommandLine
 {
 
-#if NET471
+#if !NETCOREAPP
 	[IgnoreTestCase ("Can be enabled once MonoBuild produces a dll from which we can grab the types in the Mono.Linker namespace.")]
 #else
 	[SetupCompileBefore ("CustomStep.dll", new [] { "Dependencies/CustomStepDummy.cs" }, new [] { "illink.dll" })]

--- a/test/Mono.Linker.Tests.Cases/CommandLine/AddCustomStep.cs
+++ b/test/Mono.Linker.Tests.Cases/CommandLine/AddCustomStep.cs
@@ -5,7 +5,8 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.CommandLine
 {
 	[SetupCompileBefore ("CustomStep.dll", new [] { "Dependencies/CustomStepDummy.cs" })]
-	[SetupLinkerArgument ("--custom-step", "CustomStep.CustomStepDummy", "CustomStep.dll")]
+	[SetupLinkerArgument ("--custom-step", "CustomStep.CustomStepDummy")]
+	[SetupLinkerArgument ("--custom-assembly", "CustomStep.dll")]
 	[LogContains("Custom step added")]
 	public class AddCustomStep
 	{

--- a/test/Mono.Linker.Tests.Cases/CommandLine/AddCustomStep.cs
+++ b/test/Mono.Linker.Tests.Cases/CommandLine/AddCustomStep.cs
@@ -1,14 +1,18 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.CommandLine
 {
-	[SetupCompileBefore ("CustomStep.dll", new [] { "Dependencies/CustomStepDummy.cs" })]
-	[SetupLinkerArgument ("--custom-step", "CustomStep.CustomStepDummy,,CustomStep.dll")]
-	[SetupLinkerArgument ("--custom-step", "-CleanStep:CustomStep.CustomStepDummy,,CustomStep.dll")]
-	[SetupLinkerArgument ("--custom-step", "+CleanStep:CustomStep.CustomStepDummy,,CustomStep.dll")]
-	[LogContains("Custom step added")]
+
+#if NET471
+	[IgnoreTestCase ("Can be enabled once MonoBuild produces a dll from which we can grab the types in the Mono.Linker namespace.")]
+#else
+	[SetupCompileBefore ("CustomStep.dll", new [] { "Dependencies/CustomStepDummy.cs" }, new [] { "illink.dll" })]
+#endif
+	[SetupLinkerArgument ("--custom-step", "CustomStep.CustomStepDummy,CustomStep.dll")]
+	[SetupLinkerArgument ("--custom-step", "-CleanStep:CustomStep.CustomStepDummy,CustomStep.dll")]
+	[SetupLinkerArgument ("--custom-step", "+CleanStep:CustomStep.CustomStepDummy,CustomStep.dll")]
+	[LogContains ("Custom step added")]
 	public class AddCustomStep
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/CommandLine/Dependencies/CustomStepDummy.cs
+++ b/test/Mono.Linker.Tests.Cases/CommandLine/Dependencies/CustomStepDummy.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Mono.Linker;
+using Mono.Linker.Steps;
+
+namespace CustomStep
+{
+	public class CustomStepDummy : IStep
+	{
+		public void Process(LinkContext context)
+		{
+			context.LogMessage ("Custom step added.");
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/test/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -25,6 +25,7 @@
     <Compile Remove="TypeForwarding\Dependencies\ForwarderLibrary_2.cs" />
     <Compile Remove="TypeForwarding\Dependencies\ForwarderLibrary_3.cs" />
     <Compile Remove="TypeForwarding\Dependencies\ImplementationLibrary_3.cs" />
+    <Compile Remove="CommandLine\Dependencies\CustomStepDummy.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Attributes\OnlyKeepUsed\Dependencies\UnusedAttributeWithTypeForwarderIsRemoved_Forwarder.cs" />
@@ -114,7 +115,6 @@
     <Content Include="LinkXml\UnusedTypeDeclarationPreservedByLinkXmlIsKept.xml" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\linker\Mono.Linker.csproj" />
     <ProjectReference Include="..\Mono.Linker.Tests.Cases.Expectations\Mono.Linker.Tests.Cases.Expectations.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/test/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -114,6 +114,7 @@
     <Content Include="LinkXml\UnusedTypeDeclarationPreservedByLinkXmlIsKept.xml" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\src\linker\Mono.Linker.csproj" />
     <ProjectReference Include="..\Mono.Linker.Tests.Cases.Expectations\Mono.Linker.Tests.Cases.Expectations.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadaProvider.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadaProvider.cs
@@ -55,6 +55,11 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			{
 				var ca = additionalArgumentAttr.ConstructorArguments;
 				var values = ((CustomAttributeArgument [])ca [1].Value)?.Select (arg => arg.Value.ToString ()).ToArray ();
+				// Since custom attribute arguments need to be constant expressions, we need to add
+				// the path to the temp directory (where the custom assembly is located) here.
+				if ((string)ca [0].Value == "--custom-assembly" && !Path.IsPathRooted(values[0])) {
+					values [0] = Path.Combine (inputPath, values [0]);
+				}
 				tclo.AdditionalArguments.Add (new KeyValuePair<string, string []> ((string)ca [0].Value, values));
 			}
 

--- a/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadaProvider.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadaProvider.cs
@@ -58,11 +58,11 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 				// Since custom attribute arguments need to be constant expressions, we need to add
 				// the path to the temp directory (where the custom assembly is located) here.
 				if ((string)ca [0].Value == "--custom-step") {
-					int pos = values [0].IndexOf (",,");
+					int pos = values [0].IndexOf (",");
 					if (pos != -1) {
-						string custom_assembly_path = values [0].Substring (pos + 2);
+						string custom_assembly_path = values [0].Substring (pos + 1);
 						if (!Path.IsPathRooted (custom_assembly_path))
-							values [0] = values [0].Substring (0, pos + 2) + Path.Combine (inputPath, custom_assembly_path);
+							values [0] = values [0].Substring (0, pos + 1) + Path.Combine (inputPath, custom_assembly_path);
 					}
 				}
 				tclo.AdditionalArguments.Add (new KeyValuePair<string, string []> ((string)ca [0].Value, values));

--- a/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadaProvider.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadaProvider.cs
@@ -57,8 +57,13 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 				var values = ((CustomAttributeArgument [])ca [1].Value)?.Select (arg => arg.Value.ToString ()).ToArray ();
 				// Since custom attribute arguments need to be constant expressions, we need to add
 				// the path to the temp directory (where the custom assembly is located) here.
-				if ((string)ca [0].Value == "--custom-assembly" && !Path.IsPathRooted(values[0])) {
-					values [0] = Path.Combine (inputPath, values [0]);
+				if ((string)ca [0].Value == "--custom-step") {
+					int pos = values [0].IndexOf (",,");
+					if (pos != -1) {
+						string custom_assembly_path = values [0].Substring (pos + 2);
+						if (!Path.IsPathRooted (custom_assembly_path))
+							values [0] = values [0].Substring (0, pos + 2) + Path.Combine (inputPath, custom_assembly_path);
+					}
 				}
 				tclo.AdditionalArguments.Add (new KeyValuePair<string, string []> ((string)ca [0].Value, values));
 			}


### PR DESCRIPTION
Fixes #969: These changes add the ability to specify the assembly where a custom step is defined by either specifying its full path or its file name, which we'll be looked for into the additional directories passed to the linker through the command line (with `-d`).