### PR TITLE
Retarget reference assembly

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -7,18 +7,39 @@
     <CallTarget Targets="VSTest" Condition="'$(IsTestProject)' == 'true'" />
   </Target>
 
-  <!-- set up ApiCompat with ref assemblies -->
-  <PropertyGroup Condition=" '$(RunApiCompat)' == 'true' ">
+
+  <!-- Shared logic for reference assemblies. This enables apicompat and
+       packaging logic for projects that have corresponding reference assemblies. -->
+  <PropertyGroup>
     <ContractProject Condition="'$(ContractProject)' == ''">$(MSBuildProjectDirectory)\ref\$(MSBuildProjectName).csproj</ContractProject>
     <HasMatchingContract Condition="Exists('$(ContractProject)')">true</HasMatchingContract>
     <RunApiCompat Condition="'$(HasMatchingContract)' != 'true'">false</RunApiCompat>
+    <TargetsForTfmSpecificContentInPackage Condition="'$(HasMatchingContract)' == 'true'">$(TargetsForTfmSpecificContentInPackage);_AddReferenceAssemblyToPackage</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
-  <ItemGroup Condition="'$(HasMatchingContract)' == 'true' ">
+  <!-- Add a ProjectReference to the reference assembly project for ApiCompat. -->
+  <!-- This also ensures that it is built when the current project gets packaged. -->
+  <ItemGroup Condition="'$(HasMatchingContract)' == 'true'">
     <ProjectReference Include="$(ContractProject)">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <OutputItemType>ResolvedMatchingContract</OutputItemType>
     </ProjectReference>
   </ItemGroup>
+
+  <!-- The default pack logic will include the implementation assembly in lib.
+       This also adds the reference assembly under ref. -->
+  <Target Name="_AddReferenceAssemblyToPackage">
+    <!-- Get the build output of the reference project, which has been built due to the ProjectReference. -->
+    <MSBuild Projects="$(ContractProject)" Targets="BuiltProjectOutputGroup" Properties="TargetFramework=$(TargetFramework)">
+      <Output TaskParameter="TargetOutputs" ItemName="_ReferenceAssemblies" />
+    </MSBuild>
+    <!-- Check just to be safe. -->
+    <Error Condition="!Exists('%(_ReferenceAssemblies.Identity)')" Text="Reference assembly %(Identity) does not exist. Ensure it has been built before packaging." />
+    <!-- Add it to the package. -->
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="@(_ReferenceAssemblies)" PackagePath="ref\$(TargetFramework)" />
+    </ItemGroup>
+  </Target>
+
 
   <!-- Shared logic to publish multiple projects in the same
        package. Pack doesn't support including project references

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -10,7 +10,7 @@
 
   <!-- Shared logic for reference assemblies. This enables apicompat and
        packaging logic for projects that have corresponding reference assemblies. -->
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(MonoBuild)' == ''">
     <ContractProject Condition="'$(ContractProject)' == ''">$(MSBuildProjectDirectory)\ref\$(MSBuildProjectName).csproj</ContractProject>
     <HasMatchingContract Condition="Exists('$(ContractProject)')">true</HasMatchingContract>
     <RunApiCompat Condition="'$(HasMatchingContract)' != 'true'">false</RunApiCompat>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -57,10 +57,11 @@
     <!-- Option to include Json files in the package. Default is to just include dlls. -->
     <IncludeJsonFilesInPackage Condition="'$(IncludeJsonFilesInPackage)' == ''">false</IncludeJsonFilesInPackage>
     <!-- Use a NuGet extension point to publish and set up the package files. -->
+    <!-- We can't use TargetsForTfmSpecificBuildOutput, because it doesn't run when IncludeBuildOutput is false. -->
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddPublishOutputToPackage</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
-  <Target Name="_AddPublishOutputToPackage" Condition="'$(IncludePublishOutput)' == 'true'">
+  <Target Name="_AddPublishOutputToPackage">
     <PropertyGroup>
       <PublishDir>$(BaseOutputPath)$(TargetFramework)</PublishDir>
     </PropertyGroup>
@@ -78,8 +79,13 @@
     <Delete Files="@(_FilesToDelete)" />
     <MSBuild Projects="@(ProjectsToPublish)" Targets="Publish" />
     <ItemGroup>
