### PR TITLE
Delete GetClassHierarchy/GetDerivedInterfacesForInterface

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -479,18 +479,8 @@ namespace Mono.Linker.Steps
 			var interfaceType = overrideInformation.InterfaceType;
 			var overrideDeclaringType = overrideInformation.Override.DeclaringType;
 
-			if (!IsInterfaceImplementationMarked (overrideDeclaringType, interfaceType)) {
-				var derivedInterfaceTypes = Annotations.GetDerivedInterfacesForInterface (interfaceType);
-
-				// There are no derived interface types that could be marked, it's safe to skip marking this override
-				if (derivedInterfaceTypes == null)
-					return true;
-
-				// If none of the other interfaces on the type that implement the interface from the @base type are marked, then it's safe to skip
-				// marking this override
-				if (!derivedInterfaceTypes.Any (d => IsInterfaceImplementationMarked (overrideDeclaringType, d)))
-					return true;
-			}
+			if (!IsInterfaceImplementationMarkedRecursively (overrideDeclaringType, interfaceType))
+				return true;
 
 			return false;
 		}
@@ -498,6 +488,25 @@ namespace Mono.Linker.Steps
 		bool IsInterfaceImplementationMarked (TypeDefinition type, TypeDefinition interfaceType)
 		{
 			return type.HasInterface (@interfaceType, out InterfaceImplementation implementation) && Annotations.IsMarked (implementation);
+		}
+
+		bool IsInterfaceImplementationMarkedRecursively (TypeDefinition type, TypeDefinition interfaceType)
+		{
+			if (IsInterfaceImplementationMarked (type, interfaceType))
+				return true;
+
+			if (type.HasInterfaces) {
+				foreach (var iface in type.Interfaces) {
+					var resolved = iface.InterfaceType.Resolve ();
+					if (resolved == null)
+						continue;
+
+					if (IsInterfaceImplementationMarkedRecursively (resolved, interfaceType))
+						return true;
+				}
+			}
+
+			return false;
 		}
 
 		void MarkMarshalSpec (IMarshalInfoProvider spec, in DependencyInfo reason)

--- a/src/linker/Linker.Steps/TypeMapStep.cs
+++ b/src/linker/Linker.Steps/TypeMapStep.cs
@@ -45,28 +45,12 @@ namespace Mono.Linker.Steps
 		{
 			MapVirtualMethods (type);
 			MapInterfaceMethodsInTypeHierarchy (type);
-			MapInterfaceHierarchy (type);
-			MapBaseTypeHierarchy (type);
 
 			if (!type.HasNestedTypes)
 				return;
 
 			foreach (var nested in type.NestedTypes)
 				MapType (nested);
-		}
-
-		void MapInterfaceHierarchy (TypeDefinition type)
-		{
-			if (!type.IsInterface || !type.HasInterfaces)
-				return;
-
-			foreach (var iface in type.Interfaces) {
-				var resolved = iface.InterfaceType.Resolve ();
-				if (resolved == null)
-					continue;
-
-				Annotations.AddDerivedInterfaceForInterface (resolved, type);
-			}
 		}
 
 		void MapInterfaceMethodsInTypeHierarchy (TypeDefinition type)
@@ -165,30 +149,6 @@ namespace Mono.Linker.Steps
 
 				AnnotateMethods (@override, method);
 			}
-		}
-
-		void MapBaseTypeHierarchy (TypeDefinition type)
-		{
-			if (!type.IsClass)
-				return;
-
-			var bases = new List<TypeDefinition> ();
-			var current = type.BaseType;
-
-			while (current != null) {
-				var resolved = current.Resolve ();
-				if (resolved == null)
-					break;
-
-				// Exclude Object.  That's implied and adding it to the list will just lead to lots of extra unnecessary processing
-				if (resolved.BaseType == null)
-					break;
-
-				bases.Add (resolved);
-				current = resolved.BaseType;
-			}
-
-			Annotations.SetClassHierarchy (type, bases);
 		}
 
 		void AnnotateMethods (MethodDefinition @base, MethodDefinition @override, InterfaceImplementation matchingInterfaceImplementation = null)

