### PR TITLE
Fix ref assembly symbols issue (try 2)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,8 +8,6 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(IsReferenceAssembly)' == 'true' ">
     <ProduceOnlyReferenceAssembly>true</ProduceOnlyReferenceAssembly>
-    <!-- No symbols are produced for ref assemblies, but some parts of the SDK still expect pdbs, so we explicitly tell it there are none. -->
-    <DebugType>none</DebugType>
     <!-- Used by Arcade to compute OutputPath, IntermediateOutputPath, etc. early in the import chain. -->
     <OutDirName>$(MSBuildProjectName)/ref</OutDirName>
     <!-- Don't try to publish PDBs for ref assemblies that have none. -->
@@ -27,6 +25,9 @@
     <!-- Set this to false to build against the submodule. Convenient for experimenting locally. -->
     <UseCecilPackage Condition="'$(MonoBuild)' != '' And '$(UseCecilPackage)' == ''">false</UseCecilPackage>
     <UseCecilPackage Condition="'$(UseCecilPackage)' == ''">true</UseCecilPackage>
+    <!-- No symbols are produced for ref assemblies, but some parts of the SDK still expect pdbs, so we explicitly tell it there are none. -->
+    <!-- Must be set after importing Arcade to override its defaults. -->
+    <DebugType Condition=" '$(IsReferenceAssembly)' == 'true' ">none</DebugType>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
https://github.com/mono/linker/pull/1029 didn't fix the issue because
Arcade sets its own defaults that override those in
Directory.Build.props. This moves the import so that our setting wins.

Validated by doing a local build, setting OfficialBuildId manually. I
did the same validation in the last change, but maybe I was working
with a dirty build that somehow had a pdb. I think this should
actually fix it.