### PR TITLE
Enable running monolinker tests in VS

### DIFF
--- a/test/Mono.Linker.Tests/Mono.Linker.Tests.csproj
+++ b/test/Mono.Linker.Tests/Mono.Linker.Tests.csproj
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
@@ -61,6 +61,7 @@
     <ProjectReference Include="..\..\external\cecil\symbols\mdb\Mono.Cecil.Mdb.csproj" />
     <PackageReference Include="NUnit" Version="3.10.0" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.10.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
   </ItemGroup>
 
   <Target Name="RunTestsOnMono" Condition="'$(MonoBuild)' != ''">


### PR DESCRIPTION
To run tests from VS the NUnit3TestAdapter package is required, otherwise VS doesn't correctly recognize NUnit tests.