### PR TITLE
Don't import references for forwarders which will be removed when

### DIFF
--- a/src/linker/Linker.Steps/SweepStep.cs
+++ b/src/linker/Linker.Steps/SweepStep.cs
@@ -309,6 +309,12 @@ namespace Mono.Linker.Steps {
 
 			if (assembly.MainModule.HasExportedTypes) {
 				foreach (var et in assembly.MainModule.ExportedTypes) {
+					//
+					// Don't import references for forwarders which will be removed
+					//
+					if (ShouldRemove (et))
+						continue;
+
 					var td = et.Resolve ();
 					if (td == null)
 						continue;

--- a/test/Mono.Linker.Tests.Cases.Expectations/Assertions/RemovedAssemblyReference.cs
+++ b/test/Mono.Linker.Tests.Cases.Expectations/Assertions/RemovedAssemblyReference.cs
@@ -1,0 +1,15 @@
+﻿using System;
+namespace Mono.Linker.Tests.Cases.Expectations.Assertions
+{
+	[AttributeUsage (AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+	public class RemovedAssemblyReferenceAttribute : BaseInAssemblyAttribute
+	{
+		public RemovedAssemblyReferenceAttribute (string assemblyFileName, string assemblyReferenceName)
+		{
+			if (string.IsNullOrEmpty (assemblyFileName))
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (assemblyFileName));
+			if (string.IsNullOrEmpty (assemblyReferenceName))
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (assemblyReferenceName));
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/UsedAndUnusedForwarderWithAssemblyCopy.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/UsedAndUnusedForwarderWithAssemblyCopy.cs
@@ -23,6 +23,7 @@ namespace Mono.Linker.Tests.Cases.TypeForwarding
 	[KeptMemberInAssembly ("Forwarder.dll", typeof (ImplementationLibrary))]
 	[RemovedAssembly ("Unused.dll")]
 	[RemovedForwarder ("Forwarder.dll", "Mono.Linker.Tests.Cases.TypeForwarding.Dependencies.AnotherLibrary`1")]
+	[RemovedAssemblyReference ("Forwarder.dll", "Unused")]
 	class UsedAndUnusedForwarderWithAssemblyCopy
 	{
 		static void Main()

--- a/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -258,6 +258,12 @@ namespace Mono.Linker.Tests.TestCasesRunner {
 									Assert.Fail ($"Forwarder `{expectedTypeName}' should have been removed");
 
 								break;
+
+							case nameof (RemovedAssemblyReferenceAttribute):
+								Assert.False (linkedAssembly.MainModule.AssemblyReferences.Any (l => l.Name == expectedTypeName),
+									$"AssemblyRef '{expectedTypeName}' should have been removed");
+								break;
+
 							case nameof (KeptResourceInAssemblyAttribute):
 								VerifyKeptResourceInAssembly (checkAttrInAssembly);
 								break;


### PR DESCRIPTION
regenerating the assembly.

Fixes #1108