### PR TITLE
[feature/dataflow] Propagate data flow annotations across method calls

### DIFF
--- a/src/linker/Linker.Dataflow/AttributeFlowAnnotationSource.cs
+++ b/src/linker/Linker.Dataflow/AttributeFlowAnnotationSource.cs
@@ -1,0 +1,60 @@
+﻿using Mono.Cecil;
+using System;
+using System.Diagnostics;
+
+namespace Mono.Linker.Dataflow
+{
+	class AttributeFlowAnnotationSource : IFlowAnnotationSource
+	{
+		public DynamicallyAccessedMemberKinds GetFieldAnnotation (FieldDefinition field)
+		{
+			return Get (field);
+		}
+
+		public DynamicallyAccessedMemberKinds GetParameterAnnotation (MethodDefinition method, int index)
+		{
+			return Get (method.Parameters [index]);
+		}
+
+		public DynamicallyAccessedMemberKinds GetPropertyAnnotation (PropertyDefinition property)
+		{
+			return Get (property);
+		}
+
+		public DynamicallyAccessedMemberKinds GetReturnParameterAnnotation (MethodDefinition method)
+		{
+			return Get (method.MethodReturnType);
+		}
+
+		static bool IsDynamicallyAccessedMembersAttribute (CustomAttribute attribute)
+		{
+			var attributeType = attribute.AttributeType;
+			return attributeType.Name == "DynamicallyAccessedMembersAttribute" && attributeType.Namespace == "System.Runtime.CompilerServices";
+		}
+
+		static DynamicallyAccessedMemberKinds GetFromAttribute (CustomAttribute attribute)
+		{
+			Debug.Assert (IsDynamicallyAccessedMembersAttribute (attribute));
+
+			if (attribute.HasConstructorArguments) {
+				return (DynamicallyAccessedMemberKinds)(int)attribute.ConstructorArguments [0].Value;
+			}
+
+			return 0;
+		}
+
+		static DynamicallyAccessedMemberKinds Get (ICustomAttributeProvider attributeProvider)
+		{
+			if (!attributeProvider.HasCustomAttributes)
+				return 0;
+
+			foreach (var attribute in attributeProvider.CustomAttributes) {
+				if (IsDynamicallyAccessedMembersAttribute (attribute)) {
+					return GetFromAttribute (attribute);
+				}
+			}
+
+			return 0;
+		}
+	}
+}

--- a/src/linker/Linker.Dataflow/FlowAnnotations.cs
+++ b/src/linker/Linker.Dataflow/FlowAnnotations.cs
@@ -34,7 +34,7 @@ namespace Mono.Linker.Dataflow
 		/// <returns></returns>
 		public DynamicallyAccessedMemberKinds GetParameterAnnotation (MethodDefinition method, int parameterIndex)
 		{
-			if (GetAnnotations (method.DeclaringType).TryGetAnnotation (method, out var annotation)) {
+			if (GetAnnotations (method.DeclaringType).TryGetAnnotation (method, out var annotation) && annotation.ParameterAnnotations != null) {
 				return annotation.ParameterAnnotations [parameterIndex];
 			}
 

--- a/src/linker/Linker.Dataflow/MethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/MethodBodyScanner.cs
@@ -615,6 +615,8 @@ namespace Mono.Linker.Dataflow
 			}
 		}
 
+		protected abstract ValueNode GetMethodParameterValue (MethodDefinition method, int parameterIndex);
+
 		private void ScanLdarg (Instruction operation, Stack<StackSlot> currentStack, MethodDefinition thisMethod, MethodBody methodBody)
 		{
 			int paramNum;
@@ -628,7 +630,7 @@ namespace Mono.Linker.Dataflow
 			}
 
 			// TODO: isbyref