-      <TfmSpecificPackageFile Include="$(PublishDir)/*.dll" PackagePath="$(BuildOutputTargetFolder)\$(TargetFramework)" />
-      <TfmSpecificPackageFile Include="$(PublishDir)/*.json" PackagePath="$(BuildOutputTargetFolder)\$(TargetFramework)" Condition="'$(IncludeJsonFilesInPackage)' == 'true'" />
+      <_PublishOutputInPackage Include="$(PublishDir)/*.dll" />
+      <_PublishOutputInPackage Include="$(PublishDir)/*.json" Condition="'$(IncludeJsonFilesInPackage)' == 'true'" />
+    </ItemGroup>
+    <!-- Sanity check. -->
+    <Error Condition="@(_PublishOutputInPackage->Count()) == 0" Text="No publish output included in package." />
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="@(_PublishOutputInPackage)" PackagePath="$(BuildOutputTargetFolder)\$(TargetFramework)" />
     </ItemGroup>
   </Target>
 

--- a/src/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/src/ILLink.Tasks/ILLink.Tasks.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <!-- Keep these in sync with _ILLinkTasksTFM in Sdk.props. -->
+    <!-- Keep the netcoreapp TFM in sync with the Mono.Linker.csproj condition below. -->
     <TargetFrameworks>netcoreapp3.0;net472</TargetFrameworks>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <Description>MSBuild tasks for running the IL Linker</Description>
@@ -41,7 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../linker/Mono.Linker.csproj" PrivateAssets="All" />
+    <ProjectReference Include="../linker/Mono.Linker.csproj" PrivateAssets="All" Condition=" '$(TargetFramework)' == 'netcoreapp3.0' " />
     <PackageReference Condition="'$(UseCecilPackage)' == 'true'" Include="Mono.Cecil" Version="$(MonoCecilVersion)" PrivateAssets="All" />
     <ProjectReference Condition="'$(UseCecilPackage)' != 'true'" Include="../../external/cecil/Mono.Cecil.csproj" PrivateAssets="All" />
   </ItemGroup>

--- a/src/analyzer/analyzer.csproj
+++ b/src/analyzer/analyzer.csproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>LinkerAnalyzer</RootNamespace>
     <AssemblyName>illinkanalyzer</AssemblyName>
-    <Configurations>Debug;Release</Configurations>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/linker/Directory.Build.props
+++ b/src/linker/Directory.Build.props
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(MonoBuild)' == ''">
-      <AssemblyName>illink</AssemblyName>
-      <Description>IL Linker</Description>
-      <TargetFramework>netcoreapp3.0</TargetFramework>
-      <PackageId>Microsoft.NET.ILLink</PackageId>
+    <AssemblyName>illink</AssemblyName>
+    <Description>IL Linker</Description>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <PackageId>Microsoft.NET.ILLink</PackageId>
   </PropertyGroup>
 
 </Project>

--- a/src/linker/Directory.Build.props
+++ b/src/linker/Directory.Build.props
@@ -11,6 +11,7 @@
       <AssemblyName>illink</AssemblyName>
       <Description>IL Linker</Description>
       <TargetFramework>netcoreapp3.0</TargetFramework>
+      <PackageId>Microsoft.NET.ILLink</PackageId>
   </PropertyGroup>
 
 </Project>

--- a/src/linker/Directory.Build.props
+++ b/src/linker/Directory.Build.props
@@ -1,0 +1,17 @@
+<Project>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup>
+    <RootNamespace>Mono</RootNamespace>
+    <Configurations>Debug;Release</Configurations>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(MonoBuild)' == ''">
+      <AssemblyName>illink</AssemblyName>
+      <Description>IL Linker</Description>
+      <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/linker/Directory.Build.props
+++ b/src/linker/Directory.Build.props
@@ -4,7 +4,6 @@
 
   <PropertyGroup>
     <RootNamespace>Mono</RootNamespace>
-    <Configurations>Debug;Release</Configurations>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/linker/Mono.Linker.csproj
+++ b/src/linker/Mono.Linker.csproj
@@ -11,8 +11,8 @@
     <AssemblyName>illink</AssemblyName>
     <Description>IL Linker</Description>
     <DefineConstants>$(DefineConstants);FEATURE_ILLINK</DefineConstants>
