### PR TITLE
Small fixes - flow annotations and warnings

### DIFF
--- a/src/linker/Linker.Dataflow/FlowAnnotations.cs
+++ b/src/linker/Linker.Dataflow/FlowAnnotations.cs
@@ -168,7 +168,8 @@ namespace Mono.Linker.Dataflow
 					MethodDefinition setMethod = property.SetMethod;
 					if (setMethod != null) {
 
-						if (!ScanMethodBodyForFieldAccess (setMethod.Body, write: true, out backingFieldFromSetter)) {
+						// TODO: Handle abstract properties - no way to propagate the annotation to the field
+						if (!setMethod.HasBody || !ScanMethodBodyForFieldAccess (setMethod.Body, write: true, out backingFieldFromSetter)) {
 							// TODO: warn we couldn't find a unique backing field
 						}
 
@@ -190,7 +191,8 @@ namespace Mono.Linker.Dataflow
 					MethodDefinition getMethod = property.GetMethod;
 					if (getMethod != null) {
 
-						if (ScanMethodBodyForFieldAccess (getMethod.Body, write: false, out backingFieldFromGetter)) {
+						// TODO: Handle abstract properties - no way to propagate the annotation to the field
+						if (!getMethod.HasBody || !ScanMethodBodyForFieldAccess (getMethod.Body, write: false, out backingFieldFromGetter)) {
 							// TODO: warn we couldn't find a unique backing field
 						}
 

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -3449,13 +3449,14 @@ namespace Mono.Linker.Steps {
 
 				DynamicallyAccessedMemberKinds returnValueDynamicallyAccessedMemberKinds = 0;
 
+				methodReturnValue = null;
+
+				var calledMethodDefinition = calledMethod.Resolve ();
+				if (calledMethodDefinition == null)
+					return false;
+
 				try {
 
-					methodReturnValue = null;
-
-					var calledMethodDefinition = calledMethod.Resolve ();
-					if (calledMethodDefinition == null)
-						return false;
 
 					bool requiresDataFlowAnalysis = _flowAnnotations.RequiresDataFlowAnalysis (calledMethodDefinition);
 					returnValueDynamicallyAccessedMemberKinds =  requiresDataFlowAnalysis ?
@@ -3696,7 +3697,9 @@ namespace Mono.Linker.Steps {
 				// unknown value with the return type of the method.
 				if (methodReturnValue == null) {
 					if (calledMethod.ReturnType.MetadataType != MetadataType.Void) {
-						methodReturnValue = new MethodReturnValue(returnValueDynamicallyAccessedMemberKinds);
+						methodReturnValue = new MethodReturnValue (returnValueDynamicallyAccessedMemberKinds) {
+							SourceContext = calledMethodDefinition
+						};
 					}
 				}
 


### PR DESCRIPTION
Fix a nullref when JSON annotation is applied to an abstract property.

Record the method for which we create default return value (happens for example when the code calls `typeof(T)`)