-			StackSlot slot = new StackSlot (new MethodParameterValue (paramNum), isByRef: false);
+			StackSlot slot = new StackSlot (GetMethodParameterValue (thisMethod, paramNum), isByRef: false);
 			currentStack.Push (slot);
 		}
 

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -50,6 +50,8 @@ namespace Mono.Linker.Steps {
 		protected List<TypeDefinition> _typesWithInterfaces;
 		protected List<MethodBody> _unreachableBodies;
 
+		readonly FlowAnnotations _flowAnnotations;
+
 		public MarkStep ()
 		{
 			_methods = new Queue<MethodDefinition> ();
@@ -58,6 +60,8 @@ namespace Mono.Linker.Steps {
 			_lateMarkedAttributes = new Queue<AttributeProviderPair> ();
 			_typesWithInterfaces = new List<TypeDefinition> ();
 			_unreachableBodies = new List<MethodBody> ();
+
+			_flowAnnotations = new FlowAnnotations (new AttributeFlowAnnotationSource (), _context);
 		}
 
 		public AnnotationStore Annotations => _context.Annotations;
@@ -2377,7 +2381,7 @@ namespace Mono.Linker.Steps {
 				return;
 
 			var scanner = new ReflectionMethodBodyScanner (this);
-			scanner.Scan (body);
+			scanner.ScanAndProcessReturnValue (body);
 
 			var instructions = body.Instructions;
 			ReflectionPatternDetector detector = new ReflectionPatternDetector (this, body.Method);
@@ -3379,10 +3383,26 @@ namespace Mono.Linker.Steps {
 		private class ReflectionMethodBodyScanner : Dataflow.MethodBodyScanner
 		{
 			private readonly MarkStep _markStep;
+			private readonly FlowAnnotations _flowAnnotations;
 
 			public ReflectionMethodBodyScanner(MarkStep parent)
 			{
 				_markStep = parent;
+				_flowAnnotations = _markStep._flowAnnotations;
+			}
+
+			public void ScanAndProcessReturnValue (MethodBody methodBody)
+			{
+				Scan (methodBody);
+
+				if (MethodReturnValue != null) {
+					var requiredMemberKinds = _flowAnnotations.GetReturnParameterAnnotation (methodBody.Method);
+					if (requiredMemberKinds != 0) {
+						var reflectionContext = new ReflectionPatternContext (_markStep._context, methodBody.Method, methodBody.Method, 0);
+						reflectionContext.AnalyzingPattern ();
+						RequireDynamicallyAccessedMembers (ref reflectionContext, requiredMemberKinds, MethodReturnValue);
+					}
+				}
 			}
 
 			protected override void WarnAboutInvalidILInMethod (MethodBody method, int ilOffset)
@@ -3392,13 +3412,31 @@ namespace Mono.Linker.Steps {
 				throw new Exception ();
 			}
 
+			protected override ValueNode GetMethodParameterValue (MethodDefinition method, int parameterIndex)
+			{
+				DynamicallyAccessedMemberKinds memberKinds = _flowAnnotations.GetParameterAnnotation (method, parameterIndex);
+				return new MethodParameterValue (parameterIndex, memberKinds) {
+					SourceContext = method
+				};
+			}
+
 			public override bool HandleCall (MethodBody callingMethodBody, MethodReference calledMethod, Instruction operation, ValueNodeList methodParams, out ValueNode methodReturnValue)
 			{
 				var reflectionContext = new ReflectionPatternContext (_markStep._context, callingMethodBody.Method, calledMethod.Resolve (), operation.Offset);
 
+				DynamicallyAccessedMemberKinds returnValueDynamicallyAccessedMemberKinds = 0;
+
 				try {
 
 					methodReturnValue = null;
+
+					var calledMethodDefinition = calledMethod.Resolve ();
+					if (calledMethodDefinition == null)
+						return false;
+
+					bool requiresDataFlowAnalysis = _flowAnnotations.RequiresDataFlowAnalysis (calledMethodDefinition);
+					returnValueDynamicallyAccessedMemberKinds =  requiresDataFlowAnalysis ?
+						_flowAnnotations.GetReturnParameterAnnotation (calledMethodDefinition) : 0;
 
 					switch (calledMethod.Name) {
 						case "GetTypeInfo" when calledMethod.DeclaringType.Name == "IntrospectionExtensions": {
@@ -3411,9 +3449,8 @@ namespace Mono.Linker.Steps {
 
 						case "GetTypeFromHandle" when calledMethod.DeclaringType.Name == "Type": {
 								// Infrastructure piece to support "typeof(Foo)"
-								var typeHnd = methodParams[0] as RuntimeTypeHandleValue;
-								if (typeHnd != null)
-									methodReturnValue = new SystemTypeValue (typeHnd.TypeRepresented);
+								if (methodParams[0] is RuntimeTypeHandleValue typeHandle)
+									methodReturnValue = new SystemTypeValue (typeHandle.TypeRepresented);
 							}
 							break;
 
@@ -3485,22 +3522,42 @@ namespace Mono.Linker.Steps {
 								// Go over all types we've seen
 								foreach (var value in methodParams[0].UniqueValues ()) {
 									if (value is SystemTypeValue systemTypeValue) {
+										// Special case known type values as we can do better by applying exact binding flags and parameter count.
 										MarkMethodsFromReflectionCall (ref reflectionContext, systemTypeValue.TypeRepresented, ".ctor", bindingFlags, ctorParameterCount);
-									} else if (value == NullValue.Instance) {
-										// Nothing to report. This is likely just a value on some unreachable branch.
-										reflectionContext.RecordHandledPattern ();
-									} else if (value is MethodParameterValue methodParameterValue) {
-										// This is the case where the value comes from a method parameter.
-										// TODO: If the parameter is annotated, we're good. If it's not annotated, we shold warn.
-										reflectionContext.RecordUnrecognizedPattern ($"Activator call '{calledMethod.FullName}' inside '{callingMethodBody.Method.FullName}' was detected with 1st argument expression which cannot be analyzed");
 									} else {
-										// Not known where the value is coming from
-										reflectionContext.RecordUnrecognizedPattern ($"Activator call '{calledMethod.FullName}' inside '{callingMethodBody.Method.FullName}' was detected with 1st argument expression which cannot be analyzed");
+										// Otherwise fall back to the bitfield requirements
+										var requiredMemberKinds = ctorParameterCount == 0
+											? DynamicallyAccessedMemberKinds.DefaultConstructor
+											: ((bindingFlags & BindingFlags.NonPublic) == 0)
+												? DynamicallyAccessedMemberKinds.PublicConstructors
+												: DynamicallyAccessedMemberKinds.Constructors;
+										RequireDynamicallyAccessedMembers (ref reflectionContext, requiredMemberKinds, value);
 									}
 								}
 							}
 							break;
 						default:
+							if (requiresDataFlowAnalysis) {
+								reflectionContext.AnalyzingPattern ();
+								for (int parameterIndex = 0; parameterIndex < methodParams.Count; parameterIndex ++) {
+									var requiredMemberKinds = _flowAnnotations.GetParameterAnnotation (calledMethodDefinition, parameterIndex);
+									if (requiredMemberKinds != 0)
+										RequireDynamicallyAccessedMembers (ref reflectionContext, requiredMemberKinds, methodParams [parameterIndex]);
+								}
+
+								reflectionContext.RecordHandledPattern ();
+							}
+
+							// To get good reporting of errors we need to track the origin of the value for all method calls
+							// but except Newobj as those are special.
+							if (calledMethodDefinition.ReturnType.MetadataType != MetadataType.Void && operation.OpCode.Code != Code.Newobj) {
+								methodReturnValue = new MethodReturnValue (returnValueDynamicallyAccessedMemberKinds) {
+									SourceContext = calledMethodDefinition
+								};
+
+								return true;
+							}
+
 							return false;
 					}
 				}
@@ -3513,11 +3570,56 @@ namespace Mono.Linker.Steps {
 				// unknown value with the return type of the method.
 				if (methodReturnValue == null) {
 					if (calledMethod.ReturnType.MetadataType != MetadataType.Void) {
-						methodReturnValue = UnknownValue.Instance;
+						methodReturnValue = new MethodReturnValue(returnValueDynamicallyAccessedMemberKinds);
+					}
+				}
+
+				// Validate that the return value has the correct annotations as per the method return value annotations
+				if (returnValueDynamicallyAccessedMemberKinds != 0 && methodReturnValue != null) {
+					if (methodReturnValue is LeafValueWithDynamicallyAccessedMemberNode methodReturnValueWithMemberKinds) {
+						if (!methodReturnValueWithMemberKinds.DynamicallyAccessedMemberKinds.HasFlag (returnValueDynamicallyAccessedMemberKinds))
+							throw new InvalidOperationException ($"Internal linker error: processing of call from {callingMethodBody.Method} to {calledMethod} returned value which is not correctly annotated with the expected dynamic member access kinds.");
+					}
+					else if (methodReturnValue is SystemTypeValue) {
+						// SystemTypeValue can fullfill any requirement, so it's always valid
+					}
+					else {
+						throw new InvalidOperationException ($"Internal linker error: processing of call from {callingMethodBody.Method} to {calledMethod} returned value which is not correctly annotated with the expected dynamic member access kinds.");
 					}
 				}
 
 				return true;
+			}
+
+			void RequireDynamicallyAccessedMembers(ref ReflectionPatternContext reflectionContext, DynamicallyAccessedMemberKinds requiredMemberKinds, ValueNode value)
+			{
+				foreach (var uniqueValue in value.UniqueValues ()) {
+					if (uniqueValue is LeafValueWithDynamicallyAccessedMemberNode valueWithDynamicallyAccessedMember) {
+						if (!valueWithDynamicallyAccessedMember.DynamicallyAccessedMemberKinds.HasFlag (requiredMemberKinds)) {
+							reflectionContext.RecordUnrecognizedPattern ($"Value from {valueWithDynamicallyAccessedMember.SourceContext} doesn't have enough dynamically accessed members required by {reflectionContext.MethodCalled}.");
+						} else {
+							reflectionContext.RecordHandledPattern ();
+						}
+					} else if (uniqueValue is SystemTypeValue systemTypeValue) {
+						// Note that it's important to first test for the widest selector (Constructors > PublicConstructors > DefaultConstructor)
+						// as the wider ones include the narrower ones in the bitfield values.
+						if (requiredMemberKinds.HasFlag(DynamicallyAccessedMemberKinds.Constructors)) {
+							MarkMethodsFromReflectionCall (ref reflectionContext, systemTypeValue.TypeRepresented, ".ctor", bindingFlags: null);
+						} else if (requiredMemberKinds.HasFlag(DynamicallyAccessedMemberKinds.PublicConstructors)) {
+							MarkMethodsFromReflectionCall (ref reflectionContext, systemTypeValue.TypeRepresented, ".ctor", BindingFlags.Public);
+						} else if (requiredMemberKinds.HasFlag(DynamicallyAccessedMemberKinds.DefaultConstructor)) {
+							MarkMethodsFromReflectionCall (ref reflectionContext, systemTypeValue.TypeRepresented, ".ctor", bindingFlags: null, parametersCount: 0);
+						} else {
+							throw new NotImplementedException ();
+						}
+					} else if (uniqueValue == NullValue.Instance) {
+						// Ignore - probably unreachable path as it would fail at runtime anyway.
+					} else {
+						reflectionContext.RecordUnrecognizedPattern ($"Value comes from unsupported source.");
+					}
+				}
+
+				reflectionContext.RecordHandledPattern ();
 			}
 
 			void MarkMethodsFromReflectionCall (ref ReflectionPatternContext reflectionContext, TypeDefinition declaringType, string name, BindingFlags? bindingFlags, int? parametersCount = null)
@@ -3549,8 +3651,10 @@ namespace Mono.Linker.Steps {
 					reflectionContext.RecordRecognizedPattern (method, () => _markStep.MarkIndirectlyCalledMethod (method));
 				}
 
-				if (!foundMatch)
-					reflectionContext.RecordUnrecognizedPattern ($"Reflection call '{reflectionContext.MethodCalled.FullName}' inside '{reflectionContext.MethodCalling.FullName}' could not resolve method `{name}` on type `{declaringType.FullName}`.");
+				if (!foundMatch) {
+					bool publicOnly = (bindingFlags & (BindingFlags.Public | BindingFlags.NonPublic)) == BindingFlags.Public;
+					reflectionContext.RecordUnrecognizedPattern ($"Reflection call '{reflectionContext.MethodCalled.FullName}' inside '{reflectionContext.MethodCalling.FullName}' could not resolve {(publicOnly ? "public" : "")} method `{name}` on type `{declaringType.FullName}`.");
+				}
 			}
 		}
 	}

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -3550,7 +3550,7 @@ namespace Mono.Linker.Steps {
 
 							// To get good reporting of errors we need to track the origin of the value for all method calls
 							// but except Newobj as those are special.
-							if (calledMethodDefinition.ReturnType.MetadataType != MetadataType.Void && operation.OpCode.Code != Code.Newobj) {
+							if (calledMethodDefinition.ReturnType.MetadataType != MetadataType.Void) {
 								methodReturnValue = new MethodReturnValue (returnValueDynamicallyAccessedMemberKinds) {
 									SourceContext = calledMethodDefinition
 								};

--- a/test/Mono.Linker.Tests.Cases.Expectations/Assertions/RecognizedReflectionAccessPatternAttribute.cs
+++ b/test/Mono.Linker.Tests.Cases.Expectations/Assertions/RecognizedReflectionAccessPatternAttribute.cs
@@ -5,6 +5,12 @@ namespace Mono.Linker.Tests.Cases.Expectations.Assertions
 	[AttributeUsage (AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
 	public class RecognizedReflectionAccessPatternAttribute : BaseExpectedLinkedBehaviorAttribute
 	{
+		// The default .ctor has a special meaning - don't validate any specifically recognized reflection access patterns
+		// but it will trigger the overall validation that all unrecognized patterns are expected.
+		public RecognizedReflectionAccessPatternAttribute ()
+		{
+		}
+
 		public RecognizedReflectionAccessPatternAttribute (Type reflectionMethodType, string reflectionMethodName, Type[] reflectionMethodParameters,
 			Type accessedItemType, string accessedItemName, Type[] accessedItemParameters)
 		{

--- a/test/Mono.Linker.Tests.Cases.Expectations/Support/DynamicallyAccessedMembersAttribute.cs
+++ b/test/Mono.Linker.Tests.Cases.Expectations/Support/DynamicallyAccessedMembersAttribute.cs
@@ -1,0 +1,30 @@
+﻿namespace System.Runtime.CompilerServices
+{
+	[Flags]
+	public enum DynamicallyAccessedMemberKinds
+	{
+		DefaultConstructor = 0b00000000_00000001,
+		PublicConstructors = 0b00000000_00000011,
+		Constructors = 0b00000000_00000111,
+		PublicMethods = 0b00000000_00001000,
+		Methods = 0b00000000_00011000,
+		PublicFields = 0b00000000_00100000,
+		Fields = 0b00000000_01100000,
+		PublicNestedTypes = 0b00000000_10000000,
+		NestedTypes = 0b00000001_10000000,
+		PublicProperties = 0b00000010_00000000,
+		Properties = 0b00000110_00000000,
+		PublicEvents = 0b00001000_00000000,
+		Events = 0b00011000_00000000,
+	}
+
+	public class DynamicallyAccessedMembersAttribute : Attribute
+	{
+		public DynamicallyAccessedMemberKinds MemberKinds { get; }
+
+		public DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberKinds memberKinds)
+		{
+			MemberKinds = memberKinds;
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MethodParametersDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MethodParametersDataFlow.cs
@@ -1,0 +1,197 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Mono.Linker.Tests.Cases.DataFlow
+{
+	[SetupCSharpCompilerToUse ("csc")]
+	[KeptMember(".ctor()")]
+	public class MethodParametersDataFlow
+	{
+		public static void Main ()
+		{
+			var instance = new MethodParametersDataFlow ();
+
+			DefaultConstructorParameter (typeof (TestType));
+			PublicConstructorsParameter (typeof (TestType));
+			ConstructorsParameter (typeof (TestType));
+			instance.InstanceMethod (typeof (TestType));
+			instance.TwoAnnotatedParameters (typeof (TestType), typeof (TestType));
+			instance.TwoAnnotatedParametersIntoOneValue(typeof (TestType), typeof (TestType));
+			instance.NoAnnotation (typeof (TestType));
+			instance.UnknownValue ();
+			instance.AnnotatedValueToUnAnnotatedParameter (typeof (TestType));
+			instance.UnknownValueToUnAnnotatedParameter ();
+			instance.UnknownValueToUnAnnotatedParameterOnInterestingMethod ();
+		}
+
+		[Kept]
+		[UnrecognizedReflectionAccessPattern (typeof (MethodParametersDataFlow), nameof (RequirePublicConstructors), new Type [] { typeof (Type) })]
+		[UnrecognizedReflectionAccessPattern (typeof (MethodParametersDataFlow), nameof (RequireConstructors), new Type [] { typeof (Type) })]
+		private static void DefaultConstructorParameter (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.DefaultConstructor)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type type)
+		{
+			RequireDefaultConstructor (type);
+			RequirePublicConstructors (type);
+			RequireConstructors (type);
+		}
+
+		[Kept]
+		[UnrecognizedReflectionAccessPattern (typeof (MethodParametersDataFlow), nameof (RequireConstructors), new Type [] { typeof (Type) })]
+		private static void PublicConstructorsParameter (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.PublicConstructors)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type type)
+		{
+			RequireDefaultConstructor (type);
+			RequirePublicConstructors (type);
+			RequireConstructors (type);
+		}
+
+		[RecognizedReflectionAccessPattern]
+		[Kept]
+		private static void ConstructorsParameter (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.Constructors)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type type)
+		{
+			RequireDefaultConstructor (type);
+			RequirePublicConstructors (type);
+			RequireConstructors (type);
+		}
+
+		[UnrecognizedReflectionAccessPattern (typeof (MethodParametersDataFlow), nameof (RequirePublicConstructors), new Type [] { typeof (Type) })]
+		[Kept]
+		private void InstanceMethod (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.DefaultConstructor)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type type)
+		{
+			RequireDefaultConstructor (type);
+			RequirePublicConstructors (type);
+		}
+
+		[UnrecognizedReflectionAccessPattern (typeof (MethodParametersDataFlow), nameof (RequirePublicConstructors), new Type [] { typeof (Type) })]
+		[Kept]
+		private void TwoAnnotatedParameters (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.DefaultConstructor)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type type,
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.PublicConstructors)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type type2)
+		{
+			RequireDefaultConstructor (type);
+			RequireDefaultConstructor (type2);
+			RequirePublicConstructors (type);
+			RequirePublicConstructors (type2);
+		}
+
+		[UnrecognizedReflectionAccessPattern (typeof (MethodParametersDataFlow), nameof (RequirePublicConstructors), new Type [] { typeof (Type) })]
+		[Kept]
+		private void TwoAnnotatedParametersIntoOneValue (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.DefaultConstructor)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type type,
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.PublicConstructors)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type type2)
+		{
+			Type t = type == null ? type : type2;
+			RequireDefaultConstructor (t);
+			RequirePublicConstructors (t);
+		}
+
+		[UnrecognizedReflectionAccessPattern (typeof (MethodParametersDataFlow), nameof (RequireDefaultConstructor), new Type [] { typeof (Type) })]
+		[Kept]
+		private void NoAnnotation (Type type)
+		{
+			RequireDefaultConstructor (this.GetType ());
+		}
+
+		[UnrecognizedReflectionAccessPattern (typeof (MethodParametersDataFlow), nameof (RequireDefaultConstructor), new Type [] { typeof (Type) })]
+		[Kept]
+		private void UnknownValue ()
+		{
+			RequireDefaultConstructor (this.GetType ());
+		}
+
+		[RecognizedReflectionAccessPattern]
+		[Kept]
+		private void AnnotatedValueToUnAnnotatedParameter (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.DefaultConstructor)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type type)
+		{
+			RequireNothing (type);
+		}
+
+		[RecognizedReflectionAccessPattern]
+		[Kept]
+		private void UnknownValueToUnAnnotatedParameter ()
+		{
+			RequireNothing (this.GetType());
+		}
+
+		[RecognizedReflectionAccessPattern]
+		[Kept]
+		private void UnknownValueToUnAnnotatedParameterOnInterestingMethod ()
+		{
+			RequireDefaultConstructorAndNothing (typeof (TestType), this.GetType ());
+		}
+
+		[Kept]
+		private static void RequireDefaultConstructor (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.DefaultConstructor)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type type)
+		{
+		}
+
+		[Kept]
+		private static void RequirePublicConstructors (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.PublicConstructors)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type type)
+		{
+		}
+
+		[Kept]
+		private static void RequireConstructors (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.Constructors)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type type)
+		{
+		}
+
+		[Kept]
+		private static void RequireNothing (Type type)
+		{
+		}
+
+		[Kept]
+		private static void RequireDefaultConstructorAndNothing (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.DefaultConstructor)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type type,
+			Type type2)
+		{
+		}
+
+		[Kept]
+		class TestType
+		{
+			[Kept]
+			public TestType() { }
+			[Kept]
+			public TestType (int arg) { }
+			[Kept]
+			private TestType (int arg1, int arg2) { }
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MethodParametersDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MethodParametersDataFlow.cs
@@ -7,13 +7,16 @@ using System.Text;
 
 namespace Mono.Linker.Tests.Cases.DataFlow
 {
-	[SetupCSharpCompilerToUse ("csc")]
 	[KeptMember(".ctor()")]
 	public class MethodParametersDataFlow
 	{
 		public static void Main ()
 		{
 			var instance = new MethodParametersDataFlow ();
+
+			// Note: this test's goal is to validate that the product correctly reports unrecognized patterns
+			//   - so the main validation is done by the UnrecognizedReflectionAccessPattern attributes.
+			// The test doesn't really validate that things are marked correctly, so Kept attributes are here to make it work mostly.
 
 			DefaultConstructorParameter (typeof (TestType));
 			PublicConstructorsParameter (typeof (TestType));

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MethodReturnParameterDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MethodReturnParameterDataFlow.cs
@@ -1,0 +1,178 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Mono.Linker.Tests.Cases.DataFlow
+{
+	[SetupCSharpCompilerToUse ("csc")]
+	[KeptMember (".ctor()")]
+	public class MethodReturnParameterDataFlow
+	{
+		public static void Main()
+		{
+			var instance = new MethodReturnParameterDataFlow ();
+
+			// Validation that assigning value to the return value is verified
+			NoRequirements ();
+			instance.ReturnDefaultConstructor (typeof (TestType), typeof (TestType), typeof (TestType));
+			instance.ReturnDefaultConstructorFromUnknownType (null);
+			instance.ReturnDefaultConstructorFromConstant ();
+			instance.ReturnDefaultConstructorFromNull ();
+			instance.ReturnPublicConstructorsFailure (null);
+			instance.ReturnConstructorsFailure (null);
+
+			// Validation that value comming from return value of a method is correctly propagated
+			instance.PropagateReturnDefaultConstructor ();
+			instance.PropagateReturnDefaultConstructorFromConstant ();
+		}
+
+		[Kept]
+		private static Type NoRequirements ()
+		{
+			return typeof (TestType);
+		}
+
+		[RecognizedReflectionAccessPattern]
+		[Kept]
+		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.DefaultConstructor)]
+		[return: KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+		private Type ReturnDefaultConstructor (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.DefaultConstructor)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type defaultConstructorType,
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.PublicConstructors)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type publicConstructorsType,
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.Constructors)]
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			Type constructorsType)
+		{
+			switch (GetHashCode ()) {
+				case 1:
+					return defaultConstructorType;
+				case 2:
+					return publicConstructorsType;
+				case 3:
+					return constructorsType;
+				case 4:
+					return typeof (TestType);
+				default:
+					return null;
+			}
+		}
+
+		[UnrecognizedReflectionAccessPattern (typeof (MethodReturnParameterDataFlow), nameof (ReturnDefaultConstructorFromUnknownType), new Type [] { typeof (Type) })]
+		[Kept]
+		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.DefaultConstructor)]
+		[return: KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+		private Type ReturnDefaultConstructorFromUnknownType (Type unknownType)
+		{
+			return unknownType;
+		}
+
+		[RecognizedReflectionAccessPattern]
+		[Kept]
+		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.DefaultConstructor)]
+		[return: KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+		private Type ReturnDefaultConstructorFromConstant ()
+		{
+			return typeof (TestType);
+		}
+
+		[RecognizedReflectionAccessPattern]
+		[Kept]
+		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.DefaultConstructor)]
+		[return: KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+		private Type ReturnDefaultConstructorFromNull ()
+		{
+			return null;
+		}
+
+		[UnrecognizedReflectionAccessPattern (typeof (MethodReturnParameterDataFlow), nameof (ReturnPublicConstructorsFailure), new Type [] { typeof (Type) })]
+		[Kept]
+		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.PublicConstructors)]
+		[return: KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+		private Type ReturnPublicConstructorsFailure (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.DefaultConstructor)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type defaultConstructorType)
+		{
+			return defaultConstructorType;
+		}
+
+		[UnrecognizedReflectionAccessPattern (typeof (MethodReturnParameterDataFlow), nameof (ReturnConstructorsFailure), new Type [] { typeof (Type) })]
+		[Kept]
+		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.Constructors)]
+		[return: KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+		private Type ReturnConstructorsFailure (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.PublicConstructors)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type publicConstructorsType)
+		{
+			return publicConstructorsType;
+		}
+
+		[Kept]
+		[UnrecognizedReflectionAccessPattern (typeof (MethodReturnParameterDataFlow), nameof (RequirePublicConstructors), new Type [] { typeof (Type) })]
+		[UnrecognizedReflectionAccessPattern (typeof (MethodReturnParameterDataFlow), nameof (RequireConstructors), new Type [] { typeof (Type) })]
+		private void PropagateReturnDefaultConstructor()
+		{
+			Type t = ReturnDefaultConstructor (typeof (TestType), typeof (TestType), typeof (TestType));
+			RequireDefaultConstructor (t);
+			RequirePublicConstructors (t);
+			RequireConstructors (t);
+			RequireNothing (t);
+		}
+
+		[Kept]
+		[UnrecognizedReflectionAccessPattern (typeof (MethodReturnParameterDataFlow), nameof (RequirePublicConstructors), new Type [] { typeof (Type) })]
+		[UnrecognizedReflectionAccessPattern (typeof (MethodReturnParameterDataFlow), nameof (RequireConstructors), new Type [] { typeof (Type) })]
+		private void PropagateReturnDefaultConstructorFromConstant ()
+		{
+			Type t = ReturnDefaultConstructorFromConstant ();
+			RequireDefaultConstructor (t);
+			RequirePublicConstructors (t);
+			RequireConstructors (t);
+			RequireNothing (t);
+		}
+
+		[Kept]
+		private static void RequireDefaultConstructor (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.DefaultConstructor)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type type)
+		{
+		}
+
+		[Kept]
+		private static void RequirePublicConstructors (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.PublicConstructors)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type type)
+		{
+		}
+
+		[Kept]
+		private static void RequireConstructors (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.Constructors)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type type)
+		{
+		}
+
+		[Kept]
+		private static void RequireNothing (Type type)
+		{
+		}
+
+		[Kept]
+		class TestType
+		{
+			[Kept]
+			public TestType () { }
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MethodReturnParameterDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MethodReturnParameterDataFlow.cs
@@ -7,13 +7,16 @@ using System.Text;
 
 namespace Mono.Linker.Tests.Cases.DataFlow
 {
-	[SetupCSharpCompilerToUse ("csc")]
 	[KeptMember (".ctor()")]
 	public class MethodReturnParameterDataFlow
 	{
 		public static void Main()
 		{
 			var instance = new MethodReturnParameterDataFlow ();
+
+			// Note: this test's goal is to validate that the product correctly reports unrecognized patterns
+			//   - so the main validation is done by the UnrecognizedReflectionAccessPattern attributes.
+			// The test doesn't really validate that things are marked correctly, so Kept attributes are here to make it work mostly.
 
 			// Validation that assigning value to the return value is verified
 			NoRequirements ();

--- a/test/Mono.Linker.Tests.Cases/Reflection/ActivatorCreateInstance.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ActivatorCreateInstance.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Reflection
 {
 	[SetupCSharpCompilerToUse ("csc")]
+	[KeptMember(".ctor()")]
 	public class ActivatorCreateInstance
 	{
 		[UnrecognizedReflectionAccessPattern(
@@ -18,6 +20,26 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			Activator.CreateInstance (typeof (Test4), new object [] { 1, "ss" });
 			Activator.CreateInstance ("test", "Mono.Linker.Tests.Cases.Reflection.ActivatorCreateInstance+Test5");
 			Activator.CreateInstance<Test1> ();
+
+			var p = new ActivatorCreateInstance ();
+
+			// Direct call to static method with a parameter
+			FromParameterOnStaticMethod (typeof (FromParameterOnStaticMethodType));
+
+			// Value comes from multiple sources - each must be marked appropriately
+			Type fromParameterOnStaticMethodType = p == null ?
+				typeof (FromParameterOnStaticMethodTypeA) :
+				typeof (FromParameterOnStaticMethodTypeB);
+			FromParameterOnStaticMethod (fromParameterOnStaticMethodType);
+
+			// Direct call to instance method with a parameter
+			p.FromParameterOnInstanceMethod (typeof (FromParameterOnInstanceMethodType));
+
+			// All constructors required
+			FromParameterWithConstructors (typeof (FromParameterWithConstructorsType));
+
+			// Public contructors required
+			FromParameterWithPublicConstructors (typeof (FromParameterWithPublicConstructorsType));
 		}
 
 		[Kept]
@@ -85,6 +107,101 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			public Test5 (int i, object o)
 			{
 			}
+		}
+
+		[Kept]
+		private static void FromParameterOnStaticMethod (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.DefaultConstructor)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type type)
+		{
+			Activator.CreateInstance (type);
+		}
+
+		[Kept]
+		class FromParameterOnStaticMethodType
+		{
+			[Kept]
+			public FromParameterOnStaticMethodType () { }
+			public FromParameterOnStaticMethodType (int arg) { }
+		}
+
+		[Kept]
+		class FromParameterOnStaticMethodTypeA
+		{
+			[Kept]
+			public FromParameterOnStaticMethodTypeA () { }
+			public FromParameterOnStaticMethodTypeA (int arg) { }
+		}
+
+		[Kept]
+		class FromParameterOnStaticMethodTypeB
+		{
+			[Kept]
+			public FromParameterOnStaticMethodTypeB () { }
+			public FromParameterOnStaticMethodTypeB (int arg) { }
+		}
+
+		[Kept]
+		private void FromParameterOnInstanceMethod (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.DefaultConstructor)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type type)
+		{
+			Activator.CreateInstance (type);
+		}
+
+		[Kept]
+		class FromParameterOnInstanceMethodType
+		{
+			[Kept]
+			public FromParameterOnInstanceMethodType () { }
+			public FromParameterOnInstanceMethodType (int arg) { }
+		}
+
+		[Kept]
+		private static void FromParameterWithConstructors (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.Constructors)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type type)
+
+		{
+			// All ctors are required by the parameter, so all cases should work
+			Activator.CreateInstance (type);
+			Activator.CreateInstance (type, new object [] { 1 });
+			Activator.CreateInstance (type, BindingFlags.NonPublic, new object [] { 1, 2 });
+		}
+
+		[Kept]
+		class FromParameterWithConstructorsType
+		{
+			[Kept]
+			public FromParameterWithConstructorsType () { }
+			[Kept]
+			public FromParameterWithConstructorsType (int arg) { }
+			[Kept]
+			private FromParameterWithConstructorsType (int arg, int arg2) { }
+		}
+
+		[Kept]
+		private static void FromParameterWithPublicConstructors (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.PublicConstructors)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type type)
+		{
+			// Only public ctors and default ctor are required, so only those cases should work
+			Activator.CreateInstance (type);
+			Activator.CreateInstance (type, new object [] { 1 });
+		}
+
+		[Kept]
+		class FromParameterWithPublicConstructorsType
+		{
+			[Kept]
+			public FromParameterWithPublicConstructorsType () { }
+			[Kept]
+			public FromParameterWithPublicConstructorsType (int arg) { }
+			private FromParameterWithPublicConstructorsType (int arg, int arg2) { }
 		}
 	}
 }

