### PR TITLE
Improve messages for reflection warnings

### DIFF
--- a/src/linker/Linker/LoggingReflectionPatternRecorder.cs
+++ b/src/linker/Linker/LoggingReflectionPatternRecorder.cs
@@ -44,8 +44,37 @@ namespace Mono.Linker
 
 		public void UnrecognizedReflectionAccessPattern (MethodDefinition sourceMethod, Instruction reflectionMethodCall, IMetadataTokenProvider accessedItem, string message)
 		{
-			_context.LogMessage (MessageContainer.CreateWarningMessage (message, 2006, "Unrecognized reflection pattern",
-				reflectionMethodCall != null ? MessageOrigin.TryGetOrigin (sourceMethod, reflectionMethodCall.Offset) : null));
+			var origin = reflectionMethodCall != null ? MessageOrigin.TryGetOrigin (sourceMethod, reflectionMethodCall.Offset) : null;
+			var locationInfo = origin == null ? (sourceMethod.DeclaringType.FullName + "::" + GetSignature (sourceMethod) + ": ") : string.Empty;
+			_context.LogMessage (MessageContainer.CreateWarningMessage (locationInfo + message, 2006, "Unrecognized reflection pattern", origin));
+		}
+
+		static string GetSignature (MethodDefinition method)
+		{
+			var builder = new System.Text.StringBuilder ();
+			builder.Append (method.Name);
+			if (method.HasGenericParameters) {
+				builder.Append ('<');
+
+				for (int i = 0; i < method.GenericParameters.Count - 1; i++)
+					builder.Append ($"{method.GenericParameters[i]},");
+
+				builder.Append ($"{method.GenericParameters[method.GenericParameters.Count - 1]}>");
+			}
+
+			builder.Append ("(");
+
+			if (method.HasParameters) {
+				for (int i = 0; i < method.Parameters.Count - 1; i++) {
+					builder.Append ($"{method.Parameters[i].ParameterType},");
+				}
+
+				builder.Append (method.Parameters[method.Parameters.Count - 1].ParameterType);
+			}
+
+			builder.Append (")");
+
+			return builder.ToString ();
 		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/Reflection/ConstructorUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ConstructorUsedViaReflection.cs
@@ -62,7 +62,10 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		}
 
 		[UnrecognizedReflectionAccessPattern (
-			typeof (Type), nameof (Type.GetConstructor), new Type[] { typeof (Type[]) })]
+			typeof (Type), nameof (Type.GetConstructor), new Type[] { typeof (Type[]) },
+			"The return value of method 'System.Type Mono.Linker.Tests.Cases.Reflection.ConstructorUsedViaReflection::FindType()' with dynamically accessed member kinds 'None' " +
+			"is passed into the implicit 'this' parameter of method 'System.Reflection.ConstructorInfo System.Type::GetConstructor(System.Type[])' which requires dynamically accessed member kinds 'PublicConstructors'. " +
+			"To fix this add DynamicallyAccessedMembersAttribute to it and specify at least these member kinds 'PublicConstructors'.")]
 		[Kept]
 		static void TestDataFlowType ()
 		{

--- a/test/Mono.Linker.Tests.Cases/Reflection/EventUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/EventUsedViaReflection.cs
@@ -93,7 +93,10 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
 		[Kept]
 		[UnrecognizedReflectionAccessPattern (
-			typeof (Type), nameof (Type.GetEvent), new Type[] { typeof (string) })]
+			typeof (Type), nameof (Type.GetEvent), new Type[] { typeof (string) },
+			"The return value of method 'System.Type Mono.Linker.Tests.Cases.Reflection.EventUsedViaReflection::FindType()' with dynamically accessed member kinds 'None' " +
+			"is passed into the implicit 'this' parameter of method 'System.Reflection.EventInfo System.Type::GetEvent(System.String)' which requires dynamically accessed member kinds 'PublicEvents'. " +
+			"To fix this add DynamicallyAccessedMembersAttribute to it and specify at least these member kinds 'PublicEvents'.")]
 		static void TestDataFlowType ()
 		{
 			Type type = FindType ();

--- a/test/Mono.Linker.Tests.Cases/Reflection/FieldUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/FieldUsedViaReflection.cs
@@ -88,7 +88,10 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
 		[Kept]
 		[UnrecognizedReflectionAccessPattern (
-			typeof (Type), nameof (Type.GetField), new Type[] { typeof (string) })]
+			typeof (Type), nameof (Type.GetField), new Type[] { typeof (string) },
+			"The return value of method 'System.Type Mono.Linker.Tests.Cases.Reflection.FieldUsedViaReflection::FindType()' with dynamically accessed member kinds 'None' " +
+			"is passed into the implicit 'this' parameter of method 'System.Reflection.FieldInfo System.Type::GetField(System.String)' which requires dynamically accessed member kinds 'PublicFields'. " +
+			"To fix this add DynamicallyAccessedMembersAttribute to it and specify at least these member kinds 'PublicFields'.")]
 		static void TestDataFlowType ()
 		{
 			Type type = FindType ();

--- a/test/Mono.Linker.Tests.Cases/Reflection/MethodUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/MethodUsedViaReflection.cs
@@ -132,6 +132,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		}
 
 		[Kept]
