### PR TITLE
[feature/dataflow] Remove Kept attributes from dataflow annotation propagation tests

### DIFF
--- a/test/Mono.Linker.Tests.Cases/DataFlow/FieldDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/FieldDataFlow.cs
@@ -6,16 +6,14 @@ using System.Text;
 
 namespace Mono.Linker.Tests.Cases.DataFlow
 {
-	[KeptMember (".ctor()")]
+	// Note: this test's goal is to validate that the product correctly reports unrecognized patterns
+	//   - so the main validation is done by the UnrecognizedReflectionAccessPattern attributes.
+	[SkipKeptItemsValidation]
 	public class FieldDataFlow
 	{
 		public static void Main ()
 		{
 			var instance = new FieldDataFlow ();
-
-			// Note: this test's goal is to validate that the product correctly reports unrecognized patterns
-			//   - so the main validation is done by the UnrecognizedReflectionAccessPattern attributes.
-			// The test doesn't really validate that things are marked correctly, so Kept attributes are here to make it work mostly.
 
 			instance.ReadFromInstanceField ();
 			instance.WriteToInstanceField ();
@@ -30,17 +28,12 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			instance.WriteToStaticFieldOnADifferentClass ();
 		}
 
-		[Kept]
-		[KeptAttributeAttribute(typeof (DynamicallyAccessedMembersAttribute))]
 		[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.DefaultConstructor)]
 		Type _typeWithDefaultConstructor;
 
-		[Kept]
-		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.DefaultConstructor)]
 		static Type _staticTypeWithDefaultConstructor;
 
-		[Kept]
 		[UnrecognizedReflectionAccessPattern (typeof (FieldDataFlow), nameof (RequirePublicConstructors), new Type [] { typeof (Type) },
 			"The field 'System.Type Mono.Linker.Tests.Cases.DataFlow.FieldDataFlow::_typeWithDefaultConstructor' " +
 			"with dynamically accessed member kinds 'DefaultConstructor' is passed into " +
@@ -57,7 +50,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (FieldDataFlow), nameof (WriteToInstanceField), new Type [] { })]
-		[Kept]
 		private void WriteToInstanceField ()
 		{
 			_typeWithDefaultConstructor = GetTypeWithDefaultConstructor ();
@@ -66,7 +58,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			_typeWithDefaultConstructor = GetUnkownType ();
 		}
 
-		[Kept]
 		[UnrecognizedReflectionAccessPattern (typeof (FieldDataFlow), nameof (RequirePublicConstructors), new Type [] { typeof (Type) })]
 		[UnrecognizedReflectionAccessPattern (typeof (FieldDataFlow), nameof (RequireConstructors), new Type [] { typeof (Type) })]
 		private void ReadFromInstanceFieldOnADifferentClass ()
@@ -80,7 +71,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (FieldDataFlow), nameof (WriteToInstanceFieldOnADifferentClass), new Type [] { })]
-		[Kept]
 		private void WriteToInstanceFieldOnADifferentClass ()
 		{
 			var store = new TypeStore ();
@@ -91,7 +81,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			store._typeWithDefaultConstructor = GetUnkownType ();
 		}
 
-		[Kept]
 		[UnrecognizedReflectionAccessPattern (typeof (FieldDataFlow), nameof (RequirePublicConstructors), new Type [] { typeof (Type) })]
 		[UnrecognizedReflectionAccessPattern (typeof (FieldDataFlow), nameof (RequireConstructors), new Type [] { typeof (Type) })]
 		private void ReadFromStaticField ()
@@ -103,7 +92,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (FieldDataFlow), nameof (WriteToStaticField), new Type [] { })]
-		[Kept]
 		private void WriteToStaticField ()
 		{
 			_staticTypeWithDefaultConstructor = GetTypeWithDefaultConstructor ();
@@ -112,7 +100,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			_staticTypeWithDefaultConstructor = GetUnkownType ();
 		}
 
