### PR TITLE
Fix property annotation test

### DIFF
--- a/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
@@ -77,46 +77,43 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.PublicConstructors)]
 		Type _fieldWithPublicConstructors;
 
-		[DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.PublicConstructors)]
 		Type PropertyPublicConstructorsWithExplicitAccessors {
 			[RecognizedReflectionAccessPattern]
-			[DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.PublicConstructors)]
+			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.PublicConstructors)]
 			get {
 				return _fieldWithPublicConstructors;
 			}
 
 			[RecognizedReflectionAccessPattern]
-			[DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.PublicConstructors)]
+			[param: DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.PublicConstructors)]
 			set {
 				_fieldWithPublicConstructors = value;
 			}
 		}
 
-		[DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.DefaultConstructor)]
 		Type PropertyDefaultConstructorWithExplicitAccessors {
 			[RecognizedReflectionAccessPattern]
-			[DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.DefaultConstructor)]
+			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.DefaultConstructor)]
 			get {
 				return _fieldWithPublicConstructors;
 			}
 
 			[UnrecognizedReflectionAccessPattern(typeof (PropertyDataFlow), "set_" + nameof (PropertyDefaultConstructorWithExplicitAccessors), new Type [] { typeof (Type) })]
-			[DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.DefaultConstructor)]
+			[param: DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.DefaultConstructor)]
 			set {
 				_fieldWithPublicConstructors = value;
 			}
 		}
 
-		[DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.Constructors)]
 		Type PropertyConstructorsWithExplicitAccessors {
 			[UnrecognizedReflectionAccessPattern (typeof (PropertyDataFlow), "get_" + nameof (PropertyConstructorsWithExplicitAccessors), new Type [] { })]
-			[DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.Constructors)]
+			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.Constructors)]
 			get {
 				return _fieldWithPublicConstructors;
 			}
 
 			[RecognizedReflectionAccessPattern]
-			[DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.Constructors)]
+			[param: DynamicallyAccessedMembers (DynamicallyAccessedMemberKinds.Constructors)]
 			set {
 				_fieldWithPublicConstructors = value;
 			}


### PR DESCRIPTION
I noticed that the explicit property tests had annotations that applied to `this` on the getter/setter, but they happened to work because the annotation propagation for properties was applying to the `return`/`param`. I also added tests that actually check the `this` annotations on properties.