### PR TITLE
Package ILLink.Tasks as Microsoft.NET.ILLink.Tasks

### DIFF
--- a/src/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/src/ILLink.Tasks/ILLink.Tasks.csproj
@@ -7,6 +7,7 @@
     <Description>MSBuild tasks for running the IL Linker</Description>
     <LangVersion>latest</LangVersion>
     <IsPackable>true</IsPackable>
+    <PackageId>Microsoft.NET.ILLink.Tasks</PackageId>
     <!-- We want to package the tasks package together with its
          transitive dependencies and the linker, without marking them
          as dependencies in the tasks package. -->


### PR DESCRIPTION
I've kept the assembly name and project names the same (`ILLink.Tasks`) like we have done for Mono.Linker. The only thing that changes is the package name, which is only expected to be used by .NET repos. We'll need to update the `PackageReferences` from runtime and sdk.