-		[Kept]
 		[UnrecognizedReflectionAccessPattern (typeof (FieldDataFlow), nameof (RequirePublicConstructors), new Type [] { typeof (Type) })]
 		[UnrecognizedReflectionAccessPattern (typeof (FieldDataFlow), nameof (RequireConstructors), new Type [] { typeof (Type) })]
 		private void ReadFromStaticFieldOnADifferentClass ()
@@ -124,7 +111,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (FieldDataFlow), nameof (WriteToStaticFieldOnADifferentClass), new Type [] { })]
-		[Kept]
 		private void WriteToStaticFieldOnADifferentClass ()
 		{
 			TypeStore._staticTypeWithDefaultConstructor = GetTypeWithDefaultConstructor ();
@@ -133,76 +119,56 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			TypeStore._staticTypeWithDefaultConstructor = GetUnkownType ();
 		}
 
-		[Kept]
 		private static void RequireDefaultConstructor (
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.DefaultConstructor)]
-			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type type)
 		{
 		}
 
-		[Kept]
 		private static void RequirePublicConstructors (
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.PublicConstructors)]
-			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type type)
 		{
 		}
 
-		[Kept]
 		private static void RequireConstructors (
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.Constructors)]
-			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type type)
 		{
 		}
 
-		[Kept]
 		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.DefaultConstructor)]
-		[return: KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 		private static Type GetTypeWithDefaultConstructor ()
 		{
 			return null;
 		}
 
-		[Kept]
 		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.PublicConstructors)]
-		[return: KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 		private static Type GetTypeWithPublicConstructors ()
 		{
 			return null;
 		}
 
-		[Kept]
 		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.Constructors)]
-		[return: KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 		private static Type GetTypeWithConstructors ()
 		{
 			return null;
 		}
 
-		[Kept]
 		private static Type GetUnkownType ()
 		{
 			return null;
 		}
 
-		[Kept]
 		private static void RequireNothing (Type type)
 		{
 		}
 
-		[Kept]
-		[KeptMember(".ctor()")]
 		class TypeStore
 		{
-			[Kept]
-			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.DefaultConstructor)]
 			public Type _typeWithDefaultConstructor;
 
-			[Kept]
-			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.DefaultConstructor)]
 			public static Type _staticTypeWithDefaultConstructor;
 		}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MethodParametersDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MethodParametersDataFlow.cs