-    <!-- Ensure that this netcore TFM matches that in LinkTask.cs's ILLinkPath. -->
-    <TargetFrameworks>netcoreapp3.0;net471</TargetFrameworks>
+    <!-- Ensure that this TFM matches that in LinkTask.cs's ILLinkPath. -->
+    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(MonoBuild)' != ''">
@@ -39,10 +39,6 @@
     <PackageReference Condition="'$(UseCecilPackage)' == 'true'" Include="Mono.Cecil" Version="$(MonoCecilVersion)" />
     <ProjectReference Condition="'$(UseCecilPackage)' != 'true'" Include="..\..\external\cecil\Mono.Cecil.csproj" />
     <ProjectReference Condition="'$(UseCecilPackage)' != 'true'" Include="..\..\external\cecil\symbols\pdb\Mono.Cecil.Pdb.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(MonoBuild)' == ''">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(MonoBuild)' != ''">

--- a/src/linker/Mono.Linker.csproj
+++ b/src/linker/Mono.Linker.csproj
@@ -2,17 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <RootNamespace>Mono</RootNamespace>
-    <Configurations>Debug;Release</Configurations>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(MonoBuild)' == ''">
-    <AssemblyName>illink</AssemblyName>
-    <Description>IL Linker</Description>
     <DefineConstants>$(DefineConstants);FEATURE_ILLINK</DefineConstants>
-    <!-- Ensure that this TFM matches that in LinkTask.cs's ILLinkPath. -->
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <IsPackable>true</IsPackable>
+    <!-- Nuget issues a warning about missing <reference> items in the generated nuspec,
+         used for packages.config which we do not support. -->
+    <NoWarn>$(NoWarn);NU5131</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(MonoBuild)' != ''">
@@ -20,7 +17,7 @@
     <AssemblyTitle>Mono.Linker</AssemblyTitle>
     <Description>Mono CIL Linker</Description>
     <Copyright>(C) 2006, Jb Evain</Copyright>
-    <TargetFrameworks>net471</TargetFrameworks>
+    <TargetFramework>net471</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/linker/ref/Mono.Linker.csproj
+++ b/src/linker/ref/Mono.Linker.csproj
@@ -5,7 +5,7 @@
     <LangVersion>latest</LangVersion>
     <AssemblyName>illink</AssemblyName>
     <Description>IL Linker</Description>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <IsPackable>true</IsPackable>
     <!-- Nuget issues a warning about missing <reference> items in the generated nuspec,
         used for packages.config which we do not support. -->

--- a/src/linker/ref/Mono.Linker.csproj
+++ b/src/linker/ref/Mono.Linker.csproj
@@ -1,15 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <RootNamespace>Mono</RootNamespace>
-    <LangVersion>latest</LangVersion>
-    <AssemblyName>illink</AssemblyName>
-    <Description>IL Linker</Description>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-    <IsPackable>true</IsPackable>
-    <!-- Nuget issues a warning about missing <reference> items in the generated nuspec,
-        used for packages.config which we do not support. -->
-    <NoWarn>$(NoWarn);NU5131</NoWarn>
     <BuildOutputTargetFolder>ref</BuildOutputTargetFolder>
   </PropertyGroup>
 

--- a/test/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
+++ b/test/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <Configurations>Debug;Release</Configurations>
-  </PropertyGroup>
-
   <PropertyGroup Condition="'$(MonoBuild)' == ''">
     <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>

--- a/test/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/test/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -6,7 +6,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <LangVersion>8.0</LangVersion>
-    <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(MonoBuild)' == ''">

--- a/test/Mono.Linker.Tests/Mono.Linker.Tests.csproj
+++ b/test/Mono.Linker.Tests/Mono.Linker.Tests.csproj
@@ -2,7 +2,6 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
-    <Configurations>Debug;Release</Configurations>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
This makes a few changes to the illink reference assembly build and package.

As discussed in https://github.com/mono/linker/pull/1014#discussion_r399565691:
- Removes the net471 target from illink
- Changes the reference assembly to build for netcoreapp3.0 instead of netstandard2.0
- Includes the implementation assembly in the package as well

Closes https://github.com/mono/linker/issues/1023:
- Changes the package name to Microsoft.NET.ILLink

Note that the ILLink.Tasks continues to ship as a separate package.

This also includes minor cleanup I made as I was going:
- factoring of properties shared by impl and ref assemblies
- removal of explicit Debug/Release Configurations
- addition of a sanity check for ILLink.Tasks packaging