### PR TITLE
Add reflection pattern recorder if needed by any nested type

### DIFF
--- a/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadaProvider.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadaProvider.cs
@@ -95,7 +95,18 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 				customizations.CustomizeContext += context => {
 					context.ReflectionPatternRecorder = customizations.ReflectionPatternRecorder;
 				};
-			};
+			} else if (_testCaseTypeDefinition.HasNestedTypes
+				  && _testCaseTypeDefinition.NestedTypes.Any (nestedType =>
+					  nestedType.CustomAttributes.Any (attr =>
+						  attr.AttributeType.Name == nameof (VerifyAllReflectionAccessPatternsAreValidatedAttribute)
+					  || _testCaseTypeDefinition.AllMethods ().Any (method => method.CustomAttributes.Any (attr =>
+						  attr.AttributeType.Name == nameof (RecognizedReflectionAccessPatternAttribute) ||
+						  attr.AttributeType.Name == nameof (UnrecognizedReflectionAccessPatternAttribute)))))) {
+				customizations.ReflectionPatternRecorder = new TestReflectionPatternRecorder ();
+				customizations.CustomizeContext += context => {
+					context.ReflectionPatternRecorder = customizations.ReflectionPatternRecorder;
+				};
+			}
 		}
 
 #if NETCOREAPP


### PR DESCRIPTION
This would allow us to use reflection assertions inside nested types, e.g.:

```C#
public class Foo {
	public static void Main () {
		new Bar ();
	}

	class Bar {
		[UnrecognizedReflectionAccessPattern ( ... )]
		public void SomeMethodToCheck () { .. }
	}
}
```