@@ -7,16 +7,14 @@ using System.Text;
 
 namespace Mono.Linker.Tests.Cases.DataFlow
 {
-	[KeptMember(".ctor()")]
+	// Note: this test's goal is to validate that the product correctly reports unrecognized patterns
+	//   - so the main validation is done by the UnrecognizedReflectionAccessPattern attributes.
+	[SkipKeptItemsValidation]
 	public class MethodParametersDataFlow
 	{
 		public static void Main ()
 		{
 			var instance = new MethodParametersDataFlow ();
-
-			// Note: this test's goal is to validate that the product correctly reports unrecognized patterns
-			//   - so the main validation is done by the UnrecognizedReflectionAccessPattern attributes.
-			// The test doesn't really validate that things are marked correctly, so Kept attributes are here to make it work mostly.
 
 			DefaultConstructorParameter (typeof (TestType));
 			PublicConstructorsParameter (typeof (TestType));
@@ -31,7 +29,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			instance.UnknownValueToUnAnnotatedParameterOnInterestingMethod ();
 		}
 
-		[Kept]
 		// Validate the error message when annotated parameter is passed to another annotated parameter
 		[UnrecognizedReflectionAccessPattern (typeof (MethodParametersDataFlow), nameof (RequirePublicConstructors), new Type [] { typeof (Type) },
 			"The parameter 'type' of method 'System.Void Mono.Linker.Tests.Cases.DataFlow.MethodParametersDataFlow::DefaultConstructorParameter(System.Type)' " +
@@ -42,7 +39,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[UnrecognizedReflectionAccessPattern (typeof (MethodParametersDataFlow), nameof (RequireConstructors), new Type [] { typeof (Type) })]
 		private static void DefaultConstructorParameter (
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.DefaultConstructor)]
-			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type type)
 		{
 			RequireDefaultConstructor (type);
@@ -50,11 +46,9 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			RequireConstructors (type);
 		}
 
-		[Kept]
 		[UnrecognizedReflectionAccessPattern (typeof (MethodParametersDataFlow), nameof (RequireConstructors), new Type [] { typeof (Type) })]
 		private static void PublicConstructorsParameter (
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.PublicConstructors)]
-			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type type)
 		{
 			RequireDefaultConstructor (type);
@@ -63,10 +57,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[RecognizedReflectionAccessPattern]
-		[Kept]
 		private static void ConstructorsParameter (
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.Constructors)]
-			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type type)
 		{
 			RequireDefaultConstructor (type);
@@ -75,10 +67,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (MethodParametersDataFlow), nameof (RequirePublicConstructors), new Type [] { typeof (Type) })]
-		[Kept]
 		private void InstanceMethod (
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.DefaultConstructor)]
-			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type type)
 		{
 			RequireDefaultConstructor (type);
@@ -86,13 +76,10 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (MethodParametersDataFlow), nameof (RequirePublicConstructors), new Type [] { typeof (Type) })]
-		[Kept]
 		private void TwoAnnotatedParameters (
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.DefaultConstructor)]
-			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type type,
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.PublicConstructors)]
-			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type type2)
 		{
 			RequireDefaultConstructor (type);
@@ -102,13 +89,10 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (MethodParametersDataFlow), nameof (RequirePublicConstructors), new Type [] { typeof (Type) })]
-		[Kept]
 		private void TwoAnnotatedParametersIntoOneValue (
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.DefaultConstructor)]
-			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type type,
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.PublicConstructors)]
-			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type type2)
 		{
 			Type t = type == null ? type : type2;
@@ -123,7 +107,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			"the parameter 'type' of method 'System.Void Mono.Linker.Tests.Cases.DataFlow.MethodParametersDataFlow::RequireDefaultConstructor(System.Type)' " +
 			"which requires dynamically accessed member kinds `DefaultConstructor`. " +
 			"To fix this add DynamicallyAccessedMembersAttribute to it and specify at least these member kinds 'DefaultConstructor'.")]
-		[Kept]
 		private void NoAnnotation (Type type)
 		{
 			RequireDefaultConstructor (type);
@@ -135,7 +118,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			"into the parameter 'type' of method 'System.Void Mono.Linker.Tests.Cases.DataFlow.MethodParametersDataFlow::RequireDefaultConstructor(System.Type)' " +
 			"which requires dynamically accessed member kinds `DefaultConstructor`. " +
 			"It's not possible to guarantee that these requirements are met by the application.")]
-		[Kept]
 		private void UnknownValue ()
 		{
 			var array = new object [1];
@@ -144,75 +126,58 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[RecognizedReflectionAccessPattern]
-		[Kept]
 		private void AnnotatedValueToUnAnnotatedParameter (
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.DefaultConstructor)]
-			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type type)
 		{
 			RequireNothing (type);
 		}
 
 		[RecognizedReflectionAccessPattern]
-		[Kept]
 		private void UnknownValueToUnAnnotatedParameter ()
 		{
 			RequireNothing (this.GetType());
 		}
 
 		[RecognizedReflectionAccessPattern]
-		[Kept]
 		private void UnknownValueToUnAnnotatedParameterOnInterestingMethod ()
 		{
 			RequireDefaultConstructorAndNothing (typeof (TestType), this.GetType ());
 		}
 
-		[Kept]
 		private static void RequireDefaultConstructor (
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.DefaultConstructor)]
-			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type type)
 		{
 		}
 
-		[Kept]
 		private static void RequirePublicConstructors (
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.PublicConstructors)]
-			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type type)
 		{
 		}
 
-		[Kept]
 		private static void RequireConstructors (
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.Constructors)]
-			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type type)
 		{
 		}
 
-		[Kept]
 		private static void RequireNothing (Type type)
 		{
 		}
 
