### PR TITLE
Don't use nop(s) for removed instructions in RemoveUnreachableBlocksStep

### DIFF
--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/ComplexConditions.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/ComplexConditions.cs
@@ -5,10 +5,6 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.UnreachableBlock
 {
-	// 	Invalid IL detected in F:\Temp\linker_tests\output\test.exe
-	// [IL]: Error: [F:\Temp\linker_tests\output\test.exe : Mono.Linker.Tests.Cases.UnreachableBlock.ComplexConditions::Test_1][offset 0x0000001D] Stack depth differs depending on path.
-	[IgnoreTestCase("Fails peverify on windows.")]
-	
 	[SetupCompileArgument ("/optimize-")] // Relying on debug csc behaviour
 	[SetupLinkerArgument ("--enable-opt", "ipconstprop")]
 	public class ComplexConditions
@@ -35,7 +31,6 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 			"ldnull",
 			"cgt.un",
 			"br.s",
-			"nop",
 			"br.s",
 			"ldc.i4.1",
 			"stloc.0",

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/ReplacedReturns.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/ReplacedReturns.cs
@@ -37,9 +37,6 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 			"pop",
 			"call",
 			"ldc.i4.1",
-			"ret",
-			"nop",
-			"ldc.i4.0",
 			"ret"
 			})]
 		static int Test1 ()
@@ -58,8 +55,6 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 			"pop",
 			"call",
 			"ldc.i4.0",
-			"ret",
-			"ldc.i4.0",
 			"ret"
 			})]
 		static bool Test2 ()
@@ -73,16 +68,11 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 		}
 
 		[Kept]
-		[ExpectLocalsModified]
 		[ExpectedInstructionSequence (new [] {
 			"call",
 			"pop",
 			"ldsfld",
 			"call",
-			"ret",
-			"ldloca.s",
-			"initobj",
-			"ldloc.0",
 			"ret"
 			})]
 		static DateTime Test3 ()
@@ -97,16 +87,11 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 		}
 
 		[Kept]
-		[ExpectLocalsModified]
 		[ExpectedInstructionSequence (new [] {
 			"call",
 			"pop",
 			"ldsfld",
 			"call",
-			"ret",
-			"ldloca.s",
-			"initobj",
-			"ldloc.0",
 			"ret"
 			})]
 		static DateTime Test3b ()
@@ -130,10 +115,6 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 			"pop",
 			"call",
 			"ldc.i4.3",
-			"ret",
-			"nop",
-			"nop",
-			"ldc.i4.0",
 			"ret"
 			})]
 		static TestEnum Test4 ()
@@ -155,8 +136,6 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 			"call",
 			"pop",
 			"call",
-			"leave.s",
-			"nop",
 			"leave.s",
 			"pop",
 			"call",
@@ -190,11 +169,6 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 			"conv.i8",
 			"stloc.0",
 			"leave.s",
-			"nop",
-			"nop",
-			"nop",
-			"nop",
-			"leave.s",
 			"pop",
 			"ldc.i4.2",
 			"conv.i8",
@@ -226,11 +200,6 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 			"call",
 			"ldc.i4.1",
 			"stloc.1",
-			"leave.s",
-			"nop",
-			"nop",
-			"nop",
-			"nop",
 			"leave.s",
 			"pop",
 			"ldloc.0",
@@ -266,16 +235,6 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 			"call",
 			"pop",
 			"call",
-			"ret",
-			"nop",
-			"nop",
-			"nop",
-			"nop",
-			"nop",
-			"nop",
-			"nop",
-			"nop",
-			"nop",
 			"ret"
 		})]
 		static void Test8 ()
@@ -295,9 +254,6 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 			"call",
 			"pop",
 			"call",
-			"leave.s",
-			"nop",
-			"nop",
 			"leave.s",
 			"pop",
 			"leave.s",

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/SimpleConditionalProperty.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/SimpleConditionalProperty.cs
@@ -4,7 +4,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.UnreachableBlock
 {
-//	[SetupCSharpCompilerToUse ("csc")]
+	[SetupCSharpCompilerToUse ("csc")]
 	[SetupCompileArgument ("/optimize+")]
 	[SetupLinkerArgument ("--enable-opt", "ipconstprop")]
 	public class SimpleConditionalProperty
@@ -23,7 +23,12 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 		}
 
 		[Kept]
-		[ExpectBodyModified]
+		[ExpectedInstructionSequence (new [] {
+			"call",
+			"ldc.i4.3",
+			"beq.s",
+			"ret"
+			})]
 		static void TestProperty_int_1 ()
 		{
 			if (Prop != 3)
@@ -31,7 +36,12 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 		}
 
 		[Kept]
