### PR TITLE
[feature/dataflow] Add support for byref operations

### DIFF
--- a/src/linker/Linker.Dataflow/ScannerExtensions.cs
+++ b/src/linker/Linker.Dataflow/ScannerExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-
+using Mono.Cecil;
 using Mono.Cecil.Cil;
 
 namespace Mono.Linker.Dataflow
@@ -36,6 +36,11 @@ namespace Mono.Linker.Dataflow
 				branchTargets.Add (einfo.HandlerStart.Offset);
 			}
 			return branchTargets;
+		}
+
+		public static bool IsByRefOrPointer(this TypeReference typeRef)
+		{
+			return typeRef.IsByReference || typeRef.IsPointer;
 		}
 	}
 

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -3467,6 +3467,17 @@ namespace Mono.Linker.Steps {
 				}
 			}
 
+			protected override void HandleStoreParameter (MethodDefinition method, int index, Instruction operation, ValueNode valueToStore)
+			{
+				var requiredMemberKinds = _flowAnnotations.GetParameterAnnotation (method, index);
+				if (requiredMemberKinds != 0) {
+					// TODO: There's no way to represent store to a parameter given current ReflectionPatternContext (and the underlying IReflectionPatterRecorder)
+					var reflectionContext = new ReflectionPatternContext (_markStep._context, method, method, operation.Offset);
+					reflectionContext.AnalyzingPattern ();
+					RequireDynamicallyAccessedMembers (ref reflectionContext, requiredMemberKinds, valueToStore, method.Parameters[index - (method.HasImplicitThis() ? 1 : 0)]);
+				}
+			}
+
 			public override bool HandleCall (MethodBody callingMethodBody, MethodReference calledMethod, Instruction operation, ValueNodeList methodParams, out ValueNode methodReturnValue)
 			{
 				var reflectionContext = new ReflectionPatternContext (_markStep._context, callingMethodBody.Method, calledMethod.Resolve (), operation.Offset);

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ByRefDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ByRefDataflow.cs
@@ -1,0 +1,94 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Mono.Linker.Tests.Cases.DataFlow
+{
+	[SetupCompileArgument ("/langversion:7.3")]
+	[Kept]
+	class ByRefDataflow
+	{
+		public static void Main()
+		{
+			{
+				Type t = typeof (ClassPassedToMethodTakingTypeByRef);
+				MethodWithRefParameter (ref t);
+			}
+
+			{
+				Type t1 = typeof (ClassMaybePassedToMethodTakingTypeByRef);
+				Type t2 = typeof (OtherClassMaybePassedToMethodTakingTypeByRef);
+				ref Type t = ref t1;
+				if (string.Empty.Length == 0)
+					t = ref t2;
+				MethodWithRefParameter (ref t);
+			}
+
+			PassRefToField ();
+			PassRefToParameter (null);
+		}
+
+		[Kept]
+		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.DefaultConstructor)]
+		static Type s_typeWithDefaultConstructor;
+
+		[Kept]
+		[UnrecognizedReflectionAccessPattern (typeof (ByRefDataflow), nameof (MethodWithRefParameter), new string [] { "System.Type&" })]
+		public static void PassRefToField()
+		{
+			MethodWithRefParameter (ref s_typeWithDefaultConstructor);
+		}
+
+		[Kept]
+		[UnrecognizedReflectionAccessPattern (typeof (ByRefDataflow), nameof (MethodWithRefParameter), new string [] { "System.Type&" })]
+		public static void PassRefToParameter(Type parameter)
+		{
+			MethodWithRefParameter (ref parameter);
+		}
+
+		[Kept]
+		public static void MethodWithRefParameter(
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.PublicMethods)]
+			ref Type type)
+		{
+			type = typeof (ClassReturnedAsRefFromMethodTakingTypeByRef);
+		}
+
+		[Kept]
+		class ClassPassedToMethodTakingTypeByRef
+		{
+			[Kept]
+			public static void KeptMethod() { }
+			internal static void RemovedMethod() { }
+		}
+
+		[Kept]
+		class ClassReturnedAsRefFromMethodTakingTypeByRef
+		{
+			[Kept]
+			public static void KeptMethod () { }
+			internal static void RemovedMethod () { }
+		}
+
+		[Kept]
+		class ClassMaybePassedToMethodTakingTypeByRef
+		{
+			[Kept]
+			public static void KeptMethod () { }
+			internal static void RemovedMethod () { }
+		}
+
+		[Kept]
+		class OtherClassMaybePassedToMethodTakingTypeByRef
+		{
+			[Kept]
+			public static void KeptMethod () { }
+			internal static void RemovedMethod () { }
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MethodParametersDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MethodParametersDataFlow.cs
@@ -19,6 +19,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			DefaultConstructorParameter (typeof (TestType));
 			PublicConstructorsParameter (typeof (TestType));
 			ConstructorsParameter (typeof (TestType));
+			WriteToParameterOnStaticMethod (null);
+			LongWriteToParameterOnStaticMethod (0, 0, 0, 0, null);
 			instance.InstanceMethod (typeof (TestType));
 			instance.TwoAnnotatedParameters (typeof (TestType), typeof (TestType));
 			instance.TwoAnnotatedParametersIntoOneValue(typeof (TestType), typeof (TestType));
@@ -27,6 +29,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			instance.AnnotatedValueToUnAnnotatedParameter (typeof (TestType));
 			instance.UnknownValueToUnAnnotatedParameter ();
 			instance.UnknownValueToUnAnnotatedParameterOnInterestingMethod ();
+			instance.WriteToParameterOnInstanceMethod (null);
+			instance.LongWriteToParameterOnInstanceMethod (0, 0, 0, 0, null);
 		}
 
 		// Validate the error message when annotated parameter is passed to another annotated parameter
