### PR TITLE
Add tracing reasons

### DIFF
--- a/src/linker/Linker.Steps/ClearInitLocals.cs
+++ b/src/linker/Linker.Steps/ClearInitLocals.cs
@@ -54,7 +54,7 @@ namespace Mono.Linker.Steps
 			}
 
 			if (changed && (Annotations.GetAction (assembly) == AssemblyAction.Copy))
-					Annotations.SetAction (assembly, AssemblyAction.Save);
+				Annotations.SetAction (assembly, AssemblyAction.Save);
 		}
 	}
 }

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -59,6 +59,7 @@ namespace Mono.Linker.Steps {
 		static DependencyKind [] _fieldReasons = new DependencyKind [] {
 			DependencyKind.AccessedViaReflection,
 			DependencyKind.AlreadyMarked,
+			DependencyKind.Custom,
 			DependencyKind.CustomAttributeField,
 			DependencyKind.EventSourceProviderField,
 			DependencyKind.FieldAccess,
@@ -77,6 +78,7 @@ namespace Mono.Linker.Steps {
 			DependencyKind.AttributeType,
 			DependencyKind.BaseType,
 			DependencyKind.CatchType,
+			DependencyKind.Custom,
 			DependencyKind.CustomAttributeArgumentType,
 			DependencyKind.CustomAttributeArgumentValue,
 			DependencyKind.DeclaringType,
@@ -105,6 +107,7 @@ namespace Mono.Linker.Steps {
 			DependencyKind.BaseMethod,
 			DependencyKind.CctorForType,
 			DependencyKind.CctorForField,
+			DependencyKind.Custom,
 			DependencyKind.DefaultCtorForNewConstrainedGenericArgument,
 			DependencyKind.DirectCall,
 			DependencyKind.ElementMethod,

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -209,7 +209,7 @@ namespace Mono.Linker.Steps {
 			// We may get here for a type marked by an earlier step, or by a type
 			// marked indirectly as the result of some other InitializeType call.
 			// Just track this as already marked, and don't include a new source.
-			MarkType (type, new DependencyInfo (DependencyKind.AlreadyMarked));
+			MarkType (type, DependencyInfo.AlreadyMarked);
 
 			if (type.HasFields)
 				InitializeFields (type);
@@ -238,14 +238,14 @@ namespace Mono.Linker.Steps {
 		{
 			foreach (FieldDefinition field in type.Fields)
 				if (Annotations.IsMarked (field))
-					MarkField (field, new DependencyInfo (DependencyKind.AlreadyMarked));
+					MarkField (field, DependencyInfo.AlreadyMarked);
 		}
 
 		void InitializeMethods (Collection<MethodDefinition> methods)
 		{
 			foreach (MethodDefinition method in methods)
 				if (Annotations.IsMarked (method))
-					EnqueueMethod (method, new DependencyInfo (DependencyKind.AlreadyMarked));
+					EnqueueMethod (method, DependencyInfo.AlreadyMarked);
 		}
 
 		void MarkEntireType (TypeDefinition type, in DependencyInfo reason)
@@ -2322,7 +2322,7 @@ namespace Mono.Linker.Steps {
 			if (disablePrivateReflection == null)
 				throw new NotSupportedException ("Missing predefined 'System.Runtime.CompilerServices.DisablePrivateReflectionAttribute' type");
 
-			MarkType (disablePrivateReflection, new DependencyInfo (DependencyKind.DisablePrivateReflectionRequirement));
+			MarkType (disablePrivateReflection, DependencyInfo.DisablePrivateReflectionRequirement);
 
 			var ctor = MarkMethodIf (disablePrivateReflection.Methods, MethodDefinitionExtensions.IsDefaultConstructor, new DependencyInfo (DependencyKind.DisablePrivateReflectionRequirement, disablePrivateReflection));
 			_context.MarkedKnownMembers.DisablePrivateReflectionAttributeCtor = ctor ?? throw new MarkException ($"Could not find constructor on '{disablePrivateReflection.FullName}'");

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -42,19 +42,19 @@ namespace Mono.Linker.Steps {
 	public partial class MarkStep : IStep {
 
 		protected LinkContext _context;
-		protected Queue<MethodDefinition> _methods;
+		protected Queue<(MethodDefinition, DependencyInfo)> _methods;
 		protected List<MethodDefinition> _virtual_methods;
 		protected Queue<AttributeProviderPair> _assemblyLevelAttributes;
-		protected Queue<AttributeProviderPair> _lateMarkedAttributes;
+		protected Queue<(AttributeProviderPair, DependencyInfo)> _lateMarkedAttributes;
 		protected List<TypeDefinition> _typesWithInterfaces;
 		protected List<MethodBody> _unreachableBodies;
 
 		public MarkStep ()
 		{
-			_methods = new Queue<MethodDefinition> ();
+			_methods = new Queue<(MethodDefinition, DependencyInfo)> ();
 			_virtual_methods = new List<MethodDefinition> ();
 			_assemblyLevelAttributes = new Queue<AttributeProviderPair> ();
-			_lateMarkedAttributes = new Queue<AttributeProviderPair> ();
+			_lateMarkedAttributes = new Queue<(AttributeProviderPair, DependencyInfo)> ();
 			_typesWithInterfaces = new List<TypeDefinition> ();
 			_unreachableBodies = new List<MethodBody> ();
 		}
@@ -81,9 +81,11 @@ namespace Mono.Linker.Steps {
 		{
 			Tracer.Push (assembly);
 			try {
-				switch (_context.Annotations.GetAction (assembly)) {
+				var action = _context.Annotations.GetAction (assembly);
+				switch (action) {
 				case AssemblyAction.Copy:
 				case AssemblyAction.Save:
+					Tracer.AddDirectDependency (assembly, new DependencyInfo (DependencyKind.AssemblyAction, action), marked: false);
 					MarkEntireAssembly (assembly);
 					break;
 				case AssemblyAction.Link:
@@ -118,7 +120,10 @@ namespace Mono.Linker.Steps {
 			if (!Annotations.IsMarked (type))
 				return;
 
-			MarkType (type);
+			// We may get here for a type marked by an earlier step, or by a type
+			// marked indirectly as the result of some other InitializeType call.
+			// Just track this as already marked, and don't include a new source.
+			MarkType (type, new DependencyInfo (DependencyKind.AlreadyMarked));
 
 			if (type.HasFields)
 				InitializeFields (type);
@@ -147,30 +152,40 @@ namespace Mono.Linker.Steps {
 		{
 			foreach (FieldDefinition field in type.Fields)
 				if (Annotations.IsMarked (field))
-					MarkField (field);
+					MarkField (field, new DependencyInfo (DependencyKind.AlreadyMarked));
 		}
 
 		void InitializeMethods (Collection<MethodDefinition> methods)
 		{
 			foreach (MethodDefinition method in methods)
 				if (Annotations.IsMarked (method))
-					EnqueueMethod (method);
+					EnqueueMethod (method, new DependencyInfo (DependencyKind.AlreadyMarked));
 		}
 
-		void MarkEntireType (TypeDefinition type)
+		void MarkEntireType (TypeDefinition type, DependencyInfo reason)
 		{
+#if DEBUG
+			var reasons = new DependencyKind [] {
+				DependencyKind.NestedType,
+				DependencyKind.PreservedDependency,
+				DependencyKind.TypeInAssembly,
+			};
+			if (!reasons.Contains (reason.Kind))
+				throw new InvalidOperationException ($"Internal error: unsupported type dependency {reason.Kind}");
+#endif
+
 			if (type.HasNestedTypes) {
 				foreach (TypeDefinition nested in type.NestedTypes)
-					MarkEntireType (nested);
+					MarkEntireType (nested, new DependencyInfo (DependencyKind.NestedType, type));
 			}
 
-			Annotations.Mark (type);
-			MarkCustomAttributes (type);
+			Annotations.Mark (type, reason);
+			MarkCustomAttributes (type, new DependencyInfo (DependencyKind.CustomAttribute, type));
 			MarkTypeSpecialCustomAttributes (type);
 
 			if (type.HasInterfaces) {
 				foreach (InterfaceImplementation iface in type.Interfaces) {
-					MarkInterfaceImplementation (iface);
+					MarkInterfaceImplementation (iface, type);
 				}
 			}
 
@@ -178,27 +193,28 @@ namespace Mono.Linker.Steps {
 
 			if (type.HasFields) {
 				foreach (FieldDefinition field in type.Fields) {
-					MarkField (field);
+					MarkField (field, new DependencyInfo (DependencyKind.MemberOfType, type));
 				}
 			}
 
 			if (type.HasMethods) {
 				foreach (MethodDefinition method in type.Methods) {
-					Annotations.Mark (method);
+					// Probably redundant since we EnqueueMethod below anyway.
+					Annotations.Mark (method, new DependencyInfo (DependencyKind.MemberOfType, type));
 					Annotations.SetAction (method, MethodAction.ForceParse);
-					EnqueueMethod (method);
+					EnqueueMethod (method, new DependencyInfo (DependencyKind.MemberOfType, type));
 				}
 			}
 
 			if (type.HasProperties) {
 				foreach (var property in type.Properties) {
-					MarkProperty (property);
+					MarkProperty (property, new DependencyInfo (DependencyKind.MemberOfType, type));
 				}
 			}
 
 			if (type.HasEvents) {
 				foreach (var ev in type.Events) {
-					MarkEvent (ev);
+					MarkEvent (ev, new DependencyInfo (DependencyKind.MemberOfType, type));
 				}
 			}
 		}
@@ -229,7 +245,7 @@ namespace Mono.Linker.Steps {
 						continue;
 					Tracer.Push (type);
 					try {
-						_context.MarkingHelpers.MarkExportedType (exported, assembly.MainModule);
+						_context.MarkingHelpers.MarkExportedType (exported, assembly.MainModule, new DependencyInfo (DependencyKind.ExportedType, type));
 					} finally {
 						Tracer.Pop ();
 					}
@@ -256,10 +272,10 @@ namespace Mono.Linker.Steps {
 		void ProcessQueue ()
 		{
 			while (!QueueIsEmpty ()) {
-				MethodDefinition method = _methods.Dequeue ();
+				(MethodDefinition method, DependencyInfo reason) = _methods.Dequeue ();
 				Tracer.Push (method);
 				try {
-					ProcessMethod (method);
+					ProcessMethod (method, reason);
 				} catch (Exception e) {
 					throw new MarkException (string.Format ("Error processing method: '{0}' in assembly: '{1}'", method.FullName, method.Module.Name), e, method);
 				} finally {
@@ -273,9 +289,9 @@ namespace Mono.Linker.Steps {
 			return _methods.Count == 0;
 		}
 
-		protected virtual void EnqueueMethod (MethodDefinition method)
+		protected virtual void EnqueueMethod (MethodDefinition method, DependencyInfo reason)
 		{
-			_methods.Enqueue (method);
+			_methods.Enqueue ((method, reason));
 		}
 
 		void ProcessVirtualMethods ()
@@ -349,7 +365,16 @@ namespace Mono.Linker.Steps {
 			if (!isInstantiated && !@base.IsAbstract && _context.IsOptimizationEnabled (CodeOptimizations.OverrideRemoval, method))
 				return;
 
-			MarkMethod (method);
+			// Only track instantiations if override removal is enabled and the type is instantiated.
+			// If it's disabled, all overrides are kept, so there's no instantiation site to blame.
+			if (_context.IsOptimizationEnabled (CodeOptimizations.OverrideRemoval, method) && isInstantiated) {
+				MarkMethod (method, new DependencyInfo (DependencyKind.OverrideOnInstantiatedType, method.DeclaringType));
+			} else {
+				// If the optimization is disabled or it's an abstract type, we just mark it as a normal override.
+				Debug.Assert (!_context.IsOptimizationEnabled (CodeOptimizations.OverrideRemoval, method) || @base.IsAbstract);
+				MarkMethod (method, new DependencyInfo (DependencyKind.Override, @base));
+			}
+
 			ProcessVirtualMethod (method);
 		}
 
@@ -385,16 +410,16 @@ namespace Mono.Linker.Steps {
 			return type.HasInterface (@interfaceType, out InterfaceImplementation implementation) && Annotations.IsMarked (implementation);
 		}
 
-		void MarkMarshalSpec (IMarshalInfoProvider spec)
+		void MarkMarshalSpec (IMarshalInfoProvider spec, DependencyInfo reason)
 		{
 			if (!spec.HasMarshalInfo)
 				return;
 
 			if (spec.MarshalInfo is CustomMarshalInfo marshaler)
-				MarkType (marshaler.ManagedType);
+				MarkType (marshaler.ManagedType, reason);
 		}
 
-		void MarkCustomAttributes (ICustomAttributeProvider provider)
+		void MarkCustomAttributes (ICustomAttributeProvider provider, DependencyInfo reason)
 		{
 			if (!provider.HasCustomAttributes)
 				return;
@@ -404,30 +429,33 @@ namespace Mono.Linker.Steps {
 			Tracer.Push (provider);
 			try {
 				foreach (CustomAttribute ca in provider.CustomAttributes) {
-					if (ProcessLinkerSpecialAttribute (ca, provider)) {
+					if (ProcessLinkerSpecialAttribute (ca, provider, reason)) {
 						continue;
 					}
 
 					if (markOnUse) {
-						_lateMarkedAttributes.Enqueue (new AttributeProviderPair (ca, provider));
+						_lateMarkedAttributes.Enqueue ((new AttributeProviderPair (ca, provider), reason));
 						continue;
 					}
 
-					MarkCustomAttribute (ca);
-					MarkSpecialCustomAttributeDependencies (ca);
+					MarkCustomAttribute (ca, reason);
+					MarkSpecialCustomAttributeDependencies (ca, provider);
 				}
 			} finally {
 				Tracer.Pop ();
 			}
 		}
 
-		protected virtual bool ProcessLinkerSpecialAttribute (CustomAttribute ca, ICustomAttributeProvider provider)
+		protected virtual bool ProcessLinkerSpecialAttribute (CustomAttribute ca, ICustomAttributeProvider provider, DependencyInfo reason)
 		{
 			if (IsUserDependencyMarker (ca.AttributeType) && provider is MemberReference mr) {
 				MarkUserDependency (mr, ca);
 
 				if (_context.KeepDependencyAttributes || Annotations.GetAction (mr.Module.Assembly) != AssemblyAction.Link) {
-					MarkCustomAttribute (ca);
+					MarkCustomAttribute (ca, reason);
+				} else {
+					// Record the custom attribute so that it has a reason, without actually marking it.
+					Tracer.AddDirectDependency (ca, reason, marked: false);
 				}
 
 				return true;
@@ -513,14 +541,14 @@ namespace Mono.Linker.Steps {
 			}
 
 			if (member == "*") {
-				MarkEntireType (td);
+				MarkEntireType (td, new DependencyInfo (DependencyKind.PreservedDependency, ca));
 				return;
 			}
 
-			if (MarkDependencyMethod (td, member, signature))
+			if (MarkDependencyMethod (td, member, signature, new DependencyInfo (DependencyKind.PreservedDependency, ca)))
 				return;
 
-			if (MarkDependencyField (td, member))
+			if (MarkDependencyField (td, member, new DependencyInfo (DependencyKind.PreservedDependency, ca)))
 				return;
 
 			_context.LogMessage (MessageImportance.High, $"Could not resolve dependency member '{member}' declared in type '{td.FullName}'");
@@ -534,7 +562,7 @@ namespace Mono.Linker.Steps {
 			return type?.Resolve ();
 		}
 
-		bool MarkDependencyMethod (TypeDefinition type, string name, string[] signature)
+		bool MarkDependencyMethod (TypeDefinition type, string name, string[] signature, DependencyInfo reason)
 		{
 			bool marked = false;
 
@@ -553,7 +581,7 @@ namespace Mono.Linker.Steps {
 					continue;
 
 				if (signature == null) {
-					MarkIndirectlyCalledMethod (m);
+					MarkIndirectlyCalledMethod (m, reason);
 					marked = true;
 					continue;
 				}
@@ -573,18 +601,18 @@ namespace Mono.Linker.Steps {
 				if (i < 0)
 					continue;
 
-				MarkIndirectlyCalledMethod (m);
+				MarkIndirectlyCalledMethod (m, reason);
 				marked = true;
 			}
 
 			return marked;
 		}
 
-		bool MarkDependencyField (TypeDefinition type, string name)
+		bool MarkDependencyField (TypeDefinition type, string name, DependencyInfo reason)
 		{
 			foreach (var f in type.Fields) {
 				if (f.Name == name) {
-					MarkField (f);
+					MarkField (f, reason);
 					return true;
 				}
 			}
@@ -592,21 +620,21 @@ namespace Mono.Linker.Steps {
 			return false;
 		}
 
-		void LazyMarkCustomAttributes (ICustomAttributeProvider provider, AssemblyDefinition assembly)
+		void LazyMarkCustomAttributes (ICustomAttributeProvider provider, ModuleDefinition module)
 		{
 			if (!provider.HasCustomAttributes)
 				return;
 
 			foreach (CustomAttribute ca in provider.CustomAttributes)
-				_assemblyLevelAttributes.Enqueue (new AttributeProviderPair (ca, assembly));
+				_assemblyLevelAttributes.Enqueue (new AttributeProviderPair (ca, module));
 		}
 
-		protected virtual void MarkCustomAttribute (CustomAttribute ca)
+		protected virtual void MarkCustomAttribute (CustomAttribute ca, DependencyInfo reason)
 		{
 			Tracer.Push ((object)ca.AttributeType ?? (object)ca);
 			try {
-				Annotations.Mark (ca);
-				MarkMethod (ca.Constructor);
+				Annotations.Mark (ca, reason);
+				MarkMethod (ca.Constructor, new DependencyInfo (DependencyKind.AttributeConstructor, ca));
 
 				MarkCustomAttributeArguments (ca);
 
@@ -663,9 +691,9 @@ namespace Mono.Linker.Steps {
 			return true;
 		}
 
-		protected void MarkStaticConstructor (TypeDefinition type)
+		protected void MarkStaticConstructor (TypeDefinition type, DependencyInfo reason)
 		{
-			if (MarkMethodIf (type.Methods, IsNonEmptyStaticConstructor) != null)
+			if (MarkMethodIf (type.Methods, IsNonEmptyStaticConstructor, reason) != null)
 				Annotations.SetPreservedStaticCtor (type);
 		}
 
@@ -689,13 +717,13 @@ namespace Mono.Linker.Steps {
 					var displayTargetType = GetDebuggerAttributeTargetType (app.Attribute, (AssemblyDefinition) app.Provider);
 					if (displayTargetType == null || !Annotations.IsMarked (displayTargetType))
 						return false;
-				}			
+				}
 			}
 			
 			return true;
 		}
 
-		protected void MarkSecurityDeclarations (ISecurityDeclarationProvider provider)
+		protected void MarkSecurityDeclarations (ISecurityDeclarationProvider provider, DependencyInfo reason)
 		{
 			// most security declarations are removed (if linked) but user code might still have some
 			// and if the attributes references types then they need to be marked too
@@ -703,19 +731,19 @@ namespace Mono.Linker.Steps {
 				return;
 
 			foreach (var sd in provider.SecurityDeclarations)
-				MarkSecurityDeclaration (sd);
+				MarkSecurityDeclaration (sd, reason);
 		}
 
-		protected virtual void MarkSecurityDeclaration (SecurityDeclaration sd)
+		protected virtual void MarkSecurityDeclaration (SecurityDeclaration sd, DependencyInfo reason)
 		{
 			if (!sd.HasSecurityAttributes)
 				return;
 			
 			foreach (var sa in sd.SecurityAttributes)
-				MarkSecurityAttribute (sa);
+				MarkSecurityAttribute (sa, reason);
 		}
 
-		protected virtual void MarkSecurityAttribute (SecurityAttribute sa)
+		protected virtual void MarkSecurityAttribute (SecurityAttribute sa, DependencyInfo reason)
 		{
 			TypeReference security_type = sa.AttributeType;
 			TypeDefinition type = security_type.Resolve ();
@@ -723,47 +751,31 @@ namespace Mono.Linker.Steps {
 				HandleUnresolvedType (security_type);
 				return;
 			}
-			
-			MarkType (security_type);
-			MarkSecurityAttributeProperties (sa, type);
-			MarkSecurityAttributeFields (sa, type);
+
+			// Security attributes participate in inference logic without being marked.
+			Tracer.AddDirectDependency (sa, reason, marked: false);
+			MarkType (security_type, new DependencyInfo (DependencyKind.AttributeType, sa));
+			MarkCustomAttributeProperties (sa, type);
+			MarkCustomAttributeFields (sa, type);
 		}
 
-		protected void MarkSecurityAttributeProperties (SecurityAttribute sa, TypeDefinition attribute)
-		{
-			if (!sa.HasProperties)
-				return;
-
-			foreach (var named_argument in sa.Properties)
-				MarkCustomAttributeProperty (named_argument, attribute);
-		}
-
-		protected void MarkSecurityAttributeFields (SecurityAttribute sa, TypeDefinition attribute)
-		{
-			if (!sa.HasFields)
-				return;
-
-			foreach (var named_argument in sa.Fields)
-				MarkCustomAttributeField (named_argument, attribute);
-		}
-
-		protected void MarkCustomAttributeProperties (CustomAttribute ca, TypeDefinition attribute)
+		protected void MarkCustomAttributeProperties (ICustomAttribute ca, TypeDefinition attribute)
 		{
 			if (!ca.HasProperties)
 				return;
 
 			foreach (var named_argument in ca.Properties)
-				MarkCustomAttributeProperty (named_argument, attribute);
+				MarkCustomAttributeProperty (named_argument, attribute, ca, new DependencyInfo (DependencyKind.AttributeProperty, ca));
 		}
 
-		protected void MarkCustomAttributeProperty (CustomAttributeNamedArgument namedArgument, TypeDefinition attribute)
+		protected void MarkCustomAttributeProperty (CustomAttributeNamedArgument namedArgument, TypeDefinition attribute, ICustomAttribute ca, DependencyInfo reason)
 		{
 			PropertyDefinition property = GetProperty (attribute, namedArgument.Name);
 			Tracer.Push (property);
 			if (property != null)
-				MarkMethod (property.SetMethod);
+				MarkMethod (property.SetMethod, reason);
 
-			MarkCustomAttributeArgument (namedArgument.Argument);
+			MarkCustomAttributeArgument (namedArgument.Argument, ca);
 			Tracer.Pop ();
 		}
 
@@ -774,28 +786,30 @@ namespace Mono.Linker.Steps {
 				if (property != null)
 					return property;
 
+				// This would neglect to mark parameters for generic instances.
+				Debug.Assert (!(type.BaseType is GenericInstanceType));
 				type = type.BaseType?.Resolve ();
 			}
 
 			return null;
 		}
 
-		protected void MarkCustomAttributeFields (CustomAttribute ca, TypeDefinition attribute)
+		protected void MarkCustomAttributeFields (ICustomAttribute ca, TypeDefinition attribute)
 		{
 			if (!ca.HasFields)
 				return;
 
 			foreach (var named_argument in ca.Fields)
-				MarkCustomAttributeField (named_argument, attribute);
+				MarkCustomAttributeField (named_argument, attribute, ca);
 		}
 
-		protected void MarkCustomAttributeField (CustomAttributeNamedArgument namedArgument, TypeDefinition attribute)
+		protected void MarkCustomAttributeField (CustomAttributeNamedArgument namedArgument, TypeDefinition attribute, ICustomAttribute ca)
 		{
 			FieldDefinition field = GetField (attribute, namedArgument.Name);
 			if (field != null)
-				MarkField (field);
+				MarkField (field, new DependencyInfo (DependencyKind.CustomAttributeField, ca));
 
-			MarkCustomAttributeArgument (namedArgument.Argument);
+			MarkCustomAttributeArgument (namedArgument.Argument, ca);
 		}
 
 		FieldDefinition GetField (TypeDefinition type, string fieldname)
@@ -805,6 +819,8 @@ namespace Mono.Linker.Steps {
 				if (field != null)
 					return field;
 
+				// This would neglect to mark parameters for generic instances.
+				Debug.Assert (!(type.BaseType is GenericInstanceType));
 				type = type.BaseType?.Resolve ();
 			}
 
@@ -818,6 +834,8 @@ namespace Mono.Linker.Steps {
 				if (method != null)
 					return method;
 
+				// This would neglect to mark parameters for generic instances.
+				Debug.Assert (!(type.BaseType is GenericInstanceType));
 				type = type.BaseType.Resolve ();
 			}
 
@@ -830,22 +848,24 @@ namespace Mono.Linker.Steps {
 				return;
 
 			foreach (var argument in ca.ConstructorArguments)
-				MarkCustomAttributeArgument (argument);
+				MarkCustomAttributeArgument (argument, ca);
 		}
 
-		void MarkCustomAttributeArgument (CustomAttributeArgument argument)
+		void MarkCustomAttributeArgument (CustomAttributeArgument argument, ICustomAttribute ca)
 		{
 			var at = argument.Type;
 
 			if (at.IsArray) {
 				var et = at.GetElementType ();
 
-				MarkType (et);
+				MarkType (et, new DependencyInfo (DependencyKind.CustomAttributeArgumentType, ca));
 				if (argument.Value == null)
 					return;
 
+				// Array arguments are modeled as a CustomAttributeArgument [], and will mark the
+				// Type once for each element in the array.
 				foreach (var caa in (CustomAttributeArgument [])argument.Value)
-					MarkCustomAttributeArgument (caa);
+					MarkCustomAttributeArgument (caa, ca);
 
 				return;
 			}
@@ -853,14 +873,14 @@ namespace Mono.Linker.Steps {
 			if (at.Namespace == "System") {
 				switch (at.Name) {
 				case "Type":
-					MarkType (argument.Type);
-					MarkType ((TypeReference)argument.Value);
+					MarkType (argument.Type, new DependencyInfo (DependencyKind.CustomAttributeArgumentType, ca));
+					MarkType ((TypeReference)argument.Value, new DependencyInfo (DependencyKind.CustomAttributeArgumentValue, ca));
 					return;
 
 				case "Object":
 					var boxed_value = (CustomAttributeArgument)argument.Value;
-					MarkType (boxed_value.Type);
-					MarkCustomAttributeArgument (boxed_value);
+					MarkType (boxed_value.Type, new DependencyInfo (DependencyKind.CustomAttributeArgumentType, ca));
+					MarkCustomAttributeArgument (boxed_value, ca);
 					return;
 				}
 			}
@@ -884,23 +904,23 @@ namespace Mono.Linker.Steps {
 
 			MarkAssemblyCustomAttributes (assembly);
 
-			MarkSecurityDeclarations (assembly);
+			MarkSecurityDeclarations (assembly, new DependencyInfo (DependencyKind.AssemblyOrModuleAttribute, assembly));
 
 			foreach (ModuleDefinition module in assembly.Modules)
-				LazyMarkCustomAttributes (module, assembly);
+				LazyMarkCustomAttributes (module, module);
 		}
 
 		void MarkEntireAssembly (AssemblyDefinition assembly)
 		{
-			MarkCustomAttributes (assembly);
-			MarkCustomAttributes (assembly.MainModule);
+			MarkCustomAttributes (assembly, new DependencyInfo (DependencyKind.AssemblyOrModuleAttribute, assembly));
+			MarkCustomAttributes (assembly.MainModule, new DependencyInfo (DependencyKind.AssemblyOrModuleAttribute, assembly.MainModule));
 
 			if (assembly.MainModule.HasExportedTypes) {
 				// TODO: This needs more work accross all steps
 			}
 
 			foreach (TypeDefinition type in assembly.MainModule.Types)
-				MarkEntireType (type);
+				MarkEntireType (type, new DependencyInfo (DependencyKind.TypeInAssembly, assembly));
 		}
 
 		void ProcessModule (AssemblyDefinition assembly)
@@ -911,7 +931,7 @@ namespace Mono.Linker.Steps {
 			{
 				if (type.Name == "<Module>" && type.HasMethods)
 				{
-					MarkType (type);
+					MarkType (type, new DependencyInfo (DependencyKind.TypeInAssembly, assembly));
 					break;
 				}
 			}
@@ -944,6 +964,10 @@ namespace Mono.Linker.Steps {
 					continue;
 				}
 
+
+				markOccurred = true;
+				MarkCustomAttribute (customAttribute, new DependencyInfo (DependencyKind.AssemblyOrModuleAttribute, assemblyLevelAttribute.Provider));
+
 				string attributeFullName = customAttribute.Constructor.DeclaringType.FullName;
 				switch (attributeFullName) {
 				case "System.Diagnostics.DebuggerDisplayAttribute":
@@ -953,9 +977,6 @@ namespace Mono.Linker.Steps {
 					MarkTypeWithDebuggerTypeProxyAttribute (GetDebuggerAttributeTargetType (assemblyLevelAttribute.Attribute, (AssemblyDefinition) assemblyLevelAttribute.Provider), customAttribute);
 					break;
 				}
-
-				markOccurred = true;
-				MarkCustomAttribute (customAttribute);
 			}
 
 			// requeue the items we skipped in case we need to make another pass
@@ -971,12 +992,13 @@ namespace Mono.Linker.Steps {
 			if (startingQueueCount == 0)
 				return false;
 
-			var skippedItems = new List<AttributeProviderPair> ();
+			var skippedItems = new List<(AttributeProviderPair, DependencyInfo)> ();
 			var markOccurred = false;
 
 			while (_lateMarkedAttributes.Count != 0) {
-				var attributeProviderPair = _lateMarkedAttributes.Dequeue ();
+				var (attributeProviderPair, reason) = _lateMarkedAttributes.Dequeue ();
 				var customAttribute = attributeProviderPair.Attribute;
+				var provider = attributeProviderPair.Provider;
 
 				var resolved = customAttribute.Constructor.Resolve ();
 				if (resolved == null) {
@@ -984,14 +1006,14 @@ namespace Mono.Linker.Steps {
 					continue;
 				}
 
-				if (!ShouldMarkCustomAttribute (customAttribute, attributeProviderPair.Provider)) {
-					skippedItems.Add (attributeProviderPair);
+				if (!ShouldMarkCustomAttribute (customAttribute, provider)) {
+					skippedItems.Add ((attributeProviderPair, reason));
 					continue;
 				}
 
 				markOccurred = true;
-				MarkCustomAttribute (customAttribute);
-				MarkSpecialCustomAttributeDependencies (customAttribute);
+				MarkCustomAttribute (customAttribute, reason);
+				MarkSpecialCustomAttributeDependencies (customAttribute, provider);
 			}
 
 			// requeue the items we skipped in case we need to make another pass
@@ -1001,10 +1023,17 @@ namespace Mono.Linker.Steps {
 			return markOccurred;
 		}
 
-		protected void MarkField (FieldReference reference)
+		protected void MarkField (FieldReference reference, DependencyInfo reason)
 		{
-			if (reference.DeclaringType is GenericInstanceType)
-				MarkType (reference.DeclaringType);
+			if (reference.DeclaringType is GenericInstanceType) {
+				Debug.Assert (reason.Kind == DependencyKind.FieldAccess || reason.Kind == DependencyKind.Ldtoken);
+				// Blame the field reference (without actually marking) on the original reason.
+				Tracer.AddDirectDependency (reference, reason, marked: false);
+				MarkType (reference.DeclaringType, new DependencyInfo (DependencyKind.DeclaringType, reference));
+
+				// Blame the field definition that we will resolve on the field reference.
+				reason = new DependencyInfo (DependencyKind.FieldOnGenericInstance, reference);
+			}
 
 			FieldDefinition field = reference.Resolve ();
 
@@ -1013,30 +1042,60 @@ namespace Mono.Linker.Steps {
 				return;
 			}
 
-			MarkField (field);
+			MarkField (field, reason);
 		}
 
-		void MarkField (FieldDefinition field)
+		void MarkField (FieldDefinition field, DependencyInfo reason)
 		{
+#if DEBUG
+			var reasons = new DependencyKind [] {
+				DependencyKind.AccessedViaReflection,
+				DependencyKind.AlreadyMarked,
+				DependencyKind.CustomAttributeField,
+				DependencyKind.EventSourceProviderField,
+				DependencyKind.FieldAccess,
+				DependencyKind.FieldOnGenericInstance,
+				DependencyKind.InteropMethodDependency,
+				DependencyKind.Ldtoken,
+				DependencyKind.MemberOfType,
+				DependencyKind.PreservedDependency,
+				DependencyKind.ReferencedBySpecialAttribute,
+				DependencyKind.TypePreserve,
+			};
+			if (!reasons.Contains (reason.Kind))
+				throw new InvalidOperationException ($"Internal error: unsupported field dependency {reason.Kind}");
+#endif
+
 			if (CheckProcessed (field))
 				return;
 
-			MarkType (field.DeclaringType);
-			MarkType (field.FieldType);
-			MarkCustomAttributes (field);
-			MarkMarshalSpec (field);
+			MarkType (field.DeclaringType, new DependencyInfo (DependencyKind.DeclaringType, field));
+			MarkType (field.FieldType, new DependencyInfo (DependencyKind.FieldType, field));
+			MarkCustomAttributes (field, new DependencyInfo (DependencyKind.CustomAttribute, field));
+			MarkMarshalSpec (field, new DependencyInfo (DependencyKind.FieldMarshalSpec, field));
 			DoAdditionalFieldProcessing (field);
 
 			var parent = field.DeclaringType;
-			if (!Annotations.HasPreservedStaticCtor (parent))
-				MarkStaticConstructor (parent);
+			if (!Annotations.HasPreservedStaticCtor (parent)) {
+				var cctorReason = reason.Kind switch {
+					// Report an edge directly from the method accessing the field to the static ctor it triggers
+					DependencyKind.FieldAccess => new DependencyInfo (DependencyKind.TriggersCctorThroughFieldAccess, reason.Source),
+					_ => new DependencyInfo (DependencyKind.CctorForField, field)
+				};
+				MarkStaticConstructor (parent, cctorReason);
+			}
 
 			if (Annotations.HasSubstitutedInit (field)) {
 				Annotations.SetPreservedStaticCtor (parent);
 				Annotations.SetSubstitutedInit (parent);
 			}
 
-			Annotations.Mark (field);
+			if (reason.Kind == DependencyKind.AlreadyMarked) {
+				Debug.Assert (Annotations.IsMarked (field));
+				return;
+			}
+
+			Annotations.Mark (field, reason);
 		}
 
 		protected virtual bool IgnoreScope (IMetadataScope scope)
@@ -1045,25 +1104,53 @@ namespace Mono.Linker.Steps {
 			return Annotations.GetAction (assembly) != AssemblyAction.Link;
 		}
 
-		void MarkScope (IMetadataScope scope)
+		void MarkScope (IMetadataScope scope, TypeDefinition type)
 		{
-			if (scope is IMetadataTokenProvider provider)
-				Annotations.Mark (provider);
+			Annotations.Mark (scope, new DependencyInfo (DependencyKind.ScopeOfType, type));
 		}
 
 		protected virtual void MarkSerializable (TypeDefinition type)
 		{
-			MarkDefaultConstructor (type);
+			// TODO: This marks default ctor even for types that aren't [Serializable]. Is this necessary?
+			MarkDefaultConstructor (type, new DependencyInfo (DependencyKind.SerializationMethodForType, type));
 			if (!_context.IsFeatureExcluded ("deserialization"))
-				MarkMethodsIf (type.Methods, IsSpecialSerializationConstructor);
+				MarkMethodsIf (type.Methods, IsSpecialSerializationConstructor, new DependencyInfo (DependencyKind.SerializationMethodForType, type));
 		}
 
-		protected virtual TypeDefinition MarkType (TypeReference reference)
+		protected virtual TypeDefinition MarkType (TypeReference reference, DependencyInfo reason)
 		{
+#if DEBUG
+			var reasons = new DependencyKind [] {
+				DependencyKind.AccessedViaReflection,
+				DependencyKind.AlreadyMarked,
+				DependencyKind.AttributeType,
+				DependencyKind.BaseType,
+				DependencyKind.CatchType,
+				DependencyKind.CustomAttributeArgumentType,
+				DependencyKind.CustomAttributeArgumentValue,
+				DependencyKind.DeclaringType,
+				DependencyKind.DeclaringTypeOfCalledMethod,
+				DependencyKind.ElementType,
+				DependencyKind.FieldType,
+				DependencyKind.GenericArgumentType,
+				DependencyKind.GenericParameterConstraintType,
+				DependencyKind.InterfaceImplementationInterfaceType,
+				DependencyKind.Ldtoken,
+				DependencyKind.ModifierType,
+				DependencyKind.InstructionTypeRef,
+				DependencyKind.ParameterType,
+				DependencyKind.ReferencedBySpecialAttribute,
+				DependencyKind.ReturnType,
+				DependencyKind.UnreachableBodyRequirement,
+				DependencyKind.VariableType,
+			};
+			if (!reasons.Contains (reason.Kind))
+				throw new InvalidOperationException ($"Internal error: unsupported type dependency {reason.Kind}");
+#endif
 			if (reference == null)
 				return null;
 
-			reference = GetOriginalType (reference);
+			(reference, reason) = GetOriginalType (reference, reason);
 
 			if (reference is FunctionPointerType)
 				return null;
@@ -1081,16 +1168,30 @@ namespace Mono.Linker.Steps {
 				return null;
 			}
 
+			// Track a mark reason for each call to MarkType.
+			switch (reason.Kind) {
+			case DependencyKind.AlreadyMarked:
+				Debug.Assert (Annotations.IsMarked (type));
+				break;
+			default:
+				Annotations.Mark (type, reason);
+				break;
+			}
+
+			// Treat cctors triggered by a called method specially and mark this case up-front.
+			if (type.HasMethods && ShouldMarkTypeStaticConstructor (type) && reason.Kind == DependencyKind.DeclaringTypeOfCalledMethod)
+				MarkStaticConstructor (type, new DependencyInfo (DependencyKind.TriggersCctorForCalledMethod, reason.Source));
+
 			if (CheckProcessed (type))
 				return null;
 
 			Tracer.Push (type);
 
-			MarkScope (type.Scope);
-			MarkType (type.BaseType);
-			MarkType (type.DeclaringType);
-			MarkCustomAttributes (type);
-			MarkSecurityDeclarations (type);
+			MarkScope (type.Scope, type);
+			MarkType (type.BaseType, new DependencyInfo (DependencyKind.BaseType, type));
+			MarkType (type.DeclaringType, new DependencyInfo (DependencyKind.DeclaringType, type));
+			MarkCustomAttributes (type, new DependencyInfo (DependencyKind.CustomAttribute, type));
+			MarkSecurityDeclarations (type, new DependencyInfo (DependencyKind.CustomAttribute, type));
 
 			if (type.IsMulticastDelegate ()) {
 				MarkMulticastDelegate (type);
@@ -1099,17 +1200,20 @@ namespace Mono.Linker.Steps {
 			if (type.IsSerializable ())
 				MarkSerializable (type);
 
+			// TODO: This needs work to ensure we handle EventSource appropriately.
+			// This marks static fields of KeyWords/OpCodes/Tasks subclasses of an EventSource type.
 			if (!_context.IsFeatureExcluded ("etw") && BCL.EventTracingForWindows.IsEventSourceImplementation (type, _context)) {
 				MarkEventSourceProviders (type);
 			}
 
+			// This marks properties for [EventData] types as well as other attribute dependencies.
 			MarkTypeSpecialCustomAttributes (type);
 
 			MarkGenericParameterProvider (type);
 
 			// keep fields for value-types and for classes with LayoutKind.Sequential or Explicit
 			if (type.IsValueType || !type.IsAutoLayout)
-				MarkFields (type, type.IsEnum);
+				MarkFields (type, includeStatic: type.IsEnum, reason: new DependencyInfo (DependencyKind.MemberOfType, type));
 
 			// There are a number of markings we can defer until later when we know it's possible a reference type could be instantiated
 			// For example, if no instance of a type exist, then we don't need to mark the interfaces on that type
@@ -1140,21 +1244,20 @@ namespace Mono.Linker.Steps {
 				_typesWithInterfaces.Add (type);
 
 			if (type.HasMethods) {
-				MarkMethodsIf (type.Methods, IsVirtualNeededByTypeDueToPreservedScope);
-				if (ShouldMarkTypeStaticConstructor (type))
-					MarkStaticConstructor (type);
+				// For virtuals that must be preserved, blame the declaring type.
+				MarkMethodsIf (type.Methods, IsVirtualNeededByTypeDueToPreservedScope, new DependencyInfo (DependencyKind.VirtualNeededDueToPreservedScope, type));
+				if (ShouldMarkTypeStaticConstructor (type) && reason.Kind != DependencyKind.TriggersCctorForCalledMethod)
+					MarkStaticConstructor (type, new DependencyInfo (DependencyKind.CctorForType, type));
 
 				if (_context.IsFeatureExcluded ("deserialization"))
-					MarkMethodsIf (type.Methods, HasOnSerializeAttribute);
+					MarkMethodsIf (type.Methods, HasOnSerializeAttribute, new DependencyInfo (DependencyKind.SerializationMethodForType, type));
 				else
-					MarkMethodsIf (type.Methods, HasOnSerializeOrDeserializeAttribute);
+					MarkMethodsIf (type.Methods, HasOnSerializeOrDeserializeAttribute, new DependencyInfo (DependencyKind.SerializationMethodForType, type));
 			}
 
 			DoAdditionalTypeProcessing (type);
 
 			Tracer.Pop ();
-
-			Annotations.Mark (type);
 
 			ApplyPreserveInfo (type);
 
@@ -1241,10 +1344,11 @@ namespace Mono.Linker.Steps {
 					MarkTypeWithDebuggerTypeProxyAttribute (type, attribute);
 					break;
 				case "EventDataAttribute" when attrType.Namespace == "System.Diagnostics.Tracing":
-					MarkMethodsIf (type.Methods, MethodDefinitionExtensions.IsPublicInstancePropertyMethod);
+					if (MarkMethodsIf (type.Methods, MethodDefinitionExtensions.IsPublicInstancePropertyMethod, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, type)))
+						Tracer.AddDirectDependency (attribute, new DependencyInfo (DependencyKind.CustomAttribute, type), marked: false);
 					break;
 				case "TypeDescriptionProviderAttribute" when attrType.Namespace == "System.ComponentModel":
-					MarkTypeConverterLikeDependency (attribute, l => l.IsDefaultConstructor ());
+					MarkTypeConverterLikeDependency (attribute, l => l.IsDefaultConstructor (), type);
 					break;
 				}
 			}
@@ -1253,13 +1357,14 @@ namespace Mono.Linker.Steps {
 		//
 		// Used for known framework attributes which can be applied to any element
 		//
-		bool MarkSpecialCustomAttributeDependencies (CustomAttribute ca)
+		bool MarkSpecialCustomAttributeDependencies (CustomAttribute ca, ICustomAttributeProvider provider)
 		{
 			var dt = ca.Constructor.DeclaringType;
 			if (dt.Name == "TypeConverterAttribute" && dt.Namespace == "System.ComponentModel") {
 				MarkTypeConverterLikeDependency (ca, l =>
 					l.IsDefaultConstructor () ||
-					l.Parameters.Count == 1 && l.Parameters [0].ParameterType.IsTypeOf ("System", "Type"));
+					l.Parameters.Count == 1 && l.Parameters [0].ParameterType.IsTypeOf ("System", "Type"),
+					provider);
 				return true;
 			}
 
@@ -1282,11 +1387,13 @@ namespace Mono.Linker.Steps {
 
 		void MarkXmlSchemaProvider (TypeDefinition type, CustomAttribute attribute)
 		{
-			if (TryGetStringArgument (attribute, out string name))
-				MarkNamedMethod (type, name);
+			if (TryGetStringArgument (attribute, out string name)) {
+				Tracer.AddDirectDependency (attribute, new DependencyInfo (DependencyKind.CustomAttribute, type), marked: false);
+				MarkNamedMethod (type, name, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute));
+			}
 		}
 
-		protected virtual void MarkTypeConverterLikeDependency (CustomAttribute attribute, Func<MethodDefinition, bool> predicate)
+		protected virtual void MarkTypeConverterLikeDependency (CustomAttribute attribute, Func<MethodDefinition, bool> predicate, ICustomAttributeProvider provider)
 		{
 			var args = attribute.ConstructorArguments;
 			if (args.Count < 1)
@@ -1305,12 +1412,17 @@ namespace Mono.Linker.Steps {
 			if (tdef == null)
 				return;
 
-			MarkMethodsIf (tdef.Methods, predicate);
+			Tracer.AddDirectDependency (attribute, new DependencyInfo (DependencyKind.CustomAttribute, provider), marked: false);
+			MarkMethodsIf (tdef.Methods, predicate, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute));
 		}
 
 		void MarkTypeWithDebuggerDisplayAttribute (TypeDefinition type, CustomAttribute attribute)
 		{
 			if (_context.KeepMembersForDebugger) {
+
+				// Members referenced by the DebuggerDisplayAttribute are kept even if the attribute may not be.
+				// Record a logical dependency on the attribute so that we can blame it for the kept members below.
+				Tracer.AddDirectDependency (attribute, new DependencyInfo (DependencyKind.CustomAttribute, type), marked: false);
 
 				string displayString = (string) attribute.ConstructorArguments[0].Value;
 
@@ -1330,31 +1442,34 @@ namespace Mono.Linker.Steps {
 						string methodName = realMatch.Substring (0, realMatch.Length - 2);
 						MethodDefinition method = GetMethodWithNoParameters (type, methodName);
 						if (method != null) {
-							MarkMethod (method);
+							MarkMethod (method, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute));
 							continue;
 						}
 					} else {
 						FieldDefinition field = GetField (type, realMatch);
 						if (field != null) {
-							MarkField (field);
+							MarkField (field, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute));
 							continue;
 						}
 
 						PropertyDefinition property = GetProperty (type, realMatch);
 						if (property != null) {
 							if (property.GetMethod != null) {
-								MarkMethod (property.GetMethod);
+								MarkMethod (property.GetMethod, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute));
 							}
 							if (property.SetMethod != null) {
-								MarkMethod (property.SetMethod);
+								MarkMethod (property.SetMethod, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute));
 							}
 							continue;
 						}
 					}
 
 					while (type != null) {
-						MarkMethods (type);
-						MarkFields (type, includeStatic: true);
+						// TODO: Non-understood DebuggerDisplayAttribute causes us to keep everything. Should this be a warning?
+						MarkMethods (type, new DependencyInfo (DependencyKind.KeptForSpecialAttribute, attribute));
+						MarkFields (type, includeStatic: true, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute));
+						// This logic would miss generic parameters used in methods/fields for generic types
+						Debug.Assert (!(type.BaseType is GenericInstanceType));
 						type = type.BaseType?.Resolve ();
 					}
 					return;
@@ -1377,12 +1492,13 @@ namespace Mono.Linker.Steps {
 					return;
 				}
 
-				MarkType (proxyTypeReference);
+				Tracer.AddDirectDependency (attribute, new DependencyInfo (DependencyKind.CustomAttribute, type), marked: false);
+				MarkType (proxyTypeReference, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute));
 
 				TypeDefinition proxyType = proxyTypeReference.Resolve ();
 				if (proxyType != null) {
-					MarkMethods (proxyType);
-					MarkFields (proxyType, includeStatic: true);
+					MarkMethods (proxyType, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute));
+					MarkFields (proxyType, includeStatic: true, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute));
 				}
 			}
 		}
@@ -1399,7 +1515,7 @@ namespace Mono.Linker.Steps {
 			return argument != null;
 		}
 
-		protected int MarkNamedMethod (TypeDefinition type, string method_name)
+		protected int MarkNamedMethod (TypeDefinition type, string method_name, DependencyInfo reason)
 		{
 			if (!type.HasMethods)
 				return 0;
@@ -1409,7 +1525,7 @@ namespace Mono.Linker.Steps {
 				if (method.Name != method_name)
 					continue;
 
-				MarkMethod (method);
+				MarkMethod (method, reason);
 				count++;
 			}
 
@@ -1421,11 +1537,12 @@ namespace Mono.Linker.Steps {
 			if (!TryGetStringArgument (attribute, out string member_name))
 				return;
 
-			MarkNamedField (method.DeclaringType, member_name);
-			MarkNamedProperty (method.DeclaringType, member_name);
+			MarkNamedField (method.DeclaringType, member_name, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute));
+			MarkNamedProperty (method.DeclaringType, member_name, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute));
 		}
 
-		void MarkNamedField (TypeDefinition type, string field_name)
+		// TODO: combine with MarkDependencyField?
+		void MarkNamedField (TypeDefinition type, string field_name, DependencyInfo reason)
 		{
 			if (!type.HasFields)
 				return;
@@ -1434,11 +1551,11 @@ namespace Mono.Linker.Steps {
 				if (field.Name != field_name)
 					continue;
 
-				MarkField (field);
+				MarkField (field, reason);
 			}
 		}
 
-		void MarkNamedProperty (TypeDefinition type, string property_name)
+		void MarkNamedProperty (TypeDefinition type, string property_name, DependencyInfo reason)
 		{
 			if (!type.HasProperties)
 				return;
@@ -1448,8 +1565,9 @@ namespace Mono.Linker.Steps {
 					continue;
 
 				Tracer.Push (property);
-				MarkMethod (property.GetMethod);
-				MarkMethod (property.SetMethod);
+				// This marks methods directly without reporting the property.
+				MarkMethod (property.GetMethod, reason);
+				MarkMethod (property.SetMethod, reason);
 				Tracer.Pop ();
 			}
 		}
@@ -1469,7 +1587,7 @@ namespace Mono.Linker.Steps {
 				}
 				
 				if (ShouldMarkInterfaceImplementation (type, iface, resolvedInterfaceType))
-					MarkInterfaceImplementation (iface);
+					MarkInterfaceImplementation (iface, type);
 			}
 		}
 
@@ -1484,13 +1602,13 @@ namespace Mono.Linker.Steps {
 
 		void MarkGenericParameter (GenericParameter parameter)
 		{
-			MarkCustomAttributes (parameter);
+			MarkCustomAttributes (parameter, new DependencyInfo (DependencyKind.GenericParameterCustomAttribute, parameter.Owner));
 			if (!parameter.HasConstraints)
 				return;
 
 			foreach (var constraint in parameter.Constraints) {
-				MarkCustomAttributes (constraint);
-				MarkType (constraint.ConstraintType);
+				MarkCustomAttributes (constraint, new DependencyInfo (DependencyKind.GenericParameterConstraintCustomAttribute, parameter.Owner));
+				MarkType (constraint.ConstraintType, new DependencyInfo (DependencyKind.GenericParameterConstraintType, parameter.Owner));
 			}
 		}
 
@@ -1558,30 +1676,35 @@ namespace Mono.Linker.Steps {
 				parameters [1].ParameterType.Name == "StreamingContext";
 		}
 
-		protected void MarkMethodsIf (Collection<MethodDefinition> methods, Func<MethodDefinition, bool> predicate)
+		protected bool MarkMethodsIf (Collection<MethodDefinition> methods, Func<MethodDefinition, bool> predicate, DependencyInfo reason)
 		{
-			foreach (MethodDefinition method in methods)
-				if (predicate (method))
-					MarkMethod (method);
+			bool marked = false;
+			foreach (MethodDefinition method in methods) {
+				if (predicate (method)) {
+					MarkMethod (method, reason);
+					marked = true;
+				}
+			}
+			return marked;
 		}
 
-		protected MethodDefinition MarkMethodIf (Collection<MethodDefinition> methods, Func<MethodDefinition, bool> predicate)
+		protected MethodDefinition MarkMethodIf (Collection<MethodDefinition> methods, Func<MethodDefinition, bool> predicate, DependencyInfo reason)
 		{
 			foreach (MethodDefinition method in methods) {
 				if (predicate (method)) {
-					return MarkMethod (method);
+					return MarkMethod (method, reason);
 				}
 			}
 
 			return null;
 		}
 
-		protected bool MarkDefaultConstructor (TypeDefinition type)
+		protected bool MarkDefaultConstructor (TypeDefinition type, DependencyInfo reason)
 		{
 			if (type?.HasMethods != true)
 				return false;
 
-			return MarkMethodIf (type.Methods, MethodDefinitionExtensions.IsDefaultConstructor) != null;
+			return MarkMethodIf (type.Methods, MethodDefinitionExtensions.IsDefaultConstructor, reason) != null;
 		}
 
 		static bool IsNonEmptyStaticConstructor (MethodDefinition method)
@@ -1654,13 +1777,13 @@ namespace Mono.Linker.Steps {
 		{
 			foreach (var nestedType in td.NestedTypes) {
 				if (BCL.EventTracingForWindows.IsProviderName (nestedType.Name))
-					MarkStaticFields (nestedType);
+					MarkStaticFields (nestedType, new DependencyInfo (DependencyKind.EventSourceProviderField, td));
 			}
 		}
 
 		protected virtual void MarkMulticastDelegate (TypeDefinition type)
 		{
-			MarkMethodCollection (type.Methods);
+			MarkMethodCollection (type.Methods, new DependencyInfo (DependencyKind.MethodForSpecialType, type));
 		}
 
 		TypeDefinition ResolveFullyQualifiedTypeName (string name)
@@ -1682,25 +1805,30 @@ namespace Mono.Linker.Steps {
 			return null;
 		}
 
-		protected TypeReference GetOriginalType (TypeReference type)
+		protected (TypeReference, DependencyInfo) GetOriginalType (TypeReference type, DependencyInfo reason)
 		{
 			while (type is TypeSpecification specification) {
-				if (type is GenericInstanceType git)
+				if (type is GenericInstanceType git) {
 					MarkGenericArguments (git);
+					Debug.Assert (!(specification.ElementType is TypeSpecification));
+				}
 
 				if (type is IModifierType mod)
 					MarkModifierType (mod);
 
 				if (type is FunctionPointerType fnptr) {
 					MarkParameters (fnptr);
-					MarkType (fnptr.ReturnType);
+					MarkType (fnptr.ReturnType, new DependencyInfo (DependencyKind.ReturnType, fnptr));
 					break; // FunctionPointerType is the original type
 				}
 
-				type = specification.ElementType;
+				// Blame the type reference (which isn't marked) on the original reason.
+				Tracer.AddDirectDependency (specification, reason, marked: false);
+				// Blame the outgoing element type on the specification.
+				(type, reason) = (specification.ElementType, new DependencyInfo (DependencyKind.ElementType, specification));
 			}
 
-			return type;
+			return (type, reason);
 		}
 
 		void MarkParameters (FunctionPointerType fnptr)
@@ -1710,19 +1838,19 @@ namespace Mono.Linker.Steps {
 
 			for (int i = 0; i < fnptr.Parameters.Count; i++)
 			{
-				MarkType (fnptr.Parameters[i].ParameterType);
+				MarkType (fnptr.Parameters[i].ParameterType, new DependencyInfo (DependencyKind.ParameterType, fnptr));
 			}
 		}
 
 		void MarkModifierType (IModifierType mod)
 		{
-			MarkType (mod.ModifierType);
+			MarkType (mod.ModifierType, new DependencyInfo (DependencyKind.ModifierType, mod));
 		}
 
 		void MarkGenericArguments (IGenericInstance instance)
 		{
 			foreach (TypeReference argument in instance.GenericArguments)
-				MarkType (argument);
+				MarkType (argument, new DependencyInfo (DependencyKind.GenericArgumentType, instance));
 
 			MarkGenericArgumentConstructors (instance);
 		}
@@ -1748,7 +1876,7 @@ namespace Mono.Linker.Steps {
 					continue;
 
 				var argument_definition = argument.Resolve ();
-				MarkDefaultConstructor (argument_definition);
+				MarkDefaultConstructor (argument_definition, new DependencyInfo (DependencyKind.DefaultCtorForNewConstrainedGenericArgument, instance));
 			}
 		}
 
@@ -1772,15 +1900,17 @@ namespace Mono.Linker.Steps {
 
 			switch (preserve) {
 			case TypePreserve.All:
-				MarkFields (type, true);
-				MarkMethods (type);
+				// TODO: it seems like PreserveAll on a type won't necessarily keep nested types,
+				// but PreserveAll on an assembly will. Is this correct?
+				MarkFields (type, true, new DependencyInfo (DependencyKind.TypePreserve, type));
+				MarkMethods (type, new DependencyInfo (DependencyKind.TypePreserve, type));
 				break;
 			case TypePreserve.Fields:
-				if (!MarkFields (type, true, true))
+				if (!MarkFields (type, true, new DependencyInfo (DependencyKind.TypePreserve, type), true))
 					_context.LogMessage ($"Type {type.FullName} has no fields to preserve");
 				break;
 			case TypePreserve.Methods:
-				if (!MarkMethods (type))
+				if (!MarkMethods (type, new DependencyInfo (DependencyKind.TypePreserve, type)))
 					_context.LogMessage ($"Type {type.FullName} has no methods to preserve");
 				break;
 			}
@@ -1792,7 +1922,7 @@ namespace Mono.Linker.Steps {
 			if (list == null)
 				return;
 
-			MarkMethodCollection (list);
+			MarkMethodCollection (list, new DependencyInfo (DependencyKind.PreservedMethod, type));
 		}
 
 		void ApplyPreserveMethods (MethodDefinition method)
@@ -1801,10 +1931,10 @@ namespace Mono.Linker.Steps {
 			if (list == null)
 				return;
 
-			MarkMethodCollection (list);
+			MarkMethodCollection (list, new DependencyInfo (DependencyKind.PreservedMethod, method));
 		}
 
-		protected bool MarkFields (TypeDefinition type, bool includeStatic, bool markBackingFieldsOnlyIfPropertyMarked = false)
+		protected bool MarkFields (TypeDefinition type, bool includeStatic, DependencyInfo reason, bool markBackingFieldsOnlyIfPropertyMarked = false)
 		{
 			if (!type.HasFields)
 				return false;
@@ -1825,7 +1955,7 @@ namespace Mono.Linker.Steps {
 					if (propertyDefinition != null && !Annotations.IsMarked (propertyDefinition))
 						continue;
 				}
-				MarkField (field);
+				MarkField (field, reason);
 			}
 
 			return true;
@@ -1847,48 +1977,53 @@ namespace Mono.Linker.Steps {
 			return null;
 		}
 
-		protected void MarkStaticFields (TypeDefinition type)
+		protected void MarkStaticFields (TypeDefinition type, DependencyInfo reason)
 		{
 			if (!type.HasFields)
 				return;
 
 			foreach (FieldDefinition field in type.Fields) {
 				if (field.IsStatic)
-					MarkField (field);
+					MarkField (field, reason);
 			}
 		}
 
-		protected virtual bool MarkMethods (TypeDefinition type)
+		protected virtual bool MarkMethods (TypeDefinition type, DependencyInfo reason)
 		{
 			if (!type.HasMethods)
 				return false;
 
-			MarkMethodCollection (type.Methods);
+			MarkMethodCollection (type.Methods, reason);
 			return true;
 		}
 
-		void MarkMethodCollection (IList<MethodDefinition> methods)
+		void MarkMethodCollection (IList<MethodDefinition> methods, DependencyInfo reason)
 		{
 			foreach (MethodDefinition method in methods)
-				MarkMethod (method);
+				MarkMethod (method, reason);
 		}
 
-		protected void MarkIndirectlyCalledMethod (MethodDefinition method)
+		protected void MarkIndirectlyCalledMethod (MethodDefinition method, DependencyInfo reason)
 		{
-			MarkMethod (method);
+			MarkMethod (method, reason);
 			Annotations.MarkIndirectlyCalledMethod (method);
 		}
 
-		protected virtual MethodDefinition MarkMethod (MethodReference reference)
+		protected virtual MethodDefinition MarkMethod (MethodReference reference, DependencyInfo reason)
 		{
-			reference = GetOriginalMethod (reference);
+			(reference, reason) = GetOriginalMethod (reference, reason);
 
 			if (reference.DeclaringType is ArrayType)
 				return null;
 
 			Tracer.Push (reference);
-			if (reference.DeclaringType is GenericInstanceType)
-				MarkType (reference.DeclaringType);
+			if (reference.DeclaringType is GenericInstanceType) {
+				// Blame the method reference on the original reason without marking it.
+				Tracer.AddDirectDependency (reference, reason, marked: false);
+				MarkType (reference.DeclaringType, new DependencyInfo (DependencyKind.DeclaringType, reference));
+				// Mark the resolved method definition as a dependency of the reference.
+				reason = new DependencyInfo (DependencyKind.MethodOnGenericInstance, reference);
+			}
 
 //			if (IgnoreScope (reference.DeclaringType.Scope))
 //				return;
@@ -1904,7 +2039,7 @@ namespace Mono.Linker.Steps {
 				if (Annotations.GetAction (method) == MethodAction.Nothing)
 					Annotations.SetAction (method, MethodAction.Parse);
 
-				EnqueueMethod (method);
+				EnqueueMethod (method, reason);
 			} finally {
 				Tracer.Pop ();
 			}
@@ -1920,52 +2055,125 @@ namespace Mono.Linker.Steps {
 			return assembly;
 		}
 
-		protected MethodReference GetOriginalMethod (MethodReference method)
+		protected (MethodReference, DependencyInfo) GetOriginalMethod (MethodReference method, DependencyInfo reason)
 		{
 			while (method is MethodSpecification specification) {
+				// Blame the method reference (which isn't marked) on the original reason.
+				Tracer.AddDirectDependency (specification, reason, marked: false);
+				// Blame the outgoing element method on the specification.
 				if (method is GenericInstanceMethod gim)
 					MarkGenericArguments (gim);
 
-				method = specification.ElementMethod;
+				(method, reason) = (specification.ElementMethod, new DependencyInfo (DependencyKind.ElementMethod, specification));
+				Debug.Assert (!(method is MethodSpecification));
 			}
 
-			return method;
+			return (method, reason);
 		}
 
-		protected virtual void ProcessMethod (MethodDefinition method)
+		protected virtual void ProcessMethod (MethodDefinition method, DependencyInfo reason)
 		{
+#if DEBUG
+			var reasons = new DependencyKind [] {
+				DependencyKind.AccessedViaReflection,
+				DependencyKind.AlreadyMarked,
+				DependencyKind.AttributeConstructor,
+				DependencyKind.AttributeProperty,
+				DependencyKind.BaseDefaultCtorForStubbedMethod,
+				DependencyKind.BaseMethod,
+				DependencyKind.CctorForType,
+				DependencyKind.CctorForField,
+				DependencyKind.DefaultCtorForNewConstrainedGenericArgument,
+				DependencyKind.DirectCall,
+				DependencyKind.ElementMethod,
+				DependencyKind.EventMethod,
+				DependencyKind.EventOfEventMethod,
+				DependencyKind.InteropMethodDependency,
+				DependencyKind.KeptForSpecialAttribute,
+				DependencyKind.Ldftn,
+				DependencyKind.Ldtoken,
+				DependencyKind.Ldvirtftn,
+				DependencyKind.MemberOfType,
+				DependencyKind.MethodForInstantiatedType,
+				DependencyKind.MethodForSpecialType,
+				DependencyKind.MethodImplOverride,
+				DependencyKind.MethodOnGenericInstance,
+				DependencyKind.Newobj,
+				DependencyKind.Override,
+				DependencyKind.OverrideOnInstantiatedType,
+				DependencyKind.PreservedDependency,
+				DependencyKind.ReferencedBySpecialAttribute,
+				DependencyKind.SerializationMethodForType,
+				DependencyKind.TriggersCctorForCalledMethod,
+				DependencyKind.TriggersCctorThroughFieldAccess,
+				DependencyKind.TypePreserve,
+				DependencyKind.UnreachableBodyRequirement,
+				DependencyKind.VirtualCall,
+				DependencyKind.VirtualNeededDueToPreservedScope,
+			};
+			if (!reasons.Contains (reason.Kind))
+				throw new InvalidOperationException ($"Internal error: unsupported method dependency {reason.Kind}");
+#endif
+
+			// Record the reason for marking a method on each call. The logic under CheckProcessed happens
+			// only once per method.
+			switch (reason.Kind) {
+			case DependencyKind.AlreadyMarked:
+				Debug.Assert (Annotations.IsMarked (method));
+				break;
+			default:
+				Annotations.Mark (method, reason);
+				break;
+			}
+
+			bool markedForCall = (
+				reason.Kind == DependencyKind.DirectCall ||
+				reason.Kind == DependencyKind.VirtualCall ||
+				reason.Kind == DependencyKind.Newobj
+			);
+			if (markedForCall) {
+				// Record declaring type of a called method up-front as a special case so that we may
+				// track at least some method calls that trigger a cctor.
+				Tracer.Push (method);
+				MarkType (method.DeclaringType, new DependencyInfo (DependencyKind.DeclaringTypeOfCalledMethod, method));
+				Tracer.Pop ();
+			}
+
 			if (CheckProcessed (method))
 				return;
 
 			Tracer.Push (method);
-			MarkType (method.DeclaringType);
-			MarkCustomAttributes (method);
-			MarkSecurityDeclarations (method);
+			if (!markedForCall)
+				MarkType (method.DeclaringType, new DependencyInfo (DependencyKind.DeclaringType, method));
+			MarkCustomAttributes (method, new DependencyInfo (DependencyKind.CustomAttribute, method));
+			MarkSecurityDeclarations (method, new DependencyInfo (DependencyKind.CustomAttribute, method));
 
 			MarkGenericParameterProvider (method);
 
-			if (ShouldMarkAsInstancePossible (method))
+			if (method.IsInstanceConstructor ()) {
 				MarkRequirementsForInstantiatedTypes (method.DeclaringType);
+				Tracer.AddDirectDependency (method.DeclaringType, new DependencyInfo (DependencyKind.InstantiatedByCtor, method), marked: false);
+			}
 
 			if (method.IsConstructor) {
 				if (!Annotations.ProcessSatelliteAssemblies && KnownMembers.IsSatelliteAssemblyMarker (method))
 					Annotations.ProcessSatelliteAssemblies = true;
 			} else if (method.IsPropertyMethod ())
-				MarkProperty (method.GetProperty ());
+				MarkProperty (method.GetProperty (), new DependencyInfo (DependencyKind.PropertyOfPropertyMethod, method));
 			else if (method.IsEventMethod ())
-				MarkEvent (method.GetEvent ());
+				MarkEvent (method.GetEvent (), new DependencyInfo (DependencyKind.EventOfEventMethod, method));
 
 			if (method.HasParameters) {
 				foreach (ParameterDefinition pd in method.Parameters) {
-					MarkType (pd.ParameterType);
-					MarkCustomAttributes (pd);
-					MarkMarshalSpec (pd);
+					MarkType (pd.ParameterType, new DependencyInfo (DependencyKind.ParameterType, method));
+					MarkCustomAttributes (pd, new DependencyInfo (DependencyKind.ParameterAttribute, method));
+					MarkMarshalSpec (pd, new DependencyInfo (DependencyKind.ParameterMarshalSpec, method));
 				}
 			}
 
 			if (method.HasOverrides) {
 				foreach (MethodReference ov in method.Overrides) {
-					MarkMethod (ov);
+					MarkMethod (ov, new DependencyInfo (DependencyKind.MethodImplOverride, method));
 					MarkExplicitInterfaceImplementation (method, ov);
 				}
 			}
@@ -1979,9 +2187,9 @@ namespace Mono.Linker.Steps {
 
 			MarkBaseMethods (method);
 
-			MarkType (method.ReturnType);
-			MarkCustomAttributes (method.MethodReturnType);
-			MarkMarshalSpec (method.MethodReturnType);
+			MarkType (method.ReturnType, new DependencyInfo (DependencyKind.ReturnType, method));
+			MarkCustomAttributes (method.MethodReturnType, new DependencyInfo (DependencyKind.ReturnTypeAttribute, method));
+			MarkMarshalSpec (method.MethodReturnType, new DependencyInfo (DependencyKind.ReturnTypeMarshalSpec, method));
 
 			if (method.IsPInvokeImpl || method.IsInternalCall) {
 				ProcessInteropMethod (method);
@@ -1992,8 +2200,6 @@ namespace Mono.Linker.Steps {
 
 			DoAdditionalMethodProcessing (method);
 
-			Annotations.Mark (method);
-
 			ApplyPreserveMethods (method);
 			Tracer.Pop ();
 		}
@@ -2001,21 +2207,6 @@ namespace Mono.Linker.Steps {
 		// Allow subclassers to mark additional things when marking a method
 		protected virtual void DoAdditionalMethodProcessing (MethodDefinition method)
 		{
-		}
-
-		protected virtual bool ShouldMarkAsInstancePossible (MethodDefinition method)
-		{
-			// We don't need to mark it multiple times
-			if (Annotations.IsInstantiated (method.DeclaringType))
-				return false;
-
-			if (method.IsInstanceConstructor ())
-				return true;
-
-			if (method.DeclaringType.IsInterface)
-				return true;
-
-			return false;
 		}
 
 		protected virtual void MarkRequirementsForInstantiatedTypes (TypeDefinition type)
@@ -2028,7 +2219,7 @@ namespace Mono.Linker.Steps {
 			MarkInterfaceImplementations (type);
 
 			foreach (var method in GetRequiredMethodsForInstantiatedType (type))
-				MarkMethod (method);
+				MarkMethod (method, new DependencyInfo (DependencyKind.MethodForInstantiatedType, type));
 
 			DoAdditionalInstantiatedTypeProcessing (type);
 		}
@@ -2066,7 +2257,7 @@ namespace Mono.Linker.Steps {
 					}
 
 					if (resolvedInterfaceType == resolvedOverride.DeclaringType) {
-						MarkInterfaceImplementation (ifaceImpl);
+						MarkInterfaceImplementation (ifaceImpl, method.DeclaringType);
 						return;
 					}
 				}
@@ -2081,18 +2272,18 @@ namespace Mono.Linker.Steps {
 					return;
 
 				var baseType = method.DeclaringType.BaseType.Resolve ();
-				if (!MarkDefaultConstructor (baseType))
+				if (!MarkDefaultConstructor (baseType, new DependencyInfo (DependencyKind.BaseDefaultCtorForStubbedMethod, method)))
 					throw new NotSupportedException ($"Cannot stub constructor on '{method.DeclaringType}' when base type does not have default constructor");
 
 				break;
 
 			case MethodAction.ConvertToThrow:
-				MarkAndCacheConvertToThrowExceptionCtor ();
+				MarkAndCacheConvertToThrowExceptionCtor (new DependencyInfo (DependencyKind.UnreachableBodyRequirement, method));
 				break;
 			}
 		}
 
-		protected virtual void MarkAndCacheConvertToThrowExceptionCtor ()
+		protected virtual void MarkAndCacheConvertToThrowExceptionCtor (DependencyInfo reason)
 		{
 			if (_context.MarkedKnownMembers.NotSupportedExceptionCtorString != null)
 				return;
@@ -2101,18 +2292,18 @@ namespace Mono.Linker.Steps {
 			if (nse == null)
 				throw new NotSupportedException ("Missing predefined 'System.NotSupportedException' type");
 
-			MarkType (nse);
+			MarkType (nse, reason);
 
-			var nseCtor = MarkMethodIf (nse.Methods, KnownMembers.IsNotSupportedExceptionCtorString);
+			var nseCtor = MarkMethodIf (nse.Methods, KnownMembers.IsNotSupportedExceptionCtorString, reason);
 			_context.MarkedKnownMembers.NotSupportedExceptionCtorString = nseCtor ?? throw new MarkException ($"Could not find constructor on '{nse.FullName}'");
 
 			var objectType = BCL.FindPredefinedType ("System", "Object", _context);
 			if (objectType == null)
 				throw new NotSupportedException ("Missing predefined 'System.Object' type");
 
-			MarkType (objectType);
+			MarkType (objectType, reason);
 
-			var objectCtor = MarkMethodIf (objectType.Methods, MethodDefinitionExtensions.IsDefaultConstructor);
+			var objectCtor = MarkMethodIf (objectType.Methods, MethodDefinitionExtensions.IsDefaultConstructor, reason);
 			_context.MarkedKnownMembers.ObjectCtor = objectCtor ?? throw new MarkException ($"Could not find constructor on '{objectType.FullName}'");
 		}
 
@@ -2121,14 +2312,14 @@ namespace Mono.Linker.Steps {
 			if (_context.MarkedKnownMembers.DisablePrivateReflectionAttributeCtor != null)
 				return false;
 
-			var nse = BCL.FindPredefinedType ("System.Runtime.CompilerServices", "DisablePrivateReflectionAttribute", _context);
-			if (nse == null)
+			var disablePrivateReflection = BCL.FindPredefinedType ("System.Runtime.CompilerServices", "DisablePrivateReflectionAttribute", _context);
+			if (disablePrivateReflection == null)
 				throw new NotSupportedException ("Missing predefined 'System.Runtime.CompilerServices.DisablePrivateReflectionAttribute' type");
 
-			MarkType (nse);
+			MarkType (disablePrivateReflection, new DependencyInfo (DependencyKind.DisablePrivateReflectionRequirement));
 
-			var ctor = MarkMethodIf (nse.Methods, MethodDefinitionExtensions.IsDefaultConstructor);
-			_context.MarkedKnownMembers.DisablePrivateReflectionAttributeCtor = ctor ?? throw new MarkException ($"Could not find constructor on '{nse.FullName}'");
+			var ctor = MarkMethodIf (disablePrivateReflection.Methods, MethodDefinitionExtensions.IsDefaultConstructor, new DependencyInfo (DependencyKind.DisablePrivateReflectionRequirement, disablePrivateReflection));
+			_context.MarkedKnownMembers.DisablePrivateReflectionAttributeCtor = ctor ?? throw new MarkException ($"Could not find constructor on '{disablePrivateReflection.FullName}'");
 			return true;
 		}
 
@@ -2142,7 +2333,7 @@ namespace Mono.Linker.Steps {
 				if (base_method.DeclaringType.IsInterface && !method.DeclaringType.IsInterface)
 					continue;
 
-				MarkMethod (base_method);
+				MarkMethod (base_method, new DependencyInfo (DependencyKind.BaseMethod, method));
 				MarkBaseMethods (base_method);
 			}
 		}
@@ -2162,12 +2353,12 @@ namespace Mono.Linker.Steps {
 
 			const bool includeStaticFields = false;
 			if (returnTypeDefinition != null && !returnTypeDefinition.IsImport) {
-				MarkDefaultConstructor (returnTypeDefinition);
-				MarkFields (returnTypeDefinition, includeStaticFields);
+				MarkDefaultConstructor (returnTypeDefinition, new DependencyInfo (DependencyKind.InteropMethodDependency, method));
+				MarkFields (returnTypeDefinition, includeStaticFields, new DependencyInfo (DependencyKind.InteropMethodDependency, method));
 			}
 
 			if (method.HasThis && !method.DeclaringType.IsImport) {
-				MarkFields (method.DeclaringType, includeStaticFields);
+				MarkFields (method.DeclaringType, includeStaticFields, new DependencyInfo (DependencyKind.InteropMethodDependency, method));
 			}
 
 			foreach (ParameterDefinition pd in method.Parameters) {
@@ -2177,9 +2368,9 @@ namespace Mono.Linker.Steps {
 				}
 				TypeDefinition paramTypeDefinition = paramTypeReference.Resolve ();
 				if (paramTypeDefinition != null && !paramTypeDefinition.IsImport) {
-					MarkFields (paramTypeDefinition, includeStaticFields);
+					MarkFields (paramTypeDefinition, includeStaticFields, new DependencyInfo (DependencyKind.InteropMethodDependency, method));
 					if (pd.ParameterType.IsByReference) {
-						MarkDefaultConstructor (paramTypeDefinition);
+						MarkDefaultConstructor (paramTypeDefinition, new DependencyInfo (DependencyKind.InteropMethodDependency, method));
 					}
 				}
 			}
@@ -2210,46 +2401,50 @@ namespace Mono.Linker.Steps {
 			}
 		}
 
-		protected void MarkProperty (PropertyDefinition prop)
+		protected void MarkProperty (PropertyDefinition prop, DependencyInfo reason)
 		{
-			MarkCustomAttributes (prop);
+			Tracer.AddDirectDependency (prop, reason, marked: false);
+			// Consider making this more similar to MarkEvent method?
+			MarkCustomAttributes (prop, new DependencyInfo (DependencyKind.CustomAttribute, prop));
 			DoAdditionalPropertyProcessing (prop);
 		}
 
-		protected virtual void MarkEvent (EventDefinition evt)
+		protected virtual void MarkEvent (EventDefinition evt, DependencyInfo reason)
 		{
-			MarkCustomAttributes (evt);
-			MarkMethodIfNotNull (evt.AddMethod);
-			MarkMethodIfNotNull (evt.InvokeMethod);
-			MarkMethodIfNotNull (evt.RemoveMethod);
+			// Record the event without marking it in Annotations.
+			Tracer.AddDirectDependency (evt, reason, marked: false);
+			MarkCustomAttributes (evt, new DependencyInfo (DependencyKind.CustomAttribute, evt));
+			MarkMethodIfNotNull (evt.AddMethod, new DependencyInfo (DependencyKind.EventMethod, evt));
+			MarkMethodIfNotNull (evt.InvokeMethod, new DependencyInfo (DependencyKind.EventMethod, evt));
+			MarkMethodIfNotNull (evt.RemoveMethod, new DependencyInfo (DependencyKind.EventMethod, evt));
 			DoAdditionalEventProcessing (evt);
 		}
 
-		void MarkMethodIfNotNull (MethodReference method)
+		void MarkMethodIfNotNull (MethodReference method, DependencyInfo reason)
 		{
 			if (method == null)
 				return;
 
-			MarkMethod (method);
+			MarkMethod (method, reason);
 		}
 
 		protected virtual void MarkMethodBody (MethodBody body)
 		{
 			if (_context.IsOptimizationEnabled (CodeOptimizations.UnreachableBodies, body.Method) && IsUnreachableBody (body)) {
-				MarkAndCacheConvertToThrowExceptionCtor ();
+				MarkAndCacheConvertToThrowExceptionCtor (new DependencyInfo (DependencyKind.UnreachableBodyRequirement, body.Method));
 				_unreachableBodies.Add (body);
 				return;
 			}
 
 			foreach (VariableDefinition var in body.Variables)
-				MarkType (var.VariableType);
+				MarkType (var.VariableType, new DependencyInfo (DependencyKind.VariableType, body.Method));
 
 			foreach (ExceptionHandler eh in body.ExceptionHandlers)
 				if (eh.HandlerType == ExceptionHandlerType.Catch)
-					MarkType (eh.CatchType);
+					MarkType (eh.CatchType, new DependencyInfo (DependencyKind.CatchType, body.Method));
 
 			foreach (Instruction instruction in body.Instructions)
-				MarkInstruction (instruction);
+				MarkInstruction (instruction, body.Method);
 
 			MarkInterfacesNeededByBodyStack (body);
 
@@ -2277,30 +2472,45 @@ namespace Mono.Linker.Steps {
 			if (implementations == null)
 				return;
 
-			foreach (var implementation in implementations)
-				MarkInterfaceImplementation (implementation);
+			foreach (var (implementation, type) in implementations)
+				MarkInterfaceImplementation (implementation, type);
 		}
 
-		protected virtual void MarkInstruction (Instruction instruction)
+		protected virtual void MarkInstruction (Instruction instruction, MethodDefinition method)
 		{
 			switch (instruction.OpCode.OperandType) {
 			case OperandType.InlineField:
-				MarkField ((FieldReference) instruction.Operand);
+				MarkField ((FieldReference) instruction.Operand, new DependencyInfo (DependencyKind.FieldAccess, method));
 				break;
 			case OperandType.InlineMethod:
-				MarkMethod ((MethodReference) instruction.Operand);
+			{
+				DependencyKind dependencyKind = instruction.OpCode.Code switch {
+					Code.Jmp => DependencyKind.DirectCall,
+					Code.Call => DependencyKind.DirectCall,
+					Code.Callvirt => DependencyKind.VirtualCall,
+					Code.Newobj => DependencyKind.Newobj,
+					Code.Ldvirtftn => DependencyKind.Ldvirtftn,
+					Code.Ldftn => DependencyKind.Ldftn,
+					_ => throw new Exception ($"unexpected opcode {instruction.OpCode}")
+				};
+				MarkMethod ((MethodReference) instruction.Operand, new DependencyInfo (dependencyKind, method));
 				break;
+			}
 			case OperandType.InlineTok:
+			{
 				object token = instruction.Operand;
+				Debug.Assert (instruction.OpCode.Code == Code.Ldtoken);
+				var reason = new DependencyInfo (DependencyKind.Ldtoken, method);
 				if (token is TypeReference typeReference)
-					MarkType (typeReference);
+					MarkType (typeReference, reason);
 				else if (token is MethodReference methodReference)
-					MarkMethod (methodReference);
+					MarkMethod (methodReference, reason);
 				else
-					MarkField ((FieldReference) token);
+					MarkField ((FieldReference) token, reason);
 				break;
+			}
 			case OperandType.InlineType:
-				MarkType ((TypeReference) instruction.Operand);
+				MarkType ((TypeReference) instruction.Operand, new DependencyInfo (DependencyKind.InstructionTypeRef, method));
 				break;
 			default:
 				break;
@@ -2347,11 +2557,13 @@ namespace Mono.Linker.Steps {
 			return IsFullyPreserved (type);
 		}
 
-		protected virtual void MarkInterfaceImplementation (InterfaceImplementation iface)
+		protected virtual void MarkInterfaceImplementation (InterfaceImplementation iface, TypeDefinition type)
 		{
-			MarkCustomAttributes (iface);
-			MarkType (iface.InterfaceType);
-			Annotations.Mark (iface);
+			// Blame the type that has the interfaceimpl, expecting the type itself to get marked for other reasons.
+			MarkCustomAttributes (iface, new DependencyInfo (DependencyKind.CustomAttribute, iface));
+			// Blame the interface type on the interfaceimpl itself.
+			MarkType (iface.InterfaceType, new DependencyInfo (DependencyKind.InterfaceImplementationInterfaceType, iface));
+			Annotations.Mark (iface, new DependencyInfo (DependencyKind.InterfaceImplementationOnType, type));
 		}
 
 		bool HasManuallyTrackedDependency (MethodBody methodBody)
@@ -2461,7 +2673,7 @@ namespace Mono.Linker.Steps {
 				_context.Tracer.Push ($"Reflection-{accessedItem}");
 				try {
 					mark ();
-					_context.ReflectionPatternRecorder.RecognizedReflectionAccessPattern (MethodCalling, MethodCalled, accessedItem);
+					_context.Tracer.ReportRecognizedReflectionPattern (MethodCalling, MethodCalled, accessedItem);
 				} finally {
 					_context.Tracer.Pop ();
 				}
@@ -2476,7 +2688,7 @@ namespace Mono.Linker.Steps {
 				_patternReported = true;
 #endif
 
-				_context.ReflectionPatternRecorder.UnrecognizedReflectionAccessPattern (MethodCalling, MethodCalled, message);
+				_context.Tracer.ReportUnrecognizedReflectionPattern (MethodCalling, MethodCalled, message);
 			}
 
 			public void Dispose ()
@@ -2623,7 +2835,8 @@ namespace Mono.Linker.Steps {
 										break;
 									}
 
-									reflectionContext.RecordRecognizedPattern (foundType, () => _markStep.MarkType (foundType));
+									var methodCalling = reflectionContext.MethodCalling;
+									reflectionContext.RecordRecognizedPattern (foundType, () => _markStep.MarkType (foundType, new DependencyInfo (DependencyKind.AccessedViaReflection, methodCalling)));
 								}
 								break;
 						}
@@ -3110,7 +3323,8 @@ namespace Mono.Linker.Steps {
 						continue;
 
 					foundMatch = true;
-					reflectionContext.RecordRecognizedPattern (method, () => _markStep.MarkIndirectlyCalledMethod (method));
+					var methodCalling = reflectionContext.MethodCalling;
+					reflectionContext.RecordRecognizedPattern (method, () => _markStep.MarkIndirectlyCalledMethod (method, new DependencyInfo (DependencyKind.AccessedViaReflection, methodCalling)));
 				}
 
 				if (!foundMatch)
@@ -3120,6 +3334,7 @@ namespace Mono.Linker.Steps {
 			void MarkPropertiesFromReflectionCall (ref ReflectionPatternContext reflectionContext, TypeDefinition declaringType, string name, bool staticOnly = false)
 			{
 				bool foundMatch = false;
+				var methodCalling = reflectionContext.MethodCalling;
 				foreach (var property in declaringType.Properties) {
 					if (property.Name != name)
 						continue;
@@ -3130,19 +3345,19 @@ namespace Mono.Linker.Steps {
 					// Be conservative and mark everything for the property.
 					var getter = property.GetMethod;
 					if (getter != null && (!staticOnly || staticOnly && getter.IsStatic)) {
-						reflectionContext.RecordRecognizedPattern (getter, () => _markStep.MarkIndirectlyCalledMethod (getter));
+						reflectionContext.RecordRecognizedPattern (getter, () => _markStep.MarkIndirectlyCalledMethod (getter, new DependencyInfo (DependencyKind.AccessedViaReflection, methodCalling)));
 						markedAny = true;
 					}
 
 					var setter = property.SetMethod;
 					if (setter != null && (!staticOnly || staticOnly && setter.IsStatic)) {
-						reflectionContext.RecordRecognizedPattern (setter, () => _markStep.MarkIndirectlyCalledMethod (setter));
+						reflectionContext.RecordRecognizedPattern (setter, () => _markStep.MarkIndirectlyCalledMethod (setter, new DependencyInfo (DependencyKind.AccessedViaReflection, methodCalling)));
 						markedAny = true;
 					}
 
 					if (markedAny) {
 						foundMatch = true;
-						reflectionContext.RecordRecognizedPattern (property, () => _markStep.MarkProperty (property));
+						reflectionContext.RecordRecognizedPattern (property, () => _markStep.MarkProperty (property, new DependencyInfo (DependencyKind.AccessedViaReflection, methodCalling)));
 					}
 				}
 
@@ -3153,6 +3368,7 @@ namespace Mono.Linker.Steps {
 			void MarkFieldsFromReflectionCall (ref ReflectionPatternContext reflectionContext, TypeDefinition declaringType, string name, bool staticOnly = false)
 			{
 				bool foundMatch = false;
+				var methodCalling = reflectionContext.MethodCalling;
 				foreach (var field in declaringType.Fields) {
 					if (field.Name != name)
 						continue;
@@ -3161,7 +3377,7 @@ namespace Mono.Linker.Steps {
 						continue;
 
 					foundMatch = true;
-					reflectionContext.RecordRecognizedPattern (field, () => _markStep.MarkField (field));
+					reflectionContext.RecordRecognizedPattern (field, () => _markStep.MarkField (field, new DependencyInfo (DependencyKind.AccessedViaReflection, methodCalling)));
 					break;
 				}
 
@@ -3172,12 +3388,13 @@ namespace Mono.Linker.Steps {
 			void MarkEventsFromReflectionCall (ref ReflectionPatternContext reflectionContext, TypeDefinition declaringType, string name)
 			{
 				bool foundMatch = false;
+				var methodCalling = reflectionContext.MethodCalling;
 				foreach (var eventInfo in declaringType.Events) {
 					if (eventInfo.Name != name)
 						continue;
 
 					foundMatch = true;
-					reflectionContext.RecordRecognizedPattern (eventInfo, () => _markStep.MarkEvent (eventInfo));
+					reflectionContext.RecordRecognizedPattern (eventInfo, () => _markStep.MarkEvent (eventInfo, new DependencyInfo (DependencyKind.AccessedViaReflection, methodCalling)));
 				}
 
 				if (!foundMatch)

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2679,7 +2679,7 @@ namespace Mono.Linker.Steps {
 				_context.Tracer.Push ($"Reflection-{accessedItem}");
 				try {
 					mark ();
-					_context.Tracer.ReportRecognizedReflectionPattern (MethodCalling, MethodCalled, accessedItem);
+					_context.ReflectionPatternRecorder.RecognizedReflectionAccessPattern (MethodCalling, MethodCalled, accessedItem);
 				} finally {
 					_context.Tracer.Pop ();
 				}
@@ -2694,7 +2694,7 @@ namespace Mono.Linker.Steps {
 				_patternReported = true;
 #endif
 
-				_context.Tracer.ReportUnrecognizedReflectionPattern (MethodCalling, MethodCalled, message);
+				_context.ReflectionPatternRecorder.UnrecognizedReflectionAccessPattern (MethodCalling, MethodCalled, message);
 			}
 
 			public void Dispose ()

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -248,7 +248,7 @@ namespace Mono.Linker.Steps {
 					EnqueueMethod (method, new DependencyInfo (DependencyKind.AlreadyMarked));
 		}
 
-		void MarkEntireType (TypeDefinition type, DependencyInfo reason)
+		void MarkEntireType (TypeDefinition type, in DependencyInfo reason)
 		{
 #if DEBUG
 			if (!_entireTypeReasons.Contains (reason.Kind))
@@ -370,7 +370,7 @@ namespace Mono.Linker.Steps {
 			return _methods.Count == 0;
 		}
 
-		protected virtual void EnqueueMethod (MethodDefinition method, DependencyInfo reason)
+		protected virtual void EnqueueMethod (MethodDefinition method, in DependencyInfo reason)
 		{
 			_methods.Enqueue ((method, reason));
 		}
@@ -491,7 +491,7 @@ namespace Mono.Linker.Steps {
 			return type.HasInterface (@interfaceType, out InterfaceImplementation implementation) && Annotations.IsMarked (implementation);
 		}
 
-		void MarkMarshalSpec (IMarshalInfoProvider spec, DependencyInfo reason)
+		void MarkMarshalSpec (IMarshalInfoProvider spec, in DependencyInfo reason)
 		{
 			if (!spec.HasMarshalInfo)
 				return;
@@ -500,7 +500,7 @@ namespace Mono.Linker.Steps {
 				MarkType (marshaler.ManagedType, reason);
 		}
 
-		void MarkCustomAttributes (ICustomAttributeProvider provider, DependencyInfo reason)
+		void MarkCustomAttributes (ICustomAttributeProvider provider, in DependencyInfo reason)
 		{
 			if (!provider.HasCustomAttributes)
 				return;
@@ -527,7 +527,7 @@ namespace Mono.Linker.Steps {
 			}
 		}
 
-		protected virtual bool ProcessLinkerSpecialAttribute (CustomAttribute ca, ICustomAttributeProvider provider, DependencyInfo reason)
+		protected virtual bool ProcessLinkerSpecialAttribute (CustomAttribute ca, ICustomAttributeProvider provider, in DependencyInfo reason)
 		{
 			if (IsUserDependencyMarker (ca.AttributeType) && provider is MemberReference mr) {
 				MarkUserDependency (mr, ca);
@@ -643,7 +643,7 @@ namespace Mono.Linker.Steps {
 			return type?.Resolve ();
 		}
 
-		bool MarkDependencyMethod (TypeDefinition type, string name, string[] signature, DependencyInfo reason)
+		bool MarkDependencyMethod (TypeDefinition type, string name, string[] signature, in DependencyInfo reason)
 		{
 			bool marked = false;
 
@@ -689,7 +689,7 @@ namespace Mono.Linker.Steps {
 			return marked;
 		}
 
-		bool MarkDependencyField (TypeDefinition type, string name, DependencyInfo reason)
+		bool MarkDependencyField (TypeDefinition type, string name, in DependencyInfo reason)
 		{
 			foreach (var f in type.Fields) {
 				if (f.Name == name) {
@@ -710,7 +710,7 @@ namespace Mono.Linker.Steps {
 				_assemblyLevelAttributes.Enqueue (new AttributeProviderPair (ca, module));
 		}
 
-		protected virtual void MarkCustomAttribute (CustomAttribute ca, DependencyInfo reason)
+		protected virtual void MarkCustomAttribute (CustomAttribute ca, in DependencyInfo reason)
 		{
 			Tracer.Push ((object)ca.AttributeType ?? (object)ca);
 			try {
@@ -772,7 +772,7 @@ namespace Mono.Linker.Steps {
 			return true;
 		}
 
-		protected void MarkStaticConstructor (TypeDefinition type, DependencyInfo reason)
+		protected void MarkStaticConstructor (TypeDefinition type, in DependencyInfo reason)
 		{
 			if (MarkMethodIf (type.Methods, IsNonEmptyStaticConstructor, reason) != null)
 				Annotations.SetPreservedStaticCtor (type);
@@ -804,7 +804,7 @@ namespace Mono.Linker.Steps {
 			return true;
 		}
 
-		protected void MarkSecurityDeclarations (ISecurityDeclarationProvider provider, DependencyInfo reason)
+		protected void MarkSecurityDeclarations (ISecurityDeclarationProvider provider, in DependencyInfo reason)
 		{
 			// most security declarations are removed (if linked) but user code might still have some
 			// and if the attributes references types then they need to be marked too
@@ -815,7 +815,7 @@ namespace Mono.Linker.Steps {
 				MarkSecurityDeclaration (sd, reason);
 		}
 
-		protected virtual void MarkSecurityDeclaration (SecurityDeclaration sd, DependencyInfo reason)
+		protected virtual void MarkSecurityDeclaration (SecurityDeclaration sd, in DependencyInfo reason)
 		{
 			if (!sd.HasSecurityAttributes)
 				return;
@@ -824,7 +824,7 @@ namespace Mono.Linker.Steps {
 				MarkSecurityAttribute (sa, reason);
 		}
 
-		protected virtual void MarkSecurityAttribute (SecurityAttribute sa, DependencyInfo reason)
+		protected virtual void MarkSecurityAttribute (SecurityAttribute sa, in DependencyInfo reason)
 		{
 			TypeReference security_type = sa.AttributeType;
 			TypeDefinition type = security_type.Resolve ();
@@ -849,7 +849,7 @@ namespace Mono.Linker.Steps {
 				MarkCustomAttributeProperty (named_argument, attribute, ca, new DependencyInfo (DependencyKind.AttributeProperty, ca));
 		}
 
-		protected void MarkCustomAttributeProperty (CustomAttributeNamedArgument namedArgument, TypeDefinition attribute, ICustomAttribute ca, DependencyInfo reason)
+		protected void MarkCustomAttributeProperty (CustomAttributeNamedArgument namedArgument, TypeDefinition attribute, ICustomAttribute ca, in DependencyInfo reason)
 		{
 			PropertyDefinition property = GetProperty (attribute, namedArgument.Name);
 			Tracer.Push (property);
@@ -1126,7 +1126,7 @@ namespace Mono.Linker.Steps {
 			MarkField (field, reason);
 		}
 
-		void MarkField (FieldDefinition field, DependencyInfo reason)
+		void MarkField (FieldDefinition field, in DependencyInfo reason)
 		{
 #if DEBUG
 			if (!_fieldReasons.Contains (reason.Kind))
@@ -1558,7 +1558,7 @@ namespace Mono.Linker.Steps {
 			return argument != null;
 		}
 
-		protected int MarkNamedMethod (TypeDefinition type, string method_name, DependencyInfo reason)
+		protected int MarkNamedMethod (TypeDefinition type, string method_name, in DependencyInfo reason)
 		{
 			if (!type.HasMethods)
 				return 0;
@@ -1585,7 +1585,7 @@ namespace Mono.Linker.Steps {
 		}
 
 		// TODO: combine with MarkDependencyField?
-		void MarkNamedField (TypeDefinition type, string field_name, DependencyInfo reason)
+		void MarkNamedField (TypeDefinition type, string field_name, in DependencyInfo reason)
 		{
 			if (!type.HasFields)
 				return;
@@ -1598,7 +1598,7 @@ namespace Mono.Linker.Steps {
 			}
 		}
 
-		void MarkNamedProperty (TypeDefinition type, string property_name, DependencyInfo reason)
+		void MarkNamedProperty (TypeDefinition type, string property_name, in DependencyInfo reason)
 		{
 			if (!type.HasProperties)
 				return;
@@ -1719,7 +1719,7 @@ namespace Mono.Linker.Steps {
 				parameters [1].ParameterType.Name == "StreamingContext";
 		}
 
-		protected bool MarkMethodsIf (Collection<MethodDefinition> methods, Func<MethodDefinition, bool> predicate, DependencyInfo reason)
+		protected bool MarkMethodsIf (Collection<MethodDefinition> methods, Func<MethodDefinition, bool> predicate, in DependencyInfo reason)
 		{
 			bool marked = false;
 			foreach (MethodDefinition method in methods) {
@@ -1731,7 +1731,7 @@ namespace Mono.Linker.Steps {
 			return marked;
 		}
 
-		protected MethodDefinition MarkMethodIf (Collection<MethodDefinition> methods, Func<MethodDefinition, bool> predicate, DependencyInfo reason)
+		protected MethodDefinition MarkMethodIf (Collection<MethodDefinition> methods, Func<MethodDefinition, bool> predicate, in DependencyInfo reason)
 		{
 			foreach (MethodDefinition method in methods) {
 				if (predicate (method)) {
@@ -1742,7 +1742,7 @@ namespace Mono.Linker.Steps {
 			return null;
 		}
 
-		protected bool MarkDefaultConstructor (TypeDefinition type, DependencyInfo reason)
+		protected bool MarkDefaultConstructor (TypeDefinition type, in DependencyInfo reason)
 		{
 			if (type?.HasMethods != true)
 				return false;
@@ -1977,7 +1977,7 @@ namespace Mono.Linker.Steps {
 			MarkMethodCollection (list, new DependencyInfo (DependencyKind.PreservedMethod, method));
 		}
 
-		protected bool MarkFields (TypeDefinition type, bool includeStatic, DependencyInfo reason, bool markBackingFieldsOnlyIfPropertyMarked = false)
+		protected bool MarkFields (TypeDefinition type, bool includeStatic, in DependencyInfo reason, bool markBackingFieldsOnlyIfPropertyMarked = false)
 		{
 			if (!type.HasFields)
 				return false;
@@ -2020,7 +2020,7 @@ namespace Mono.Linker.Steps {
 			return null;
 		}
 
-		protected void MarkStaticFields (TypeDefinition type, DependencyInfo reason)
+		protected void MarkStaticFields (TypeDefinition type, in DependencyInfo reason)
 		{
 			if (!type.HasFields)
 				return;
@@ -2031,7 +2031,7 @@ namespace Mono.Linker.Steps {
 			}
 		}
 
-		protected virtual bool MarkMethods (TypeDefinition type, DependencyInfo reason)
+		protected virtual bool MarkMethods (TypeDefinition type, in DependencyInfo reason)
 		{
 			if (!type.HasMethods)
 				return false;
@@ -2040,13 +2040,13 @@ namespace Mono.Linker.Steps {
 			return true;
 		}
 
-		void MarkMethodCollection (IList<MethodDefinition> methods, DependencyInfo reason)
+		void MarkMethodCollection (IList<MethodDefinition> methods, in DependencyInfo reason)
 		{
 			foreach (MethodDefinition method in methods)
 				MarkMethod (method, reason);
 		}
 
-		protected void MarkIndirectlyCalledMethod (MethodDefinition method, DependencyInfo reason)
+		protected void MarkIndirectlyCalledMethod (MethodDefinition method, in DependencyInfo reason)
 		{
 			MarkMethod (method, reason);
 			Annotations.MarkIndirectlyCalledMethod (method);
@@ -2114,7 +2114,7 @@ namespace Mono.Linker.Steps {
 			return (method, reason);
 		}
 
-		protected virtual void ProcessMethod (MethodDefinition method, DependencyInfo reason)
+		protected virtual void ProcessMethod (MethodDefinition method, in DependencyInfo reason)
 		{
 #if DEBUG
 			if (!_methodReasons.Contains (reason.Kind))
@@ -2407,7 +2407,7 @@ namespace Mono.Linker.Steps {
 			}
 		}
 
-		protected void MarkProperty (PropertyDefinition prop, DependencyInfo reason)
+		protected void MarkProperty (PropertyDefinition prop, in DependencyInfo reason)
 		{
 			Tracer.AddDirectDependency (prop, reason, marked: false);
 			// Consider making this more similar to MarkEvent method?
@@ -2415,7 +2415,7 @@ namespace Mono.Linker.Steps {
 			DoAdditionalPropertyProcessing (prop);
 		}
 
-		protected virtual void MarkEvent (EventDefinition evt, DependencyInfo reason)
+		protected virtual void MarkEvent (EventDefinition evt, in DependencyInfo reason)
 		{
 			// Record the event without marking it in Annotations.
 			Tracer.AddDirectDependency (evt, reason, marked: false);
@@ -2426,7 +2426,7 @@ namespace Mono.Linker.Steps {
 			DoAdditionalEventProcessing (evt);
 		}
 
-		void MarkMethodIfNotNull (MethodReference method, DependencyInfo reason)
+		void MarkMethodIfNotNull (MethodReference method, in DependencyInfo reason)
 		{
 			if (method == null)
 				return;

--- a/src/linker/Linker.Steps/OutputStep.cs
+++ b/src/linker/Linker.Steps/OutputStep.cs
@@ -139,13 +139,11 @@ namespace Mono.Linker.Steps {
 			case AssemblyAction.Save:
 			case AssemblyAction.Link:
 			case AssemblyAction.AddBypassNGen:
-				Context.Tracer.AddDependency (assembly);
 				WriteAssembly (assembly, directory);
 				CopySatelliteAssembliesIfNeeded (assembly, directory);
 				assembliesWritten.Add (GetOriginalAssemblyFileInfo (assembly).Name);
 				break;
 			case AssemblyAction.Copy:
-				Context.Tracer.AddDependency (assembly);
 				CloseSymbols (assembly);
 				CopyAssembly (assembly, directory);
 				CopySatelliteAssembliesIfNeeded (assembly, directory);

--- a/src/linker/Linker.Steps/ReflectionBlockedStep.cs
+++ b/src/linker/Linker.Steps/ReflectionBlockedStep.cs
@@ -61,7 +61,7 @@ namespace Mono.Linker.Steps
 
 			var ca = new CustomAttribute (ctor);
 			caProvider.CustomAttributes.Add (ca);
-			Annotations.Mark (ca);
+			Annotations.Mark (ca, new DependencyInfo (DependencyKind.DisablePrivateReflection, ca));
 		}
 	}
 }

--- a/src/linker/Linker.Steps/ResolveFromAssemblyStep.cs
+++ b/src/linker/Linker.Steps/ResolveFromAssemblyStep.cs
@@ -94,8 +94,6 @@ namespace Mono.Linker.Steps
 			var action = rootVisibility == RootVisibility.Any ? AssemblyAction.Copy : AssemblyAction.Link;
 			context.SetAction (assembly, action);
 
-			context.Tracer.Push (assembly);
-
 			foreach (TypeDefinition type in assembly.MainModule.Types)
 				MarkType (context, type, rootVisibility);
 
@@ -135,8 +133,6 @@ namespace Mono.Linker.Steps
 					context.MarkingHelpers.MarkExportedType (exported, assembly.MainModule, new DependencyInfo (DependencyKind.ExportedType, resolvedExportedType));
 				}
 			}
-
-			context.Tracer.Pop ();
 		}
 
 		static void MarkType (LinkContext context, TypeDefinition type, RootVisibility rootVisibility)
@@ -152,8 +148,6 @@ namespace Mono.Linker.Steps
 			}
 
 			context.Annotations.Mark (type, new DependencyInfo (DependencyKind.RootAssembly, type.Module.Assembly));
-			context.Annotations.Push (type);
-
 			if (type.HasFields)
 				MarkFields (context, type.Fields, rootVisibility);
 			if (type.HasMethods)
@@ -161,23 +155,17 @@ namespace Mono.Linker.Steps
 			if (type.HasNestedTypes)
 				foreach (var nested in type.NestedTypes)
 					MarkType (context, nested, rootVisibility);
-
-			context.Tracer.Pop ();
 		}
 
 		void ProcessExecutable (AssemblyDefinition assembly)
 		{
 			Context.SetAction (assembly, AssemblyAction.Link);
 
-			Tracer.Push (assembly);
-
 			MethodDefinition entryPoint = assembly.EntryPoint;
 			TypeDefinition declaringType = entryPoint.DeclaringType;
 			Annotations.Mark (declaringType, new DependencyInfo (DependencyKind.RootAssembly, declaringType.Module.Assembly));
 
 			MarkMethod (Context, entryPoint, MethodAction.Parse, RootVisibility.Any);
-
-			Tracer.Pop ();
 		}
 
 		static void MarkFields (LinkContext context, Collection<FieldDefinition> fields, RootVisibility rootVisibility)

--- a/src/linker/Linker.Steps/ResolveFromAssemblyStep.cs
+++ b/src/linker/Linker.Steps/ResolveFromAssemblyStep.cs
@@ -132,7 +132,7 @@ namespace Mono.Linker.Steps
 
 					context.Resolve (resolvedExportedType.Scope);
 					MarkType (context, resolvedExportedType, rootVisibility);
-					context.MarkingHelpers.MarkExportedType (exported, assembly.MainModule);
+					context.MarkingHelpers.MarkExportedType (exported, assembly.MainModule, new DependencyInfo (DependencyKind.ExportedType, resolvedExportedType));
 				}
 			}
 
@@ -151,7 +151,8 @@ namespace Mono.Linker.Steps
 				return;
 			}
 
-			context.Annotations.MarkAndPush (type);
+			context.Annotations.Mark (type, new DependencyInfo (DependencyKind.RootAssembly, type.Module.Assembly));
+			context.Annotations.Push (type);
 
 			if (type.HasFields)
 				MarkFields (context, type.Fields, rootVisibility);
@@ -170,9 +171,11 @@ namespace Mono.Linker.Steps
 
 			Tracer.Push (assembly);
 
-			Annotations.Mark (assembly.EntryPoint.DeclaringType);
+			MethodDefinition entryPoint = assembly.EntryPoint;
+			TypeDefinition declaringType = entryPoint.DeclaringType;
+			Annotations.Mark (declaringType, new DependencyInfo (DependencyKind.RootAssembly, declaringType.Module.Assembly));
 
-			MarkMethod (Context, assembly.EntryPoint, MethodAction.Parse, RootVisibility.Any);
+			MarkMethod (Context, entryPoint, MethodAction.Parse, RootVisibility.Any);
 
 			Tracer.Pop ();
 		}
@@ -186,7 +189,7 @@ namespace Mono.Linker.Steps
 					_ => true
 				};
 				if (markField) {
-					context.Annotations.Mark (field);
+					context.Annotations.Mark (field, new DependencyInfo (DependencyKind.RootAssembly, field.Module.Assembly));
 				}
 			}
 		}
@@ -206,7 +209,7 @@ namespace Mono.Linker.Steps
 			};
 
 			if (markMethod) {
-				context.Annotations.Mark (method);
+				context.Annotations.Mark (method, new DependencyInfo (DependencyKind.RootAssembly, method.Module.Assembly));
 				context.Annotations.SetAction (method, action);
 			}
 		}

--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -151,6 +151,12 @@ namespace Mono.Linker {
 			return fieldType_init.Contains (type);
 		}
 
+		[Obsolete ("Mark token providers with a reason instead.")]
+		public void Mark (IMetadataTokenProvider provider)
+		{
+			marked.Add (provider);
+		}
+
 		public void Mark (IMetadataTokenProvider provider, in DependencyInfo reason)
 		{
 			Debug.Assert (!(reason.Kind == DependencyKind.AlreadyMarked));

--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -151,13 +151,6 @@ namespace Mono.Linker {
 			return fieldType_init.Contains (type);
 		}
 
-		[Obsolete ("Mark token providers with a reason instead.")]
-		public void Mark (IMetadataTokenProvider provider)
-		{
-			marked.Add (provider);
-			Tracer.AddDependency (provider, true);
-		}
-
 		public void Mark (IMetadataTokenProvider provider, in DependencyInfo reason)
 		{
 			Debug.Assert (!(reason.Kind == DependencyKind.AlreadyMarked));
@@ -176,18 +169,6 @@ namespace Mono.Linker {
 			Debug.Assert (!(reason.Kind == DependencyKind.AlreadyMarked));
 			marked_attributes.Add (attribute);
 			Tracer.AddDirectDependency (attribute, reason, marked: true);
-		}
-
-		public void Push (IMetadataTokenProvider provider)
-		{
-			Tracer.Push (provider, false);
-		}
-
-		[Obsolete ("Mark token providers with a reason instead.")]
-		public void MarkAndPush (IMetadataTokenProvider provider)
-		{
-			Mark (provider);
-			Tracer.Push (provider, false);
 		}
 
 		public bool IsMarked (IMetadataTokenProvider provider)

--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -28,6 +28,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 
@@ -150,17 +151,39 @@ namespace Mono.Linker {
 			return fieldType_init.Contains (type);
 		}
 
+		[Obsolete ("Mark token providers with a reason instead.")]
 		public void Mark (IMetadataTokenProvider provider)
 		{
 			marked.Add (provider);
 			Tracer.AddDependency (provider, true);
 		}
 
+		public void Mark (IMetadataTokenProvider provider, DependencyInfo reason)
+		{
+			Debug.Assert (!(reason.Kind == DependencyKind.AlreadyMarked));
+			marked.Add (provider);
+			Tracer.AddDirectDependency (provider, reason, marked: true);
+		}
+
+		[Obsolete ("Mark attributes with a reason instead.")]
 		public void Mark (CustomAttribute attribute)
 		{
 			marked_attributes.Add (attribute);
 		}
 
+		public void Mark (CustomAttribute attribute, DependencyInfo reason)
+		{
+			Debug.Assert (!(reason.Kind == DependencyKind.AlreadyMarked));
+			marked_attributes.Add (attribute);
+			Tracer.AddDirectDependency (attribute, reason, marked: true);
+		}
+
+		public void Push (IMetadataTokenProvider provider)
+		{
+			Tracer.Push (provider, false);
+		}
+
+		[Obsolete ("Mark token providers with a reason instead.")]
 		public void MarkAndPush (IMetadataTokenProvider provider)
 		{
 			Mark (provider);

--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -158,7 +158,7 @@ namespace Mono.Linker {
 			Tracer.AddDependency (provider, true);
 		}
 
-		public void Mark (IMetadataTokenProvider provider, DependencyInfo reason)
+		public void Mark (IMetadataTokenProvider provider, in DependencyInfo reason)
 		{
 			Debug.Assert (!(reason.Kind == DependencyKind.AlreadyMarked));
 			marked.Add (provider);
@@ -171,7 +171,7 @@ namespace Mono.Linker {
 			marked_attributes.Add (attribute);
 		}
 
-		public void Mark (CustomAttribute attribute, DependencyInfo reason)
+		public void Mark (CustomAttribute attribute, in DependencyInfo reason)
 		{
 			Debug.Assert (!(reason.Kind == DependencyKind.AlreadyMarked));
 			marked_attributes.Add (attribute);

--- a/src/linker/Linker/DependencyInfo.cs
+++ b/src/linker/Linker/DependencyInfo.cs
@@ -129,8 +129,9 @@ namespace Mono.Linker
 		public DependencyKind Kind { get; }
 		public object Source { get; }
 		public DependencyInfo (DependencyKind kind, object source) => (Kind, Source) = (kind, source);
-		public DependencyInfo (DependencyKind kind) => (Kind, Source) = (kind, default);
-
+		public static readonly DependencyInfo Unspecified = new DependencyInfo (DependencyKind.Unspecified, null);
+		public static readonly DependencyInfo AlreadyMarked = new DependencyInfo (DependencyKind.AlreadyMarked, null);
+		public static readonly DependencyInfo DisablePrivateReflectionRequirement = new DependencyInfo (DependencyKind.DisablePrivateReflectionRequirement, null);
 		public bool Equals (DependencyInfo other) => (Kind, Source) == (other.Kind, other.Source);
 		public override bool Equals (Object obj) => obj is DependencyInfo info && this.Equals (info);
 		public override int GetHashCode() => (Kind, Source).GetHashCode ();

--- a/src/linker/Linker/DependencyInfo.cs
+++ b/src/linker/Linker/DependencyInfo.cs
@@ -123,6 +123,9 @@ namespace Mono.Linker
 		UnreachableBodyRequirement = 77, // method -> well-known type required for unreachable bodies optimization
 		DisablePrivateReflectionRequirement = 78, // null -> DisablePrivateReflectionAttribute type/methods (note that no specific source is reported)
 		AlreadyMarked = 79, // null -> member that has already been marked for a particular reason (used to propagate reasons internally, not reported)
+
+	// For tracking any other kinds of dependencies in extensions to the core logic
+		Custom = 80, // the source is reserved to carry any dependency information tracked by the extender
 	}
 
 	readonly public struct DependencyInfo : IEquatable<DependencyInfo> {

--- a/src/linker/Linker/DependencyInfo.cs
+++ b/src/linker/Linker/DependencyInfo.cs
@@ -31,7 +31,6 @@ namespace Mono.Linker
 		BaseMethod, // override -> base method
 		Override, // base method -> override
 		MethodImplOverride, // method -> .override on the method
-	// 
 		VirtualNeededDueToPreservedScope, // type -> virtuals kept because scope requires it
 		MethodForInstantiatedType, // type -> methods kept because type is instantiated or scope requires it
 		BaseDefaultCtorForStubbedMethod, // stubbed method -> default ctor of base type
@@ -77,20 +76,20 @@ namespace Mono.Linker
 		InstructionTypeRef, // other instructions that have an inline type token (method -> type)
 
 	// Custom attributes on various providers
-		CustomAttribute,
-		ParameterAttribute,
-		ReturnTypeAttribute,
-		GenericParameterCustomAttribute,
-		GenericParameterConstraintCustomAttribute,
+		CustomAttribute, // attribute provider (type/field/method/etc...) -> attribute on it
+		ParameterAttribute, // method parameter -> attribute on it
+		ReturnTypeAttribute, // method return type -> attribute on it
+		GenericParameterCustomAttribute, // generic parameter -> attribute on it
+		GenericParameterConstraintCustomAttribute, // generic parameter constraint -> attribute on it
 
 	// Dependencies of custom attributes
 		AttributeConstructor, // attribute -> its ctor
 		// used for security attributes, where we mark the type/properties directly
 		AttributeType, // attribute -> attribute type
-		AttributeProperty, // attribute -> attribute ptroperty
-		CustomAttributeArgumentType,
-		CustomAttributeArgumentValue,
-		CustomAttributeField,
+		AttributeProperty, // attribute -> attribute property
+		CustomAttributeArgumentType, // attribute -> type of an argument to the attribute ctor
+		CustomAttributeArgumentValue, // attribute -> type passed as an argument to the attribute ctor
+		CustomAttributeField, // attribute -> field on the attribute
 
 	// Tracking cctors
 		TriggersCctorThroughFieldAccess, // field-accessing method -> cctor of field's declaring type
@@ -100,7 +99,7 @@ namespace Mono.Linker
 		CctorForField, // field -> cctor of field's declaring type
 
 	// Tracking instantiations
-		InstantiatedByCtor, // ctor -> type it instantiates			
+		InstantiatedByCtor, // ctor -> its declaring type (indicating that it was marked instantiated due to the ctor)
 		OverrideOnInstantiatedType, // instantiated type -> override method on the type
 
 	// Linker-specific behavior (preservation hints, patterns, user inputs, linker outputs, etc.)

--- a/src/linker/Linker/DependencyInfo.cs
+++ b/src/linker/Linker/DependencyInfo.cs
@@ -3,127 +3,126 @@ using System;
 namespace Mono.Linker
 {
 	public enum DependencyKind {
+	// For use when we don't care about tracking a particular dependency
+		Unspecified = 0, // currently unused
 
 	// Entry points to the analysis
-		AssemblyAction, // assembly action -> entry assembly
-		RootAssembly, // assembly -> entry type
-		XmlDescriptor, // xml document -> entry member
+		AssemblyAction = 1, // assembly action -> entry assembly
+		RootAssembly = 2, // assembly -> entry type
+		XmlDescriptor = 3, // xml document -> entry member
 		// Attributes on assemblies are marked whether or not we keep
 		// the assembly, so mark these as entry points.
-		AssemblyOrModuleAttribute, // assembly/module -> entry attribute
+		AssemblyOrModuleAttribute = 4, // assembly/module -> entry attribute
 
 	// Membership and containment relationships
-		NestedType, // parent type -> nested type
-		MemberOfType, // type -> member
-		DeclaringType, // member -> type
-		FieldOnGenericInstance, // fieldref on instantiated generic -> field on generic typedef
-		MethodOnGenericInstance, // methodref on instantiated generic -> method on generic typedef
+		NestedType = 5, // parent type -> nested type
+		MemberOfType = 6, // type -> member
+		DeclaringType = 7, // member -> type
+		FieldOnGenericInstance = 8, // fieldref on instantiated generic -> field on generic typedef
+		MethodOnGenericInstance = 9, // methodref on instantiated generic -> method on generic typedef
 
 	// Type relationships
-		BaseType, // type -> its base type
-		FieldType, // field -> its type
-		ParameterType, // method -> types of its parameters
-		ReturnType, // method -> type it returns
-		VariableType, // method -> types of its variables
-		CatchType, // method -> types of its exception handlers
+		BaseType = 10, // type -> its base type
+		FieldType = 11, // field -> its type
+		ParameterType = 12, // method -> types of its parameters
+		ReturnType = 13, // method -> type it returns
+		VariableType = 14, // method -> types of its variables
+		CatchType = 15, // method -> types of its exception handlers
 
 	// Override relationships
-		BaseMethod, // override -> base method
-		Override, // base method -> override
-		MethodImplOverride, // method -> .override on the method
-		VirtualNeededDueToPreservedScope, // type -> virtuals kept because scope requires it
-		MethodForInstantiatedType, // type -> methods kept because type is instantiated or scope requires it
-		BaseDefaultCtorForStubbedMethod, // stubbed method -> default ctor of base type
+		BaseMethod = 16, // override -> base method
+		Override = 17, // base method -> override
+		MethodImplOverride = 18, // method -> .override on the method
+		VirtualNeededDueToPreservedScope = 19, // type -> virtuals kept because scope requires it
+		MethodForInstantiatedType = 20, // type -> methods kept because type is instantiated or scope requires it
+		BaseDefaultCtorForStubbedMethod = 21, // stubbed method -> default ctor of base type
 
 	// Generic type relationships
-		GenericArgumentType, // generic instance -> argument type
-		GenericParameterConstraintType, // generic typedef/methoddef -> parameter constraint type
-		DefaultCtorForNewConstrainedGenericArgument, // generic instance -> argument ctor
-		ElementType, // generic type instantiation -> generic typedef
-		ElementMethod, // generic method instantiation -> generic methoddef
-		ModifierType, // modified type -> type modifier
+		GenericArgumentType = 22, // generic instance -> argument type
+		GenericParameterConstraintType = 23, // generic typedef/methoddef -> parameter constraint type
+		DefaultCtorForNewConstrainedGenericArgument = 24, // generic instance -> argument ctor
+		ElementType = 25, // generic type instantiation -> generic typedef
+		ElementMethod = 26, // generic method instantiation -> generic methoddef
+		ModifierType = 27, // modified type -> type modifier
 
 	// Modules and assemblies
-		ScopeOfType, // type -> module/assembly
-		TypeInAssembly, // assembly -> type
-		ModuleOfExportedType, // exported type -> module
-		ExportedType, // type -> exported type
+		ScopeOfType = 28, // type -> module/assembly
+		TypeInAssembly = 29, // assembly -> type
+		ModuleOfExportedType = 30, // exported type -> module
+		ExportedType = 31, // type -> exported type
 
 	// Grouping of property/event methods
-		PropertyOfPropertyMethod, // property method -> its property
-		EventOfEventMethod, // event method -> its event
-		EventMethod, // event -> its event methods
+		PropertyOfPropertyMethod = 32, // property method -> its property
+		EventOfEventMethod = 33, // event method -> its event
+		EventMethod = 34, // event -> its event methods
 		// PropertyMethod doesn't exist because property methods aren't always marked for a property
 
 	// Interface implementations
-		InterfaceImplementationInterfaceType, // interfaceimpl -> interface type
-		InterfaceImplementationOnType, // type -> interfaceimpl on it
+		InterfaceImplementationInterfaceType = 35, // interfaceimpl -> interface type
+		InterfaceImplementationOnType = 36, // type -> interfaceimpl on it
 
 	// Interop methods
-		ReturnTypeMarshalSpec, // interop method -> marshal spec of its return type
-		ParameterMarshalSpec, // interop method -> marshal spec of its parameters
-		FieldMarshalSpec, // field -> its marshal spec
-		InteropMethodDependency, // interop method -> required members of its parameters, return type, declaring type
+		ReturnTypeMarshalSpec = 37, // interop method -> marshal spec of its return type
+		ParameterMarshalSpec = 38, // interop method -> marshal spec of its parameters
+		FieldMarshalSpec = 39, // field -> its marshal spec
+		InteropMethodDependency = 40, // interop method -> required members of its parameters, return type, declaring type
 
 	// Dependencies created by instructions
-		DirectCall, // method -> method
-		VirtualCall, // method -> method
-		Ldvirtftn, // method -> method
-		Ldftn, // method -> method
-		Newobj, // method -> method
-		Ldtoken, // method -> member referenced
-		FieldAccess, // method -> field (for instructions that load/store fields)
-		InstructionTypeRef, // other instructions that have an inline type token (method -> type)
+		DirectCall = 41, // method -> method
+		VirtualCall = 42, // method -> method
+		Ldvirtftn = 43, // method -> method
+		Ldftn = 44, // method -> method
+		Newobj = 45, // method -> method
+		Ldtoken = 46, // method -> member referenced
+		FieldAccess = 47, // method -> field (for instructions that load/store fields)
+		InstructionTypeRef = 48, // other instructions that have an inline type token (method -> type)
 
 	// Custom attributes on various providers
-		CustomAttribute, // attribute provider (type/field/method/etc...) -> attribute on it
-		ParameterAttribute, // method parameter -> attribute on it
-		ReturnTypeAttribute, // method return type -> attribute on it
-		GenericParameterCustomAttribute, // generic parameter -> attribute on it
-		GenericParameterConstraintCustomAttribute, // generic parameter constraint -> attribute on it
+		CustomAttribute = 49, // attribute provider (type/field/method/etc...) -> attribute on it
+		ParameterAttribute = 50, // method parameter -> attribute on it
+		ReturnTypeAttribute = 51, // method return type -> attribute on it
+		GenericParameterCustomAttribute = 52, // generic parameter -> attribute on it
+		GenericParameterConstraintCustomAttribute = 53, // generic parameter constraint -> attribute on it
 
 	// Dependencies of custom attributes
-		AttributeConstructor, // attribute -> its ctor
+		AttributeConstructor = 54, // attribute -> its ctor
 		// used for security attributes, where we mark the type/properties directly
-		AttributeType, // attribute -> attribute type
-		AttributeProperty, // attribute -> attribute property
-		CustomAttributeArgumentType, // attribute -> type of an argument to the attribute ctor
-		CustomAttributeArgumentValue, // attribute -> type passed as an argument to the attribute ctor
-		CustomAttributeField, // attribute -> field on the attribute
+		AttributeType = 55, // attribute -> attribute type
+		AttributeProperty = 56, // attribute -> attribute property
+		CustomAttributeArgumentType = 57, // attribute -> type of an argument to the attribute ctor
+		CustomAttributeArgumentValue = 58, // attribute -> type passed as an argument to the attribute ctor
+		CustomAttributeField = 59, // attribute -> field on the attribute
 
 	// Tracking cctors
-		TriggersCctorThroughFieldAccess, // field-accessing method -> cctor of field's declaring type
-		TriggersCctorForCalledMethod, // caller method -> callee method type cctor
-		DeclaringTypeOfCalledMethod, // called method -> its declaring type (used to track when a cctor is triggered by a method call)
-		CctorForType, // type -> cctor of type
-		CctorForField, // field -> cctor of field's declaring type
+		TriggersCctorThroughFieldAccess = 60, // field-accessing method -> cctor of field's declaring type
+		TriggersCctorForCalledMethod = 61, // caller method -> callee method type cctor
+		DeclaringTypeOfCalledMethod = 62, // called method -> its declaring type (used to track when a cctor is triggered by a method call)
+		CctorForType = 63, // type -> cctor of type
+		CctorForField = 64, // field -> cctor of field's declaring type
 
 	// Tracking instantiations
-		InstantiatedByCtor, // ctor -> its declaring type (indicating that it was marked instantiated due to the ctor)
-		OverrideOnInstantiatedType, // instantiated type -> override method on the type
+		InstantiatedByCtor = 65, // ctor -> its declaring type (indicating that it was marked instantiated due to the ctor)
+		OverrideOnInstantiatedType = 66, // instantiated type -> override method on the type
 
 	// Linker-specific behavior (preservation hints, patterns, user inputs, linker outputs, etc.)
-		PreservedDependency, // PreserveDependency attribute -> member
-		AccessedViaReflection, // method -> detected member accessed via reflection from that method
-		PreservedMethod, // type/method -> preserved method (explicitly preserved in Annotations by XML or other steps)
-		TypePreserve, // type -> field/method preserved for the type (explicitly set in Annotations by XML or other steps)
-		DisablePrivateReflection, // type/method -> DisablePrivateReflection attribute added by linkerf
+		PreservedDependency = 67, // PreserveDependency attribute -> member
+		AccessedViaReflection = 68, // method -> detected member accessed via reflection from that method
+		PreservedMethod = 69, // type/method -> preserved method (explicitly preserved in Annotations by XML or other steps)
+		TypePreserve = 70, // type -> field/method preserved for the type (explicitly set in Annotations by XML or other steps)
+		DisablePrivateReflection = 71, // type/method -> DisablePrivateReflection attribute added by linkerf
 
 	// Built-in knowledge of special runtime/diagnostic subsystems
 		// XmlSchemaProvider, DebuggerDisplay, DebuggerTypeProxy, SoapHeader, TypeDescriptionProvider
-		ReferencedBySpecialAttribute, // attribute -> referenced members
-		KeptForSpecialAttribute, // attribute -> kept members (used when the members are not explicitly referenced)
-		SerializationMethodForType, // type -> method required for serialization
-		EventSourceProviderField, // EventSource derived type -> fields on nested Keywords/Tasks/Opcodes provider classes
-		MethodForSpecialType, // type -> methods kept (currently used for MulticastDelegate)
+		ReferencedBySpecialAttribute = 72, // attribute -> referenced members
+		KeptForSpecialAttribute = 73, // attribute -> kept members (used when the members are not explicitly referenced)
+		SerializationMethodForType = 74, // type -> method required for serialization
+		EventSourceProviderField = 75, // EventSource derived type -> fields on nested Keywords/Tasks/Opcodes provider classes
+		MethodForSpecialType = 76, // type -> methods kept (currently used for MulticastDelegate)
 
 	// Linker internals, requirements for certain optimizations
-		UnreachableBodyRequirement, // method -> well-known type required for unreachable bodies optimization
-		DisablePrivateReflectionRequirement, // null -> DisablePrivateReflectionAttribute type/methods (note that no specific source is reported)
-		AlreadyMarked, // null -> member that has already been marked for a particular reason (used to propagate reasons internally, not reported)
-
-	// For use when we don't care about tracking a particular dependency
-		Unspecified, // currently unused
+		UnreachableBodyRequirement = 77, // method -> well-known type required for unreachable bodies optimization
+		DisablePrivateReflectionRequirement = 78, // null -> DisablePrivateReflectionAttribute type/methods (note that no specific source is reported)
+		AlreadyMarked = 79, // null -> member that has already been marked for a particular reason (used to propagate reasons internally, not reported)
 	}
 
 	readonly public struct DependencyInfo : IEquatable<DependencyInfo> {

--- a/src/linker/Linker/DependencyInfo.cs
+++ b/src/linker/Linker/DependencyInfo.cs
@@ -1,0 +1,142 @@
+using System;
+
+namespace Mono.Linker
+{
+	public enum DependencyKind {
+
+	// Entry points to the analysis
+		AssemblyAction, // assembly action -> entry assembly
+		RootAssembly, // assembly -> entry type
+		XmlDescriptor, // xml document -> entry member
+		// Attributes on assemblies are marked whether or not we keep
+		// the assembly, so mark these as entry points.
+		AssemblyOrModuleAttribute, // assembly/module -> entry attribute
+
+	// Membership and containment relationships
+		NestedType, // parent type -> nested type
+		MemberOfType, // type -> member
+		DeclaringType, // member -> type
+		FieldOnGenericInstance, // fieldref on instantiated generic -> field on generic typedef
+		MethodOnGenericInstance, // methodref on instantiated generic -> method on generic typedef
+
+	// Type relationships
+		BaseType, // type -> its base type
+		FieldType, // field -> its type
+		ParameterType, // method -> types of its parameters
+		ReturnType, // method -> type it returns
+		VariableType, // method -> types of its variables
+		CatchType, // method -> types of its exception handlers
+
+	// Override relationships
+		BaseMethod, // override -> base method
+		Override, // base method -> override
+		MethodImplOverride, // method -> .override on the method
+	// 
+		VirtualNeededDueToPreservedScope, // type -> virtuals kept because scope requires it
+		MethodForInstantiatedType, // type -> methods kept because type is instantiated or scope requires it
+		BaseDefaultCtorForStubbedMethod, // stubbed method -> default ctor of base type
+
+	// Generic type relationships
+		GenericArgumentType, // generic instance -> argument type
+		GenericParameterConstraintType, // generic typedef/methoddef -> parameter constraint type
+		DefaultCtorForNewConstrainedGenericArgument, // generic instance -> argument ctor
+		ElementType, // generic type instantiation -> generic typedef
+		ElementMethod, // generic method instantiation -> generic methoddef
+		ModifierType, // modified type -> type modifier
+
+	// Modules and assemblies
+		ScopeOfType, // type -> module/assembly
+		TypeInAssembly, // assembly -> type
+		ModuleOfExportedType, // exported type -> module
+		ExportedType, // type -> exported type
+
+	// Grouping of property/event methods
+		PropertyOfPropertyMethod, // property method -> its property
+		EventOfEventMethod, // event method -> its event
+		EventMethod, // event -> its event methods
+		// PropertyMethod doesn't exist because property methods aren't always marked for a property
+
+	// Interface implementations
+		InterfaceImplementationInterfaceType, // interfaceimpl -> interface type
+		InterfaceImplementationOnType, // type -> interfaceimpl on it
+
+	// Interop methods
+		ReturnTypeMarshalSpec, // interop method -> marshal spec of its return type
+		ParameterMarshalSpec, // interop method -> marshal spec of its parameters
+		FieldMarshalSpec, // field -> its marshal spec
+		InteropMethodDependency, // interop method -> required members of its parameters, return type, declaring type
+
+	// Dependencies created by instructions
+		DirectCall, // method -> method
+		VirtualCall, // method -> method
+		Ldvirtftn, // method -> method
+		Ldftn, // method -> method
+		Newobj, // method -> method
+		Ldtoken, // method -> member referenced
+		FieldAccess, // method -> field (for instructions that load/store fields)
+		InstructionTypeRef, // other instructions that have an inline type token (method -> type)
+
+	// Custom attributes on various providers
+		CustomAttribute,
+		ParameterAttribute,
+		ReturnTypeAttribute,
+		GenericParameterCustomAttribute,
+		GenericParameterConstraintCustomAttribute,
+
+	// Dependencies of custom attributes
+		AttributeConstructor, // attribute -> its ctor
+		// used for security attributes, where we mark the type/properties directly
+		AttributeType, // attribute -> attribute type
+		AttributeProperty, // attribute -> attribute ptroperty
+		CustomAttributeArgumentType,
+		CustomAttributeArgumentValue,
+		CustomAttributeField,
+
+	// Tracking cctors
+		TriggersCctorThroughFieldAccess, // field-accessing method -> cctor of field's declaring type
+		TriggersCctorForCalledMethod, // caller method -> callee method type cctor
+		DeclaringTypeOfCalledMethod, // called method -> its declaring type (used to track when a cctor is triggered by a method call)
+		CctorForType, // type -> cctor of type
+		CctorForField, // field -> cctor of field's declaring type
+
+	// Tracking instantiations
+		InstantiatedByCtor, // ctor -> type it instantiates			
+		OverrideOnInstantiatedType, // instantiated type -> override method on the type
+
+	// Linker-specific behavior (preservation hints, patterns, user inputs, linker outputs, etc.)
+		PreservedDependency, // PreserveDependency attribute -> member
+		AccessedViaReflection, // method -> detected member accessed via reflection from that method
+		PreservedMethod, // type/method -> preserved method (explicitly preserved in Annotations by XML or other steps)
+		TypePreserve, // type -> field/method preserved for the type (explicitly set in Annotations by XML or other steps)
+		DisablePrivateReflection, // type/method -> DisablePrivateReflection attribute added by linkerf
+
+	// Built-in knowledge of special runtime/diagnostic subsystems
+		// XmlSchemaProvider, DebuggerDisplay, DebuggerTypeProxy, SoapHeader, TypeDescriptionProvider
+		ReferencedBySpecialAttribute, // attribute -> referenced members
+		KeptForSpecialAttribute, // attribute -> kept members (used when the members are not explicitly referenced)
+		SerializationMethodForType, // type -> method required for serialization
+		EventSourceProviderField, // EventSource derived type -> fields on nested Keywords/Tasks/Opcodes provider classes
+		MethodForSpecialType, // type -> methods kept (currently used for MulticastDelegate)
+
+	// Linker internals, requirements for certain optimizations
+		UnreachableBodyRequirement, // method -> well-known type required for unreachable bodies optimization
+		DisablePrivateReflectionRequirement, // null -> DisablePrivateReflectionAttribute type/methods (note that no specific source is reported)
+		AlreadyMarked, // null -> member that has already been marked for a particular reason (used to propagate reasons internally, not reported)
+
+	// For use when we don't care about tracking a particular dependency
+		Unspecified, // currently unused
+	}
+
+	readonly public struct DependencyInfo : IEquatable<DependencyInfo> {
+		public DependencyKind Kind { get; }
+		public object Source { get; }
+		public DependencyInfo (DependencyKind kind, object source) => (Kind, Source) = (kind, source);
+		public DependencyInfo (DependencyKind kind) => (Kind, Source) = (kind, default);
+
+		public bool Equals (DependencyInfo other) => (Kind, Source) == (other.Kind, other.Source);
+		public override bool Equals (Object obj) => obj is DependencyInfo info && this.Equals (info);
+		public override int GetHashCode() => (Kind, Source).GetHashCode ();
+		public static bool operator == (DependencyInfo lhs, DependencyInfo rhs) => lhs.Equals (rhs);
+		public static bool operator != (DependencyInfo lhs, DependencyInfo rhs) => !lhs.Equals (rhs);
+	}
+}

--- a/src/linker/Linker/DependencyInfo.cs
+++ b/src/linker/Linker/DependencyInfo.cs
@@ -3,6 +3,9 @@ using System;
 namespace Mono.Linker
 {
 	public enum DependencyKind {
+	// For tracking any other kinds of dependencies in extensions to the core logic
+		Custom = -1, // the source is reserved to carry any dependency information tracked by the extender
+
 	// For use when we don't care about tracking a particular dependency
 		Unspecified = 0, // currently unused
 
@@ -123,9 +126,6 @@ namespace Mono.Linker
 		UnreachableBodyRequirement = 77, // method -> well-known type required for unreachable bodies optimization
 		DisablePrivateReflectionRequirement = 78, // null -> DisablePrivateReflectionAttribute type/methods (note that no specific source is reported)
 		AlreadyMarked = 79, // null -> member that has already been marked for a particular reason (used to propagate reasons internally, not reported)
-
-	// For tracking any other kinds of dependencies in extensions to the core logic
-		Custom = 80, // the source is reserved to carry any dependency information tracked by the extender
 	}
 
 	readonly public struct DependencyInfo : IEquatable<DependencyInfo> {

--- a/src/linker/Linker/DirectoryAssemblyResolver.cs
+++ b/src/linker/Linker/DirectoryAssemblyResolver.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Reflection;
 using System.Collections.Generic;
 using System.IO;
 using Mono.Collections.Generic;

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -405,7 +405,7 @@ namespace Mono.Linker {
 						case "x":
 							if (!GetStringParam (token, l => {
 								foreach (string file in GetFiles (l))
-									p.PrependStep (new ResolveFromXmlStep (new XPathDocument (file)));
+									p.PrependStep (new ResolveFromXmlStep (new XPathDocument (file), file));
 
 								}))
 								return false;
@@ -499,6 +499,8 @@ namespace Mono.Linker {
 
 				if (dumpDependencies)
 					context.Tracer.AddRecorder (new XmlDependencyRecorder (context, dependenciesFileName));
+
+				context.Tracer.AddReflectionPatternRecorder (new LoggingReflectionPatternRecorder (context));
 
 				if (set_optimizations.Count > 0) {
 					foreach (var item in set_optimizations) {

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -500,8 +500,6 @@ namespace Mono.Linker {
 				if (dumpDependencies)
 					context.Tracer.AddRecorder (new XmlDependencyRecorder (context, dependenciesFileName));
 
-				context.Tracer.AddReflectionPatternRecorder (new LoggingReflectionPatternRecorder (context));
-
 				if (set_optimizations.Count > 0) {
 					foreach (var item in set_optimizations) {
 						if (item.Item3)

--- a/src/linker/Linker/IDependencyRecorder.cs
+++ b/src/linker/Linker/IDependencyRecorder.cs
@@ -50,6 +50,6 @@ namespace Mono.Linker
 		/// <remarks>The target is typically a Cecil metadata object (MethodDefinition, TypeDefinition, ...)
 		/// but can also be the linker steps or really any other object. "marked" may be false for a target that
 		/// is still marked for some other reason.</remarks>
-		void RecordDependency (object target, DependencyInfo reason, bool marked);
+		void RecordDependency (object target, in DependencyInfo reason, bool marked);
 	}
 }

--- a/src/linker/Linker/IDependencyRecorder.cs
+++ b/src/linker/Linker/IDependencyRecorder.cs
@@ -40,5 +40,16 @@ namespace Mono.Linker
 		/// <remarks>The source and target are typically Cecil metadata objects (MethodDefinition, TypeDefinition, ...)
 		/// but they can also be the linker steps or really any other object.</remarks>
 		void RecordDependency (object source, object target, bool marked);
+
+		/// <summary>
+		/// Reports a dependency detected by the linker, with a well-defined reason for keeping the dependency.
+		/// </summary>
+		/// <param name="target">The target of the dependency (for example the callee method).</param>
+		/// <param name="reason">The reason for including the target dependency (for example a direct call from another method).</param>
+		/// <param name="marked">true if the target is also marked by the MarkStep as a result of this particular reason.</param>
+		/// <remarks>The target is typically a Cecil metadata object (MethodDefinition, TypeDefinition, ...)
+		/// but can also be the linker steps or really any other object. "marked" may be false for a target that
+		/// is still marked for some other reason.</remarks>
+		void RecordDependency (object target, DependencyInfo reason, bool marked);
 	}
 }

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // LinkContext.cs
 //
 // Author:
@@ -156,8 +156,6 @@ namespace Mono.Linker {
 
 		public Tracer Tracer { get; private set; }
 
-		public IReflectionPatternRecorder ReflectionPatternRecorder { get; set; }
-
 		public string [] ExcludedFeatures { get; set; }
 
 		public CodeOptimizationsSettings Optimizations { get; set; }
@@ -196,7 +194,6 @@ namespace Mono.Linker {
 			_annotations = factory.CreateAnnotationStore (this);
 			MarkingHelpers = factory.CreateMarkingHelpers (this);
 			Tracer = factory.CreateTracer (this);
-			ReflectionPatternRecorder = new LoggingReflectionPatternRecorder (this);
 			MarkedKnownMembers = new KnownMembers ();
 			StripResources = true;
 			PInvokes = new List<PInvokeInfo> ();

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -156,6 +156,8 @@ namespace Mono.Linker {
 
 		public Tracer Tracer { get; private set; }
 
+		public IReflectionPatternRecorder ReflectionPatternRecorder { get; set; }
+
 		public string [] ExcludedFeatures { get; set; }
 
 		public CodeOptimizationsSettings Optimizations { get; set; }
@@ -194,6 +196,7 @@ namespace Mono.Linker {
 			_annotations = factory.CreateAnnotationStore (this);
 			MarkingHelpers = factory.CreateMarkingHelpers (this);
 			Tracer = factory.CreateTracer (this);
+			ReflectionPatternRecorder = new LoggingReflectionPatternRecorder (this);
 			MarkedKnownMembers = new KnownMembers ();
 			StripResources = true;
 			PInvokes = new List<PInvokeInfo> ();

--- a/src/linker/Linker/MarkingHelpers.cs
+++ b/src/linker/Linker/MarkingHelpers.cs
@@ -10,7 +10,7 @@ namespace Mono.Linker {
 			_context = context;
 		}
 
-		public void MarkExportedType (ExportedType type, ModuleDefinition module, DependencyInfo reason)
+		public void MarkExportedType (ExportedType type, ModuleDefinition module, in DependencyInfo reason)
 		{
 			_context.Annotations.Mark (type, reason);
 			if (_context.KeepTypeForwarderOnlyAssemblies)

--- a/src/linker/Linker/MarkingHelpers.cs
+++ b/src/linker/Linker/MarkingHelpers.cs
@@ -10,11 +10,11 @@ namespace Mono.Linker {
 			_context = context;
 		}
 
-		public void MarkExportedType (ExportedType type, ModuleDefinition module)
+		public void MarkExportedType (ExportedType type, ModuleDefinition module, DependencyInfo reason)
 		{
-			_context.Annotations.Mark (type);
+			_context.Annotations.Mark (type, reason);
 			if (_context.KeepTypeForwarderOnlyAssemblies)
-				_context.Annotations.Mark (module);
+				_context.Annotations.Mark (module, new DependencyInfo (DependencyKind.ModuleOfExportedType, type));
 		}
 	}
 }

--- a/src/linker/Linker/MethodBodyScanner.cs
+++ b/src/linker/Linker/MethodBodyScanner.cs
@@ -49,7 +49,7 @@ namespace Mono.Linker {
 			return true;
 		}
 
-		public static IEnumerable<InterfaceImplementation> GetReferencedInterfaces (AnnotationStore annotations, MethodBody body)
+		public static IEnumerable<(InterfaceImplementation, TypeDefinition)> GetReferencedInterfaces (AnnotationStore annotations, MethodBody body)
 		{
 			var possibleStackTypes = AllPossibleStackTypes (body.Method);
 			if (possibleStackTypes.Count == 0)
@@ -59,7 +59,7 @@ namespace Mono.Linker {
 			if (interfaceTypes.Length == 0)
 				return null;
 
-			var interfaceImplementations = new HashSet<InterfaceImplementation> ();
+			var interfaceImplementations = new HashSet<(InterfaceImplementation, TypeDefinition)> ();
 
 			// If a type could be on the stack in the body and an interface it implements could be on the stack on the body
 			// then we need to mark that interface implementation.  When this occurs it is not safe to remove the interface implementation from the type
@@ -126,11 +126,11 @@ namespace Mono.Linker {
 			return types;
 		}
 
-		static void AddMatchingInterfaces (HashSet<InterfaceImplementation> results, TypeDefinition type, TypeDefinition [] interfaceTypes)
+		static void AddMatchingInterfaces (HashSet<(InterfaceImplementation, TypeDefinition)> results, TypeDefinition type, TypeDefinition [] interfaceTypes)
 		{
 			foreach (var interfaceType in interfaceTypes) {
 				if (type.HasInterface (interfaceType, out InterfaceImplementation implementation))
-					results.Add (implementation);
+					results.Add ((implementation, type));
 			}
 		}
 

--- a/src/linker/Linker/Pipeline.cs
+++ b/src/linker/Linker/Pipeline.cs
@@ -130,9 +130,7 @@ namespace Mono.Linker {
 		
 		protected virtual void ProcessStep (LinkContext context, IStep step)
 		{
-			context.Tracer.Push (step);
 			step.Process (context);
-			context.Tracer.Pop ();
 		}
 
 		public IStep [] GetSteps ()

--- a/src/linker/Linker/Tracer.cs
+++ b/src/linker/Linker/Tracer.cs
@@ -28,7 +28,6 @@
 
 using System;
 using System.Collections.Generic;
-using Mono.Cecil;
 
 namespace Mono.Linker
 {
@@ -38,7 +37,6 @@ namespace Mono.Linker
 
 		Stack<object> dependency_stack;
 		List<IDependencyRecorder> recorders;
-		List<IReflectionPatternRecorder> reflectionPatternRecorders;
 
 		public Tracer (LinkContext context)
 		{
@@ -68,15 +66,6 @@ namespace Mono.Linker
 			recorders.Add (recorder);
 		}
 
-		public void AddReflectionPatternRecorder (IReflectionPatternRecorder recorder)
-		{
-			if (reflectionPatternRecorders == null) {
-				reflectionPatternRecorders = new List<IReflectionPatternRecorder> ();
-			}
-
-			reflectionPatternRecorders.Add (recorder);
-		}
-
 		public void Push (object o, bool addDependency = true)
 		{
 			if (!IsRecordingEnabled ())
@@ -99,11 +88,6 @@ namespace Mono.Linker
 		bool IsRecordingEnabled ()
 		{
 			return recorders != null;
-		}
-
-		bool IsReflectionRecordingEnabled ()
-		{
-			return reflectionPatternRecorders != null;
 		}
 
 		public void AddDirectDependency (object b, object e)
@@ -132,24 +116,6 @@ namespace Mono.Linker
 			if (IsRecordingEnabled ()) {
 				foreach (IDependencyRecorder recorder in recorders) {
 					recorder.RecordDependency (source, target, marked);
-				}
-			}
-		}
-
-		public void ReportUnrecognizedReflectionPattern (MethodDefinition sourceMethod, MethodDefinition reflectionMethod, string message)
-		{
-			if (IsReflectionRecordingEnabled ()) {
-				foreach (IReflectionPatternRecorder recorder in reflectionPatternRecorders) {
-					recorder.UnrecognizedReflectionAccessPattern (sourceMethod, reflectionMethod, message);
-				}
-			}
-		}
-
-		public void ReportRecognizedReflectionPattern (MethodDefinition sourceMethod, MethodDefinition reflectionMethod, IMemberDefinition accessedItem)
-		{
-			if (IsReflectionRecordingEnabled ()) {
-				foreach (IReflectionPatternRecorder recorder in reflectionPatternRecorders) {
-					recorder.RecognizedReflectionAccessPattern (sourceMethod, reflectionMethod, accessedItem);
 				}
 			}
 		}

--- a/src/linker/Linker/Tracer.cs
+++ b/src/linker/Linker/Tracer.cs
@@ -66,33 +66,9 @@ namespace Mono.Linker
 			recorders.Add (recorder);
 		}
 
-		public void Push (object o, bool addDependency = true)
-		{
-			if (!IsRecordingEnabled ())
-				return;
-
-			if (addDependency && dependency_stack.Count > 0)
-				AddDependency (o);
-
-			dependency_stack.Push (o);
-		}
-
-		public void Pop ()
-		{
-			if (!IsRecordingEnabled ())
-				return;
-
-			dependency_stack.Pop ();
-		}
-
 		bool IsRecordingEnabled ()
 		{
 			return recorders != null;
-		}
-
-		public void AddDirectDependency (object b, object e)
-		{
-			ReportDependency (b, e, false);
 		}
 
 		public void AddDirectDependency (object target, in DependencyInfo reason, bool marked)
@@ -100,23 +76,6 @@ namespace Mono.Linker
 			if (IsRecordingEnabled ()) {
 				foreach (IDependencyRecorder recorder in recorders)
 					recorder.RecordDependency (target, reason, marked);
-			}
-		}
-
-		public void AddDependency (object o, bool marked = false)
-		{
-			if (!IsRecordingEnabled ())
-				return;
-
-			ReportDependency (dependency_stack.Count > 0 ? dependency_stack.Peek () : null, o, marked);
-		}
-
-		private void ReportDependency (object source, object target, bool marked)
-		{
-			if (IsRecordingEnabled ()) {
-				foreach (IDependencyRecorder recorder in recorders) {
-					recorder.RecordDependency (source, target, marked);
-				}
 			}
 		}
 	}

--- a/src/linker/Linker/Tracer.cs
+++ b/src/linker/Linker/Tracer.cs
@@ -111,7 +111,7 @@ namespace Mono.Linker
 			ReportDependency (b, e, false);
 		}
 
-		public void AddDirectDependency (object target, DependencyInfo reason, bool marked)
+		public void AddDirectDependency (object target, in DependencyInfo reason, bool marked)
 		{
 			if (IsRecordingEnabled ()) {
 				foreach (IDependencyRecorder recorder in recorders)

--- a/src/linker/Linker/XmlDependencyRecorder.cs
+++ b/src/linker/Linker/XmlDependencyRecorder.cs
@@ -89,6 +89,12 @@ namespace Mono.Linker
 			stream = null;
 		}
 
+		public void RecordDependency (object target, DependencyInfo reason, bool marked)
+		{
+			// Used for the DependencyInfo-based recorders. Don't do anything as we only
+			// record dependencies for the stack-based recorder.
+		}
+
 		public void RecordDependency (object source, object target, bool marked)
 		{
 			if (!ShouldRecord (source) && !ShouldRecord (target))

--- a/src/linker/Linker/XmlDependencyRecorder.cs
+++ b/src/linker/Linker/XmlDependencyRecorder.cs
@@ -89,7 +89,7 @@ namespace Mono.Linker
 			stream = null;
 		}
 
-		public void RecordDependency (object target, DependencyInfo reason, bool marked)
+		public void RecordDependency (object target, in DependencyInfo reason, bool marked)
 		{
 			// Used for the DependencyInfo-based recorders. Don't do anything as we only
 			// record dependencies for the stack-based recorder.

--- a/src/linker/Linker/XmlDependencyRecorder.cs
+++ b/src/linker/Linker/XmlDependencyRecorder.cs
@@ -91,8 +91,8 @@ namespace Mono.Linker
 
 		public void RecordDependency (object target, in DependencyInfo reason, bool marked)
 		{
-			// Used for the DependencyInfo-based recorders. Don't do anything as we only
-			// record dependencies for the stack-based recorder.
+			// For now, just report a dependency from source to target without noting the DependencyKind.
+			RecordDependency (reason.Source, target, marked);
 		}
 
 		public void RecordDependency (object source, object target, bool marked)

--- a/src/linker/Linker/XmlDependencyRecorder.cs
+++ b/src/linker/Linker/XmlDependencyRecorder.cs
@@ -100,18 +100,16 @@ namespace Mono.Linker
 			if (!ShouldRecord (source) && !ShouldRecord (target))
 				return;
 
-			// This is a hack to work around a quirk of MarkStep that results in outputting ~6k edges even with the above ShouldRecord checks.
-			// What happens is that due to the method queueing in MarkStep, the dependency chain is broken in many cases.  And in these cases
-			// we end up adding an edge for MarkStep -> <queued Method>
-			// This isn't particularly useful information since it's incomplete, but it's especially not useful in ReducedTracing mode when there is one of these for
-			// every class library method that was queued.
-			if (context.EnableReducedTracing && source is MarkStep && !ShouldRecord (target))
+			// We use a few hacks to work around MarkStep outputting thousands of edges even
+			// with the above ShouldRecord checks. Ideally we would format these into a meaningful format
+			// however I don't think that is worth the effort at the moment.
+
+			// Prevent useless logging of attributes like `e="Other:Mono.Cecil.CustomAttribute"`.
+			if (source is CustomAttribute || target is CustomAttribute)
 				return;
 
-			// This is another hack to prevent useless information from being logged.  With the introduction of interface sweeping there are a lot of edges such as
-			// `e="InterfaceImpl:Mono.Cecil.InterfaceImplementation"` which are useless information.  Ideally we would format the interface implementation into a meaningful format
-			// however I don't think that is worth the effort at the moment.
-			if (target is InterfaceImplementation)
+			// Prevent useless logging of interface implementations like `e="InterfaceImpl:Mono.Cecil.InterfaceImplementation"`.
+			if (source is InterfaceImplementation || target is InterfaceImplementation)
 				return;
 
 			if (source != target) {

--- a/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadaProvider.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadaProvider.cs
@@ -93,7 +93,7 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 					attr.AttributeType.Name == nameof (UnrecognizedReflectionAccessPatternAttribute)))) {
 				customizations.ReflectionPatternRecorder = new TestReflectionPatternRecorder ();
 				customizations.CustomizeContext += context => {
-					context.ReflectionPatternRecorder = customizations.ReflectionPatternRecorder;
+					context.Tracer.AddReflectionPatternRecorder (customizations.ReflectionPatternRecorder);
 				};
 			};
 		}

--- a/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadaProvider.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadaProvider.cs
@@ -93,7 +93,7 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 					attr.AttributeType.Name == nameof (UnrecognizedReflectionAccessPatternAttribute)))) {
 				customizations.ReflectionPatternRecorder = new TestReflectionPatternRecorder ();
 				customizations.CustomizeContext += context => {
-					context.Tracer.AddReflectionPatternRecorder (customizations.ReflectionPatternRecorder);
+					context.ReflectionPatternRecorder = customizations.ReflectionPatternRecorder;
 				};
 			};
 		}

--- a/test/Mono.Linker.Tests/TestCasesRunner/TestDependencyRecorder.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestDependencyRecorder.cs
@@ -21,5 +21,14 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				Marked = marked
 			});
 		}
+
+		public void RecordDependency (object target, DependencyInfo reason, bool marked)
+		{
+			Dependencies.Add (new Dependency () {
+				Source = reason.Source?.ToString (),
+				Target = target.ToString (),
+				Marked = marked
+			});
+		}
 	}
 }

--- a/test/Mono.Linker.Tests/TestCasesRunner/TestDependencyRecorder.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestDependencyRecorder.cs
@@ -22,7 +22,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			});
 		}
 
-		public void RecordDependency (object target, DependencyInfo reason, bool marked)
+		public void RecordDependency (object target, in DependencyInfo reason, bool marked)
 		{
 			Dependencies.Add (new Dependency () {
 				Source = reason.Source?.ToString (),


### PR DESCRIPTION
This supplies a "reason" every time that we mark a piece of IL.

A "reason" is an instance of a new type, DependencyInfo, which tracks
a single source object and a flag (DependencyKind) indicating what
kind of dependency this is. Annotations.Mark now expects a
DependencyInfo, and the dependency reporting interface is extended to
report these reasons.

The mark sites within MarkStep and other steps have been updated with
specific reasons, and the corresponding Mark* methods have been
modified to take a reason that is passed through as many layers of the
marking logic as necessary until it reaches a call to
Annotations.Mark. The marking logic has been modified to more
frequently allow marking Cecil objects multiple times for different
reasons - while still ensuring that any expensive operations are done
only once per object (usually under an IsProcessed check, rather than
an IsMarked check).

In a few cases, the marking logic will process a Cecil object and mark
its dependencies, without marking the original Cecil object. This can
happen, for example, for custom attributes in some cases, or for
generic instantiations (since we only mark definitions). In these
cases, there are extra calls that report these intermediate
dependencies to the tracing interface without actually marking them.

Some of the DependencyKinds (for example AlreadyMarked) are only used
for internal tracking, and will not be reported to the dependency
tracing interface.

The set of DependencyKinds has been selected based on what seems like
an intuitive reason to report for each object, though sometimes the
choice is not obvious since the reasons are restricted to supplying a
single source object. Some interesting cases where potentially
non-obvious choices were made follow:

- When marking overrides on instantiated type, we choose as the reason
the instantiated type, rather than the base method (unless the
override removal optimization is disabled, in which case
instantiations are not taken into account when marking overrides - so
we blame the base method).

- When marking static constructors, we keep track of cases where they
are marked due to a field access or method call from another method,
and report these separately. For cases where we track enough
information to do so, this results in a more direct dependency chain
like: "method A triggers static constructor B", rather than "method A
access field B, field B has declaring type C, declaring type C has
static constructor D".

- When marking custom attributes on assemblies or modules, we record a
dependency from the assembly/module to the attribute, even though the
assembly/module may not have been marked or even recorded. Since the
attributes and their dependencies are kept regardless of what happens
to the assembly, these are conceptually entry points to the analysis.

This also includes a change that moves the reflection reporter from
LinkContext to Tracer, and extended to support multiple sinks, similar
to the dependency reporting.

I have also added assertions in a few places where I think it makes
sense to check invariants when we are running tests in Debug mode.