### PR TITLE
Speed up linker by 10%

### DIFF
--- a/src/linker/Linker.Steps/OutputStep.cs
+++ b/src/linker/Linker.Steps/OutputStep.cs
@@ -259,7 +259,7 @@ namespace Mono.Linker.Steps {
 
 		FileInfo GetOriginalAssemblyFileInfo (AssemblyDefinition assembly)
 		{
-			return new FileInfo (Context.Resolver.AssemblyToPath [assembly]);
+			return new FileInfo (Context.Resolver.GetAssemblyFileName (assembly));
 		}
 
 		protected virtual void CopyAssembly (AssemblyDefinition assembly, string directory)

--- a/src/linker/Linker.Steps/OutputStep.cs
+++ b/src/linker/Linker.Steps/OutputStep.cs
@@ -257,9 +257,9 @@ namespace Mono.Linker.Steps {
 			return assembly + ".config";
 		}
 
-		static FileInfo GetOriginalAssemblyFileInfo (AssemblyDefinition assembly)
+		FileInfo GetOriginalAssemblyFileInfo (AssemblyDefinition assembly)
 		{
-			return new FileInfo (assembly.MainModule.FileName);
+			return new FileInfo (Context.Resolver.AssemblyToPath [assembly]);
 		}
 
 		protected virtual void CopyAssembly (AssemblyDefinition assembly, string directory)

--- a/src/linker/Linker/AssemblyResolver.cs
+++ b/src/linker/Linker/AssemblyResolver.cs
@@ -83,6 +83,20 @@ namespace Mono.Linker {
 		}
 #endif
 
+		public string GetAssemblyFileName(AssemblyDefinition assembly)
+		{
+#if FEATURE_ILLINK
+			if (assemblyToPath.TryGetValue(assembly, out string path)) {
+				return path;
+			}
+			else
+#endif
+			{
+				// Must be an assembly that we didn't open through the resolver
+				return assembly.MainModule.FileName;
+			}
+		}
+
 		AssemblyDefinition ResolveFromReferences (AssemblyNameReference name, Collection<string> references, ReaderParameters parameters)
 		{
 			var fileName = name.Name + ".dll";
@@ -138,7 +152,7 @@ namespace Mono.Linker {
 		public virtual AssemblyDefinition CacheAssembly (AssemblyDefinition assembly)
 		{
 			_assemblies [assembly.Name.Name] = assembly;
-			base.AddSearchDirectory (Path.GetDirectoryName (AssemblyToPath[assembly]));
+			base.AddSearchDirectory (Path.GetDirectoryName (GetAssemblyFileName(assembly)));
 			return assembly;
 		}
 

--- a/src/linker/Linker/AssemblyResolver.cs
+++ b/src/linker/Linker/AssemblyResolver.cs
@@ -99,6 +99,11 @@ namespace Mono.Linker {
 			return null;
 		}
 
+		public AssemblyDefinition ResolveFromPath(string path, ReaderParameters parameters)
+		{
+			return CacheAssembly (GetAssembly (path, parameters));
+		}
+
 		public override AssemblyDefinition Resolve (AssemblyNameReference name, ReaderParameters parameters)
 		{
 			// Validate arguments, similarly to how the base class does it.
@@ -133,7 +138,7 @@ namespace Mono.Linker {
 		public virtual AssemblyDefinition CacheAssembly (AssemblyDefinition assembly)
 		{
 			_assemblies [assembly.Name.Name] = assembly;
-			base.AddSearchDirectory (Path.GetDirectoryName (assembly.MainModule.FileName));
+			base.AddSearchDirectory (Path.GetDirectoryName (AssemblyToPath[assembly]));
 			return assembly;
 		}
 
@@ -151,6 +156,8 @@ namespace Mono.Linker {
 			_assemblies.Clear ();
 			if (_unresolvedAssemblies != null)
 				_unresolvedAssemblies.Clear ();
+
+			base.Dispose (disposing);
 		}
 	}
 }

--- a/src/linker/Linker/DirectoryAssemblyResolver.cs
+++ b/src/linker/Linker/DirectoryAssemblyResolver.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using Mono.Collections.Generic;
 using Mono.Cecil;
+using System.IO.MemoryMappedFiles;
 
 #if FEATURE_ILLINK
 namespace Mono.Linker {
@@ -14,6 +15,10 @@ namespace Mono.Linker {
 	public abstract class DirectoryAssemblyResolver : IAssemblyResolver {
 
 		readonly Collection<string> directories;
+
+		public readonly Dictionary<AssemblyDefinition, string> AssemblyToPath = new Dictionary<AssemblyDefinition, string> ();
+
+		readonly List<MemoryMappedViewStream> viewStreams = new List<MemoryMappedViewStream> ();
 
 		public void AddSearchDirectory (string directory)
 		{
@@ -40,7 +45,34 @@ namespace Mono.Linker {
 			if (parameters.AssemblyResolver == null)
 				parameters.AssemblyResolver = this;
 
-			return ModuleDefinition.ReadModule (file, parameters).Assembly;
+			FileStream fileStream = null;
+			MemoryMappedFile mappedFile = null;
+			MemoryMappedViewStream viewStream = null;
+			try {
+				// Create stream because CreateFromFile(string, ...) uses FileShare.None which is too strict
+				fileStream = new FileStream (file, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, false);
+				mappedFile = MemoryMappedFile.CreateFromFile (
+					fileStream, null, fileStream.Length, MemoryMappedFileAccess.Read, HandleInheritability.None, true);
+				viewStream = mappedFile.CreateViewStream (0, 0, MemoryMappedFileAccess.Read);
+
+				AssemblyDefinition result = ModuleDefinition.ReadModule (viewStream, parameters).Assembly;
+
+				AssemblyToPath.Add (result, file);
+
+				viewStreams.Add (viewStream);
+
+				// We transferred the ownership of the viewStream to the collection.
+				viewStream = null;
+
+				return result;
+			} finally {
+				if (fileStream != null)
+					fileStream.Dispose ();
+				if (mappedFile != null)
+					mappedFile.Dispose ();
+				if (viewStream != null)
+					viewStream.Dispose ();
+			}
 		}
 
 		public virtual AssemblyDefinition Resolve (AssemblyNameReference name)
@@ -89,6 +121,13 @@ namespace Mono.Linker {
 
 		protected virtual void Dispose (bool disposing)
 		{
+			if (disposing) {
+				foreach (var viewStream in viewStreams) {
+					viewStream.Dispose ();
+				}
+
+				viewStreams.Clear ();
+			}
 		}
 	}
 }

--- a/src/linker/Linker/DirectoryAssemblyResolver.cs
+++ b/src/linker/Linker/DirectoryAssemblyResolver.cs
@@ -5,9 +5,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.MemoryMappedFiles;
 using Mono.Collections.Generic;
 using Mono.Cecil;
-using System.IO.MemoryMappedFiles;
 
 #if FEATURE_ILLINK
 namespace Mono.Linker {

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -264,8 +264,7 @@ namespace Mono.Linker {
 		{
 			if (File.Exists (name)) {
 				try {
-					AssemblyDefinition assembly = AssemblyDefinition.ReadAssembly (name, _readerParameters);
-					return _resolver.CacheAssembly (assembly);
+					return _resolver.ResolveFromPath (name, _readerParameters);
 				} catch (Exception e) {
 					throw new AssemblyResolutionException (new AssemblyNameReference (name, new Version ()), e);
 				}
@@ -314,7 +313,7 @@ namespace Mono.Linker {
 			try {
 				var symbolReader = _symbolReaderProvider.GetSymbolReader (
 					assembly.MainModule,
-					assembly.MainModule.FileName);
+					_resolver.AssemblyToPath[assembly]);
 
 				if (symbolReader == null)
 					return;

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -313,7 +313,7 @@ namespace Mono.Linker {
 			try {
 				var symbolReader = _symbolReaderProvider.GetSymbolReader (
 					assembly.MainModule,
-					_resolver.AssemblyToPath[assembly]);
+					_resolver.GetAssemblyFileName(assembly));
 
 				if (symbolReader == null)
 					return;


### PR DESCRIPTION
...using one weird trick.

Cecil uses file I/O to read assemblies, but for our use cases this means we're spending a ton of time context switching between kernel mode and user mode.

Memory mapped I/O is more efficient for these access patterns.

The change is bigger than I would want it to be because:
* Loading assemblies from disk is not centralized in linker (and in fact there are more extensibility points that encourage everyone to do their own loading)
* Cecil violates OOP principles by giving certain kinds of streams preferential treatment (`ModuleDefinition.FileName` is useless if the assembly wasn't opened with the blessed stream kind and Cecil doesn't have a way to provide it through other means).