### PR TITLE
Implement a couple more dataflow intrinsics

### DIFF
--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -157,6 +157,8 @@ namespace Mono.Linker.Dataflow
 			IntrospectionExtensions_GetTypeInfo,
 			Type_GetTypeFromHandle,
 			Type_get_TypeHandle,
+			Object_GetType,
+			TypeDelegator_Ctor,
 
 			// Anything above this marker will require the method to be run through
 			// the reflection body scanner.
@@ -168,6 +170,7 @@ namespace Mono.Linker.Dataflow
 			Type_GetField,
 			Type_GetProperty,
 			Type_GetEvent,
+			Type_GetNestedType,
 			Expression_Call,
 			Expression_Field,
 			Expression_Property,
@@ -298,6 +301,13 @@ namespace Mono.Linker.Dataflow
 					&& calledMethod.HasThis
 					=> IntrinsicId.Type_GetEvent,
 
+				// System.Type.GetNestedType (string)
+				// System.Type.GetNestedType (string, BindingFlags)
+				"GetNestedType" when calledMethod.IsDeclaredOnType ("System", "Type")
+					&& calledMethod.HasParameterOfType (0, "System", "String")
+					&& calledMethod.HasThis
+					=> IntrinsicId.Type_GetNestedType,
+
 				// System.Type.GetProperty (string)
 				// System.Type.GetProperty (string, BindingFlags)
 				// System.Type.GetProperty (string, Type)
@@ -309,6 +319,14 @@ namespace Mono.Linker.Dataflow
 					&& calledMethod.HasParameterOfType (0, "System", "String")
 					&& calledMethod.HasThis
 					=> IntrinsicId.Type_GetProperty,
+
+				// static System.Object.GetType ()
+				"GetType" when calledMethod.IsDeclaredOnType ("System", "Object")
+					=> IntrinsicId.Object_GetType,
+
+				".ctor" when calledMethod.IsDeclaredOnType ("System.Reflection", "TypeDelegator")
+					&& calledMethod.HasParameterOfType (0, "System", "Type")
+					=> IntrinsicId.TypeDelegator_Ctor,
 
 				// static System.Activator.CreateInstance (System.Type type)
 				// static System.Activator.CreateInstance (System.Type type, bool nonPublic)
@@ -418,6 +436,12 @@ namespace Mono.Linker.Dataflow
 						// the dead-end reflection refactoring. The call doesn't do anything and we
 						// don't want to lose the annotation.
 						methodReturnValue = methodParams[0];
+					}
+					break;
+
+				case IntrinsicId.TypeDelegator_Ctor: {
+						// This is an identity function for analysis purposes
+						methodReturnValue = methodParams[1];
 					}
 					break;
 
@@ -616,6 +640,50 @@ namespace Mono.Linker.Dataflow
 					break;
 
 				//
+				// System.Object
+				// 
+				// GetType()
+				//
+				case IntrinsicId.Object_GetType: {
+						// We could do better here if we start tracking the static types of values within the method body.
+						// Right now, this can only analyze a couple cases for which we have static information for.
+						TypeDefinition staticType = null;
+						if (methodParams[0] is MethodParameterValue methodParam) {
+							if (callingMethodBody.Method.HasThis) {
+								if (methodParam.ParameterIndex == 0) {
+									staticType = callingMethodBody.Method.DeclaringType;
+								}
+								else {
+									staticType = callingMethodBody.Method.Parameters[methodParam.ParameterIndex - 1].ParameterType.Resolve ();
+								}
+							}
+							else {
+								staticType = callingMethodBody.Method.Parameters[methodParam.ParameterIndex].ParameterType.Resolve ();
+							}
+						}
+						else if (methodParams[0] is LoadFieldValue loadedField) {
+							staticType = loadedField.Field.FieldType.Resolve ();
+						}
+
+						if (staticType != null) {
+							// We can only analyze the Object.GetType call with the precise type if the type is sealed.
+							// The type could be a descendant of the type in question, making us miss reflection.
+							bool canUse = staticType.IsSealed;
+
+							if (!canUse) {
+								// We can allow Object.GetType to be modeled as System.Delegate because we keep all methods
+								// on delegates anyway so reflection on something this approximation would miss is actually safe.
+								canUse = staticType.IsTypeOf ("System", "Delegate");
+							}
+
+							if (canUse) {
+								methodReturnValue = new SystemTypeValue (staticType);
+							}
+						}
+					}
+					break;
+
+				//
 				// System.Type
 				//
 				// GetType (string)
