### PR TITLE
Add pre-pass to look for Type.GetType strings

### DIFF
--- a/src/linker/Linker.Steps/TypeStringLookupStep.cs
+++ b/src/linker/Linker.Steps/TypeStringLookupStep.cs
@@ -1,0 +1,108 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Text;
+
+#if FEATURE_ILLINK
+namespace Mono.Linker.Steps
+{
+	/// <summary>
+	/// Looks up strings within the assembly closure that look like Type.GetType strings.
+	/// Adds assemblies referenced from the strings to the closure.
+	/// </summary>
+	class TypeStringLookupStep : LoadReferencesStep
+	{
+		protected override void ProcessAssembly (Cecil.AssemblyDefinition assembly)
+		{
+			MetadataReader reader = Context.Resolver.GetMetadataReaderForAssembly (assembly);
+			if (reader != null) {
+				ProcessAssembly (reader);
+			}
+		}
+
+		void ProcessAssembly (MetadataReader reader)
+		{
+			UserStringHandle handle = MetadataTokens.UserStringHandle (0);
+			do {
+				ProcessString (reader.GetUserString (handle));
+				handle = reader.GetNextHandle(handle);
+			} while (handle != default);
+		}
+
+		void ProcessString (string s)
+		{
+			// We're looking for strings in the form:
+			// "TypeName, AssemblyName[, PublicKeyToken=...][, Version=...][, Culture=...]"
+			//
+			// The string needs to have a comma.
+			//
+			// We're not shooting for being 100% complete - this format is pretty difficult to
+			// parse because of various escaping rules that AssemblyUtilities.ResolveFullyQualifiedTypeName
+			// doesn't handle either, so there's no point bothering here.
+			int indexOfComma = s.IndexOf (',');
+			if (indexOfComma > 0) {
+
+				// The part before the comma could be a type name
+				string assumedTypeName = s.Substring (0, indexOfComma).Trim ();
+
+				// Does this look like an identifier?
+				if (IsValidIdentifier (assumedTypeName)) {
+
+					// The part after the comma until the next comma or end of string
+					// could be an assembly name
+					int indexOfEndAssemblyName = s.IndexOf (',', indexOfComma + 1);
+					if (indexOfEndAssemblyName < 0)
+						indexOfEndAssemblyName = s.Length;
+					string assumedAssemblyName = s.Substring (indexOfComma + 1, indexOfEndAssemblyName - indexOfComma - 1).Trim ();
+
+					// Does this look like an assembly name?
+					if (IsValidIdentifier (assumedAssemblyName)) {
+
+						// If we had more components after the assembly name, let's look at them
+						if (indexOfEndAssemblyName == s.Length
+							|| s.IndexOf ("Version", indexOfEndAssemblyName) > 0
+							|| s.IndexOf ("PublicKeyToken", indexOfEndAssemblyName) > 0
+							|| s.IndexOf ("Culture", indexOfEndAssemblyName) > 0) {
+
+							// We have what appears to be an assembly name
+							var newDependency = Context.Resolve (new Cecil.AssemblyNameReference (assumedAssemblyName, new Version ()), reportFailures: false);
+							if (newDependency != null)
+								ProcessReferences (newDependency);
+						}
+					}
+				}
+			}
+		}
+
+		static bool IsValidIdentifier (string id)
+		{
+			// If the name is empty or contains a space... probably not an identifier
+			if (id.Length == 0 || id.IndexOf (' ') >= 0)
+				return false;
+
+			if (id == "\"")
+				return false;
+
+			// Lets assume nobody names their type with a " in the middle.
+			int quoteIndex = id.IndexOf ('"', 1);
+			if (quoteIndex > 0 && quoteIndex < id.Length - 1)
+				return false;
+
+			if (id.IndexOfAny (new char[] { '(', ')', '{', '}', '/', '<', '>', '%', '#', ';' }) >= 0)
+				return false;
+
+			// = character needs to be escaped
+			char prevChar = default;
+			foreach (var c in id)
+				if (c == '=' && prevChar != '\\')
+					return false;
+			return true;
+		}
+	}
+}
+#endif

