### PR TITLE
Add tests for Expression.Call/Field/Property for members on a base class

### DIFF
--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallString.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallString.cs
@@ -18,6 +18,8 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestNonExistingName ();
 			TestNullType ();
 			TestDataFlowType ();
+			TestPublicOnBase ();
+			TestProtectedOnBase ();
 		}
 
 		[RecognizedReflectionAccessPattern (
@@ -65,6 +67,18 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		}
 
 		[Kept]
+		static void TestPublicOnBase ()
+		{
+			Expression.Call (typeof (ADerived), "PublicOnBase", Type.EmptyTypes);
+		}
+
+		[Kept]
+		static void TestProtectedOnBase ()
+		{
+			Expression.Call (typeof (ADerived), "ProtectedOnBase", Type.EmptyTypes);
+		}
+
+		[Kept]
 		static Type FindType ()
 		{
 			return typeof (ExpressionCallString);
@@ -94,6 +108,26 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		protected static T Count<T> (T t)
 		{
 			return default (T);
+		}
+
+		[Kept]
+		class ABase
+		{
+			// [Kept] : TODO - should be kept: https://github.com/mono/linker/issues/1042
+			public static void PublicOnBase ()
+			{
+			}
+
+			// [Kept] : TODO - should be kept: https://github.com/mono/linker/issues/1042
+			protected static void ProtectedOnBase ()
+			{
+			}
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (ABase))]
+		class ADerived : ABase
+		{
 		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionFieldString.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionFieldString.cs
@@ -13,6 +13,9 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			var e2 = Expression.Field (null, typeof (ExpressionFieldString), "TestOnlyStatic2");
 
 			var e3 = Expression.Field (Expression.Parameter (typeof(int), "somename"), typeof (ExpressionFieldString), "TestName1");
+
+			Expression.Field (null, typeof (ADerived), "_protectedFieldOnBase");
+			Expression.Field (null, typeof (ADerived), "_publicFieldOnBase");
 		}
 
 		[Kept]
@@ -22,5 +25,21 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
 		[Kept]
 		private int TestName1;
+	}
+
+	[Kept]
+	class ABase
+	{
+		// [Kept] - TODO - should be kept: https://github.com/mono/linker/issues/1042
+		protected static bool _protectedFieldOnBase;
+
+		// [Kept] - TODO - should be kept: https://github.com/mono/linker/issues/1042
+		public static bool _publicFieldOnBase;
+	}
+
+	[Kept]
+	[KeptBaseType (typeof (ABase))]
+	class ADerived : ABase
+	{
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionPropertyString.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionPropertyString.cs
@@ -18,6 +18,9 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			var e2 = Expression.Property (null, typeof (Foo), "TestOnlyStatic2");
 
 			var e3 = Expression.Property (Expression.Parameter (typeof(int), "somename"), typeof (Foo), "TestName1");
+
+			Expression.Property (null, typeof (ADerived), "ProtectedPropertyOnBase");
+			Expression.Property (null, typeof (ADerived), "PublicPropertyOnBase");
 		}
 
 		[KeptMember (".ctor()")]
@@ -32,6 +35,22 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[Kept]
 			[KeptBackingField]
 			private int TestName1 { [Kept] get; }
+		}
+
+		[Kept]
+		class ABase
+		{
+			// [Kept] - TODO - should be kept: https://github.com/mono/linker/issues/1042
+			protected bool ProtectedPropertyOnBase { get; }
+
+			// [Kept] - TODO - should be kept: https://github.com/mono/linker/issues/1042
+			public bool PublicPropertyOnBase { get; }
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (ABase))]
+		class ADerived : ABase
+		{
 		}
 	}
 }


### PR DESCRIPTION
Currently this is hitting a bug https://github.com/mono/linker/issues/1042.