### PR TITLE
[feature/dataflow] Implement dataflow to custom attributes

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -3386,9 +3386,11 @@ namespace Mono.Linker.Steps {
 
 			public void ProcessAttributeDataflow (MethodDefinition method, Collection<CustomAttributeArgument> arguments)
 			{
+				int paramOffset = method.HasImplicitThis () ? 1 : 0;
+
 				for (int i = 0; i < method.Parameters.Count; i++)
 				{
-					var annotation = _flowAnnotations.GetParameterAnnotation (method, i + 1 /* adjust for `this` */);
+					var annotation = _flowAnnotations.GetParameterAnnotation (method, i + paramOffset);
 					if (annotation != 0) {
 						ValueNode valueNode = GetValueNodeForCustomAttributeArgument (arguments [i]);
 						if (valueNode != null) {
@@ -3424,8 +3426,8 @@ namespace Mono.Linker.Steps {
 				} else if (argument.Type.MetadataType == MetadataType.String) {
 					valueNode = new KnownStringValue ((string)argument.Value);
 				} else {
-					Debug.Fail ("We shouldn't have gotten a non-null annotation for this from GetParameterAnnotation.");
-					valueNode = null;
+					// We shouldn't have gotten a non-null annotation for this from GetParameterAnnotation
+					throw new InvalidOperationException ();
 				}
 
 				return valueNode;

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -846,6 +846,11 @@ namespace Mono.Linker.Steps {
 				MarkMethod (property.SetMethod, reason);
 
 			MarkCustomAttributeArgument (namedArgument.Argument, ca);
+
+			if (property != null && _flowAnnotations.RequiresDataFlowAnalysis (property.SetMethod)) {
+				var scanner = new ReflectionMethodBodyScanner (this);
+				scanner.ProcessAttributeDataflow (property.SetMethod, new Collection<CustomAttributeArgument> { namedArgument.Argument });
+			}
 		}
 
 		PropertyDefinition GetProperty (TypeDefinition type, string propertyname)
@@ -879,6 +884,11 @@ namespace Mono.Linker.Steps {
 				MarkField (field, new DependencyInfo (DependencyKind.CustomAttributeField, ca));
 
 			MarkCustomAttributeArgument (namedArgument.Argument, ca);
+
+			if (field != null && _flowAnnotations.RequiresDataFlowAnalysis (field)) {
+				var scanner = new ReflectionMethodBodyScanner (this);
+				scanner.ProcessAttributeDataflow (field, namedArgument.Argument);
+			}
 		}
 
 		FieldDefinition GetField (TypeDefinition type, string fieldname)
@@ -918,6 +928,12 @@ namespace Mono.Linker.Steps {
 
 			foreach (var argument in ca.ConstructorArguments)
 				MarkCustomAttributeArgument (argument, ca);
+
+			var resolvedConstructor = ca.Constructor.Resolve ();
+			if (resolvedConstructor != null && _flowAnnotations.RequiresDataFlowAnalysis (resolvedConstructor)) {
+				var scanner = new ReflectionMethodBodyScanner (this);
+				scanner.ProcessAttributeDataflow (resolvedConstructor, ca.ConstructorArguments);
+			}
 		}
 
 		void MarkCustomAttributeArgument (CustomAttributeArgument argument, ICustomAttribute ca)
@@ -3407,6 +3423,53 @@ namespace Mono.Linker.Steps {
 						RequireDynamicallyAccessedMembers (ref reflectionContext, requiredMemberKinds, MethodReturnValue, methodBody.Method.MethodReturnType);
 					}
 				}
+			}
+
+			public void ProcessAttributeDataflow (MethodDefinition method, Collection<CustomAttributeArgument> arguments)
+			{
+				for (int i = 0; i < method.Parameters.Count; i++)
+				{
+					var annotation = _flowAnnotations.GetParameterAnnotation (method, i + 1 /* adjust for `this` */);
+					if (annotation != 0) {
+						ValueNode valueNode = GetValueNodeForCustomAttributeArgument (arguments [i]);
+						if (valueNode != null) {
+							// TODO: There's no way to represent attribute dataflow in current ReflectionPatternContext (and the underlying IReflectionPatterRecorder)
+							ReflectionPatternContext context = new ReflectionPatternContext (_markStep._context, method, method, 0);
+							context.AnalyzingPattern ();
+							RequireDynamicallyAccessedMembers (ref context, annotation, valueNode, method);
+						}
+					}
+				}
+			}
+
+			public void ProcessAttributeDataflow (FieldDefinition field, CustomAttributeArgument value)
+			{
+				var annotation = _flowAnnotations.GetFieldAnnotation (field);
+				Debug.Assert (annotation != 0);
+
+				ValueNode valueNode = GetValueNodeForCustomAttributeArgument (value);
+				if (valueNode != null) {
+					// TODO: There's no way to represent store to a field given current ReflectionPatternContext (and the underlying IReflectionPatterRecorder)
+					var reflectionContext = new ReflectionPatternContext (_markStep._context, field.DeclaringType.Methods [0], field.DeclaringType.Methods [0], 0);
+					reflectionContext.AnalyzingPattern ();
+					RequireDynamicallyAccessedMembers (ref reflectionContext, annotation, valueNode, field);
+				}
+			}
+
+			private ValueNode GetValueNodeForCustomAttributeArgument(CustomAttributeArgument argument)
+			{
+				ValueNode valueNode;
+				if (argument.Type.Name == "Type") {
+					TypeDefinition referencedType = ((TypeReference)argument.Value).Resolve ();
+					valueNode = referencedType == null ? null : new SystemTypeValue (referencedType);
+				} else if (argument.Type.MetadataType == MetadataType.String) {
+					valueNode = new KnownStringValue ((string)argument.Value);
+				} else {
+					Debug.Fail ("We shouldn't have gotten a non-null annotation for this from GetParameterAnnotation.");
+					valueNode = null;
+				}
+
+				return valueNode;
 			}
 
 			protected override void WarnAboutInvalidILInMethod (MethodBody method, int ilOffset)

--- a/test/Mono.Linker.Tests.Cases/DataFlow/AttributeConstructorDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/AttributeConstructorDataflow.cs
@@ -1,0 +1,69 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Mono.Linker.Tests.Cases.DataFlow
+{
+	[Kept]
+	class AttributeConstructorDataflow
+	{
+		[KeptAttributeAttribute(typeof(KeepsPublicConstructorAttribute))]
+		[KeepsPublicConstructor(typeof(ClassWithKeptPublicConstructor))]
+		// TODO: String [KeepsPublicMethods(nameof(ClassWithKeptPublicMethods))]
+		public static void Main()
+		{
+			typeof (AttributeConstructorDataflow).GetMethod ("Main").GetCustomAttribute (typeof (KeepsPublicConstructorAttribute));
+			// typeof (AttributeConstructorDataflow).GetMethod ("Main").GetCustomAttribute (typeof (KeepsPublicMethodsAttribute));
+		}
+
+		[Kept]
+		[KeptBaseType(typeof(Attribute))]
+		class KeepsPublicConstructorAttribute : Attribute
+		{
+			[Kept]
+			public KeepsPublicConstructorAttribute(
+				[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+				[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.PublicConstructors)]
+				Type type)
+			{
+			}
+		}
+
+		// TODO
+		/*[Kept]
+		[KeptBaseType(typeof(Attribute))]
+		class KeepsPublicMethodsAttribute : Attribute
+		{
+			[Kept]
+			public KeepsPublicMethodsAttribute (
+				[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.PublicMethods)]
+				string type)
+			{
+			}
+		}*/
+
+		[Kept]
+		class ClassWithKeptPublicConstructor
+		{
+			[Kept]
+			public ClassWithKeptPublicConstructor(int unused) { }
+
+			private ClassWithKeptPublicConstructor(short unused) { }
+
+			public void Method() { }
+		}
+
+		// TODO: String
+		/*[Kept]
+		class ClassWithKeptPublicMethods
+		{
+			[Kept]
+			public static void KeptMethod() { }
+			static void Method() { }
+		}*/
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/AttributeConstructorDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/AttributeConstructorDataflow.cs
@@ -11,12 +11,13 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 	class AttributeConstructorDataflow
 	{
 		[KeptAttributeAttribute(typeof(KeepsPublicConstructorAttribute))]
+		[KeptAttributeAttribute (typeof (KeepsPublicMethodsAttribute))]
 		[KeepsPublicConstructor(typeof(ClassWithKeptPublicConstructor))]
-		// TODO: String [KeepsPublicMethods(nameof(ClassWithKeptPublicMethods))]
+		[KeepsPublicMethods("Mono.Linker.Tests.Cases.DataFlow.AttributeConstructorDataflow+ClassWithKeptPublicMethods")]
 		public static void Main()
 		{
 			typeof (AttributeConstructorDataflow).GetMethod ("Main").GetCustomAttribute (typeof (KeepsPublicConstructorAttribute));
-			// typeof (AttributeConstructorDataflow).GetMethod ("Main").GetCustomAttribute (typeof (KeepsPublicMethodsAttribute));
+			typeof (AttributeConstructorDataflow).GetMethod ("Main").GetCustomAttribute (typeof (KeepsPublicMethodsAttribute));
 		}
 
 		[Kept]
@@ -32,8 +33,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			}
 		}
 
-		// TODO
-		/*[Kept]
+		[Kept]
 		[KeptBaseType(typeof(Attribute))]
 		class KeepsPublicMethodsAttribute : Attribute
 		{
@@ -44,7 +44,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				string type)
 			{
 			}
-		}*/
+		}
 
 		[Kept]
 		class ClassWithKeptPublicConstructor
@@ -57,13 +57,12 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			public void Method() { }
 		}
 
-		// TODO: String
-		/*[Kept]
+		[Kept]
 		class ClassWithKeptPublicMethods
 		{
 			[Kept]
 			public static void KeptMethod() { }
 			static void Method() { }
-		}*/
+		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/DataFlow/AttributeFieldDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/AttributeFieldDataflow.cs
@@ -11,12 +11,13 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 	class AttributeFieldDataflow
 	{
 		[KeptAttributeAttribute (typeof (KeepsPublicConstructorsAttribute))]
+		[KeptAttributeAttribute (typeof (KeepsPublicMethodsAttribute))]
 		[KeepsPublicConstructors (Type = typeof (ClassWithKeptPublicConstructor))]
-		// TODO: String [KeepsPublicMethods(nameof(ClassWithKeptPublicMethods))]
+		[KeepsPublicMethods("Mono.Linker.Tests.Cases.DataFlow.AttributeFieldDataflow+ClassWithKeptPublicMethods")]
 		public static void Main ()
 		{
 			typeof (AttributeFieldDataflow).GetMethod ("Main").GetCustomAttribute (typeof (KeepsPublicConstructorsAttribute));
-			// typeof (AttributeFieldDataflow).GetMethod ("Main").GetCustomAttribute (typeof (KeepsPublicMethodsAttribute));
+			typeof (AttributeFieldDataflow).GetMethod ("Main").GetCustomAttribute (typeof (KeepsPublicMethodsAttribute));
 		}
 
 		[Kept]
@@ -34,8 +35,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			public Type Type;
 		}
 
-		// TODO
-		/*[Kept]
+		[Kept]
 		[KeptBaseType(typeof(Attribute))]
 		class KeepsPublicMethodsAttribute : Attribute
 		{
@@ -46,7 +46,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				string type)
 			{
 			}
-		}*/
+		}
 
 		[Kept]
 		class ClassWithKeptPublicConstructor
@@ -59,13 +59,12 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			public void Method () { }
 		}
 