@@ -723,6 +791,45 @@ namespace Mono.Linker.Dataflow
 								// Otherwise fall back to the bitfield requirements
 								RequireDynamicallyAccessedMembers (ref reflectionContext, requiredMemberKinds, value, calledMethod.Parameters[0]);
 							}
+						}
+					}
+					break;
+
+				//
+				// GetNestedType (string)
+				// GetNestedType (string, BindingFlags)
+				//
+				case IntrinsicId.Type_GetNestedType: {
+						reflectionContext.AnalyzingPattern ();
+
+						BindingFlags bindingFlags = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public;
+						if (calledMethod.Parameters.Count > 1 && calledMethod.Parameters[1].ParameterType.Name == "BindingFlags" && methodParams[2].AsConstInt () != null) {
+							bindingFlags = (BindingFlags) methodParams[2].AsConstInt ();
+						}
+
+						var requiredMemberKinds = GetDynamicallyAccessedMemberTypesFromBindingFlagsForTypes (bindingFlags);
+						foreach (var value in methodParams[0].UniqueValues ()) {
+							if (value is SystemTypeValue systemTypeValue) {
+								foreach (var stringParam in methodParams[1].UniqueValues ()) {
+									if (stringParam is KnownStringValue stringValue) {
+										TypeDefinition[] matchingNestedTypes = MarkNestedTypesOnType (ref reflectionContext, systemTypeValue.TypeRepresented, m => m.Name == stringValue.Contents, bindingFlags);
+
+										if (matchingNestedTypes != null) {
+											for (int i = 0; i < matchingNestedTypes.Length; i++)
+												methodReturnValue = MergePointValue.MergeValues (methodReturnValue, new SystemTypeValue (matchingNestedTypes[i]));
+										}
+
+										reflectionContext.RecordHandledPattern ();
+									} else {
+										// Otherwise fall back to the bitfield requirements
+										RequireDynamicallyAccessedMembers (ref reflectionContext, requiredMemberKinds, value, calledMethod.Parameters[0]);
+									}
+								}
+							} else {
+								// Otherwise fall back to the bitfield requirements
+								RequireDynamicallyAccessedMembers (ref reflectionContext, requiredMemberKinds, value, calledMethod.Parameters[0]);
+							}
+
 						}
 					}
 					break;
