### PR TITLE
Implement support for RequiresUnreferencedCodeAttribute

### DIFF
--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -163,6 +163,10 @@ error and warning codes.
 
 - The linker found a call to a method which is annotated with 'RequiresUnreferencedCodeAttribute' which can break functionality of a trimmed application.
 
-#### `IL2027`: Found multiple instances of attribute 'attribut'` on 'method', but only one is allowed. Only the first one will be used, the others will be ignored.
+#### `IL2027`: Attribute 'attribute' should only be used once on 'method'.
 
 - The linker found multiple instances of attribute 'attribute' on 'method'. This attribute is only allowed to have one instance, linker will only use the fist instance and ignore the rest.
+
+#### `IL2028`: Attribute 'attribute' on 'method' doesn't have a required constructor argument.
+
+- The linker found an instance of attribute 'attribute' on 'method' but it lacks a required constructor argument. Linker will ignore this attribute.

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -158,3 +158,7 @@ error and warning codes.
 #### `IL2025`: Duplicate preserve of 'member' in 'XML document location'
 
 - The XML descriptor marks for preservation the member or type 'member' more than once.
+
+#### `IL2026`: Calling method annotated with `RequiresUnreferencedCodeAttribute`
+
+- The linker found a call to a method which is annotated with `RequiresUnreferencedCodeAttribute` which can break functionality of a trimmed application.

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -161,4 +161,8 @@ error and warning codes.
 
 #### `IL2026`: Calling method annotated with `RequiresUnreferencedCodeAttribute`
 
-- The linker found a call to a method which is annotated with `RequiresUnreferencedCodeAttribute` which can break functionality of a trimmed application.
+- The linker found a call to a method which is annotated with 'RequiresUnreferencedCodeAttribute' which can break functionality of a trimmed application.
+
+#### `IL2027`: Found multiple instances of attribute 'attribut'` on 'method', but only one is allowed. Only the first one will be used, the others will be ignored.
+
+- The linker found multiple instances of attribute 'attribute' on 'method'. This attribute is only allowed to have one instance, linker will only use the fist instance and ignore the rest.

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -25,10 +25,10 @@ namespace Mono.Linker.Dataflow
 		{
 			MethodDefinition methodDefinition = calledMethod.Resolve ();
 			if (methodDefinition != null) {
-				return 
+				return
 					GetIntrinsicIdForMethod (methodDefinition) > IntrinsicId.RequiresReflectionBodyScanner_Sentinel ||
 					flowAnnotations.RequiresDataFlowAnalysis (methodDefinition) ||
-					context.Annotations.TryGetLinkerAttribute <RequiresUnreferencedCodeAttribute> (methodDefinition, out _);
+					context.Annotations.TryGetLinkerAttribute<RequiresUnreferencedCodeAttribute> (methodDefinition, out _);
 			}
 
 			return false;

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -21,21 +21,46 @@ namespace Mono.Linker.Dataflow
 		readonly MarkStep _markStep;
 		readonly FlowAnnotations _flowAnnotations;
 
-		public static bool RequiresReflectionMethodBodyScanner (FlowAnnotations flowAnnotations, MethodReference method)
+		public static bool RequiresReflectionMethodBodyScannerForCallSite (LinkContext context, FlowAnnotations flowAnnotations, MethodReference calledMethod)
 		{
-			MethodDefinition methodDefinition = method.Resolve ();
+			MethodDefinition methodDefinition = calledMethod.Resolve ();
 			if (methodDefinition != null) {
-				return GetIntrinsicIdForMethod (methodDefinition) > IntrinsicId.RequiresReflectionBodyScanner_Sentinel || flowAnnotations.RequiresDataFlowAnalysis (methodDefinition);
+				return 
+					GetIntrinsicIdForMethod (methodDefinition) > IntrinsicId.RequiresReflectionBodyScanner_Sentinel ||
+					flowAnnotations.RequiresDataFlowAnalysis (methodDefinition) ||
+					context.Annotations.TryGetLinkerAttribute <RequiresUnreferencedCodeAttribute> (methodDefinition, out _);
 			}
 
 			return false;
 		}
 
-		public static bool RequiresReflectionMethodBodyScanner (FlowAnnotations flowAnnotations, FieldReference field)
+		public static bool RequiresReflectionMethodBodyScannerForMethodBody (FlowAnnotations flowAnnotations, MethodReference method)
+		{
+			MethodDefinition methodDefinition = method.Resolve ();
+			if (methodDefinition != null) {
+				return
+					GetIntrinsicIdForMethod (methodDefinition) > IntrinsicId.RequiresReflectionBodyScanner_Sentinel ||
+					flowAnnotations.RequiresDataFlowAnalysis (methodDefinition);
+			}
+
+			return false;
+		}
+
+		public static bool RequiresReflectionMethodBodyScannerForAccess (FlowAnnotations flowAnnotations, FieldReference field)
 		{
 			FieldDefinition fieldDefinition = field.Resolve ();
 			if (fieldDefinition != null)
 				return flowAnnotations.RequiresDataFlowAnalysis (fieldDefinition);
+
+			return false;
+		}
+
+		public static bool AutomaticallySuppressReflectionmethodBodyScannerForMethod (LinkContext context, MethodReference method)
+		{
+			MethodDefinition methodDefinition = method.Resolve ();
+			if (methodDefinition != null) {
+				return context.Annotations.TryGetLinkerAttribute<RequiresUnreferencedCodeAttribute> (methodDefinition, out _);
+			}
 
 			return false;
 		}
@@ -406,7 +431,6 @@ namespace Mono.Linker.Dataflow
 				return false;
 
 			try {
-
 
 				bool requiresDataFlowAnalysis = _flowAnnotations.RequiresDataFlowAnalysis (calledMethodDefinition);
 				returnValueDynamicallyAccessedMemberKinds = requiresDataFlowAnalysis ?
@@ -973,6 +997,18 @@ namespace Mono.Linker.Dataflow
 						}
 
 						reflectionContext.RecordHandledPattern ();
+					}
+
+					if (_context.Annotations.TryGetLinkerAttribute<RequiresUnreferencedCodeAttribute> (calledMethodDefinition, out var requiresUnreferencedCode)) {
+						string message =
+							$"Calling '{calledMethodDefinition}' which has `RequiresUnreferencedCodeAttribute` can break functionality when trimming application code. " +
+							$"{requiresUnreferencedCode.Message}.";
+
+						if (requiresUnreferencedCode.Url != null) {
+							message += " " + requiresUnreferencedCode.Url;
+						}
+
+						_context.LogMessage (MessageContainer.CreateWarningMessage (message, 2026, origin: MessageOrigin.TryGetOrigin (callingMethodBody.Method, operation.Offset)));
 					}
 
 					// To get good reporting of errors we need to track the origin of the value for all method calls

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -999,7 +999,7 @@ namespace Mono.Linker.Dataflow
 						reflectionContext.RecordHandledPattern ();
 					}
 