--- a/src/linker/Linker.Steps/TypeStringLookupStep.cs
+++ b/src/linker/Linker.Steps/TypeStringLookupStep.cs
@@ -61,7 +61,8 @@ namespace Mono.Linker.Steps
 					string assumedAssemblyName = s.Substring (indexOfComma + 1, indexOfEndAssemblyName - indexOfComma - 1).Trim ();
 
 					// Does this look like an assembly name?
-					if (IsValidIdentifier (assumedAssemblyName)) {
+					if (IsValidIdentifier (assumedAssemblyName) &&
+						!IsProblematicAssembly(assumedAssemblyName)) {
 
 						// If we had more components after the assembly name, let's look at them
 						if (indexOfEndAssemblyName == s.Length
@@ -77,6 +78,12 @@ namespace Mono.Linker.Steps
 					}
 				}
 			}
+		}
+
+		static bool IsProblematicAssembly(string s)
+		{
+			// Workaround for https://github.com/mono/linker/issues/1151
+			return s == "System.Runtime.WindowsRuntime";
 		}
 
 		static bool IsValidIdentifier (string id)

--- a/src/linker/Linker/AssemblyResolver.cs
+++ b/src/linker/Linker/AssemblyResolver.cs
@@ -122,6 +122,11 @@ namespace Mono.Linker
 
 		public override AssemblyDefinition Resolve (AssemblyNameReference name, ReaderParameters parameters)
 		{
+			return Resolve (name, parameters, reportFailures: true);
+		}
+
+		public AssemblyDefinition Resolve (AssemblyNameReference name, ReaderParameters parameters, bool reportFailures)
+		{
 			// Validate arguments, similarly to how the base class does it.
 			if (name == null)
 				throw new ArgumentNullException ("name");
@@ -139,9 +144,10 @@ namespace Mono.Linker
 
 					_assemblies[name.Name] = asm;
 				} catch (AssemblyResolutionException) {
-					if (!_ignoreUnresolved)
+					if (reportFailures && !_ignoreUnresolved)
 						throw;
-					_context.LogMessage ($"warning: Ignoring unresolved assembly '{name.Name}'.");
+					if (reportFailures)
+						_context.LogMessage ($"warning: Ignoring unresolved assembly '{name.Name}'.");
 					if (_unresolvedAssemblies == null)
 						_unresolvedAssemblies = new HashSet<string> ();
 					_unresolvedAssemblies.Add (name.Name);

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -1044,6 +1044,7 @@ namespace Mono.Linker
 			p.AppendStep (new LoadReferencesStep ());
 			p.AppendStep (new BlacklistStep ());
 			p.AppendStep (new PreserveDependencyLookupStep ());
+			p.AppendStep (new TypeStringLookupStep ());
 			p.AppendStep (new TypeMapStep ());
 			p.AppendStep (new MarkStep ());
 			p.AppendStep (new SweepStep ());

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -271,11 +271,11 @@ namespace Mono.Linker
 			return Resolve (new AssemblyNameReference (name, new Version ()));
 		}
 