-		[Kept]
 		private static void RequireDefaultConstructorAndNothing (
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.DefaultConstructor)]
-			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type type,
 			Type type2)
 		{
 		}
 
-		[Kept]
 		class TestType
 		{
-			[Kept]
 			public TestType() { }
-			[Kept]
 			public TestType (int arg) { }
-			[Kept]
 			private TestType (int arg1, int arg2) { }
 		}
 	}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MethodReturnParameterDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MethodReturnParameterDataFlow.cs
@@ -7,16 +7,14 @@ using System.Text;
 
 namespace Mono.Linker.Tests.Cases.DataFlow
 {
-	[KeptMember (".ctor()")]
+	// Note: this test's goal is to validate that the product correctly reports unrecognized patterns
+	//   - so the main validation is done by the UnrecognizedReflectionAccessPattern attributes.
+	[SkipKeptItemsValidation]
 	public class MethodReturnParameterDataFlow
 	{
 		public static void Main()
 		{
 			var instance = new MethodReturnParameterDataFlow ();
-
-			// Note: this test's goal is to validate that the product correctly reports unrecognized patterns
-			//   - so the main validation is done by the UnrecognizedReflectionAccessPattern attributes.
-			// The test doesn't really validate that things are marked correctly, so Kept attributes are here to make it work mostly.
 
 			// Validation that assigning value to the return value is verified
 			NoRequirements ();
@@ -32,25 +30,19 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			instance.PropagateReturnDefaultConstructorFromConstant ();
 		}
 
-		[Kept]
 		private static Type NoRequirements ()
 		{
 			return typeof (TestType);
 		}
 
 		[RecognizedReflectionAccessPattern]
-		[Kept]
 		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.DefaultConstructor)]
-		[return: KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 		private Type ReturnDefaultConstructor (
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.DefaultConstructor)]
-			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type defaultConstructorType,
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.PublicConstructors)]
-			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type publicConstructorsType,
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.Constructors)]
-			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 			Type constructorsType)
 		{
 			switch (GetHashCode ()) {
@@ -68,27 +60,21 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (MethodReturnParameterDataFlow), nameof (ReturnDefaultConstructorFromUnknownType), new Type [] { typeof (Type) })]
-		[Kept]
 		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.DefaultConstructor)]
-		[return: KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 		private Type ReturnDefaultConstructorFromUnknownType (Type unknownType)
 		{
 			return unknownType;
 		}
 
 		[RecognizedReflectionAccessPattern]
-		[Kept]
 		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.DefaultConstructor)]
-		[return: KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 		private Type ReturnDefaultConstructorFromConstant ()
 		{
 			return typeof (TestType);
 		}
 
 		[RecognizedReflectionAccessPattern]
-		[Kept]
 		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.DefaultConstructor)]
-		[return: KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 		private Type ReturnDefaultConstructorFromNull ()
 		{
 			return null;
@@ -101,30 +87,23 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			"passed into the return value of method 'System.Type Mono.Linker.Tests.Cases.DataFlow.MethodReturnParameterDataFlow::ReturnPublicConstructorsFailure(System.Type)' " +
 			"which requires dynamically accessed member kinds `PublicConstructors`. " +
 			"To fix this add DynamicallyAccessedMembersAttribute to it and specify at least these member kinds 'PublicConstructors'.")]
-		[Kept]
 		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.PublicConstructors)]
-		[return: KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 		private Type ReturnPublicConstructorsFailure (
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.DefaultConstructor)]
-			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type defaultConstructorType)
 		{
 			return defaultConstructorType;
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (MethodReturnParameterDataFlow), nameof (ReturnConstructorsFailure), new Type [] { typeof (Type) })]
-		[Kept]
 		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.Constructors)]
-		[return: KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 		private Type ReturnConstructorsFailure (
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.PublicConstructors)]
-			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type publicConstructorsType)
 		{
 			return publicConstructorsType;
 		}
 
