### PR TITLE
Revert "[feature/dataflow] Look for fields, properties and methods in base type"

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -3537,12 +3537,10 @@ namespace Mono.Linker.Steps {
 										foreach (var stringParam in methodParams [1].UniqueValues ()) {
 											// TODO: Change this as needed after deciding whether or not we are to keep
 											// all methods on a type that was accessed via reflection.
-											if (stringParam is KnownStringValue stringValue) {
-												MarkMethodsOnTypeHierarchy (ref reflectionContext, systemTypeValue.TypeRepresented, m => m.Name == stringValue.Contents, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
-												reflectionContext.RecordHandledPattern ();
-											} else {
+											if (stringParam is KnownStringValue stringValue)
+												MarkMethodsFromReflectionCall (ref reflectionContext, systemTypeValue.TypeRepresented, stringValue.Contents, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+											else
 												reflectionContext.RecordUnrecognizedPattern ($"Expression call '{calledMethod.FullName}' inside '{callingMethodBody.Method.FullName}' was detected with 2nd argument which cannot be analyzed");
-											}
 										}
 									} else if (value == NullValue.Instance) {
 										reflectionContext.RecordHandledPattern ();
@@ -3575,13 +3573,10 @@ namespace Mono.Linker.Steps {
 												bool staticOnly = methodParams [0].Kind == ValueNodeKind.Null;
 												// TODO: Change this as needed after deciding if we are to keep all fields/properties on a type
 												// that is accessed via reflection. For now, let's only keep the field/property that is retrieved.
-												if (calledMethod.Name [0] == 'P') {
-													MarkPropertiesOnTypeHierarchy (ref reflectionContext, systemTypeValue.TypeRepresented, filter: p => p.Name == stringValue.Contents, staticOnly);
-												} else {
-													MarkFieldsOnTypeHierarchy (ref reflectionContext, systemTypeValue.TypeRepresented, filter: f => f.Name == stringValue.Contents, staticOnly);
-												}
-
-												reflectionContext.RecordHandledPattern ();
+												if (calledMethod.Name [0] == 'P')
+													MarkPropertiesFromReflectionCall (ref reflectionContext, systemTypeValue.TypeRepresented, stringValue.Contents, staticOnly);
+												else
+													MarkFieldsFromReflectionCall (ref reflectionContext, systemTypeValue.TypeRepresented, stringValue.Contents, staticOnly);
 											} else {
 												reflectionContext.RecordUnrecognizedPattern ($"Expression call '{calledMethod.FullName}' inside '{callingMethodBody.Method.FullName}' was detected with 3rd argument which cannot be analyzed");
 											}
@@ -3610,12 +3605,10 @@ namespace Mono.Linker.Steps {
 								reflectionContext.AnalyzingPattern();
 
 								foreach (var value in methodParams [0].UniqueValues ()) {
-									if (value is SystemTypeValue systemTypeValue) {
-										MarkConstructorsOnType (ref reflectionContext, systemTypeValue.TypeRepresented, null, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-										reflectionContext.RecordHandledPattern ();
-									} else {
+									if (value is SystemTypeValue systemTypeValue)
+										MarkMethodsFromReflectionCall (ref reflectionContext, systemTypeValue.TypeRepresented, ".ctor", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, parametersCount: 0);
+									else
 										RequireDynamicallyAccessedMembers (ref reflectionContext, DynamicallyAccessedMemberKinds.DefaultConstructor, value, calledMethod.Parameters [0]);
-									}
 								}
 							}
 							break;
@@ -3724,9 +3717,7 @@ namespace Mono.Linker.Steps {
 								foreach (var value in methodParams [0].UniqueValues ()) {
 									if (value is SystemTypeValue systemTypeValue) {
 										// Special case known type values as we can do better by applying exact binding flags and parameter count.
-										MarkConstructorsOnType (ref reflectionContext, systemTypeValue.TypeRepresented,
-											ctorParameterCount == null ? (Func<MethodDefinition, bool>) null : m => m.Parameters.Count == ctorParameterCount, bindingFlags);
-										reflectionContext.RecordHandledPattern ();
+										MarkMethodsFromReflectionCall (ref reflectionContext, systemTypeValue.TypeRepresented, ".ctor", bindingFlags, ctorParameterCount);
 									} else {
 										// Otherwise fall back to the bitfield requirements
 										var requiredMemberKinds = ctorParameterCount == 0
@@ -3888,14 +3879,15 @@ namespace Mono.Linker.Steps {
 				}
 			}
 
-			void MarkConstructorsOnType (ref ReflectionPatternContext reflectionContext, TypeDefinition type, Func<MethodDefinition, bool> filter, BindingFlags? bindingFlags = null)
+			void MarkMethodsFromReflectionCall (ref ReflectionPatternContext reflectionContext, TypeDefinition declaringType, string name, BindingFlags? bindingFlags, int? parametersCount = null)
 			{
-				foreach (var method in type.Methods) {
-					if (!method.IsConstructor)
-						continue;
+				bool foundMatch = false;
+				foreach (var method in declaringType.Methods) {
+					var mname = method.Name;
 
-					if (filter != null && !filter (method))
+					if (mname != name) {
 						continue;
+					}
 
 					if ((bindingFlags & (BindingFlags.Instance | BindingFlags.Static)) == BindingFlags.Static && !method.IsStatic)
 						continue;
@@ -3909,12 +3901,89 @@ namespace Mono.Linker.Steps {
 					if ((bindingFlags & (BindingFlags.Public | BindingFlags.NonPublic)) == BindingFlags.NonPublic && method.IsPublic)
 						continue;
 
+					if (parametersCount != null && parametersCount != method.Parameters.Count)
+						continue;
+
+					foundMatch = true;
+					var methodCalling = reflectionContext.MethodCalling;
+					reflectionContext.RecordRecognizedPattern (method, () => _markStep.MarkIndirectlyCalledMethod (method, new DependencyInfo (DependencyKind.AccessedViaReflection, methodCalling)));
+				}
+
+				if (!foundMatch) {
+					bool publicOnly = (bindingFlags & (BindingFlags.Public | BindingFlags.NonPublic)) == BindingFlags.Public;
+					reflectionContext.RecordUnrecognizedPattern ($"Reflection call '{reflectionContext.MethodCalled.FullName}' inside '{reflectionContext.MethodCalling.FullName}' could not resolve {(publicOnly ? "public" : "")} method `{name}` on type `{declaringType.FullName}`.");
+				}
+			}
+
+			void MarkPropertiesFromReflectionCall (ref ReflectionPatternContext reflectionContext, TypeDefinition declaringType, string name, bool staticOnly = false)
+			{
+				bool foundMatch = false;
+				foreach (var property in declaringType.Properties) {
+					if (property.Name != name)
+						continue;
+
+					bool markedAny = false;
+					var methodCalling = reflectionContext.MethodCalling;
+
+					// It is not easy to reliably detect in the IL code whether the getter or setter (or both) are used.
+					// Be conservative and mark everything for the property.
+					var getter = property.GetMethod;
+					if (getter != null && (!staticOnly || staticOnly && getter.IsStatic)) {
+						reflectionContext.RecordRecognizedPattern (getter, () => _markStep.MarkIndirectlyCalledMethod (getter, new DependencyInfo (DependencyKind.AccessedViaReflection, methodCalling)));
+						markedAny = true;
+					}
+
+					var setter = property.SetMethod;
+					if (setter != null && (!staticOnly || staticOnly && setter.IsStatic)) {
+						reflectionContext.RecordRecognizedPattern (setter, () => _markStep.MarkIndirectlyCalledMethod (setter, new DependencyInfo (DependencyKind.AccessedViaReflection, methodCalling)));
+						markedAny = true;
+					}
+
+					if (markedAny) {
+						foundMatch = true;
+						reflectionContext.RecordRecognizedPattern (property, () => _markStep.MarkProperty (property, new DependencyInfo (DependencyKind.AccessedViaReflection, methodCalling)));
+					}
+				}
+
+				if (!foundMatch)
+					reflectionContext.RecordUnrecognizedPattern ($"Reflection call '{reflectionContext.MethodCalled.FullName}' inside '{reflectionContext.MethodCalling.FullName}' could not resolve property `{name}` on type `{declaringType.FullName}`.");
+			}
+
+			void MarkFieldsFromReflectionCall (ref ReflectionPatternContext reflectionContext, TypeDefinition declaringType, string name, bool staticOnly = false)
+			{
+				bool foundMatch = false;
+				var methodCalling = reflectionContext.MethodCalling;
+				foreach (var field in declaringType.Fields) {
+					if (field.Name != name)
+						continue;
+
+					if (staticOnly && !field.IsStatic)
+						continue;
+
+					foundMatch = true;
+					reflectionContext.RecordRecognizedPattern (field, () => _markStep.MarkField (field, new DependencyInfo (DependencyKind.AccessedViaReflection, methodCalling)));
+					break;
+				}
+
+				if (!foundMatch)
+					reflectionContext.RecordUnrecognizedPattern ($"Reflection call '{reflectionContext.MethodCalled.FullName}' inside '{reflectionContext.MethodCalling.FullName}' could not resolve field `{name}` on type `{declaringType.FullName}`.");
+			}
+
+			void MarkConstructorsOnType (ref ReflectionPatternContext reflectionContext, TypeDefinition type, Func<MethodDefinition, bool> filter)
+			{
+				foreach (var method in type.Methods) {
+					if (!method.IsConstructor)
+						continue;
+
+					if (filter != null && !filter (method))
+						continue;
+
 					var methodCalling = reflectionContext.MethodCalling;
 					reflectionContext.RecordRecognizedPattern (method, () => _markStep.MarkIndirectlyCalledMethod (method, new DependencyInfo (DependencyKind.AccessedViaReflection, methodCalling)));
 				}
 			}
 
-			void MarkMethodsOnTypeHierarchy (ref ReflectionPatternContext reflectionContext, TypeDefinition type, Func<MethodDefinition, bool> filter, BindingFlags? bindingFlags = null)
+			void MarkMethodsOnTypeHierarchy (ref ReflectionPatternContext reflectionContext, TypeDefinition type, Func<MethodDefinition, bool> filter)
 			{
 				bool onBaseType = false;
 				while (type != null) {
@@ -3934,18 +4003,6 @@ namespace Mono.Linker.Steps {
 						if (filter != null && !filter (method))
 							continue;
 
-						if ((bindingFlags & (BindingFlags.Instance | BindingFlags.Static)) == BindingFlags.Static && !method.IsStatic)
-							continue;
-
-						if ((bindingFlags & (BindingFlags.Instance | BindingFlags.Static)) == BindingFlags.Instance && method.IsStatic)
-							continue;
-
-						if ((bindingFlags & (BindingFlags.Public | BindingFlags.NonPublic)) == BindingFlags.Public && !method.IsPublic)
-							continue;
-
-						if ((bindingFlags & (BindingFlags.Public | BindingFlags.NonPublic)) == BindingFlags.NonPublic && method.IsPublic)
-							continue;
-
 						var methodCalling = reflectionContext.MethodCalling;
 						reflectionContext.RecordRecognizedPattern (method, () => _markStep.MarkIndirectlyCalledMethod (method, new DependencyInfo (DependencyKind.AccessedViaReflection, methodCalling)));
 					}
@@ -3955,7 +4012,7 @@ namespace Mono.Linker.Steps {
 				}
 			}
 
-			void MarkFieldsOnTypeHierarchy (ref ReflectionPatternContext reflectionContext, TypeDefinition type, Func<FieldDefinition, bool> filter, bool staticOnly = false)
+			void MarkFieldsOnTypeHierarchy (ref ReflectionPatternContext reflectionContext, TypeDefinition type, Func<FieldDefinition, bool> filter)
 			{
 				bool onBaseType = false;
 				while (type != null) {
@@ -3969,9 +4026,6 @@ namespace Mono.Linker.Steps {
 						// This is intentional as reflection treats these as fields as well.
 
 						if (filter != null && !filter (field))
-							continue;
-
-						if (staticOnly && !field.IsStatic)
 							continue;
 
 						var methodCalling = reflectionContext.MethodCalling;
@@ -3994,7 +4048,7 @@ namespace Mono.Linker.Steps {
 				}
 			}
 
-			void MarkPropertiesOnTypeHierarchy (ref ReflectionPatternContext reflectionContext, TypeDefinition type, Func<PropertyDefinition, bool> filter, bool staticOnly = false)
+			void MarkPropertiesOnTypeHierarchy (ref ReflectionPatternContext reflectionContext, TypeDefinition type, Func<PropertyDefinition, bool> filter)
 			{
 				bool onBaseType = false;
 				while (type != null) {
@@ -4009,11 +4063,6 @@ namespace Mono.Linker.Steps {
 
 						if (filter != null && !filter (property))
 							continue;
-
-						if (staticOnly) {
-							if ((property.GetMethod != null) && !property.GetMethod.IsStatic) continue;
-							if ((property.SetMethod != null) && !property.SetMethod.IsStatic) continue;
-						}
 
 						var methodCalling = reflectionContext.MethodCalling;
 						reflectionContext.RecordRecognizedPattern (property, () => {

--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallString.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallString.cs
@@ -123,6 +123,8 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			Expression.Call (FindType (), "OnlyCalledViaExpression", Type.EmptyTypes);
 		}
 
+		[UnrecognizedReflectionAccessPattern (
+			typeof (Expression), nameof (Expression.Call), new Type [] { typeof (Type), typeof (string), typeof (Type []), typeof (Expression []) })]
 		[Kept]
 		static void TestNonExistingName ()
 		{
@@ -194,12 +196,12 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		[Kept]
 		class ABase
 		{
-			[Kept]
+			// [Kept] : TODO - should be kept: https://github.com/mono/linker/issues/1042
 			public static void PublicOnBase ()
 			{
 			}
 
-			[Kept]
+			// [Kept] : TODO - should be kept: https://github.com/mono/linker/issues/1042
 			protected static void ProtectedOnBase ()
 			{
 			}

--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionFieldString.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionFieldString.cs
@@ -16,6 +16,9 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			Branch_SystemTypeValueNode_UnknownStringValue ();
 			Branch_MethodParameterValueNode (typeof (ExpressionFieldString), "Foo");
 			Branch_UnrecognizedPatterns ();
+			// TODO
+			Expression.Field(null, typeof(ADerived), "_protectedFieldOnBase");
+			Expression.Field(null, typeof(ADerived), "_publicFieldOnBase");
 		}
 
 		[Kept]
@@ -26,7 +29,6 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestType (0);
 			TestType (1);
 			StaticFieldExpected ();
-			FieldsOnBaseType ();
 		}
 
 		[Kept]
@@ -94,22 +96,18 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
 			Expression.Field (null, T, "Foo");
 		}
+		#endregion
 
-		[Kept]
-		static void FieldsOnBaseType ()
-		{
-			Expression.Field (null, typeof (ADerived), "_protectedFieldOnBase");
-			Expression.Field (null, typeof (ADerived), "_publicFieldOnBase");
-		}
-
+		#region UnrecognizedReflectionAccessPatterns
+		[UnrecognizedReflectionAccessPattern (
+				typeof (Expression), nameof (Expression.Field), new Type [] { typeof (Expression), typeof (Type), typeof (string) })]
 		[Kept]
 		static void StaticFieldExpected ()
 		{
 			var expr = Expression.Field (null, typeof (ExpressionFieldString), "TestOnlyStatic2");
 		}
-		#endregion
 
-		#region UnrecognizedReflectionAccessPatterns
+
 		[UnrecognizedReflectionAccessPattern (
 			typeof (Expression), nameof (Expression.Field), new Type [] { typeof (Expression), typeof (Type), typeof (string) })]
 		[Kept]
@@ -175,22 +173,22 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		{
 			return "unknownstring";
 		}
-
-		[Kept]
-		class ABase
-		{
-			[Kept]
-			protected static bool _protectedFieldOnBase;
-
-			[Kept]
-			public static bool _publicFieldOnBase;
-		}
-
-		[Kept]
-		[KeptBaseType (typeof (ABase))]
-		class ADerived : ABase
-		{
-		}
 		#endregion
+	}
+
+	[Kept]
+	class ABase
+	{
+		// [Kept] - TODO - should be kept: https://github.com/mono/linker/issues/1042
+		protected static bool _protectedFieldOnBase;
+
+		// [Kept] - TODO - should be kept: https://github.com/mono/linker/issues/1042
+		public static bool _publicFieldOnBase;
+	}
+
+	[Kept]
+	[KeptBaseType (typeof (ABase))]
+	class ADerived : ABase
+	{
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionPropertyString.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionPropertyString.cs
@@ -21,6 +21,9 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			Foo.Branch_NullValueNode ();
 			Foo.Branch_MethodParameterValueNode (typeof (Foo), "Foo");
 			Foo.Branch_UnrecognizedPatterns ();
+			// TODO
+			Expression.Property(null, typeof(ADerived), "ProtectedPropertyOnBase");
+			Expression.Property(null, typeof(ADerived), "PublicPropertyOnBase");
 		}
 
 		[KeptMember (".ctor()")]
@@ -34,7 +37,6 @@ namespace Mono.Linker.Tests.Cases.Reflection
 				TestByType (0);
 				TestByType (1);
 				StaticPropertyExpected ();
-				PropertyOnBaseType ();
 			}
 
 			[Kept]
@@ -102,22 +104,17 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
 				Expression.Property (null, T, "Foo");
 			}
+			#endregion
 
-			[Kept]
-			static void PropertyOnBaseType ()
-			{
-				Expression.Property (Expression.Parameter (typeof (bool), "somename"), typeof (ADerived), "ProtectedPropertyOnBase");
-				Expression.Property (null, typeof (ADerived), "PublicPropertyOnBase");
-			}
-
+			#region UnrecognizedReflectionAccessPatterns
+			[UnrecognizedReflectionAccessPattern (
+				typeof (Expression), nameof (Expression.Property), new Type [] { typeof (Expression), typeof (Type), typeof (string) })]
 			[Kept]
 			public void StaticPropertyExpected ()
 			{
 				var expr = Expression.Property (null, typeof (Foo), "TestOnlyStatic2");
 			}
-			#endregion
 
-			#region UnrecognizedReflectionAccessPatterns
 			[UnrecognizedReflectionAccessPattern (
 				typeof (Expression), nameof (Expression.Property), new Type [] { typeof (Expression), typeof (Type), typeof (string) })]
 			[Kept]
@@ -188,25 +185,23 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			{
 				return "unknownstring";
 			}
-
-			[Kept]
-			class ABase
-			{
-				[Kept]
-				[KeptBackingField]
-				protected bool ProtectedPropertyOnBase { [Kept] get; }
-
-				[Kept]
-				[KeptBackingField]
-				public static bool PublicPropertyOnBase { [Kept] get; }
-			}
-
-			[Kept]
-			[KeptBaseType (typeof (ABase))]
-			class ADerived : ABase
-			{
-			}
 			#endregion
+		}
+
+		[Kept]
+		class ABase
+		{
+			// [Kept] - TODO - should be kept: https://github.com/mono/linker/issues/1042
+			protected bool ProtectedPropertyOnBase { get; }
+
+			// [Kept] - TODO - should be kept: https://github.com/mono/linker/issues/1042
+			public bool PublicPropertyOnBase { get; }
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (ABase))]
+		class ADerived : ABase
+		{
 		}
 	}
 }


### PR DESCRIPTION
Reverts mono/linker#1081: I started seeing more unrecognized patterns recorded than the ones that are expected. This behavior can't be seen on the previous commit. I'll see what happened and put back the changes related to #1081 

/cc @MichalStrehovsky @vitek-karas 