### PR TITLE
Fixes to reflection tests when running on windows

### DIFF
--- a/test/Mono.Linker.Tests.Cases/Reflection/ActivatorCreateInstance.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ActivatorCreateInstance.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Reflection;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Reflection
 {
+	[SetupCSharpCompilerToUse ("csc")]
 	public class ActivatorCreateInstance
 	{
 		[UnrecognizedReflectionAccessPattern(

--- a/test/Mono.Linker.Tests.Cases/Reflection/ConstructorUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ConstructorUsedViaReflection.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Reflection;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Reflection
 {
+	[SetupCSharpCompilerToUse ("csc")]
 	public class ConstructorUsedViaReflection {
 		public static void Main ()
 		{

--- a/test/Mono.Linker.Tests.Cases/Reflection/CoreLibMessages.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/CoreLibMessages.cs
@@ -3,8 +3,9 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Reflection
 {
+	[SetupCSharpCompilerToUse ("csc")]
 	[SetupLinkerAction ("copy", "CoreLibEmulator")]
-	[SetupCompileBefore ("CoreLibEmulator.dll", new string [] { "Dependencies/CoreLibEmulator.cs" }, null, new string [] { "INCLUDE_CORELIB_IMPL" })]
+	[SetupCompileBefore ("CoreLibEmulator.dll", new string [] { "Dependencies/CoreLibEmulator.cs" }, null, new string [] { "INCLUDE_CORELIB_IMPL" }, compilerToUse: "csc")]
 
 	// Validate that calls from one overload of Type.Get* to another overload of the same method don't produce warning
 	[LogDoesNotContain ("Reflection call 'System.Reflection.ConstructorInfo System.Type::GetConstructor\\([^)]*\\)' inside 'System.Reflection.ConstructorInfo System.Type::GetConstructor\\([^)]*\\)' does not use detectable instance type extraction")]

--- a/test/Mono.Linker.Tests.Cases/Reflection/EventUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/EventUsedViaReflection.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Reflection {
+	[SetupCSharpCompilerToUse ("csc")]
 	public class EventUsedViaReflection {
 		public static void Main ()
 		{

--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallString.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallString.cs
@@ -6,6 +6,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Reflection
 {
+	[SetupCSharpCompilerToUse ("csc")]
 	[Reference ("System.Core.dll")]
 	public class ExpressionCallString
 	{

--- a/test/Mono.Linker.Tests.Cases/Reflection/FieldUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/FieldUsedViaReflection.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Reflection;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Reflection {
+	[SetupCSharpCompilerToUse ("csc")]
 	public class FieldUsedViaReflection {
 		public static void Main ()
 		{

--- a/test/Mono.Linker.Tests.Cases/Reflection/MethodUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/MethodUsedViaReflection.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Reflection;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Reflection {
 
+	[SetupCSharpCompilerToUse ("csc")]
 	[VerifyAllReflectionAccessPatternsAreValidated]
 	public class MethodUsedViaReflection {
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/Reflection/PropertyUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/PropertyUsedViaReflection.cs
@@ -1,7 +1,9 @@
 ﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using System;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Reflection {
+	[SetupCSharpCompilerToUse ("csc")]
 	public class PropertyUsedViaReflection {
 		public static void Main ()
 		{

--- a/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflection.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Reflection {
+	[SetupCSharpCompilerToUse ("csc")]
 	public class TypeUsedViaReflection {
 		public static void Main ()
 		{

--- a/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflectionTypeDoesntExist.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflectionTypeDoesntExist.cs
@@ -1,7 +1,9 @@
 ﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using System;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Reflection {
+	[SetupCSharpCompilerToUse ("csc")]
 	[VerifyAllReflectionAccessPatternsAreValidated]
 	public class TypeUsedViaReflectionTypeDoesntExist {
 		[UnrecognizedReflectionAccessPatternAttribute (


### PR DESCRIPTION
Need to explicitly use roslyn in order for these tests to pass on windows.  Otherwise they fail complaining about the nameof() usages in attributes.