### PR TITLE
Open up ReflectionPatternRecorder more

### DIFF
--- a/src/linker/Linker/IReflectionPatternRecorder.cs
+++ b/src/linker/Linker/IReflectionPatternRecorder.cs
@@ -46,8 +46,8 @@ namespace Mono.Linker
 		/// <param name="sourceMethod">The method which contains the reflection access pattern.</param>
 		/// <param name="reflectionMethod">The reflection method which is at the heart of the access pattern.</param>
 		/// <param name="accessedItem">The item accessed through reflection. This can be one of:
-		///   TypeDefinition, MethodDefinition, PropertyDefinition, FieldDefinition, EventDefinition.</param>
-		void RecognizedReflectionAccessPattern (MethodDefinition sourceMethod, MethodDefinition reflectionMethod, IMemberDefinition accessedItem);
+		///   TypeDefinition, MethodDefinition, PropertyDefinition, FieldDefinition, EventDefinition, InterfaceImplementation.</param>
+		void RecognizedReflectionAccessPattern (MethodDefinition sourceMethod, MethodDefinition reflectionMethod, IMetadataTokenProvider accessedItem);
 
 		/// <summary>
 		/// Called when the linker detected a reflection access but was not able to recognize the entire pattern.

--- a/src/linker/Linker/LoggingReflectionPatternRecorder.cs
+++ b/src/linker/Linker/LoggingReflectionPatternRecorder.cs
@@ -36,7 +36,7 @@ namespace Mono.Linker
 			_context = context;
 		}
 
-		public void RecognizedReflectionAccessPattern (MethodDefinition sourceMethod, MethodDefinition reflectionMethod, IMemberDefinition accessedItem)
+		public void RecognizedReflectionAccessPattern (MethodDefinition sourceMethod, MethodDefinition reflectionMethod, IMetadataTokenProvider accessedItem)
 		{
 			// Do nothing - there's no logging for successfully recognized patterns
 		}

--- a/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -772,7 +772,7 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			return fullName;
 		}
 
-		static string GetFullMemberNameFromDefinition (IMemberDefinition member)
+		static string GetFullMemberNameFromDefinition (IMetadataTokenProvider member)
 		{
 			// Method which basically returns the same as member.ToString() but without the return type
 			// of a method (if it's a method).
@@ -780,19 +780,22 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 			// as it would have to actually resolve the referenced method, which is very expensive and no necessary
 			// for the tests to work (the return types are redundant piece of information anyway).
 
-			if (member is TypeDefinition) {
-				return member.FullName;
+			if (member is IMemberDefinition memberDefinition) {
+				if (memberDefinition is TypeDefinition) {
+					return memberDefinition.FullName;
+				}
+
+				string fullName = memberDefinition.DeclaringType.FullName + "::";
+				if (memberDefinition is MethodDefinition method) {
+					fullName += method.GetSignature ();
+				} else {
+					fullName += memberDefinition.Name;
+				}
+
+				return fullName;
 			}
 
-			string fullName = member.DeclaringType.FullName + "::";
-			if (member is MethodDefinition method) {
-				fullName += method.GetSignature ();
-			}
-			else {
-				fullName += member.Name;
-			}
-
-			return fullName;
+			throw new NotImplementedException ($"Getting the full member name has not been implemented for {member}");
 		}
 
 		static string RecognizedReflectionAccessPatternToString (TestReflectionPatternRecorder.ReflectionAccessPattern pattern)

--- a/test/Mono.Linker.Tests/TestCasesRunner/TestReflectionPatternRecorder.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestReflectionPatternRecorder.cs
@@ -9,14 +9,14 @@ namespace Mono.Linker.Tests.TestCasesRunner
 		{
 			public MethodDefinition SourceMethod;
 			public MethodDefinition ReflectionMethod;
-			public IMemberDefinition AccessedItem;
+			public IMetadataTokenProvider AccessedItem;
 			public string Message;
 		}
 
 		public List<ReflectionAccessPattern> RecognizedPatterns = new List<ReflectionAccessPattern> ();
 		public List<ReflectionAccessPattern> UnrecognizedPatterns = new List<ReflectionAccessPattern> ();
 
-		public void RecognizedReflectionAccessPattern (MethodDefinition sourceMethod, MethodDefinition reflectionMethod, IMemberDefinition accessedItem)
+		public void RecognizedReflectionAccessPattern (MethodDefinition sourceMethod, MethodDefinition reflectionMethod, IMetadataTokenProvider accessedItem)
 		{
 			RecognizedPatterns.Add (new ReflectionAccessPattern {
 				SourceMethod = sourceMethod,


### PR DESCRIPTION
We implement detection of methods such as IsAssignableFrom which requires marking of an InterfaceImplementation.  An InterfaceImplementation is not an IMemberDefinition so I was unable to record this reflection pattern.

Changing RecognizedReflectionAccessPattern to accept an IMetadataTokenProvider allows us to record this detection.