### PR TITLE
[feature/dataflow] Look for fields, properties and methods in base type

### DIFF
--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallString.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallString.cs
@@ -196,12 +196,12 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		[Kept]
 		class ABase
 		{
-			// [Kept] : TODO - should be kept: https://github.com/mono/linker/issues/1042
+			[Kept]
 			public static void PublicOnBase ()
 			{
 			}
 
-			// [Kept] : TODO - should be kept: https://github.com/mono/linker/issues/1042
+			[Kept]
 			protected static void ProtectedOnBase ()
 			{
 			}

--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallString.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallString.cs
@@ -123,8 +123,6 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			Expression.Call (FindType (), "OnlyCalledViaExpression", Type.EmptyTypes);
 		}
 
-		[UnrecognizedReflectionAccessPattern (
-			typeof (Expression), nameof (Expression.Call), new Type [] { typeof (Type), typeof (string), typeof (Type []), typeof (Expression []) })]
 		[Kept]
 		static void TestNonExistingName ()
 		{
@@ -196,12 +194,12 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		[Kept]
 		class ABase
 		{
-			// [Kept] : TODO - should be kept: https://github.com/mono/linker/issues/1042
+			[Kept]
 			public static void PublicOnBase ()
 			{
 			}
 
-			// [Kept] : TODO - should be kept: https://github.com/mono/linker/issues/1042
+			[Kept]
 			protected static void ProtectedOnBase ()
 			{
 			}

--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallString.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallString.cs
@@ -196,12 +196,12 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		[Kept]
 		class ABase
 		{
-			[Kept]
+			// [Kept] : TODO - should be kept: https://github.com/mono/linker/issues/1042
 			public static void PublicOnBase ()
 			{
 			}
 
-			[Kept]
+			// [Kept] : TODO - should be kept: https://github.com/mono/linker/issues/1042
 			protected static void ProtectedOnBase ()
 			{
 			}

--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionFieldString.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionFieldString.cs
@@ -179,10 +179,10 @@ namespace Mono.Linker.Tests.Cases.Reflection
 	[Kept]
 	class ABase
 	{
-		// [Kept] - TODO - should be kept: https://github.com/mono/linker/issues/1042
+		[Kept]
 		protected static bool _protectedFieldOnBase;
 
-		// [Kept] - TODO - should be kept: https://github.com/mono/linker/issues/1042
+		[Kept]
 		public static bool _publicFieldOnBase;
 	}
 

--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionFieldString.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionFieldString.cs
@@ -16,9 +16,6 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			Branch_SystemTypeValueNode_UnknownStringValue ();
 			Branch_MethodParameterValueNode (typeof (ExpressionFieldString), "Foo");
 			Branch_UnrecognizedPatterns ();
-			// TODO
-			Expression.Field(null, typeof(ADerived), "_protectedFieldOnBase");
-			Expression.Field(null, typeof(ADerived), "_publicFieldOnBase");
 		}
 
 		[Kept]
@@ -29,6 +26,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestType (0);
 			TestType (1);
 			StaticFieldExpected ();
+			FieldsOnBaseType ();
 		}
 
 		[Kept]
@@ -95,6 +93,13 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			}
 
 			Expression.Field (null, T, "Foo");
+		}
+
+		[Kept]
+		static void FieldsOnBaseType ()
+		{
+			Expression.Field (null, typeof (ADerived), "_protectedFieldOnBase");
+			Expression.Field (null, typeof (ADerived), "_publicFieldOnBase");
 		}
 		#endregion
 

--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionFieldString.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionFieldString.cs
@@ -101,18 +101,15 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			Expression.Field (null, typeof (ADerived), "_protectedFieldOnBase");
 			Expression.Field (null, typeof (ADerived), "_publicFieldOnBase");
 		}
-		#endregion
 
-		#region UnrecognizedReflectionAccessPatterns
-		[UnrecognizedReflectionAccessPattern (
-				typeof (Expression), nameof (Expression.Field), new Type [] { typeof (Expression), typeof (Type), typeof (string) })]
 		[Kept]
 		static void StaticFieldExpected ()
 		{
 			var expr = Expression.Field (null, typeof (ExpressionFieldString), "TestOnlyStatic2");
 		}
+		#endregion
 
-
+		#region UnrecognizedReflectionAccessPatterns
 		[UnrecognizedReflectionAccessPattern (
 			typeof (Expression), nameof (Expression.Field), new Type [] { typeof (Expression), typeof (Type), typeof (string) })]
 		[Kept]
@@ -178,22 +175,22 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		{
 			return "unknownstring";
 		}