-		[Kept]
 		[UnrecognizedReflectionAccessPattern (typeof (MethodReturnParameterDataFlow), nameof (RequirePublicConstructors), new Type [] { typeof (Type) })]
 		[UnrecognizedReflectionAccessPattern (typeof (MethodReturnParameterDataFlow), nameof (RequireConstructors), new Type [] { typeof (Type) })]
 		private void PropagateReturnDefaultConstructor()
@@ -136,7 +115,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			RequireNothing (t);
 		}
 
-		[Kept]
 		[UnrecognizedReflectionAccessPattern (typeof (MethodReturnParameterDataFlow), nameof (RequirePublicConstructors), new Type [] { typeof (Type) })]
 		[UnrecognizedReflectionAccessPattern (typeof (MethodReturnParameterDataFlow), nameof (RequireConstructors), new Type [] { typeof (Type) })]
 		private void PropagateReturnDefaultConstructorFromConstant ()
@@ -148,39 +126,30 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			RequireNothing (t);
 		}
 
-		[Kept]
 		private static void RequireDefaultConstructor (
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.DefaultConstructor)]
-			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type type)
 		{
 		}
 
-		[Kept]
 		private static void RequirePublicConstructors (
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.PublicConstructors)]
-			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type type)
 		{
 		}
 
-		[Kept]
 		private static void RequireConstructors (
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.Constructors)]
-			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type type)
 		{
 		}
 
-		[Kept]
 		private static void RequireNothing (Type type)
 		{
 		}
 
-		[Kept]
 		class TestType
 		{
-			[Kept]
 			public TestType () { }
 		}
 	}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
@@ -7,16 +7,14 @@ using System.Text;
 
 namespace Mono.Linker.Tests.Cases.DataFlow
 {
-	[KeptMember (".ctor()")]
+	// Note: this test's goal is to validate that the product correctly reports unrecognized patterns
+	//   - so the main validation is done by the UnrecognizedReflectionAccessPattern attributes.
+	[SkipKeptItemsValidation]
 	public class PropertyDataFlow
 	{
 		public static void Main ()
 		{
 			var instance = new PropertyDataFlow ();
-
-			// Note: this test's goal is to validate that the product correctly reports unrecognized patterns
-			//   - so the main validation is done by the UnrecognizedReflectionAccessPattern attributes.
-			// The test doesn't really validate that things are marked correctly, so Kept attributes are here to make it work mostly.
 
 			instance.ReadFromInstanceProperty ();
 			instance.WriteToInstanceProperty ();
@@ -32,20 +30,13 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			instance.PropertyConstructorsWithExplicitAccessors = null;
 		}
 
-		[Kept]
-		[KeptBackingField]
-		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.PublicConstructors)]
-		Type PropertyWithPublicConstructor { [Kept] get; [Kept] set; }
+		Type PropertyWithPublicConstructor { get; set; }
 
-		[Kept]
-		[KeptBackingField]
-		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.PublicConstructors)]
-		static Type StaticPropertyWithPublicConstructor { [Kept] get; [Kept] set; }
+		static Type StaticPropertyWithPublicConstructor { get; set; }
 
 		[UnrecognizedReflectionAccessPattern (typeof (PropertyDataFlow), nameof (RequireConstructors), new Type [] { typeof (Type) })]
