### PR TITLE
Constant property option

### DIFF
--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -319,6 +319,17 @@ namespace Mono.Linker {
 
 							continue;
 
+						case "--set-property":
+							if (!GetStringParam (token, prop => {
+								if (!GetBoolParam (token, value => {
+									context.AddConstantProperty (prop, value);
+								}))
+									return;
+							}))
+								return false;
+
+							continue;
+
 						case "--new-mvid":
 							//
 							// This is not same as --deterministic which calculates MVID
@@ -904,6 +915,7 @@ namespace Mono.Linker {
 #endif
 			Console.WriteLine ("                              sre: System.Reflection.Emit namespace");
 			Console.WriteLine ("                              globalization: Globalization data and globalization behavior");
+			Console.WriteLine ("  --set-property PROP BOOL  Rewrites the specified static property to return a constant value");
 			Console.WriteLine ("  --explicit-reflection     Adds to members never used through reflection DisablePrivateReflection attribute. Defaults to false");
 			Console.WriteLine ("  --keep-dep-attributes     Keep attributes used for manual dependency tracking. Defaults to false");
 			Console.WriteLine ("  --new-mvid                Generate a new guid for each linked assembly (short -g). Defaults to true");

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -120,6 +120,8 @@ namespace Mono.Linker {
 
 		public List<string> Substitutions { get; private set; }
 
+		public List<(string, bool)> ConstantProperties { get; private set; }
+
 		public List<PInvokeInfo> PInvokes { get; private set; }
 
 		public string PInvokesListFile;
@@ -209,6 +211,21 @@ namespace Mono.Linker {
 				CodeOptimizations.IPConstantPropagation;
 
 			Optimizations = new CodeOptimizationsSettings (defaultOptimizations);
+		}
+
+		public void AddConstantProperty (string property, bool value)
+		{
+			Debug.Assert (!String.IsNullOrEmpty (property));
+			var pair = (property, value);
+			if (ConstantProperties == null) {
+				ConstantProperties = new List<(string, bool)> { pair };
+				return;
+			}
+
+			if (ConstantProperties.Contains (pair))
+				return;
+
+			ConstantProperties.Add (pair);
 		}
 
 		public void AddSubstitutionFile (string file)

--- a/test/Mono.Linker.Tests.Cases/Substitutions/ConstantProperty.cs
+++ b/test/Mono.Linker.Tests.Cases/Substitutions/ConstantProperty.cs
@@ -1,0 +1,30 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Substitutions
+{
+	[SetupLinkerArgument ("--set-property", "Mono.Linker.Tests.Cases.Substitutions.ConstantProperty.BoolProperty", "true")]
+	public class ConstantProperty
+	{
+		[Kept]
+		static bool BoolProperty {
+			[Kept]
+			[ExpectedInstructionSequence (new [] {
+				"ldc.i4.1",
+				"ret"
+			})]
+			get;
+		}
+
+		public static void Main()
+		{
+			TestProperty_1 ();
+		}
+
+		[Kept]
+		static bool TestProperty_1 ()
+		{
+			return BoolProperty;
+		}
+	}
+}


### PR DESCRIPTION
Initial implementation of https://github.com/dotnet/designs/pull/99 on the linker side. This adds an option `--set-property NAME BOOL` which will substitute the body of the specified static property so that it returns a constant boolean. The intended use makes this conceptually similar to `--exclude-feature`, but unlike that option, it makes it the framework's responsibility to define the behavior when a feature is explicitly enabled or disabled.

For now:
- The property name is the same as the feature name.
- This only supports bools
- This supports arbitrary static properties. We could also restrict the supported patterns to enforce that it's only used for static readonly backing fields, or to enforce visibility constraints.
- The backing field is left unchanged

We need to decide specifically which "feature property" patterns this should support. Do we want to enforce additional constraints on the feature-defining properties? Should we check that they are backed by readonly fields? (Or that they are backed by AppContext switches?)