--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -54,8 +54,6 @@ namespace Mono.Linker
 		protected readonly Dictionary<MethodDefinition, List<OverrideInformation>> override_methods = new Dictionary<MethodDefinition, List<OverrideInformation>> ();
 		protected readonly Dictionary<MethodDefinition, List<MethodDefinition>> base_methods = new Dictionary<MethodDefinition, List<MethodDefinition>> ();
 		protected readonly Dictionary<AssemblyDefinition, ISymbolReader> symbol_readers = new Dictionary<AssemblyDefinition, ISymbolReader> ();
-		protected readonly Dictionary<TypeDefinition, List<TypeDefinition>> class_type_base_hierarchy = new Dictionary<TypeDefinition, List<TypeDefinition>> ();
-		protected readonly Dictionary<TypeDefinition, List<TypeDefinition>> derived_interfaces = new Dictionary<TypeDefinition, List<TypeDefinition>> ();
 
 		readonly Dictionary<object, Dictionary<IMetadataTokenProvider, object>> custom_annotations = new Dictionary<object, Dictionary<IMetadataTokenProvider, object>> ();
 		protected readonly Dictionary<AssemblyDefinition, HashSet<string>> resources_to_remove = new Dictionary<AssemblyDefinition, HashSet<string>> ();
@@ -427,44 +425,6 @@ namespace Mono.Linker
 		public bool SetPreservedStaticCtor (TypeDefinition type)
 		{
 			return marked_types_with_cctor.Add (type);
-		}
-
-		public void SetClassHierarchy (TypeDefinition type, List<TypeDefinition> bases)
-		{
-			class_type_base_hierarchy[type] = bases;
-		}
-
-		public List<TypeDefinition> GetClassHierarchy (TypeDefinition type)
-		{
-			if (class_type_base_hierarchy.TryGetValue (type, out List<TypeDefinition> bases))
-				return bases;
-
-			return null;
-		}
-
-		public void AddDerivedInterfaceForInterface (TypeDefinition @base, TypeDefinition derived)
-		{
-			if (!@base.IsInterface)
-				throw new ArgumentException ($"{nameof (@base)} must be an interface");
-
-			if (!derived.IsInterface)
-				throw new ArgumentException ($"{nameof (derived)} must be an interface");
-
-			if (!derived_interfaces.TryGetValue (@base, out List<TypeDefinition> derivedInterfaces))
-				derived_interfaces[@base] = derivedInterfaces = new List<TypeDefinition> ();
-
-			derivedInterfaces.Add (derived);
-		}
-
-		public List<TypeDefinition> GetDerivedInterfacesForInterface (TypeDefinition @interface)
-		{
-			if (!@interface.IsInterface)
-				throw new ArgumentException ($"{nameof (@interface)} must be an interface");
-
-			if (derived_interfaces.TryGetValue (@interface, out List<TypeDefinition> derivedInterfaces))
-				return derivedInterfaces;
-
-			return null;
 		}
 	}
 }

--- a/src/linker/Linker/MethodBodyScanner.cs
+++ b/src/linker/Linker/MethodBodyScanner.cs
@@ -71,10 +71,11 @@ namespace Mono.Linker
 				if (!type.IsClass)
 					continue;
 
-				AddMatchingInterfaces (interfaceImplementations, type, interfaceTypes);
-				var bases = annotations.GetClassHierarchy (type);
-				foreach (var @base in bases) {
-					AddMatchingInterfaces (interfaceImplementations, @base, interfaceTypes);
+				TypeDefinition currentType = type;
+				while (currentType?.BaseType != null) // Checking BaseType != null to skip System.Object
+				{
+					AddMatchingInterfaces (interfaceImplementations, currentType, interfaceTypes);
+					currentType = currentType.BaseType.Resolve ();
 				}
 			}
 
@@ -130,6 +131,9 @@ namespace Mono.Linker
 
 		static void AddMatchingInterfaces (HashSet<(InterfaceImplementation, TypeDefinition)> results, TypeDefinition type, TypeDefinition[] interfaceTypes)
 		{
+			if (!type.HasInterfaces)
+				return;
+
 			foreach (var interfaceType in interfaceTypes) {
 				if (type.HasInterface (interfaceType, out InterfaceImplementation implementation))
 					results.Add ((implementation, type));


### PR DESCRIPTION
This removes the easily removable parts of the TypeMap step. Contributes to #1164.