### PR TITLE
[feature/dataflow] Only keep public DefaultConstructor

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -3843,7 +3843,8 @@ namespace Mono.Linker.Steps {
 				if (requiredMemberKinds.HasFlag (DynamicallyAccessedMemberKinds.Constructors)) {
 					MarkConstructorsOnType (ref reflectionContext, typeDefinition, filter: null);
 				} else if (requiredMemberKinds.HasFlag (DynamicallyAccessedMemberKinds.PublicConstructors)) {
-					MarkConstructorsOnType (ref reflectionContext, typeDefinition, filter: m => m.IsPublic);
+					// Also keep default ctor which may be non-public.
+					MarkConstructorsOnType (ref reflectionContext, typeDefinition, filter: m => m.IsPublic || m.Parameters.Count == 0);
 				} else if (requiredMemberKinds.HasFlag (DynamicallyAccessedMemberKinds.DefaultConstructor)) {
 					MarkConstructorsOnType (ref reflectionContext, typeDefinition, filter: m => m.Parameters.Count == 0);
 				}

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -3843,10 +3843,9 @@ namespace Mono.Linker.Steps {
 				if (requiredMemberKinds.HasFlag (DynamicallyAccessedMemberKinds.Constructors)) {
 					MarkConstructorsOnType (ref reflectionContext, typeDefinition, filter: null);
 				} else if (requiredMemberKinds.HasFlag (DynamicallyAccessedMemberKinds.PublicConstructors)) {
-					// Also keep default ctor which may be non-public.
-					MarkConstructorsOnType (ref reflectionContext, typeDefinition, filter: m => m.IsPublic || m.Parameters.Count == 0);
+					MarkConstructorsOnType (ref reflectionContext, typeDefinition, filter: m => m.IsPublic);
 				} else if (requiredMemberKinds.HasFlag (DynamicallyAccessedMemberKinds.DefaultConstructor)) {
-					MarkConstructorsOnType (ref reflectionContext, typeDefinition, filter: m => m.Parameters.Count == 0);
+					MarkConstructorsOnType (ref reflectionContext, typeDefinition, filter: m => m.IsPublic && m.Parameters.Count == 0);
 				}
 
 				if (requiredMemberKinds.HasFlag (DynamicallyAccessedMemberKinds.Methods)) {

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MemberKinds.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MemberKinds.cs
@@ -15,10 +15,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			RequirePublicConstructors (typeof (PublicConstructorsType));
 			RequireConstructors (typeof (ConstructorsType));
 			RequireDefaultConstructor (typeof (PrivateDefaultConstructorType));
-			RequireDefaultOrPublicConstructors (typeof (PrivateDefaultAndPublicConstructorsType));
-			// I expect this^ to have the same effect on the type as:
-			//   RequireDefaultConstructor (typeof (PrivateDefaultAndPublicConstructorsType));
-			//   RequirePublicConstructors (typeof (PrivateDefaultAndPublicConstructorsType));
+			RequirePublicConstructors (typeof (PrivateDefaultAndPublicConstructorsType));
 			RequirePublicMethods (typeof (PublicMethodsType));
 			RequireMethods (typeof (MethodsType));
 			RequirePublicFields (typeof (PublicFieldsType));
@@ -63,15 +60,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			public void Method1 () { }
 			public bool Property1 { get; set; }
 			public bool Field1;
-		}
-
-		[Kept]
-		private static void RequireDefaultOrPublicConstructors (
-			// Encoded the same as just PublicConstructors
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.DefaultConstructor | DynamicallyAccessedMemberKinds.PublicConstructors)]
-			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
-			Type type)
-		{
 		}
 
 		[Kept]