+		[RecognizedReflectionAccessPattern]
 		static void TestNullType ()
 		{
 			Type type = null;
@@ -146,7 +147,10 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
 		[Kept]
 		[UnrecognizedReflectionAccessPattern (
-			typeof (Type), nameof (Type.GetMethod), new Type[] { typeof (string), typeof (BindingFlags) })]
+			typeof (Type), nameof (Type.GetMethod), new Type[] { typeof (string), typeof (BindingFlags) },
+			"The return value of method 'System.Type Mono.Linker.Tests.Cases.Reflection.MethodUsedViaReflection::FindType()' with dynamically accessed member kinds 'None' " +
+			"is passed into the implicit 'this' parameter of method 'System.Reflection.MethodInfo System.Type::GetMethod(System.String,System.Reflection.BindingFlags)' which requires dynamically accessed member kinds 'PublicMethods'. " +
+			"To fix this add DynamicallyAccessedMembersAttribute to it and specify at least these member kinds 'PublicMethods'.")]
 		static void TestDataFlowType ()
 		{
 			Type type = FindType ();

--- a/test/Mono.Linker.Tests.Cases/Reflection/PropertyUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/PropertyUsedViaReflection.cs
@@ -93,7 +93,10 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
 		[Kept]
 		[UnrecognizedReflectionAccessPattern (
-			typeof (Type), nameof (Type.GetProperty), new Type[] { typeof (string) })]
+			typeof (Type), nameof (Type.GetProperty), new Type[] { typeof (string) },
+			"The return value of method 'System.Type Mono.Linker.Tests.Cases.Reflection.PropertyUsedViaReflection::FindType()' with dynamically accessed member kinds 'None' " +
+			"is passed into the implicit 'this' parameter of method 'System.Reflection.PropertyInfo System.Type::GetProperty(System.String)' which requires dynamically accessed member kinds 'PublicProperties'. " +
+			"To fix this add DynamicallyAccessedMembersAttribute to it and specify at least these member kinds 'PublicProperties'.")]
 		static void TestDataFlowType ()
 		{
 			Type type = FindType ();


### PR DESCRIPTION
Adds a location for messages which don't have source code location. For now this is added as the name of the method where the warning occured. This is definitely a temporary improvement and we should do better once we invest more into the location information.

Fixes several smaller issues with warning messages:
- In some cases Cecil doesn't have parameter names, so use parameter index in that case
- Correctly specify the "this" parameter (which doesn't have a Cecil representation) as the method definition itself which will lead to the correct message