@@ -1083,7 +1190,7 @@ namespace Mono.Linker.Dataflow
 			foreach (var uniqueValue in value.UniqueValues ()) {
 				if (uniqueValue is LeafValueWithDynamicallyAccessedMemberNode valueWithDynamicallyAccessedMember) {
 					if (!valueWithDynamicallyAccessedMember.DynamicallyAccessedMemberKinds.HasFlag (requiredMemberKinds)) {
-						reflectionContext.RecordUnrecognizedPattern ($"The {GetValueDescriptionForErrorMessage (valueWithDynamicallyAccessedMember)} " +
+						reflectionContext.RecordUnrecognizedPattern ($"{reflectionContext.SourceMethod} The {GetValueDescriptionForErrorMessage (valueWithDynamicallyAccessedMember)} " +
 							$"with dynamically accessed member kinds '{GetDynamicallyAccessedMemberKindsDescription (valueWithDynamicallyAccessedMember.DynamicallyAccessedMemberKinds)}' " +
 							$"is passed into the {GetMetadataTokenDescriptionForErrorMessage (targetContext)} " +
 							$"which requires dynamically accessed member kinds '{GetDynamicallyAccessedMemberKindsDescription (requiredMemberKinds)}'. " +
@@ -1266,15 +1373,31 @@ namespace Mono.Linker.Dataflow
 			}
 		}
 
-		void MarkNestedTypesOnType (ref ReflectionPatternContext reflectionContext, TypeDefinition type, Func<TypeDefinition, bool> filter)
+		TypeDefinition[] MarkNestedTypesOnType (ref ReflectionPatternContext reflectionContext, TypeDefinition type, Func<TypeDefinition, bool> filter, BindingFlags bindingFlags = BindingFlags.Default)
 		{
+			var result = new ArrayBuilder<TypeDefinition>();
+
 			foreach (var nestedType in type.NestedTypes) {
 				if (filter != null && !filter (nestedType))
 					continue;
 
+				if ((bindingFlags & (BindingFlags.Public | BindingFlags.NonPublic)) == BindingFlags.Public) {
+					if (!nestedType.IsNestedPublic)
+						continue;
+				}
+
+				if ((bindingFlags & (BindingFlags.Public | BindingFlags.NonPublic)) == BindingFlags.NonPublic) {
+					if (nestedType.IsNestedPublic)
+						continue;
+				}
+
+				result.Add (nestedType);
+
 				var methodCalling = reflectionContext.SourceMethod;
 				reflectionContext.RecordRecognizedPattern (nestedType, () => _markStep.MarkType (nestedType, new DependencyInfo (DependencyKind.AccessedViaReflection, methodCalling)));
 			}
+
+			return result.ToArray ();
 		}
 
 		void MarkPropertiesOnTypeHierarchy (ref ReflectionPatternContext reflectionContext, TypeDefinition type, Func<PropertyDefinition, bool> filter, BindingFlags bindingFlags = BindingFlags.Default)
@@ -1482,6 +1605,10 @@ namespace Mono.Linker.Dataflow
 
 			return string.Join (" | ", results.Select (r => r.ToString ()));
 		}
+
+		static DynamicallyAccessedMemberTypes GetDynamicallyAccessedMemberTypesFromBindingFlagsForTypes (BindingFlags bindingFlags) =>
+			(bindingFlags.HasFlag (BindingFlags.Public) ? DynamicallyAccessedMemberTypes.PublicNestedTypes : DynamicallyAccessedMemberTypes.None) |
+			(bindingFlags.HasFlag (BindingFlags.NonPublic) ? DynamicallyAccessedMemberTypes.NonPublicNestedTypes : DynamicallyAccessedMemberTypes.None);
 
 		static DynamicallyAccessedMemberTypes GetDynamicallyAccessedMemberTypesFromBindingFlagsForConstructors (BindingFlags bindingFlags) =>
 			(bindingFlags.HasFlag (BindingFlags.Public) ? DynamicallyAccessedMemberTypes.PublicConstructors : DynamicallyAccessedMemberTypes.None) |

--- a/test/Mono.Linker.Tests.Cases/Reflection/NestedTypeUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/NestedTypeUsedViaReflection.cs
@@ -26,7 +26,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		[Kept]
 		[RecognizedReflectionAccessPattern (
 			typeof (Type), nameof (Type.GetNestedType), new Type[] { typeof (string) },
-			typeof (NestedTypeUsedViaReflection), nameof (NestedTypeUsedViaReflection.NestedType), (Type[]) null)]
+			typeof (NestedTypeUsedViaReflection.NestedType), null, (Type[]) null)]
 		static void TestByName ()
 		{
 			_ = typeof (NestedTypeUsedViaReflection).GetNestedType (nameof (NestedType));
@@ -53,13 +53,13 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		[Kept]
 		[RecognizedReflectionAccessPattern (
 			typeof (Type), nameof (Type.GetNestedType), new Type[] { typeof (string), typeof (BindingFlags) },
-			typeof (NestedTypeUsedViaReflection), nameof (NestedTypeUsedViaReflection.PrivateNestedType), (Type[]) null)]
+			typeof (NestedTypeUsedViaReflection.PrivateNestedType), null, (Type[]) null)]
 		[RecognizedReflectionAccessPattern (
 			typeof (Type), nameof (Type.GetNestedType), new Type[] { typeof (string), typeof (BindingFlags) },
-			typeof (NestedTypeUsedViaReflection), nameof (NestedTypeUsedViaReflection.PublicNestedType), (Type[]) null)]
+			typeof (NestedTypeUsedViaReflection.PublicNestedType), null, (Type[]) null)]
 		[RecognizedReflectionAccessPattern (
 			typeof (Type), nameof (Type.GetNestedType), new Type[] { typeof (string), typeof (BindingFlags) },
-			typeof (NestedTypeUsedViaReflection), nameof (NestedTypeUsedViaReflection.ProtectedNestedType), (Type[]) null)]
+			typeof (NestedTypeUsedViaReflection.ProtectedNestedType), null, (Type[]) null)]
 		static void TestByBindingFlags ()
 		{
 			_ = typeof (NestedTypeUsedViaReflection).GetNestedType (nameof (PrivateNestedType), BindingFlags.NonPublic);

--- a/test/Mono.Linker.Tests.Cases/Reflection/NestedTypeUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/NestedTypeUsedViaReflection.cs
@@ -1,0 +1,83 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reflection;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Reflection
+{
+	public class NestedTypeUsedViaReflection
+	{
+		public static void Main ()
+		{
+			TestByName ();
+			TestPrivateByName ();
+			TestByBindingFlags ();
+			TestNonExistingName ();
+			TestNullType ();
+		}
+
+		[Kept]
+		public static class NestedType { }
+
+		[Kept]
+		[RecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetNestedType), new Type[] { typeof (string) },
+			typeof (NestedTypeUsedViaReflection), nameof (NestedTypeUsedViaReflection.NestedType), (Type[]) null)]
+		static void TestByName ()
+		{
+			_ = typeof (NestedTypeUsedViaReflection).GetNestedType (nameof (NestedType));
+		}
+
+		static class PrivateUnreferencedNestedType { }
+
+		[Kept]
+		static void TestPrivateByName ()
+		{
+			_ = typeof (NestedTypeUsedViaReflection).GetNestedType (nameof (PrivateUnreferencedNestedType)); // This will not mark the nested type as GetNestedType(string) only returns public
+			_ = typeof (NestedTypeUsedViaReflection).GetNestedType (nameof (PrivateUnreferencedNestedType), BindingFlags.Public);
+		}
+
+		[Kept]
+		public static class PublicNestedType { }
+
+		[Kept]
+		private static class PrivateNestedType { }
+
+		[Kept]
+		protected static class ProtectedNestedType { }
+
+		[Kept]
+		[RecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetNestedType), new Type[] { typeof (string), typeof (BindingFlags) },
+			typeof (NestedTypeUsedViaReflection), nameof (NestedTypeUsedViaReflection.PrivateNestedType), (Type[]) null)]
+		[RecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetNestedType), new Type[] { typeof (string), typeof (BindingFlags) },
+			typeof (NestedTypeUsedViaReflection), nameof (NestedTypeUsedViaReflection.PublicNestedType), (Type[]) null)]
+		[RecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetNestedType), new Type[] { typeof (string), typeof (BindingFlags) },
+			typeof (NestedTypeUsedViaReflection), nameof (NestedTypeUsedViaReflection.ProtectedNestedType), (Type[]) null)]
+		static void TestByBindingFlags ()
+		{
+			_ = typeof (NestedTypeUsedViaReflection).GetNestedType (nameof (PrivateNestedType), BindingFlags.NonPublic);
+			_ = typeof (NestedTypeUsedViaReflection).GetNestedType (nameof (PublicNestedType), BindingFlags.Public);
+			_ = typeof (NestedTypeUsedViaReflection).GetNestedType (nameof (ProtectedNestedType), BindingFlags.NonPublic);
+		}
+
+		[Kept]
+		static void TestNonExistingName ()
+		{
+			_ = typeof (NestedTypeUsedViaReflection).GetNestedType ("NonExisting");
+		}
+
+		[Kept]
+		static void TestNullType ()
+		{
+			Type type = null;
+			_ = type.GetNestedType ("NestedType");
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Reflection/ObjectGetType.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ObjectGetType.cs
@@ -1,0 +1,64 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Reflection
+{
+	public class ObjectGetType
+	{
+		public static void Main ()
+		{
+			TestSealed ();
+			TestUnsealed ();
+		}
+
+		[Kept]
+		static void TestSealed ()
+		{
+			s_sealedClassField = new SealedClass ();
+			s_sealedClassField.GetType ().GetMethod ("Method");
+		}
+
+		[Kept]
+		[UnrecognizedReflectionAccessPattern (typeof (Type), nameof (Type.GetMethod), new Type[] { typeof (string) })]
+		static void TestUnsealed ()
+		{
+			s_unsealedClassField = new UnsealedClass ();
+
+			// GetType call on an unsealed type is not recognized and produces a warning
+			s_unsealedClassField.GetType ().GetMethod ("Method");
+		}
+
+		[Kept]
+		static SealedClass s_sealedClassField;
+
+		[Kept]
+		sealed class SealedClass
+		{
+			[Kept]
+			public SealedClass () { }
+
+			[Kept]
+			public static void Method () { }
+
+			public static void UnusedMethod () { }
+		}
+
+		[Kept]
+		static UnsealedClass s_unsealedClassField;
+
+		[Kept]
+		class UnsealedClass
+		{
+			[Kept]
+			public UnsealedClass () { }
+
+			public static void Method () { }
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Reflection/TypeDelegator.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/TypeDelegator.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Reflection
+{
+	public class TypeDelegator
+	{
+		public static void Main ()
+		{
+			_ = new System.Reflection.TypeDelegator (typeof (TypeUsedWithDelegator)).GetMethod ("Method");
+		}
+
+		[Kept]
+		static class TypeUsedWithDelegator
+		{
+			[Kept]
+			public static void Method () { }
+
+			public static void UnrelatedMethod () { }
+		}
+	}
+}

--- a/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -825,7 +825,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				member = memberReference.Resolve ();
 
 			if (member is IMemberDefinition memberDefinition) {
-				if (memberDefinition is TypeDefinition type) {
+				if (memberDefinition is TypeDefinition) {
 					return memberDefinition.FullName;
 				}
 

--- a/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -826,11 +826,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 			if (member is IMemberDefinition memberDefinition) {
 				if (memberDefinition is TypeDefinition type) {
-					if (type.DeclaringType != null) {
-						return GetFullMemberNameFromDefinition (type.DeclaringType) + "::" + type.Name;
-					} else {
-						return memberDefinition.FullName;
-					}
+					return memberDefinition.FullName;
 				}
 
 				string fullName = memberDefinition.DeclaringType.FullName + "::";

--- a/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -825,8 +825,12 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				member = memberReference.Resolve ();
 
 			if (member is IMemberDefinition memberDefinition) {
-				if (memberDefinition is TypeDefinition) {
-					return memberDefinition.FullName;
+				if (memberDefinition is TypeDefinition type) {
+					if (type.DeclaringType != null) {
+						return GetFullMemberNameFromDefinition (type.DeclaringType) + "::" + type.Name;
+					} else {
+						return memberDefinition.FullName;
+					}
 				}
 
 				string fullName = memberDefinition.DeclaringType.FullName + "::";


### PR DESCRIPTION
* `Type.GetNestedType` - should be straighforward
* `TypeDelegator..ctor` - this is used in CoreLib - we should just treat it as identity so that we don't lose dataflow annotations
* `object.GetType` - I specifically need the delegate part for `CoreLib`; the rest of the behavior is nice to have but I don't expect it to kick in too often.

Creating as draft because it obviously misses tests, but it's Friday...