-		public AssemblyDefinition Resolve (IMetadataScope scope)
+		public AssemblyDefinition Resolve (IMetadataScope scope, bool reportFailures = true)
 		{
 			AssemblyNameReference reference = GetReference (scope);
 			try {
-				AssemblyDefinition assembly = _resolver.Resolve (reference, _readerParameters);
+				AssemblyDefinition assembly = _resolver.Resolve (reference, _readerParameters, reportFailures);
 
 				if (assembly != null)
 					RegisterAssembly (assembly);

--- a/src/linker/Mono.Linker.csproj
+++ b/src/linker/Mono.Linker.csproj
@@ -18,6 +18,7 @@
     <Description>Mono CIL Linker</Description>
     <Copyright>(C) 2006, Jb Evain</Copyright>
     <TargetFramework>net471</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/linker/Mono.Linker.csproj
+++ b/src/linker/Mono.Linker.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(MonoBuild)' == ''">
@@ -18,7 +19,6 @@
     <Description>Mono CIL Linker</Description>
     <Copyright>(C) 2006, Jb Evain</Copyright>
     <TargetFramework>net471</TargetFramework>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Mono.Linker.Tests.Cases/DataFlow/Dependencies/AssemblyReferencedWithTypeGetType.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/Dependencies/AssemblyReferencedWithTypeGetType.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Mono.Linker.Tests.Cases.DataFlow
+{
+	class TypeReferencedWithTypeGetType
+	{
+		public static void ReflectionReferencedMethod () => throw null;
+
+		public static void UnreferencedMethod () => throw null;
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/TypeGetTypeWithUnreferencedAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/TypeGetTypeWithUnreferencedAssembly.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.DataFlow
+{
+	[SetupCompileBefore ("library.dll", new[] { "Dependencies/AssemblyReferencedWithTypeGetType.cs" }, addAsReference: false)]
+	[SkipUnresolved(true)]
+	[KeptAssembly ("library.dll")]
+	[KeptMemberInAssembly ("library.dll", "Mono.Linker.Tests.Cases.DataFlow.TypeReferencedWithTypeGetType", "ReflectionReferencedMethod()")]
+	class TypeGetTypeWithUnreferencedAssembly
+	{
+		public static void Main()
+		{
+			Type.GetType ("Mono.Linker.Tests.Cases.DataFlow.TypeReferencedWithTypeGetType, library")
+				.GetMethod ("ReflectionReferencedMethod");
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Reflection/AssemblyImportedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/AssemblyImportedViaReflection.cs
@@ -5,7 +5,6 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Reflection
 {
-	[IgnoreTestCase ("Requires support for using a type in an unreferences assembly via reflection")]
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/AssemblyDependency.cs" }, addAsReference: false)]
 	[KeptAssembly ("library.dll")]
 	[KeptTypeInAssembly ("library.dll", "Mono.Linker.Tests.Cases.Reflection.Dependencies.AssemblyDependency")]

--- a/test/Mono.Linker.Tests.Cases/Reflection/AssemblyImportedViaReflectionWithDerivedType.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/AssemblyImportedViaReflectionWithDerivedType.cs
@@ -5,7 +5,6 @@ using Mono.Linker.Tests.Cases.Reflection.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Reflection
 {
-	[IgnoreTestCase ("Requires support for using a type in an unreferences assembly via reflection")]
 	[SetupCompileBefore ("base.dll", new[] { "Dependencies/AssemblyImportedViaReflectionWithDerivedType_Base.cs" })]
 	[SetupCompileBefore ("reflection.dll", new[] { "Dependencies/AssemblyImportedViaReflectionWithDerivedType_Reflect.cs" }, references: new[] { "base.dll" }, addAsReference: false)]
 	[KeptAssembly ("base.dll")]

--- a/test/Mono.Linker.Tests.Cases/Reflection/AssemblyImportedViaReflectionWithReference.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/AssemblyImportedViaReflectionWithReference.cs
@@ -4,7 +4,6 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Reflection
 {
-	[IgnoreTestCase ("Requires support for using a type in an unreferences assembly via reflection")]
 	[SetupCompileBefore ("reference.dll", new[] { "Dependencies/AssemblyDependency.cs" }, addAsReference: false)]
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/AssemblyDependencyWithReference.cs" }, references: new[] { "reference.dll" }, addAsReference: false)]
 	[KeptAssembly ("reference.dll")]


### PR DESCRIPTION
Linker has a design limitation that makes it impossible to add new assemblies to the closure when MarkStep is running. This is problematic because in reflection lightup it's common to use Type.GetType to access assemblies that might not have been referenced otherwise. To be able to analyze this, a global prepass is needed to find all assemblies that could possibly be referenced.

This is similar to the prepass done for PreserveDependencyAttribute and has similar problems (we're looking at everything, which means we could be looking at Type.GetType strings that are not actually reachable from what MarkStep is going to look at).

This is done with the expectation that adding a new assembly to the closure is not going to be more harmful than an existing hard AssemblyRef to an assembly that ends up not being needed by any of the code that survives trimming.

We'll need to overhaul these global pre-passes after .NET 5.

The new pass is pretty fast and mostly within noise range.

For an empty blazor app, it finds 52 strings that look like Type.GetType, out of which 37 are legitimate matches. The rest is things like "x, y", or "Width, Height".