@@ -147,6 +135,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[KeptBaseType (typeof (PublicConstructorsBaseType))]
 		class PublicConstructorsType : PublicConstructorsBaseType
 		{
+			// Private default ctor is also kept for DynamicallyAccessedMemberKinds.PublicConstructors
+			[Kept]
 			private PublicConstructorsType () { }
 
 			[Kept]

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MemberKinds.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MemberKinds.cs
@@ -12,10 +12,12 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		public static void Main ()
 		{
 			RequireDefaultConstructor (typeof (DefaultConstructorType));
+			RequireDefaultConstructor (typeof (PrivateParameterlessConstructorType));
+			RequireDefaultConstructor (typeof (DefaultConstructorBeforeFieldInitType));
 			RequirePublicConstructors (typeof (PublicConstructorsType));
+			RequirePublicConstructors (typeof (PublicConstructorsBeforeFieldInitType));
 			RequireConstructors (typeof (ConstructorsType));
-			RequireDefaultConstructor (typeof (PrivateDefaultConstructorType));
-			RequirePublicConstructors (typeof (PrivateDefaultAndPublicConstructorsType));
+			RequireConstructors (typeof (ConstructorsBeforeFieldInitType));
 			RequirePublicMethods (typeof (PublicMethodsType));
 			RequireMethods (typeof (MethodsType));
 			RequirePublicFields (typeof (PublicFieldsType));
@@ -57,55 +59,40 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 			private DefaultConstructorType (int i, int j) { }
 
+			// Not implied by the DynamicallyAccessedMemberKinds logic, but
+			// explicit cctors would be kept by the linker.
+			// [Kept]
+			// static DefaultConstructorType () { }
+
 			public void Method1 () { }
 			public bool Property1 { get; set; }
 			public bool Field1;
 		}
 
 		[Kept]
-		class PrivateDefaultConstructorBaseType
+		class DefaultConstructorBeforeFieldInitType
 		{
-			[Kept]
-			protected PrivateDefaultConstructorBaseType () { }
+			static int i = 10;
 
-			PrivateDefaultConstructorBaseType (int i) { }
+			[Kept]
+			public DefaultConstructorBeforeFieldInitType () { }
 		}
 
 		[Kept]
-		[KeptBaseType (typeof (PrivateDefaultConstructorBaseType))]
-		class PrivateDefaultConstructorType : PrivateDefaultConstructorBaseType
+		class PrivateParameterlessConstructorBaseType
 		{
-			[Kept]
-			PrivateDefaultConstructorType () { }
+			protected PrivateParameterlessConstructorBaseType () { }
 
-			public PrivateDefaultConstructorType (int i) { }
-
-			public void Method1 () { }
-
-			public bool Property1 { get; set; }
-
-			public bool Field1;
+			PrivateParameterlessConstructorBaseType (int i) { }
 		}
 
 		[Kept]
-		class PrivateDefaultAndPublicConstructorsBaseType
+		[KeptBaseType (typeof (PrivateParameterlessConstructorBaseType))]
+		class PrivateParameterlessConstructorType : PrivateParameterlessConstructorBaseType
 		{
-			[Kept]
-			protected PrivateDefaultAndPublicConstructorsBaseType () { }
+			PrivateParameterlessConstructorType () { }
 
-			public PrivateDefaultAndPublicConstructorsBaseType (int i) { }
-		}
-
-		// Same as PrivateDefaultConstructorType, with different [Kept] expectations
-		[Kept]
-		[KeptBaseType (typeof (PrivateDefaultAndPublicConstructorsBaseType))]
-		class PrivateDefaultAndPublicConstructorsType : PrivateDefaultAndPublicConstructorsBaseType
-		{
-			[Kept]
-			PrivateDefaultAndPublicConstructorsType () { }
-
-			[Kept]
-			public PrivateDefaultAndPublicConstructorsType (int i) { }
+			public PrivateParameterlessConstructorType (int i) { }
 
 			public void Method1 () { }
 
@@ -135,8 +122,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[KeptBaseType (typeof (PublicConstructorsBaseType))]
 		class PublicConstructorsType : PublicConstructorsBaseType
 		{
-			// Private default ctor is also kept for DynamicallyAccessedMemberKinds.PublicConstructors
-			[Kept]
 			private PublicConstructorsType () { }
 
 			[Kept]
@@ -144,9 +129,22 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 			private PublicConstructorsType (int i, int j) { }
 
+			// Not implied by the DynamicallyAccessedMemberKinds logic, but
+			// explicit cctors would be kept by the linker.
+			// [Kept]
+			// static PublicConstructorsType () { }
+
 			public void Method1 () { }
 			public bool Property1 { get; set; }
 			public bool Field1;
+		}
+
+		class PublicConstructorsBeforeFieldInitType
+		{
+			static int i = 10;
+
+			[Kept]
+			public PublicConstructorsBeforeFieldInitType () { }
 		}
 
 
@@ -180,6 +178,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[Kept]
 			private ConstructorsType (int i, int j) { }
 
+			// Kept by the DynamicallyAccessedMembers logic
 			[Kept]
 			static ConstructorsType () { }
 
@@ -188,6 +187,15 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			public bool Field1;
 		}
 
+		[Kept]
+		class ConstructorsBeforeFieldInitType
+		{
+			[Kept]
+			public int i = 10;
+
+			[Kept]
+			public ConstructorsBeforeFieldInitType () { }
+		}
 
 		[Kept]
 		private static void RequirePublicMethods (

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MemberKinds.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MemberKinds.cs
@@ -1,4 +1,4 @@
-﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -14,6 +14,11 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			RequireDefaultConstructor (typeof (DefaultConstructorType));
 			RequirePublicConstructors (typeof (PublicConstructorsType));
 			RequireConstructors (typeof (ConstructorsType));
+			RequireDefaultConstructor (typeof (PrivateDefaultConstructorType));
+			RequireDefaultOrPublicConstructors (typeof (PrivateDefaultAndPublicConstructorsType));
+			// I expect this^ to have the same effect on the type as:
+			//   RequireDefaultConstructor (typeof (PrivateDefaultAndPublicConstructorsType));
+			//   RequirePublicConstructors (typeof (PrivateDefaultAndPublicConstructorsType));
 			RequirePublicMethods (typeof (PublicMethodsType));
 			RequireMethods (typeof (MethodsType));
 			RequirePublicFields (typeof (PublicFieldsType));
@@ -60,6 +65,66 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			public bool Field1;
 		}
 
+		[Kept]
+		private static void RequireDefaultOrPublicConstructors (
+			// Encoded the same as just PublicConstructors
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberKinds.DefaultConstructor | DynamicallyAccessedMemberKinds.PublicConstructors)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type type)
+		{
+		}
+
+		[Kept]
+		class PrivateDefaultConstructorBaseType
+		{
+			[Kept]
+			protected PrivateDefaultConstructorBaseType () { }
+
+			PrivateDefaultConstructorBaseType (int i) { }
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (PrivateDefaultConstructorBaseType))]
+		class PrivateDefaultConstructorType : PrivateDefaultConstructorBaseType
+		{
+			[Kept]
+			PrivateDefaultConstructorType () { }
+
+			public PrivateDefaultConstructorType (int i) { }
+
+			public void Method1 () { }
+
+			public bool Property1 { get; set; }
+
+			public bool Field1;
+		}
+
+		[Kept]
+		class PrivateDefaultAndPublicConstructorsBaseType
+		{
+			[Kept]
+			protected PrivateDefaultAndPublicConstructorsBaseType () { }
+
+			public PrivateDefaultAndPublicConstructorsBaseType (int i) { }
+		}
+
+		// Same as PrivateDefaultConstructorType, with different [Kept] expectations
+		[Kept]
+		[KeptBaseType (typeof (PrivateDefaultAndPublicConstructorsBaseType))]
+		class PrivateDefaultAndPublicConstructorsType : PrivateDefaultAndPublicConstructorsBaseType
+		{
+			[Kept]
+			PrivateDefaultAndPublicConstructorsType () { }
+
+			[Kept]
+			public PrivateDefaultAndPublicConstructorsType (int i) { }
+
+			public void Method1 () { }
+
+			public bool Property1 { get; set; }
+
+			public bool Field1;
+		}
 
 		[Kept]
 		private static void RequirePublicConstructors (


### PR DESCRIPTION
Posting this mostly to ask a question @MichalStrehovsky @vitek-karas

The attribute encoding sort of assumes that the default ctor is public. The logic that keeps default ctors works for private default ctors, but the logic that keeps public ctors will not keep a private default ctor. Should we do something differently to prevent the behavior illustrated in this failing testcase? (`RequireDefaultConstructor` works, but `RequireDefaultOrPublicConstructors` will not keep the default private ctor on `PrivateDefaultAndPublicConstructorsType`).