### PR TITLE
Fix a couple nits

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1263,6 +1263,9 @@ namespace Mono.Linker.Steps
 				MarkMulticastDelegate (type);
 			}
 
+			if (type.IsClass && type.BaseType == null && type.Name == "Object")
+				MarkMethodIf (type.Methods, m => m.Name == "Finalize", new DependencyInfo (DependencyKind.MethodForSpecialType, type));
+
 			if (type.IsSerializable ())
 				MarkSerializable (type);
 
@@ -2238,7 +2241,7 @@ namespace Mono.Linker.Steps
 		protected virtual IEnumerable<MethodDefinition> GetRequiredMethodsForInstantiatedType (TypeDefinition type)
 		{
 			foreach (var method in type.Methods) {
-				if (method.IsFinalizer () || IsVirtualNeededByInstantiatedTypeDueToPreservedScope (method))
+				if (IsVirtualNeededByInstantiatedTypeDueToPreservedScope (method))
 					yield return method;
 			}
 		}

--- a/src/linker/Linker/MethodDefinitionExtensions.cs
+++ b/src/linker/Linker/MethodDefinitionExtensions.cs
@@ -74,15 +74,15 @@ namespace Mono.Linker
 #if !FEATURE_ILLINK
 		// This implementation is wrong. It should return true if this is a virtual override
 		// of System.Object::Finalize, but that's not what this is doing. Do not use.
-		public static bool IsFinalizer (this MethodDefinition method)	
-		{	
-			if (method.Name != "Finalize" || method.ReturnType.MetadataType != MetadataType.Void)	
-				return false;	
+		public static bool IsFinalizer (this MethodDefinition method)
+		{
+			if (method.Name != "Finalize" || method.ReturnType.MetadataType != MetadataType.Void)
+				return false;
 
-			if (method.HasParameters || method.HasGenericParameters || method.IsStatic)	
-				return false;	
+			if (method.HasParameters || method.HasGenericParameters || method.IsStatic)
+				return false;
 
-			return true;	
+			return true;
 		}
 #endif
 		

--- a/src/linker/Linker/MethodDefinitionExtensions.cs
+++ b/src/linker/Linker/MethodDefinitionExtensions.cs
@@ -85,7 +85,7 @@ namespace Mono.Linker
 			return true;
 		}
 #endif
-		
+
 		public static void ClearDebugInformation (this MethodDefinition method)
 		{
 			// TODO: This always allocates, update when Cecil catches up

--- a/src/linker/Linker/MethodDefinitionExtensions.cs
+++ b/src/linker/Linker/MethodDefinitionExtensions.cs
@@ -71,17 +71,6 @@ namespace Mono.Linker
 			return method.IsConstructor && method.IsStatic;
 		}
 
-		public static bool IsFinalizer (this MethodDefinition method)
-		{
-			if (method.Name != "Finalize" || method.ReturnType.MetadataType != MetadataType.Void)
-				return false;
-
-			if (method.HasParameters || method.HasGenericParameters || method.IsStatic)
-				return false;
-
-			return true;
-		}
-
 		public static void ClearDebugInformation (this MethodDefinition method)
 		{
 			// TODO: This always allocates, update when Cecil catches up

--- a/src/linker/Linker/MethodDefinitionExtensions.cs
+++ b/src/linker/Linker/MethodDefinitionExtensions.cs
@@ -71,6 +71,21 @@ namespace Mono.Linker
 			return method.IsConstructor && method.IsStatic;
 		}
 
+#if !FEATURE_ILLINK
+		// This implementation is wrong. It should return true if this is a virtual override
+		// of System.Object::Finalize, but that's not what this is doing. Do not use.
+		public static bool IsFinalizer (this MethodDefinition method)	
+		{	
+			if (method.Name != "Finalize" || method.ReturnType.MetadataType != MetadataType.Void)	
+				return false;	
+
+			if (method.HasParameters || method.HasGenericParameters || method.IsStatic)	
+				return false;	
+
+			return true;	
+		}
+#endif
+		
 		public static void ClearDebugInformation (this MethodDefinition method)
 		{
 			// TODO: This always allocates, update when Cecil catches up

--- a/src/linker/Linker/TypeDefinitionExtensions.cs
+++ b/src/linker/Linker/TypeDefinitionExtensions.cs
@@ -25,12 +25,12 @@ namespace Mono.Linker
 		public static TypeReference GetEnumUnderlyingType (this TypeDefinition enumType)
 		{
 			foreach (var field in enumType.Fields) {
-				if (!field.IsStatic && field.Name == "value__") {
+				if (!field.IsStatic) {
 					return field.FieldType;
 				}
 			}
 
-			throw new MissingFieldException ($"Enum type '{enumType.FullName}' is missing 'value__' field");
+			throw new MissingFieldException ($"Enum type '{enumType.FullName}' is missing instance field");
 		}
 
 		public static bool IsMulticastDelegate (this TypeDefinition td)


### PR DESCRIPTION
* It's not mandatory to name the single instance field on enums `value__`. C#/VB do that, but the spec only requires there is an instance field. The name check is unnecessary work.
* The `IsFinalizer` extension method was wrong: one one side it includes unnecessary methods (for people who like to fight CS0465 warning from the C# compiler and name their methods `Finalize` - and yes there are those people), and on the other side it doesn't include finalizers that are not named `Finalize` (one can just `MethodImpl` the `Finalize` method). Instead of trying to get the extension method right, just letting the general virtual method handling take care of it.