-		// TODO: String
-		/*[Kept]
+		[Kept]
 		class ClassWithKeptPublicMethods
 		{
 			[Kept]
 			public static void KeptMethod() { }
 			static void Method() { }
-		}*/
+		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/DataFlow/AttributeFieldDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/AttributeFieldDataflow.cs
@@ -1,0 +1,71 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Mono.Linker.Tests.Cases.DataFlow
+{
+	[Kept]
+	class AttributeFieldDataflow
+	{
+		[KeptAttributeAttribute (typeof (KeepsPublicConstructorsAttribute))]
+		[KeepsPublicConstructors (Type = typeof (ClassWithKeptPublicConstructor))]
+		// TODO: String [KeepsPublicMethods(nameof(ClassWithKeptPublicMethods))]
+		public static void Main ()
+		{
+			typeof (AttributeFieldDataflow).GetMethod ("Main").GetCustomAttribute (typeof (KeepsPublicConstructorsAttribute));
+			// typeof (AttributeFieldDataflow).GetMethod ("Main").GetCustomAttribute (typeof (KeepsPublicMethodsAttribute));
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (Attribute))]
+		class KeepsPublicConstructorsAttribute : Attribute
+		{
+			[Kept]
+			public KeepsPublicConstructorsAttribute ()
+			{
+			}
+
+			[Kept]
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.PublicConstructors)]
+			public Type Type;
+		}
+
+		// TODO
+		/*[Kept]
+		[KeptBaseType(typeof(Attribute))]
+		class KeepsPublicMethodsAttribute : Attribute
+		{
+			[Kept]
+			public KeepsPublicMethodsAttribute (
+				[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.PublicMethods)]
+				string type)
+			{
+			}
+		}*/
+
+		[Kept]
+		class ClassWithKeptPublicConstructor
+		{
+			[Kept]
+			public ClassWithKeptPublicConstructor (int unused) { }
+
+			private ClassWithKeptPublicConstructor (short unused) { }
+
+			public void Method () { }
+		}
+
+		// TODO: String
+		/*[Kept]
+		class ClassWithKeptPublicMethods
+		{
+			[Kept]
+			public static void KeptMethod() { }
+			static void Method() { }
+		}*/
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/AttributePropertyDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/AttributePropertyDataflow.cs
@@ -11,12 +11,13 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 	class AttributePropertyDataflow
 	{
 		[KeptAttributeAttribute (typeof (KeepsPublicConstructorsAttribute))]
+		[KeptAttributeAttribute (typeof (KeepsPublicMethodsAttribute))]
 		[KeepsPublicConstructors (Type = typeof (ClassWithKeptPublicConstructor))]
-		// TODO: String [KeepsPublicMethods(nameof(ClassWithKeptPublicMethods))]
+		[KeepsPublicMethods("Mono.Linker.Tests.Cases.DataFlow.AttributePropertyDataflow+ClassWithKeptPublicMethods")]
 		public static void Main ()
 		{
 			typeof (AttributePropertyDataflow).GetMethod ("Main").GetCustomAttribute (typeof (KeepsPublicConstructorsAttribute));
-			// typeof (AttributePropertyDataflow).GetMethod ("Main").GetCustomAttribute (typeof (KeepsPublicMethodsAttribute));
+			typeof (AttributePropertyDataflow).GetMethod ("Main").GetCustomAttribute (typeof (KeepsPublicMethodsAttribute));
 		}
 
 		[Kept]
@@ -35,8 +36,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			public Type Type { get; [Kept] set; }
 		}
 