-					if (_context.Annotations.TryGetLinkerAttribute<RequiresUnreferencedCodeAttribute> (calledMethodDefinition, out var requiresUnreferencedCode)) {
+					if (_context.Annotations.TryGetLinkerAttribute (calledMethodDefinition, out RequiresUnreferencedCodeAttribute requiresUnreferencedCode)) {
 						string message =
 							$"Calling '{calledMethodDefinition}' which has `RequiresUnreferencedCodeAttribute` can break functionality when trimming application code. " +
 							$"{requiresUnreferencedCode.Message}.";

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -28,7 +28,7 @@ namespace Mono.Linker.Dataflow
 				return
 					GetIntrinsicIdForMethod (methodDefinition) > IntrinsicId.RequiresReflectionBodyScanner_Sentinel ||
 					flowAnnotations.RequiresDataFlowAnalysis (methodDefinition) ||
-					context.Annotations.TryGetLinkerAttribute<RequiresUnreferencedCodeAttribute> (methodDefinition, out _);
+					context.Annotations.HasLinkerAttribute<RequiresUnreferencedCodeAttribute> (methodDefinition);
 			}
 
 			return false;
@@ -55,11 +55,11 @@ namespace Mono.Linker.Dataflow
 			return false;
 		}
 
-		public static bool AutomaticallySuppressReflectionmethodBodyScannerForMethod (LinkContext context, MethodReference method)
+		public static bool AutomaticallySuppressReflectionMethodBodyScannerForMethod (LinkContext context, MethodReference method)
 		{
 			MethodDefinition methodDefinition = method.Resolve ();
 			if (methodDefinition != null) {
-				return context.Annotations.TryGetLinkerAttribute<RequiresUnreferencedCodeAttribute> (methodDefinition, out _);
+				return context.Annotations.HasLinkerAttribute<RequiresUnreferencedCodeAttribute> (methodDefinition);
 			}
 
 			return false;

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2460,7 +2460,7 @@ namespace Mono.Linker.Steps
 				if (eh.HandlerType == ExceptionHandlerType.Catch)
 					MarkType (eh.CatchType, new DependencyInfo (DependencyKind.CatchType, body.Method));
 
-			bool requiresReflectionMethodBodyScanner = 
+			bool requiresReflectionMethodBodyScanner =
 				ReflectionMethodBodyScanner.RequiresReflectionMethodBodyScannerForMethodBody (_flowAnnotations, body.Method);
 			foreach (Instruction instruction in body.Instructions)
 				MarkInstruction (instruction, body.Method, ref requiresReflectionMethodBodyScanner);
@@ -2507,7 +2507,7 @@ namespace Mono.Linker.Steps
 				case Code.Stsfld:
 				case Code.Ldflda: // Field address loads (as those can be used to store values to annotated field and thus must be checked)
 				case Code.Ldsflda:
-					requiresReflectionMethodBodyScanner |= 
+					requiresReflectionMethodBodyScanner |=
 						ReflectionMethodBodyScanner.RequiresReflectionMethodBodyScannerForAccess (_flowAnnotations, (FieldReference) instruction.Operand);
 					break;
 
@@ -2528,7 +2528,7 @@ namespace Mono.Linker.Steps
 						Code.Ldftn => DependencyKind.Ldftn,
 						_ => throw new Exception ($"unexpected opcode {instruction.OpCode}")
 					};