+
+		[Kept]
+		class ABase
+		{
+			[Kept]
+			protected static bool _protectedFieldOnBase;
+
+			[Kept]
+			public static bool _publicFieldOnBase;
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (ABase))]
+		class ADerived : ABase
+		{
+		}
 		#endregion
-	}
-
-	[Kept]
-	class ABase
-	{
-		[Kept]
-		protected static bool _protectedFieldOnBase;
-
-		[Kept]
-		public static bool _publicFieldOnBase;
-	}
-
-	[Kept]
-	[KeptBaseType (typeof (ABase))]
-	class ADerived : ABase
-	{
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionPropertyString.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionPropertyString.cs
@@ -21,9 +21,6 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			Foo.Branch_NullValueNode ();
 			Foo.Branch_MethodParameterValueNode (typeof (Foo), "Foo");
 			Foo.Branch_UnrecognizedPatterns ();
-			// TODO
-			Expression.Property(null, typeof(ADerived), "ProtectedPropertyOnBase");
-			Expression.Property(null, typeof(ADerived), "PublicPropertyOnBase");
 		}
 
 		[KeptMember (".ctor()")]
@@ -37,6 +34,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 				TestByType (0);
 				TestByType (1);
 				StaticPropertyExpected ();
+				PropertyOnBaseType ();
 			}
 
 			[Kept]
@@ -103,6 +101,13 @@ namespace Mono.Linker.Tests.Cases.Reflection
 				}
 
 				Expression.Property (null, T, "Foo");
+			}
+
+			[Kept]
+			static void PropertyOnBaseType ()
+			{
+				Expression.Property (Expression.Parameter (typeof (bool), "somename"), typeof (ADerived), "ProtectedPropertyOnBase");
+				Expression.Property (null, typeof (ADerived), "PublicPropertyOnBase");
 			}
 			#endregion
 
@@ -191,11 +196,13 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		[Kept]
 		class ABase
 		{
-			// [Kept] - TODO - should be kept: https://github.com/mono/linker/issues/1042
-			protected bool ProtectedPropertyOnBase { get; }
+			[Kept]
+			[KeptBackingField]
+			protected bool ProtectedPropertyOnBase { [Kept] get; }
 
-			// [Kept] - TODO - should be kept: https://github.com/mono/linker/issues/1042
-			public bool PublicPropertyOnBase { get; }
+			[Kept]
+			[KeptBackingField]
+			public static bool PublicPropertyOnBase { [Kept] get; }
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionPropertyString.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionPropertyString.cs
@@ -109,17 +109,15 @@ namespace Mono.Linker.Tests.Cases.Reflection
 				Expression.Property (Expression.Parameter (typeof (bool), "somename"), typeof (ADerived), "ProtectedPropertyOnBase");
 				Expression.Property (null, typeof (ADerived), "PublicPropertyOnBase");
 			}
-			#endregion
 
-			#region UnrecognizedReflectionAccessPatterns
-			[UnrecognizedReflectionAccessPattern (
-				typeof (Expression), nameof (Expression.Property), new Type [] { typeof (Expression), typeof (Type), typeof (string) })]
 			[Kept]
 			public void StaticPropertyExpected ()
 			{
 				var expr = Expression.Property (null, typeof (Foo), "TestOnlyStatic2");
 			}
+			#endregion
 
+			#region UnrecognizedReflectionAccessPatterns
 			[UnrecognizedReflectionAccessPattern (
 				typeof (Expression), nameof (Expression.Property), new Type [] { typeof (Expression), typeof (Type), typeof (string) })]
 			[Kept]
@@ -190,25 +188,25 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			{
 				return "unknownstring";
 			}
+
+			[Kept]
+			class ABase
+			{
+				[Kept]
+				[KeptBackingField]
+				protected bool ProtectedPropertyOnBase { [Kept] get; }
+
+				[Kept]
+				[KeptBackingField]
+				public static bool PublicPropertyOnBase { [Kept] get; }
+			}
+
+			[Kept]
+			[KeptBaseType (typeof (ABase))]
+			class ADerived : ABase
+			{
+			}
 			#endregion
-		}
-
-		[Kept]
-		class ABase
-		{
-			[Kept]
-			[KeptBackingField]
-			protected bool ProtectedPropertyOnBase { [Kept] get; }
-
-			[Kept]
-			[KeptBackingField]
-			public static bool PublicPropertyOnBase { [Kept] get; }
-		}
-
-		[Kept]
-		[KeptBaseType (typeof (ABase))]
-		class ADerived : ABase
-		{
 		}
 	}
 }


### PR DESCRIPTION
If a field, property or method which is accessed via reflection is not found inside the callers type, look for it in it's base type (if any). This fixes #1042.  