### PR TITLE
Remove duplicate --enable-opt clearinitlocals in ILLink

### DIFF
--- a/src/ILLink.Tasks/LinkTask.cs
+++ b/src/ILLink.Tasks/LinkTask.cs
@@ -328,11 +328,8 @@ namespace ILLink.Tasks
 			if (_sealer is bool sealer)
 				SetOpt (args, "sealer", sealer);
 
-			if (clearInitLocals) {
-				args.AppendLine ("--enable-opt clearinitlocals");
-				if (ClearInitLocalsAssemblies?.Length > 0) {
-					args.AppendFormat ($"--custom-data ClearInitLocalsAssemblies={ClearInitLocalsAssemblies} ");
-				}
+			if (clearInitLocals && ClearInitLocalsAssemblies?.Length > 0) {
+				args.AppendFormat ($"--custom-data ClearInitLocalsAssemblies={ClearInitLocalsAssemblies} ");
 			}
 
 			if (FeatureSettings != null) {


### PR DESCRIPTION
The line is already appended to the response file above this code on line 317:

```
			if (_clearInitLocals is bool clearInitLocals) {
				SetOpt (args, "clearinitlocals", clearInitLocals);
			} else {
				clearInitLocals = false;
			}
```

So there is no need to add it here again.

cc @sbomer 