-					requiresReflectionMethodBodyScanner |= 
+					requiresReflectionMethodBodyScanner |=
 						ReflectionMethodBodyScanner.RequiresReflectionMethodBodyScannerForCallSite (_context, _flowAnnotations, (MethodReference) instruction.Operand);
 					MarkMethod ((MethodReference) instruction.Operand, new DependencyInfo (dependencyKind, method));
 					break;

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2465,7 +2465,7 @@ namespace Mono.Linker.Steps
 			foreach (Instruction instruction in body.Instructions)
 				MarkInstruction (instruction, body.Method, ref requiresReflectionMethodBodyScanner);
 
-			if (ReflectionMethodBodyScanner.AutomaticallySuppressReflectionmethodBodyScannerForMethod (_context, body.Method))
+			if (ReflectionMethodBodyScanner.AutomaticallySuppressReflectionMethodBodyScannerForMethod (_context, body.Method))
 				requiresReflectionMethodBodyScanner = false;
 
 			MarkInterfacesNeededByBodyStack (body);

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2460,9 +2460,13 @@ namespace Mono.Linker.Steps
 				if (eh.HandlerType == ExceptionHandlerType.Catch)
 					MarkType (eh.CatchType, new DependencyInfo (DependencyKind.CatchType, body.Method));
 
-			bool requiresReflectionMethodBodyScanner = ReflectionMethodBodyScanner.RequiresReflectionMethodBodyScanner (_flowAnnotations, body.Method);
+			bool requiresReflectionMethodBodyScanner = 
+				ReflectionMethodBodyScanner.RequiresReflectionMethodBodyScannerForMethodBody (_flowAnnotations, body.Method);
 			foreach (Instruction instruction in body.Instructions)
 				MarkInstruction (instruction, body.Method, ref requiresReflectionMethodBodyScanner);
+
+			if (ReflectionMethodBodyScanner.AutomaticallySuppressReflectionmethodBodyScannerForMethod (_context, body.Method))
+				requiresReflectionMethodBodyScanner = false;
 
 			MarkInterfacesNeededByBodyStack (body);
 
@@ -2503,7 +2507,8 @@ namespace Mono.Linker.Steps
 				case Code.Stsfld:
 				case Code.Ldflda: // Field address loads (as those can be used to store values to annotated field and thus must be checked)
 				case Code.Ldsflda:
-					requiresReflectionMethodBodyScanner |= ReflectionMethodBodyScanner.RequiresReflectionMethodBodyScanner (_flowAnnotations, (FieldReference) instruction.Operand);
+					requiresReflectionMethodBodyScanner |= 
+						ReflectionMethodBodyScanner.RequiresReflectionMethodBodyScannerForAccess (_flowAnnotations, (FieldReference) instruction.Operand);
 					break;
 
 				default: // Other field operations are not interesting as they don't need to be checked
@@ -2523,7 +2528,8 @@ namespace Mono.Linker.Steps
 						Code.Ldftn => DependencyKind.Ldftn,
 						_ => throw new Exception ($"unexpected opcode {instruction.OpCode}")
 					};
-					requiresReflectionMethodBodyScanner |= ReflectionMethodBodyScanner.RequiresReflectionMethodBodyScanner (_flowAnnotations, (MethodReference) instruction.Operand);
+					requiresReflectionMethodBodyScanner |= 
+						ReflectionMethodBodyScanner.RequiresReflectionMethodBodyScannerForCallSite (_context, _flowAnnotations, (MethodReference) instruction.Operand);
 					MarkMethod ((MethodReference) instruction.Operand, new DependencyInfo (dependencyKind, method));
 					break;
 				}

--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -54,6 +54,7 @@ namespace Mono.Linker
 		protected readonly Dictionary<MethodDefinition, List<OverrideInformation>> override_methods = new Dictionary<MethodDefinition, List<OverrideInformation>> ();
 		protected readonly Dictionary<MethodDefinition, List<MethodDefinition>> base_methods = new Dictionary<MethodDefinition, List<MethodDefinition>> ();
 		protected readonly Dictionary<AssemblyDefinition, ISymbolReader> symbol_readers = new Dictionary<AssemblyDefinition, ISymbolReader> ();