-		// TODO
-		/*[Kept]
+		[Kept]
 		[KeptBaseType(typeof(Attribute))]
 		class KeepsPublicMethodsAttribute : Attribute
 		{
@@ -47,7 +47,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				string type)
 			{
 			}
-		}*/
+		}
 
 		[Kept]
 		class ClassWithKeptPublicConstructor
@@ -60,13 +60,12 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			public void Method () { }
 		}
 
-		// TODO: String
-		/*[Kept]
+		[Kept]
 		class ClassWithKeptPublicMethods
 		{
 			[Kept]
 			public static void KeptMethod() { }
 			static void Method() { }
-		}*/
+		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/DataFlow/AttributePropertyDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/AttributePropertyDataflow.cs
@@ -1,0 +1,72 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Mono.Linker.Tests.Cases.DataFlow
+{
+	[Kept]
+	class AttributePropertyDataflow
+	{
+		[KeptAttributeAttribute (typeof (KeepsPublicConstructorsAttribute))]
+		[KeepsPublicConstructors (Type = typeof (ClassWithKeptPublicConstructor))]
+		// TODO: String [KeepsPublicMethods(nameof(ClassWithKeptPublicMethods))]
+		public static void Main ()
+		{
+			typeof (AttributePropertyDataflow).GetMethod ("Main").GetCustomAttribute (typeof (KeepsPublicConstructorsAttribute));
+			// typeof (AttributePropertyDataflow).GetMethod ("Main").GetCustomAttribute (typeof (KeepsPublicMethodsAttribute));
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (Attribute))]
+		class KeepsPublicConstructorsAttribute : Attribute
+		{
+			[Kept]
+			public KeepsPublicConstructorsAttribute ()
+			{
+			}
+
+			[field: Kept]
+			[Kept]
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.PublicConstructors)]
+			public Type Type { get; [Kept] set; }
+		}
+
+		// TODO
+		/*[Kept]
+		[KeptBaseType(typeof(Attribute))]
+		class KeepsPublicMethodsAttribute : Attribute
+		{
+			[Kept]
+			public KeepsPublicMethodsAttribute (
+				[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.PublicMethods)]
+				string type)
+			{
+			}
+		}*/
+
+		[Kept]
+		class ClassWithKeptPublicConstructor
+		{
+			[Kept]
+			public ClassWithKeptPublicConstructor (int unused) { }
+
+			private ClassWithKeptPublicConstructor (short unused) { }
+
+			public void Method () { }
+		}
+
+		// TODO: String
+		/*[Kept]
+		class ClassWithKeptPublicMethods
+		{
+			[Kept]
+			public static void KeptMethod() { }
+			static void Method() { }
+		}*/
+	}
+}


### PR DESCRIPTION
A custom attribute application should be treated the same as a method call (followed by potentially several calls to property setters and field stores). All parameters will be statically known by definition.

I plan to fix up the string-based tests before this is merged (going to merge after #1078 that is a prerequisite).

Fixes #1072