-		[ExpectBodyModified]
+		[ExpectedInstructionSequence (new [] {
+			"ldc.i4.3",
+			"call",
+			"beq.s",
+			"ret"
+			})]
 		static void TestProperty_int_2 ()
 		{
 			if (3 == Prop) {
@@ -42,7 +52,13 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 		}
 
 		[Kept]
-		[ExpectBodyModified]
+		[ExpectedInstructionSequence (new [] {
+			"call",
+			"ldc.i4.5",
+			"ble.s",
+			"ldc.i4.0",
+			"ret"
+			})]
 		static int TestProperty_int_3 ()
 		{
 			if (Prop > 5 && TestProperty_int_3 () == 0) {
@@ -53,8 +69,15 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 		}
 
 		[Kept]
-		[ExpectBodyModified]
-		[ExpectLocalsModified]
+		[ExpectedInstructionSequence (new [] {
+			"call",
+			"pop",
+			"nop",
+			"ldloca.s",
+			"initobj",
+			"ldloc.0",
+			"ret"
+			})]
 		static long? TestProperty_int_4 ()
 		{
 			if (Prop == 3)
@@ -64,7 +87,11 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 		}
 
 		[Kept]
-		[ExpectBodyModified]
+		[ExpectedInstructionSequence (new [] {
+			"call",
+			"brfalse.s",
+			"ret"
+			})]
 		static void TestProperty_bool_1 ()
 		{
 			if (!PropBool) {
@@ -75,7 +102,11 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 		}
 
 		[Kept]
-		[ExpectBodyModified]
+		[ExpectedInstructionSequence (new [] {
+			"call",
+			"brfalse.s",
+			"ret"
+			})]
 		static void TestProperty_bool_2 ()
 		{
 			if (PropBool) {
@@ -84,7 +115,12 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 		}
 
 		[Kept]
-		[ExpectBodyModified]
+		[ExpectedInstructionSequence (new [] {
+			"call",
+			"call",
+			"beq.s",
+			"ret"
+			})]
 		static void TestProperty_bool_3 ()
 		{
 			if (PropBool != PropBool) {
@@ -93,7 +129,13 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 		}
 
 		[Kept]
-		[ExpectBodyModified]
+		[ExpectedInstructionSequence (new [] {
+			"br.s",
+			"call",
+			"pop",
+			"nop",
+			"ret"
+			})]
 		static void TestProperty_enum_1 ()
 		{
 			while (PropEnum == TestEnum.C) {
@@ -102,7 +144,11 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 		}
 
 		[Kept]
-		[ExpectBodyModified]
+		[ExpectedInstructionSequence (new [] {
+			"call",
+			"brfalse.s",
+			"ret"
+			})]
 		static void TestProperty_null_1 ()
 		{
 			if (PropNull != null)

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/TryCatchBlocks.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/TryCatchBlocks.cs
@@ -6,35 +6,42 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 	[SetupCSharpCompilerToUse ("csc")]
 	[SetupCompileArgument ("/optimize+")]
 	[SetupLinkerArgument ("--enable-opt", "ipconstprop")]
-	public class TryFinallyBlocks
+	public class TryCatchBlocks
 	{
 		public static void Main ()
 		{
-			TestSimpleTry ();
+			TestSimpleTryUnreachable ();
 		}
 
 		[Kept]
 		[ExpectedInstructionSequence (new [] {
 			"call",
-			"ldc.i4.3",
+			"ldc.i4.6",
 			"beq.s",
+			"ldc.i4.3",
 			"ret"
 		})]
-		static void TestSimpleTry ()
+		[ExpectedExceptionHandlerSequence (new string[0])]
+		[ExpectedLocalsSequence (new string[0])]
+		static int TestSimpleTryUnreachable ()
 		{
-			if (Prop != 3)
-				Unreached_1 ();
+			if (Prop != 6) {
+                try {
+					Unreached_1 ();
+					return 1;
+                } catch {
+                    return 2;
+                }
+            }
+
+			return 3;
 		}
 
 		[Kept]
 		static int Prop {
 			[Kept]
 			get {
-				try {
-					return 3;
-				} finally {
-
-				}
+				return 6;
 			}
 		}
 


### PR DESCRIPTION
The CLR spec in Backward Branch Contraints recognizes only unconditional
jumps. For any other instruction including nop it mandates

>In particular, if that single-pass analysis arrives at an instruction,
call it location X, that immediately follows an unconditional branch,
and where X is not the target of an earlier branch instruction, then the
state of the evaluation stack at X, clearly, cannot be derived from
existing information. In this case, the CLI demands that the evaluation

Fixes #975