### PR TITLE
Fixes regression caused by missing space after `--custom-data` argument

### DIFF
--- a/src/ILLink.Tasks/LinkTask.cs
+++ b/src/ILLink.Tasks/LinkTask.cs
@@ -331,7 +331,7 @@ namespace ILLink.Tasks
 			if (clearInitLocals) {
 				args.AppendLine ("--enable-opt clearinitlocals");
 				if (ClearInitLocalsAssemblies?.Length > 0) {
-					args.AppendFormat ($"--custom-data ClearInitLocalsAssemblies={ClearInitLocalsAssemblies}");
+					args.AppendFormat ($"--custom-data ClearInitLocalsAssemblies={ClearInitLocalsAssemblies} ");
 				}
 			}
 


### PR DESCRIPTION
Introduced in f8d216d8611265af051163b07bccc6fdb83f3571