+		readonly Dictionary<MethodDefinition, LinkerAttributesInformation> method_linker_attributes = new Dictionary<MethodDefinition, LinkerAttributesInformation> ();
 
 		readonly Dictionary<object, Dictionary<IMetadataTokenProvider, object>> custom_annotations = new Dictionary<object, Dictionary<IMetadataTokenProvider, object>> ();
 		protected readonly Dictionary<AssemblyDefinition, HashSet<string>> resources_to_remove = new Dictionary<AssemblyDefinition, HashSet<string>> ();
@@ -425,6 +426,16 @@ namespace Mono.Linker
 		public bool SetPreservedStaticCtor (TypeDefinition type)
 		{
 			return marked_types_with_cctor.Add (type);
+		}
+
+		public bool TryGetLinkerAttribute<T> (MethodDefinition method, out T attributeValue) where T : class
+		{
+			if (!method_linker_attributes.TryGetValue (method, out var linkerAttributeInformation)) {
+				linkerAttributeInformation.InitializeForMethod (method);
+				method_linker_attributes.Add (method, linkerAttributeInformation);
+			}
+
+			return linkerAttributeInformation.TryGetAttribute (out attributeValue);
 		}
 	}
 }

--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -432,7 +432,7 @@ namespace Mono.Linker
 		public bool HasLinkerAttribute<T> (MethodDefinition method) where T : Attribute
 		{
 			if (!method_linker_attributes.TryGetValue (method, out var linkerAttributeInformation)) {
-				linkerAttributeInformation = new LinkerAttributesInformation (method);
+				linkerAttributeInformation = new LinkerAttributesInformation (context, method);
 				method_linker_attributes.Add (method, linkerAttributeInformation);
 			}
 
@@ -442,7 +442,7 @@ namespace Mono.Linker
 		public IEnumerable<T> GetLinkerAttributes<T> (MethodDefinition method) where T : Attribute
 		{
 			if (!method_linker_attributes.TryGetValue (method, out var linkerAttributeInformation)) {
-				linkerAttributeInformation = new LinkerAttributesInformation (method);
+				linkerAttributeInformation = new LinkerAttributesInformation (context, method);
 				method_linker_attributes.Add (method, linkerAttributeInformation);
 			}
 
@@ -454,7 +454,7 @@ namespace Mono.Linker
 			var attributes = GetLinkerAttributes<T> (method);
 			if (attributes.Count () > 1) {
 				context.LogMessage (MessageContainer.CreateWarningMessage (
-					$"Found multiple instances of attribute '{typeof (T).FullName}' on '{method}', but only one is allowed. Only the first one will be used, the others will be ignored.",
+					$"Attribute '{typeof (T).FullName}' should only be used once on '{method}'.",
 					2027,
 					origin: MessageOrigin.TryGetOrigin (method, 0)));
 			}

--- a/src/linker/Linker/LinkerAttributesInformation.cs
+++ b/src/linker/Linker/LinkerAttributesInformation.cs
@@ -29,7 +29,7 @@ namespace Mono.Linker
 			attributeValue = null;
 
 			if (_linkerAttributes != null && _linkerAttributes.TryGetValue (typeof (T), out var returnValue)) {
-				attributeValue = (T)returnValue;
+				attributeValue = (T) returnValue;
 				return true;
 			}
 

--- a/src/linker/Linker/LinkerAttributesInformation.cs
+++ b/src/linker/Linker/LinkerAttributesInformation.cs
@@ -1,0 +1,67 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Mono.Cecil;
+
+namespace Mono.Linker
+{
+	struct LinkerAttributesInformation
+	{
+		Dictionary<Type, object> _linkerAttributes;
+
+		public void InitializeForMethod (MethodDefinition method)
+		{
+			if (method.HasCustomAttributes)
+				foreach (var customAttribute in method.CustomAttributes) {
+					var attributeType = customAttribute.AttributeType;
+					if (attributeType.Name == "RequiresUnreferencedCodeAttribute" && attributeType.Namespace == "System.Diagnostics.CodeAnalysis") {
+						AddAttribute (ProcessRequiresUnreferencedCodeAttribute (customAttribute));
+					}
+				}
+		}
+
+		public bool TryGetAttribute<T> (out T attributeValue) where T : class
+		{
+			attributeValue = null;
+
+			if (_linkerAttributes != null && _linkerAttributes.TryGetValue (typeof (T), out var returnValue)) {
+				attributeValue = (T)returnValue;
+				return true;
+			}
+
+			return false;
+		}
+
+		void AddAttribute (object attribute)
+		{
+			if (attribute == null)
+				return;
+
+			if (_linkerAttributes == null)
+				_linkerAttributes = new Dictionary<Type, object> ();
+
+			_linkerAttributes.Add (attribute.GetType (), attribute);
+		}
+
+		static object ProcessRequiresUnreferencedCodeAttribute (CustomAttribute customAttribute)
+		{
+			if (customAttribute.HasConstructorArguments) {
+				string message = (string) customAttribute.ConstructorArguments[0].Value;
+				string url = null;
+				foreach (var prop in customAttribute.Properties) {
+					if (prop.Name == "Url") {
+						url = (string) prop.Argument.Value;
+					}
+				}
+
+				return new RequiresUnreferencedCodeAttribute (message) { Url = url };
+			}
+
+			return null;
+		}
+	}
+}

--- a/src/linker/Linker/LinkerFatalErrorException.cs
+++ b/src/linker/Linker/LinkerFatalErrorException.cs
@@ -7,6 +7,18 @@ namespace Mono.Linker
 		public MessageContainer MessageContainer { get; }
 
 		/// <summary>
+		/// Represents an internal error that occured during link time which is not solvable by the user.
+		/// </summary>
+		/// <param name="internalErrorMessage">The additional message to attach to the error.
+		/// The main error message will be about internal error and make it clear this is not a user error.</param>
+		public LinkerFatalErrorException (string internalErrorMessage)
+			: this (MessageContainer.CreateErrorMessage (
+				"IL Linker has encountered an unexpected error. Please report the issue at https://github.com/mono/linker/issues \n" + internalErrorMessage,
+				1012))
+		{
+		}
+
+		/// <summary>
 		/// Represents a known error that occurred during link time which is solvable by the user.
 		/// </summary>
 		/// <param name="message">Error message with a description of what went wrong</param>

--- a/src/linker/System.Diagnostics.CodeAnalysis/RequiresUnreferencedCodeAttribute.cs
+++ b/src/linker/System.Diagnostics.CodeAnalysis/RequiresUnreferencedCodeAttribute.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+namespace System.Diagnostics.CodeAnalysis
+{
+	/// <summary>
+	/// Indicates that the specified method requires dynamic access to code that is not referenced
+	/// statically, for example through <see cref="System.Reflection"/>.
+	/// </summary>
+	/// <remarks>
+	/// This allows tools to understand which methods are unsafe to call when removing unreferenced
+	/// code from an application.
+	/// 
+	/// This is a copy of the attribute from dotnet/runtime repo - once linker runs on .NET 5 this should be removed.
+	/// </remarks>
+	[AttributeUsage (AttributeTargets.Method | AttributeTargets.Constructor, Inherited = false)]
+	internal sealed class RequiresUnreferencedCodeAttribute : Attribute
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="RequiresUnreferencedCodeAttribute"/> class
+		/// with the specified message.
+		/// </summary>
+		/// <param name="message">
+		/// A message that contains information about the usage of unreferenced code.
+		/// </param>
+		public RequiresUnreferencedCodeAttribute (string message)
+		{
+			Message = message;
+		}
+
+		/// <summary>
+		/// Gets a message that contains information about the usage of unreferenced code.
+		/// </summary>
+		public string Message { get; }
+
+		/// <summary>
+		/// Gets or sets an optional URL that contains more information about the method,
+		/// why it requries unreferenced code, and what options a consumer has to deal with it.
+		/// </summary>
+		public string? Url { get; set; }
+	}
+}

--- a/src/linker/System.Diagnostics.CodeAnalysis/RequiresUnreferencedCodeAttribute.cs
+++ b/src/linker/System.Diagnostics.CodeAnalysis/RequiresUnreferencedCodeAttribute.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 namespace System.Diagnostics.CodeAnalysis
 {
 	/// <summary>
@@ -40,6 +38,6 @@ namespace System.Diagnostics.CodeAnalysis
 		/// Gets or sets an optional URL that contains more information about the method,
 		/// why it requries unreferenced code, and what options a consumer has to deal with it.
 		/// </summary>
-		public string? Url { get; set; }
+		public string Url { get; set; }
 	}
 }

