### PR TITLE
Preserve marked children of XML descriptor

### DIFF
--- a/src/linker/Linker.Steps/ResolveFromXmlStep.cs
+++ b/src/linker/Linker.Steps/ResolveFromXmlStep.cs
@@ -247,6 +247,7 @@ namespace Mono.Linker.Steps {
 
 			if (!IsRequired (nav)) {
 				Annotations.SetPreserve (type, preserve);
+				MarkChildren (type, nav);
 				return;
 			}
 
@@ -270,12 +271,7 @@ namespace Mono.Linker.Steps {
 			if (preserve != TypePreserve.Nothing)
 				Annotations.SetPreserve (type, preserve);
 
-			if (nav.HasChildren) {
-				MarkSelectedFields (nav, type);
-				MarkSelectedMethods (nav, type);
-				MarkSelectedEvents (nav, type);
-				MarkSelectedProperties (nav, type);
-			}
+			MarkChildren (type, nav);
 			Tracer.Pop ();
 		}
 
@@ -286,6 +282,16 @@ namespace Mono.Linker.Steps {
 				return;
 
 			ProcessFields (type, fields);
+		}
+
+		private void MarkChildren (TypeDefinition type, XPathNavigator nav)
+		{
+			if (nav.HasChildren) {
+				MarkSelectedFields (nav, type);
+				MarkSelectedMethods (nav, type);
+				MarkSelectedEvents (nav, type);
+				MarkSelectedProperties (nav, type);
+			}
 		}
 
 		void MarkSelectedMethods (XPathNavigator nav, TypeDefinition type)

--- a/src/linker/Linker.Steps/ResolveFromXmlStep.cs
+++ b/src/linker/Linker.Steps/ResolveFromXmlStep.cs
@@ -244,10 +244,10 @@ namespace Mono.Linker.Steps {
 				return;
 			
 			TypePreserve preserve = GetTypePreserve (nav);
+			MarkChildren (type, nav);
 
 			if (!IsRequired (nav)) {
 				Annotations.SetPreserve (type, preserve);
-				MarkChildren (type, nav);
 				return;
 			}
 
@@ -271,7 +271,6 @@ namespace Mono.Linker.Steps {
 			if (preserve != TypePreserve.Nothing)
 				Annotations.SetPreserve (type, preserve);
 
-			MarkChildren (type, nav);
 			Tracer.Pop ();
 		}
 

--- a/src/linker/Linker.Steps/ResolveFromXmlStep.cs
+++ b/src/linker/Linker.Steps/ResolveFromXmlStep.cs
@@ -283,7 +283,7 @@ namespace Mono.Linker.Steps {
 			ProcessFields (type, fields);
 		}
 
-		private void MarkChildren (TypeDefinition type, XPathNavigator nav)
+		void MarkChildren (TypeDefinition type, XPathNavigator nav)
 		{
 			if (nav.HasChildren) {
 				MarkSelectedFields (nav, type);

--- a/test/Mono.Linker.Tests.Cases/LinkXml/CanPreserveMarkedChildrenOfUnrequiredType.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/CanPreserveMarkedChildrenOfUnrequiredType.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.LinkXml.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.LinkXml
+{
+	[SetupCompileBefore ("Library.dll", new [] { "Dependencies/CanPreserveMarkedChildrenOfUnrequiredType_Library.cs" })]
+	[KeptMemberInAssembly ("Library.dll", typeof (CanPreserveMarkedChildrenOfUnrequiredType_Library), "Field1", "Method1()", "Property1")]
+
+	class CanPreserveMarkedChildrenOfUnrequiredType
+	{
+		public static void Main () {
+			// Mark the type by calling its ctor.
+			new CanPreserveMarkedChildrenOfUnrequiredType_Library ();
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/LinkXml/CanPreserveMarkedChildrenOfUnrequiredType.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/CanPreserveMarkedChildrenOfUnrequiredType.cs
@@ -7,6 +7,7 @@ namespace Mono.Linker.Tests.Cases.LinkXml
 {
 	[SetupCompileBefore ("Library.dll", new [] { "Dependencies/CanPreserveMarkedChildrenOfUnrequiredType_Library.cs" })]
 	[KeptMemberInAssembly ("Library.dll", typeof (CanPreserveMarkedChildrenOfUnrequiredType_Library), "Field1", "Method1()", "Property1")]
+	[RemovedMemberInAssembly ("Library.dll", typeof (CanPreserveMarkedChildrenOfUnrequiredType_Library), "Field2", "Method2()", "Property2")]
 
 	class CanPreserveMarkedChildrenOfUnrequiredType
 	{

--- a/test/Mono.Linker.Tests.Cases/LinkXml/CanPreserveMarkedChildrenOfUnrequiredType.xml
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/CanPreserveMarkedChildrenOfUnrequiredType.xml
@@ -1,0 +1,9 @@
+﻿<linker>
+  <assembly fullname="Library, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+    <type fullname="Mono.Linker.Tests.Cases.LinkXml.Dependencies.CanPreserveMarkedChildrenOfUnrequiredType_Library" required="false">
+      <field name="Field1" />
+      <method name="Method1" />
+      <property name="Property1" />
+    </type>
+  </assembly>
+</linker>

--- a/test/Mono.Linker.Tests.Cases/LinkXml/Dependencies/CanPreserveMarkedChildrenOfUnrequiredType_Library.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/Dependencies/CanPreserveMarkedChildrenOfUnrequiredType_Library.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+namespace Mono.Linker.Tests.Cases.LinkXml.Dependencies
+{
+	public class CanPreserveMarkedChildrenOfUnrequiredType_Library
+	{
+		public int Field1;
+		
+		public int Field2;
+		
+		public void Method1 () { }
+		
+		public void Method2 () { }
+		
+		public int Property1 {
+			get {
+				return Field1;
+			}
+			set {
+				Field1 = value;
+			}
+		}
+		
+		public int Property2 {
+			get {
+				return Field2;
+			}
+			set {
+				Field2 = value;
+			}
+		}
+	}
+}


### PR DESCRIPTION
This fixes #965 by preserving all children marked in a XML descriptor regardless of the `required` attribute value.