-		[Kept]
 		private void ReadFromInstanceProperty ()
 		{
 			RequireDefaultConstructor (PropertyWithPublicConstructor);
@@ -55,7 +46,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (PropertyDataFlow), nameof (RequireConstructors), new Type [] { typeof (Type) })]
-		[Kept]
 		private void ReadFromStaticProperty ()
 		{
 			RequireDefaultConstructor (StaticPropertyWithPublicConstructor);
@@ -66,7 +56,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		[UnrecognizedReflectionAccessPattern (typeof (PropertyDataFlow), "set_" + nameof (PropertyWithPublicConstructor), new Type [] { typeof (Type) })]
 		[UnrecognizedReflectionAccessPattern (typeof (PropertyDataFlow), "set_" + nameof (PropertyWithPublicConstructor), new Type [] { typeof (Type) })]
-		[Kept]
 		private void WriteToInstanceProperty ()
 		{
 			PropertyWithPublicConstructor = GetTypeWithDefaultConstructor ();
@@ -77,7 +66,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		[UnrecognizedReflectionAccessPattern (typeof (PropertyDataFlow), "set_" + nameof (StaticPropertyWithPublicConstructor), new Type [] { typeof (Type) })]
 		[UnrecognizedReflectionAccessPattern (typeof (PropertyDataFlow), "set_" + nameof (StaticPropertyWithPublicConstructor), new Type [] { typeof (Type) })]
-		[Kept]
 		private void WriteToStaticProperty ()
 		{
 			StaticPropertyWithPublicConstructor = GetTypeWithDefaultConstructor ();
@@ -86,129 +74,95 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			StaticPropertyWithPublicConstructor = GetUnkownType ();
 		}
 
-		[Kept]
-		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.PublicConstructors)]
 		Type _fieldWithPublicConstructors;
 
-		[Kept]
-		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.PublicConstructors)]
 		Type PropertyPublicConstructorsWithExplicitAccessors {
 			[RecognizedReflectionAccessPattern]
-			[Kept]
-			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.PublicConstructors)]
 			get {
 				return _fieldWithPublicConstructors;
 			}
 
 			[RecognizedReflectionAccessPattern]
-			[Kept]
-			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.PublicConstructors)]
 			set {
 				_fieldWithPublicConstructors = value;
 			}
 		}
 
-		[Kept]
-		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.DefaultConstructor)]
 		Type PropertyDefaultConstructorWithExplicitAccessors {
 			[RecognizedReflectionAccessPattern]
-			[Kept]
-			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.DefaultConstructor)]
 			get {
 				return _fieldWithPublicConstructors;
 			}
 
 			[UnrecognizedReflectionAccessPattern(typeof (PropertyDataFlow), "set_" + nameof (PropertyDefaultConstructorWithExplicitAccessors), new Type [] { typeof (Type) })]
-			[Kept]
-			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.DefaultConstructor)]
 			set {
 				_fieldWithPublicConstructors = value;
 			}
 		}
 
-		[Kept]
-		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.Constructors)]
 		Type PropertyConstructorsWithExplicitAccessors {
 			[UnrecognizedReflectionAccessPattern (typeof (PropertyDataFlow), "get_" + nameof (PropertyConstructorsWithExplicitAccessors), new Type [] { })]
-			[Kept]
-			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.Constructors)]
 			get {
 				return _fieldWithPublicConstructors;
 			}
 
 			[RecognizedReflectionAccessPattern]
-			[Kept]
-			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.Constructors)]
 			set {
 				_fieldWithPublicConstructors = value;
 			}
 		}
 
-		[Kept]
 		private static void RequireDefaultConstructor (
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.DefaultConstructor)]
-			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type type)
 		{
 		}
 
-		[Kept]
 		private static void RequirePublicConstructors (
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.PublicConstructors)]
-			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type type)
 		{
 		}
 
-		[Kept]
 		private static void RequireConstructors (
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.Constructors)]
-			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type type)
 		{
 		}
 
-		[Kept]
 		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.DefaultConstructor)]
-		[return: KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 		private static Type GetTypeWithDefaultConstructor ()
 		{
 			return null;
 		}
 
-		[Kept]
 		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.PublicConstructors)]
-		[return: KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 		private static Type GetTypeWithPublicConstructors ()
 		{
 			return null;
 		}
 
-		[Kept]
 		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.Constructors)]
-		[return: KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 		private static Type GetTypeWithConstructors ()
 		{
 			return null;
 		}
 
-		[Kept]
 		private static Type GetUnkownType ()
 		{
 			return null;
 		}
 
-		[Kept]
 		private static void RequireNothing (Type type)
 		{
 		}


### PR DESCRIPTION
These tests don't rely on the Kept validation, instead they use the reflection pattern recorder to validate the product behavior. Using Kept attributes just makes the tests unnecessarily verbose.