--- a/test/Mono.Linker.Tests/TestCases/TestDatabase.cs
+++ b/test/Mono.Linker.Tests/TestCases/TestDatabase.cs
@@ -162,6 +162,11 @@ namespace Mono.Linker.Tests.TestCases
 			return NUnitCasesBySuiteName ("Tracing");
 		}
 
+		public static IEnumerable<TestCaseData> DataFlowTests ()
+		{
+			return NUnitCasesBySuiteName ("DataFlow");
+		}
+
 		public static TestCaseCollector CreateCollector ()
 		{
 			GetDirectoryPaths (out string rootSourceDirectory, out string testCaseAssemblyPath);

--- a/test/Mono.Linker.Tests/TestCases/TestSuites.cs
+++ b/test/Mono.Linker.Tests/TestCases/TestSuites.cs
@@ -193,6 +193,12 @@ namespace Mono.Linker.Tests.TestCases
 			Run (testCase);
 		}
 
+		[TestCaseSource (typeof (TestDatabase), nameof (TestDatabase.DataFlowTests))]
+		public void DataFlowTests (TestCase testCase)
+		{
+			Run (testCase);
+		}
+
 		protected virtual void Run (TestCase testCase)
 		{
 			var runner = new TestRunner (new ObjectFactory ());


### PR DESCRIPTION
Implements propagation of data flow annotations from/to method parameters and from/to method return value.

Still lacks some functionality:
* Not all member access kinds are implemented - only ctors are
* Error reporting is pretty bad, needs more work