### PR TITLE
Fix for pinvoke output test

### DIFF
--- a/test/Mono.Linker.Tests/TestCases/IndividualTests.cs
+++ b/test/Mono.Linker.Tests/TestCases/IndividualTests.cs
@@ -19,6 +19,8 @@ namespace Mono.Linker.Tests.TestCases
 	[TestFixture]
 	public class IndividualTests
 	{
+		private NPath TestsDirectory => TestDatabase.TestCasesRootDirectory.Parent.Combine ("Mono.Linker.Tests");
+	
 		[Test]
 		public void CanSkipUnresolved ()
 		{
@@ -45,7 +47,7 @@ namespace Mono.Linker.Tests.TestCases
 			var jsonSerializer = new DataContractJsonSerializer (typeof (List<PInvokeInfo>));
 
 			using (var fsActual = File.Open(outputPath, FileMode.Open))
-			using (var fsExpected = File.Open("TestCases/Dependencies/PInvokesExpectations.json", FileMode.Open)) {
+			using (var fsExpected = File.Open (TestsDirectory.Combine ("TestCases/Dependencies/PInvokesExpectations.json"), FileMode.Open)) {
 				var actual = jsonSerializer.ReadObject (fsActual) as List<PInvokeInfo>;
 				var expected = jsonSerializer.ReadObject (fsExpected) as List<PInvokeInfo>;
 				foreach (var pinvokePair in Enumerable.Zip(actual, expected, (fst, snd) => Tuple.Create(fst, snd))) {

--- a/test/Mono.Linker.Tests/TestCases/TestDatabase.cs
+++ b/test/Mono.Linker.Tests/TestCases/TestDatabase.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using NUnit.Framework;
 using System.Runtime.CompilerServices;
 using System.IO;
+using Mono.Linker.Tests.Extensions;
 using Mono.Linker.Tests.TestCasesRunner;
 
 namespace Mono.Linker.Tests.TestCases
@@ -160,6 +161,13 @@ namespace Mono.Linker.Tests.TestCases
 		{
 			GetDirectoryPaths (out string rootSourceDirectory, out string testCaseAssemblyPath);
 			return new TestCaseCollector (rootSourceDirectory, testCaseAssemblyPath);
+		}
+
+		public static NPath TestCasesRootDirectory {
+			get {
+				GetDirectoryPaths (out string rootSourceDirectory, out string _);
+				return rootSourceDirectory.ToNPath ();
+			}
 		}
 
 		static IEnumerable<TestCase> AllCases ()


### PR DESCRIPTION
Don't assume that the test is running from the project directory.  Some test runners will set the CurrentDirectory to a temporary directory.