### PR TITLE
Don't enable IPConstantPropagation by default

### DIFF
--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -200,8 +200,7 @@ namespace Mono.Linker {
 			const CodeOptimizations defaultOptimizations =
 				CodeOptimizations.BeforeFieldInit |
 				CodeOptimizations.OverrideRemoval |
-				CodeOptimizations.UnusedInterfaces |
-				CodeOptimizations.IPConstantPropagation;
+				CodeOptimizations.UnusedInterfaces;
 
 			Optimizations = new CodeOptimizationsSettings (defaultOptimizations);
 		}


### PR DESCRIPTION
On windows when linking against .NET Framework class libraries every test with `[SetupCoreLinkAction("link")]` fails due to
```
System.NotImplementedException : Initialization of return value in method.....
```

Between this and https://github.com/mono/linker/pull/990 and https://github.com/mono/linker/issues/975 I don't think this option is ready to be turned on by default.