@@ -73,6 +77,46 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		{
 			RequireDefaultConstructor (type);
 			RequirePublicConstructors (type);
+		}
+
+		[UnrecognizedReflectionAccessPattern (typeof (MethodParametersDataFlow), nameof (WriteToParameterOnInstanceMethod), new Type [] { typeof (Type) })]
+		private void WriteToParameterOnInstanceMethod (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.Constructors)]
+			Type type)
+		{
+			type = ReturnThingsWithDefaultConstructor ();
+		}
+
+		[UnrecognizedReflectionAccessPattern (typeof (MethodParametersDataFlow), nameof (WriteToParameterOnStaticMethod), new Type [] { typeof (Type) })]
+		private static void WriteToParameterOnStaticMethod (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.Constructors)]
+			Type type)
+		{
+			type = ReturnThingsWithDefaultConstructor ();
+		}
+
+		[UnrecognizedReflectionAccessPattern (typeof (MethodParametersDataFlow), nameof (LongWriteToParameterOnInstanceMethod), new Type [] { typeof(int), typeof (int), typeof (int), typeof (int), typeof (Type) })]
+		private void LongWriteToParameterOnInstanceMethod (
+			int a, int b, int c, int d,
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.Constructors)]
+			Type type)
+		{
+			type = ReturnThingsWithDefaultConstructor ();
+		}
+
+		[UnrecognizedReflectionAccessPattern (typeof (MethodParametersDataFlow), nameof (LongWriteToParameterOnStaticMethod), new Type [] { typeof (int), typeof (int), typeof (int), typeof (int), typeof (Type) })]
+		private static void LongWriteToParameterOnStaticMethod (
+			int a, int b, int c, int d,
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.Constructors)]
+			Type type)
+		{
+			type = ReturnThingsWithDefaultConstructor ();
+		}
+
+		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.DefaultConstructor)]
+		static private Type ReturnThingsWithDefaultConstructor()
+		{
+			return null;
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (MethodParametersDataFlow), nameof (RequirePublicConstructors), new Type [] { typeof (Type) })]


### PR DESCRIPTION
We track indirect writes to method parameters and fields. This is necessary to support dataflow annotations on `out` and `ref` parameters.