### PR TITLE
Remove PreserveDependencyAttribute from the expectations assembly

### DIFF
--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtor/PreserveDependencyPreservesInterfaceMethod.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtor/PreserveDependencyPreservesInterfaceMethod.cs
@@ -1,10 +1,12 @@
 using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoKeptCtor {
 	/// <summary>
 	/// The interface can still be removed in this case because PreserveDependency is just preserving Foo() on the current type
 	/// </summary>
+	[SetupCompileBefore ("FakeSystemAssembly.dll", new [] { "../../../PreserveDependencies/Dependencies/PreserveDependencyAttribute.cs" })]
 	public class PreserveDependencyPreservesInterfaceMethod {
 		public static void Main ()
 		{

--- a/test/Mono.Linker.Tests.Cases/PreserveDependencies/Dependencies/PreserveDependencyAttribute.cs
+++ b/test/Mono.Linker.Tests.Cases/PreserveDependencies/Dependencies/PreserveDependencyAttribute.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // PreserveDependencyAttribute.cs
 //
 // Authors:

--- a/test/Mono.Linker.Tests.Cases/PreserveDependencies/Dependencies/PreserveDependencyInCopyAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/PreserveDependencies/Dependencies/PreserveDependencyInCopyAssembly.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies
 {

--- a/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyField.cs
+++ b/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyField.cs
@@ -1,7 +1,9 @@
 ﻿using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.PreserveDependencies {
+	[SetupCompileBefore ("FakeSystemAssembly.dll", new [] { "Dependencies/PreserveDependencyAttribute.cs" })]
 	public class PreserveDependencyField {
 		public static void Main ()
 		{

--- a/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyFromCopiedAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyFromCopiedAssembly.cs
@@ -4,7 +4,8 @@ using Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.PreserveDependencies {
 	[SetupLinkerAction ("copy", "lib")]
-	[SetupCompileBefore ("lib.dll", new [] { "Dependencies/PreserveDependencyInCopyAssembly.cs" })]
+	[SetupCompileBefore ("FakeSystemAssembly.dll", new [] { "Dependencies/PreserveDependencyAttribute.cs" })]
+	[SetupCompileBefore ("lib.dll", new [] { "Dependencies/PreserveDependencyInCopyAssembly.cs" }, new [] { "FakeSystemAssembly.dll" })]
 	[KeptAllTypesAndMembersInAssembly ("lib.dll")]
 	public class PreserveDependencyFromCopiedAssembly
 	{

--- a/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyKeptOption.cs
+++ b/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyKeptOption.cs
@@ -4,7 +4,9 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.PreserveDependencies
 {
+	[SetupCompileBefore ("FakeSystemAssembly.dll", new [] { "Dependencies/PreserveDependencyAttribute.cs" })]
 	[SetupLinkerArgument ("--keep-dep-attributes", "true")]
+	[KeptTypeInAssembly("FakeSystemAssembly.dll", typeof(PreserveDependencyAttribute))]
 	class PreserveDependencyKeptOption
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMemberSignatureWildcard.cs
+++ b/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMemberSignatureWildcard.cs
@@ -6,7 +6,8 @@ namespace Mono.Linker.Tests.Cases.PreserveDependencies
 {
 	[KeptMemberInAssembly ("library.dll", "Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies.PreserveDependencyMethodInAssemblyLibrary", ".ctor()")]
 	[KeptMemberInAssembly ("library.dll", "Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies.PreserveDependencyMethodInAssemblyLibrary", "Foo()")]
-	[SetupCompileBefore ("library.dll", new [] { "Dependencies/PreserveDependencyMethodInAssemblyLibrary.cs" })]
+	[SetupCompileBefore ("FakeSystemAssembly.dll", new [] { "Dependencies/PreserveDependencyAttribute.cs" })]
+	[SetupCompileBefore ("library.dll", new [] { "Dependencies/PreserveDependencyMethodInAssemblyLibrary.cs" }, new [] { "FakeSystemAssembly.dll" })]
 	public class PreserveDependencyMemberSignatureWildcard
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethod.cs
+++ b/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethod.cs
@@ -1,8 +1,10 @@
 ﻿using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.PreserveDependencies {
-	
+
+	[SetupCompileBefore ("FakeSystemAssembly.dll", new [] { "Dependencies/PreserveDependencyAttribute.cs" })]
 	[LogContains("Could not resolve 'Mono.Linker.Tests.Cases.PreserveDependencies.MissingType' type dependency")]
 	[LogContains("Could not resolve dependency member 'MissingMethod' declared in type 'Mono.Linker.Tests.Cases.PreserveDependencies.C'")]
 	[LogContains("Could not resolve dependency member 'Dependency2`1' declared in type 'Mono.Linker.Tests.Cases.PreserveDependencies.C'")]

--- a/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethodInAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethodInAssembly.cs
@@ -5,7 +5,8 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.PreserveDependencies
 {
 	[KeptMemberInAssembly ("library.dll", "Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies.PreserveDependencyMethodInAssemblyLibrary", ".ctor()")]
-	[SetupCompileBefore ("library.dll", new [] { "Dependencies/PreserveDependencyMethodInAssemblyLibrary.cs" })]
+	[SetupCompileBefore ("FakeSystemAssembly.dll", new [] { "Dependencies/PreserveDependencyAttribute.cs" })]
+	[SetupCompileBefore ("library.dll", new [] { "Dependencies/PreserveDependencyMethodInAssemblyLibrary.cs" }, new [] { "FakeSystemAssembly.dll" })]
 	public class PreserveDependencyMethodInAssembly
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethodInNonReferencedAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethodInNonReferencedAssembly.cs
@@ -4,6 +4,7 @@ using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.PreserveDependencies {
+	[SetupCompileBefore ("FakeSystemAssembly.dll", new [] { "Dependencies/PreserveDependencyAttribute.cs" })]
 	[SetupCompileBefore ("base.dll", new [] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyBase.cs" })]
 	[SetupCompileBefore ("library.dll", new [] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyLibrary.cs" }, references: new [] { "base.dll" }, addAsReference: false)]
 	[KeptAssembly ("base.dll")]

--- a/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethodInNonReferencedAssemblyChained.cs
+++ b/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethodInNonReferencedAssemblyChained.cs
@@ -5,6 +5,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.PreserveDependencies {
 	[IgnoreTestCase ("Currently failing")]
+	[SetupCompileBefore ("FakeSystemAssembly.dll", new [] { "Dependencies/PreserveDependencyAttribute.cs" })]
 	[SetupCompileBefore ("base.dll", new [] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyBase.cs" })]
 	[SetupCompileBefore ("base2.dll", new [] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyBase2.cs" }, references: new [] { "base.dll" }, addAsReference: false)]
 	[SetupCompileBefore ("library.dll", new [] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyChainedLibrary.cs" }, references: new [] { "base.dll" }, addAsReference: false)]

--- a/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethodInNonReferencedAssemblyChainedReference.cs
+++ b/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethodInNonReferencedAssemblyChainedReference.cs
@@ -5,6 +5,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.PreserveDependencies {
 	[IgnoreTestCase ("Currently failing")]
+	[SetupCompileBefore ("FakeSystemAssembly.dll", new [] { "Dependencies/PreserveDependencyAttribute.cs" })]
 	[SetupCompileBefore ("base.dll", new [] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyBase.cs" })]
 	[SetupCompileBefore ("base2.dll", new [] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyBase2.cs" }, references: new [] { "base.dll" }, addAsReference: false)]
 	[SetupCompileBefore ("reference.dll", new [] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyChainedLibrary.cs" }, references: new [] { "base.dll" }, addAsReference: false)]

--- a/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethodInNonReferencedAssemblyWithEmbeddedXml.cs
+++ b/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethodInNonReferencedAssemblyWithEmbeddedXml.cs
@@ -8,6 +8,7 @@ namespace Mono.Linker.Tests.Cases.PreserveDependencies {
 	/// This is an acceptable bug with the currently implementation.  Embedded link xml files will not be processed
 	/// </summary>
 	[IncludeBlacklistStep (true)]
+	[SetupCompileBefore ("FakeSystemAssembly.dll", new [] { "Dependencies/PreserveDependencyAttribute.cs" })]
 	[SetupCompileBefore ("base.dll", new [] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyBase.cs" })]
 	[SetupCompileBefore (
 		"PreserveDependencyMethodInNonReferencedAssemblyLibrary.dll",

--- a/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyOnUnusedMethodInNonReferencedAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyOnUnusedMethodInNonReferencedAssembly.cs
@@ -4,6 +4,7 @@ using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.PreserveDependencies {
+	[SetupCompileBefore ("FakeSystemAssembly.dll", new [] { "Dependencies/PreserveDependencyAttribute.cs" })]
 	[SetupCompileBefore ("base.dll", new [] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyBase.cs" })]
 	[SetupCompileBefore ("library.dll", new [] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyLibrary.cs" }, references: new [] { "base.dll" }, addAsReference: false)]
 	[KeptAssembly ("base.dll")]

--- a/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithCopyUsedAction.cs
+++ b/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithCopyUsedAction.cs
@@ -4,6 +4,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.PreserveDependencies {
 	[SetupLinkerUserAction ("copyused")]
+	[SetupCompileBefore ("FakeSystemAssembly.dll", new [] { "Dependencies/PreserveDependencyAttribute.cs" })]
 	[SetupCompileBefore ("library.dll", new [] {"Dependencies/PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithCopyUsedAction_Lib.cs"}, addAsReference: false)]
 	[RemovedAssembly ("library.dll")]
 	public class PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithCopyUsedAction {

--- a/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithEmbeddedXml.cs
+++ b/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithEmbeddedXml.cs
@@ -8,6 +8,7 @@ namespace Mono.Linker.Tests.Cases.PreserveDependencies {
 	/// This test is here to ensure that link xml embedded in an assembly used by a [PreserveDependency] is not processed if the dependency is not used
 	/// </summary>
 	[IncludeBlacklistStep (true)]
+	[SetupCompileBefore ("FakeSystemAssembly.dll", new [] { "Dependencies/PreserveDependencyAttribute.cs" })]
 	[SetupCompileBefore ("base.dll", new [] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyBase.cs" })]
 	[SetupCompileBefore (
 		"PreserveDependencyMethodInNonReferencedAssemblyLibrary.dll",

--- a/test/Mono.Linker.Tests.Cases/UnreachableBody/WorksWithPreserveDependency.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBody/WorksWithPreserveDependency.cs
@@ -4,6 +4,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.UnreachableBody {
 	[SetupLinkerArgument ("--enable-opt", "unreachablebodies")]
+	[SetupCompileBefore ("FakeSystemAssembly.dll", new [] { "../PreserveDependencies/Dependencies/PreserveDependencyAttribute.cs" })]
 	public class WorksWithPreserveDependency {
 		public static void Main()
 		{


### PR DESCRIPTION
The expectations assembly should never survive linking.  However, putting this attribute in there was causing it to survive during some tests.

I moved the attribute into it's own assembly that is compiled during the tests that need it