--- a/test/Mono.Linker.Tests.Cases.Expectations/Assertions/LogContainsAttribute.cs
+++ b/test/Mono.Linker.Tests.Cases.Expectations/Assertions/LogContainsAttribute.cs
@@ -3,7 +3,7 @@ using System;
 namespace Mono.Linker.Tests.Cases.Expectations.Assertions
 {
 	[AttributeUsage (
-		AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Constructor | AttributeTargets.Field, 
+		AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Constructor | AttributeTargets.Field,
 		AllowMultiple = true,
 		Inherited = false)]
 	public class LogContainsAttribute : EnableLoggerAttribute

--- a/test/Mono.Linker.Tests.Cases.Expectations/Assertions/LogContainsAttribute.cs
+++ b/test/Mono.Linker.Tests.Cases.Expectations/Assertions/LogContainsAttribute.cs
@@ -2,7 +2,10 @@ using System;
 
 namespace Mono.Linker.Tests.Cases.Expectations.Assertions
 {
-	[AttributeUsage (AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+	[AttributeUsage (
+		AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Constructor | AttributeTargets.Field, 
+		AllowMultiple = true,
+		Inherited = false)]
 	public class LogContainsAttribute : EnableLoggerAttribute
 	{
 		public LogContainsAttribute (string message, bool regexMatch = false)

--- a/test/Mono.Linker.Tests.Cases.Expectations/Assertions/LogDoesNotContainAttribute.cs
+++ b/test/Mono.Linker.Tests.Cases.Expectations/Assertions/LogDoesNotContainAttribute.cs
@@ -2,7 +2,10 @@
 
 namespace Mono.Linker.Tests.Cases.Expectations.Assertions
 {
-	[AttributeUsage (AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+	[AttributeUsage (
+		AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Constructor | AttributeTargets.Field,
+		AllowMultiple = true,
+		Inherited = false)]
 	public class LogDoesNotContainAttribute : EnableLoggerAttribute
 	{
 		public LogDoesNotContainAttribute (string message)

--- a/test/Mono.Linker.Tests.Cases.Expectations/System.Diagnostics.CodeAnalysis/RequiresUnreferencedCodeAttribute.cs
+++ b/test/Mono.Linker.Tests.Cases.Expectations/System.Diagnostics.CodeAnalysis/RequiresUnreferencedCodeAttribute.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 namespace System.Diagnostics.CodeAnalysis
 {
 	/// <summary>
@@ -40,6 +38,6 @@ namespace System.Diagnostics.CodeAnalysis
 		/// Gets or sets an optional URL that contains more information about the method,
 		/// why it requries unreferenced code, and what options a consumer has to deal with it.
 		/// </summary>
-		public string? Url { get; set; }
+		public string Url { get; set; }
 	}
 }

--- a/test/Mono.Linker.Tests.Cases.Expectations/System.Diagnostics.CodeAnalysis/RequiresUnreferencedCodeAttribute.cs
+++ b/test/Mono.Linker.Tests.Cases.Expectations/System.Diagnostics.CodeAnalysis/RequiresUnreferencedCodeAttribute.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+namespace System.Diagnostics.CodeAnalysis
+{
+	/// <summary>
+	/// Indicates that the specified method requires dynamic access to code that is not referenced
+	/// statically, for example through <see cref="System.Reflection"/>.
+	/// </summary>
+	/// <remarks>
+	/// This allows tools to understand which methods are unsafe to call when removing unreferenced
+	/// code from an application.
+	/// 
+	/// This is a copy of the attribute from dotnet/runtime repo - once linker runs on .NET 5 this should be removed.
+	/// </remarks>
+	[AttributeUsage (AttributeTargets.Method | AttributeTargets.Constructor, Inherited = false)]
+	public sealed class RequiresUnreferencedCodeAttribute : Attribute
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="RequiresUnreferencedCodeAttribute"/> class
+		/// with the specified message.
+		/// </summary>
+		/// <param name="message">
+		/// A message that contains information about the usage of unreferenced code.
+		/// </param>
+		public RequiresUnreferencedCodeAttribute (string message)
+		{
+			Message = message;
+		}
+
+		/// <summary>
+		/// Gets a message that contains information about the usage of unreferenced code.
+		/// </summary>
+		public string Message { get; }
+
+		/// <summary>
+		/// Gets or sets an optional URL that contains more information about the method,
+		/// why it requries unreferenced code, and what options a consumer has to deal with it.
+		/// </summary>
+		public string? Url { get; set; }
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
@@ -1,0 +1,123 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.RequiresCapability
+{
+	[SkipKeptItemsValidation]
+	public class RequiresUnreferencedCodeCapability
+	{
+		public static void Main ()
+		{
+			TestRequiresWithMessageOnlyOnMethod ();
+			TestRequiresWithMessageAndUrlOnMethod ();
+			TestRequiresOnConstructor ();
+			TestRequiresOnPropertyGetterAndSetter ();
+			TestRequiresSuppressesReflectionAnalysis ();
+		}
+
+		[LogContains (
+			"warning IL2026: Calling 'System.Void Mono.Linker.Tests.Cases.RequiresCapability.RequiresUnreferencedCodeCapability::RequiresWithMessageOnly()' which has `RequiresUnreferencedCodeAttribute` can break functionality when trimming application code. " +
+			"Message for --RequiresWithMessageOnly--.")]
+		static void TestRequiresWithMessageOnlyOnMethod ()
+		{
+			RequiresWithMessageOnly ();
+		}
+
+		[RequiresUnreferencedCode ("Message for --RequiresWithMessageOnly--")]
+		static void RequiresWithMessageOnly ()
+		{
+		}
+
+		[LogContains (
+			"warning IL2026: Calling 'System.Void Mono.Linker.Tests.Cases.RequiresCapability.RequiresUnreferencedCodeCapability::RequiresWithMessageAndUrl()' which has `RequiresUnreferencedCodeAttribute` can break functionality when trimming application code. " +
+			"Message for --RequiresWithMessageAndUrl--. " +
+			"https://helpurl")]
+		static void TestRequiresWithMessageAndUrlOnMethod ()
+		{
+			RequiresWithMessageAndUrl ();
+		}
+
+		[RequiresUnreferencedCode ("Message for --RequiresWithMessageAndUrl--", Url = "https://helpurl")]
+		static void RequiresWithMessageAndUrl ()
+		{
+		}
+
+		[LogContains (
+			"warning IL2026: Calling 'System.Void Mono.Linker.Tests.Cases.RequiresCapability.RequiresUnreferencedCodeCapability/ConstructorRequires::.ctor()' which has `RequiresUnreferencedCodeAttribute` can break functionality when trimming application code. " +
+			"Message for --ConstructorRequires--.")]
+		static void TestRequiresOnConstructor ()
+		{
+			new ConstructorRequires ();
+		}
+
+		class ConstructorRequires
+		{
+			[RequiresUnreferencedCode ("Message for --ConstructorRequires--")]
+			public ConstructorRequires ()
+			{
+			}
+		}
+
+		[LogContains (
+			"warning IL2026: Calling 'System.Int32 Mono.Linker.Tests.Cases.RequiresCapability.RequiresUnreferencedCodeCapability::get_PropertyRequires()' which has `RequiresUnreferencedCodeAttribute` can break functionality when trimming application code. " +
+			"Message for --getter PropertyRequires--.")]
+		[LogContains (
+			"warning IL2026: Calling 'System.Void Mono.Linker.Tests.Cases.RequiresCapability.RequiresUnreferencedCodeCapability::set_PropertyRequires(System.Int32)' which has `RequiresUnreferencedCodeAttribute` can break functionality when trimming application code. " +
+			"Message for --setter PropertyRequires--.")]
+		static void TestRequiresOnPropertyGetterAndSetter ()
+		{
+			_ = PropertyRequires;
+			PropertyRequires = 0;
+		}
+
+		static int PropertyRequires {
+			[RequiresUnreferencedCode ("Message for --getter PropertyRequires--")]
+			get { return 42; }
+
+			[RequiresUnreferencedCode ("Message for --setter PropertyRequires--")]
+			set { }
+		}
+
+		[LogContains (
+			"warning IL2026: Calling 'System.Void Mono.Linker.Tests.Cases.RequiresCapability.RequiresUnreferencedCodeCapability::RequiresAndCallsOtherRequiresMethods()' which has `RequiresUnreferencedCodeAttribute` can break functionality when trimming application code. " +
+			"Message for --RequiresAndCallsOtherRequiresMethods--.")]
+		static void TestRequiresSuppressesReflectionAnalysis ()
+		{
+			RequiresAndCallsOtherRequiresMethods ();
+		}
+
+		[RequiresUnreferencedCode("Message for --RequiresAndCallsOtherRequiresMethods--")]
+		[LogDoesNotContain ("Message for --RequiresUnreferencedCodeMethod--")]
+		[RecognizedReflectionAccessPattern]
+		static void RequiresAndCallsOtherRequiresMethods ()
+		{
+			// Normally this would warn, but with the attribute on this method it should be auto-suppressed
+			RequiresUnreferencedCodeMethod ();
+
+			// Normally this would warn due to incompatible annotations, but with the attribute on this method it should be auto-suppressed
+			RequiresPublicFields (GetTypeWithPublicMethods ());
+		}
+
+		[RequiresUnreferencedCode("Message for --RequiresUnreferencedCodeMethod--")]
+		static void RequiresUnreferencedCodeMethod ()
+		{
+		}
+
+		static void RequiresPublicFields ([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] Type type)
+		{
+		}
+
+		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+		static Type GetTypeWithPublicMethods ()
+		{
+			return null;
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
@@ -93,7 +93,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			RequiresAndCallsOtherRequiresMethods ();
 		}
 
-		[RequiresUnreferencedCode("Message for --RequiresAndCallsOtherRequiresMethods--")]
+		[RequiresUnreferencedCode ("Message for --RequiresAndCallsOtherRequiresMethods--")]
 		[LogDoesNotContain ("Message for --RequiresUnreferencedCodeMethod--")]
 		[RecognizedReflectionAccessPattern]
 		static void RequiresAndCallsOtherRequiresMethods ()
@@ -105,12 +105,12 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			RequiresPublicFields (GetTypeWithPublicMethods ());
 		}
 
-		[RequiresUnreferencedCode("Message for --RequiresUnreferencedCodeMethod--")]
+		[RequiresUnreferencedCode ("Message for --RequiresUnreferencedCodeMethod--")]
 		static void RequiresUnreferencedCodeMethod ()
 		{
 		}
 
-		static void RequiresPublicFields ([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] Type type)
+		static void RequiresPublicFields ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] Type type)
 		{
 		}
 

--- a/test/Mono.Linker.Tests/TestCases/TestDatabase.cs
+++ b/test/Mono.Linker.Tests/TestCases/TestDatabase.cs
@@ -168,6 +168,11 @@ namespace Mono.Linker.Tests.TestCases
 			return NUnitCasesBySuiteName ("DataFlow");
 		}
 
+		public static IEnumerable<TestCaseData> RequiresCapabilityTests ()
+		{
+			return NUnitCasesBySuiteName ("RequiresCapability");
+		}
+
 		public static IEnumerable<TestCaseData> LoggingTests ()
 		{
 			return NUnitCasesBySuiteName ("Logging");

--- a/test/Mono.Linker.Tests/TestCases/TestSuites.cs
+++ b/test/Mono.Linker.Tests/TestCases/TestSuites.cs
@@ -212,6 +212,12 @@ namespace Mono.Linker.Tests.TestCases
 			Run (testCase);
 		}
 
+		[TestCaseSource (typeof (TestDatabase), nameof (TestDatabase.RequiresCapabilityTests))]
+		public void RequiresCapabilityTests (TestCase testCase)
+		{
+			Run (testCase);
+		}
+
 		protected virtual void Run (TestCase testCase)
 		{
 			var runner = new TestRunner (new ObjectFactory ());

--- a/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -595,8 +595,8 @@ namespace Mono.Linker.Tests.TestCasesRunner
 		{
 			string allMessages = string.Join (Environment.NewLine, logger.Messages.Select (mc => mc.Message));
 
-			foreach (var typeWithRemoveInAssembly in original.AllDefinedTypes ()) {
-				foreach (var attr in typeWithRemoveInAssembly.CustomAttributes) {
+			foreach (var testType in original.AllDefinedTypes ()) {
+				foreach (var attr in testType.CustomAttributes.Concat (testType.AllMembers ().SelectMany (m => m.CustomAttributes))) {
 					if (attr.AttributeType.Resolve ().Name == nameof (LogContainsAttribute)) {
 						var expectedMessage = (string) attr.ConstructorArguments[0].Value;
 

--- a/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadaProvider.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadaProvider.cs
@@ -77,7 +77,9 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			}
 
 			if (_testCaseTypeDefinition.CustomAttributes.Any (attr =>
-				attr.AttributeType.Name == nameof (LogContainsAttribute) || attr.AttributeType.Name == nameof (LogDoesNotContainAttribute))) {
+				attr.AttributeType.Name == nameof (LogContainsAttribute) || attr.AttributeType.Name == nameof (LogDoesNotContainAttribute)) ||
+				_testCaseTypeDefinition.AllMembers ().Any (method => method.CustomAttributes.Any (attr =>
+				attr.AttributeType.Name == nameof (LogContainsAttribute) || attr.AttributeType.Name == nameof (LogDoesNotContainAttribute)))) {
 				tclo.AdditionalArguments.Add (new KeyValuePair<string, string[]> ("--verbose", new string[] { }));
 			}
 
@@ -103,7 +105,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			}
 		}
 
-		private bool ValidatesReflectionAccessPatterns (TypeDefinition testCaseTypeDefinition)
+		bool ValidatesReflectionAccessPatterns (TypeDefinition testCaseTypeDefinition)
 		{
 			if (testCaseTypeDefinition.HasNestedTypes) {
 				var nestedTypes = new Queue<TypeDefinition> (testCaseTypeDefinition.NestedTypes.ToList ());


### PR DESCRIPTION
Introduces a cache of "linker attributes", currently only RequiresUnreferencedCodeAttribute is supported, but it's highly likely we will need this for other attributes as well (DynamicDependency, future AOT/Single-file related attributes, UnconditionalSuppressMessage, ...). The cache is on Annotations class and should also act as a natural point to unify attribute and XML based inputs (once we have the XML based attribute injection).

RequiresUnreferencedCode now causes a linker warning whenever a method with it is called.
It also auto-suppresses warnings within the method with this attribute - it actually disables data flow analysis on the method right now.

In the future when we have AOT/Single-File related analysis we will need to modify this to selectively support a subset and only auto-suppress warnings related to the relevant subsets.

Extends the LogContains/LogDoesNotContain test attributes so that they can appear on anything within the test class. Functionality is still the same as if they're on the class, but it makes it easier to structure the tests and make them more readable. Once we have solid warning origins, we could also auto-validate that the warning came from the method it is on.

Fixes #1166 