### PR TITLE
Allow types and other metadata item as source for reflection access pattern

### DIFF
--- a/src/linker/Linker.Dataflow/ReflectionPatternContext.cs
+++ b/src/linker/Linker.Dataflow/ReflectionPatternContext.cs
@@ -25,11 +25,11 @@ namespace Mono.Linker.Dataflow
 		bool _patternReported;
 #endif
 
-		public IMetadataTokenProvider Source { get; private set; }
+		public IMemberDefinition Source { get; private set; }
 		public IMetadataTokenProvider MemberWithRequirements { get; private set; }
 		public Instruction Instruction { get; private set; }
 
-		public ReflectionPatternContext (LinkContext context, IMetadataTokenProvider source, IMetadataTokenProvider memberWithRequirements,
+		public ReflectionPatternContext (LinkContext context, IMemberDefinition source, IMetadataTokenProvider memberWithRequirements,
 			Instruction instruction = null)
 		{
 			_context = context;

--- a/src/linker/Linker.Dataflow/ReflectionPatternContext.cs
+++ b/src/linker/Linker.Dataflow/ReflectionPatternContext.cs
@@ -25,15 +25,15 @@ namespace Mono.Linker.Dataflow
 		bool _patternReported;
 #endif
 
-		public MethodDefinition SourceMethod { get; private set; }
+		public IMetadataTokenProvider Source { get; private set; }
 		public IMetadataTokenProvider MemberWithRequirements { get; private set; }
 		public Instruction Instruction { get; private set; }
 
-		public ReflectionPatternContext (LinkContext context, MethodDefinition sourceMethod, IMetadataTokenProvider memberWithRequirements,
+		public ReflectionPatternContext (LinkContext context, IMetadataTokenProvider source, IMetadataTokenProvider memberWithRequirements,
 			Instruction instruction = null)
 		{
 			_context = context;
-			SourceMethod = sourceMethod;
+			Source = source;
 			MemberWithRequirements = memberWithRequirements;
 			Instruction = instruction;
 
@@ -64,31 +64,31 @@ namespace Mono.Linker.Dataflow
 		{
 #if DEBUG
 			if (!_patternAnalysisAttempted)
-				throw new InvalidOperationException ($"Internal error: To correctly report all patterns, when starting to analyze a pattern the AnalyzingPattern must be called first. {SourceMethod} -> {MemberWithRequirements}");
+				throw new InvalidOperationException ($"Internal error: To correctly report all patterns, when starting to analyze a pattern the AnalyzingPattern must be called first. {Source} -> {MemberWithRequirements}");
 
 			_patternReported = true;
 #endif
 
 			mark ();
-			_context.ReflectionPatternRecorder.RecognizedReflectionAccessPattern (SourceMethod, Instruction, accessedItem);
+			_context.ReflectionPatternRecorder.RecognizedReflectionAccessPattern (Source, Instruction, accessedItem);
 		}
 
 		public void RecordUnrecognizedPattern (string message)
 		{
 #if DEBUG
 			if (!_patternAnalysisAttempted)
-				throw new InvalidOperationException ($"Internal error: To correctly report all patterns, when starting to analyze a pattern the AnalyzingPattern must be called first. {SourceMethod} -> {MemberWithRequirements}");
+				throw new InvalidOperationException ($"Internal error: To correctly report all patterns, when starting to analyze a pattern the AnalyzingPattern must be called first. {Source} -> {MemberWithRequirements}");
 
 			_patternReported = true;
 #endif
-			_context.ReflectionPatternRecorder.UnrecognizedReflectionAccessPattern (SourceMethod, Instruction, MemberWithRequirements, message);
+			_context.ReflectionPatternRecorder.UnrecognizedReflectionAccessPattern (Source, Instruction, MemberWithRequirements, message);
 		}
 
 		public void Dispose ()
 		{
 #if DEBUG
 			if (_patternAnalysisAttempted && !_patternReported)
-				throw new InvalidOperationException ($"Internal error: A reflection pattern was analyzed, but no result was reported. {SourceMethod} -> {MemberWithRequirements}");
+				throw new InvalidOperationException ($"Internal error: A reflection pattern was analyzed, but no result was reported. {Source} -> {MemberWithRequirements}");
 #endif
 		}
 	}

--- a/src/linker/Linker/IReflectionPatternRecorder.cs
+++ b/src/linker/Linker/IReflectionPatternRecorder.cs
@@ -44,22 +44,24 @@ namespace Mono.Linker
 		/// <summary>
 		/// Called when the linker recognized a reflection access pattern (and thus was able to correctly apply marking to the accessed item).
 		/// </summary>
-		/// <param name="sourceMethod">The method which contains the reflection access pattern.</param>
-		/// <param name="reflectionMethodCall">The il instruction where the reflection method which is at the heart of the access pattern is called.</param>
+		/// <param name="source">The item which is the source of the reflection pattern. Typically this is the method in which the pattern is detected, but it can also be other things..</param>
+		/// <param name="sourceInstruction">The il instruction which is at the heart of the reflection access pattern. For example the call to the reflection API.
+		/// This can be null if there's no logical instruction to assign to the pattern.</param>
 		/// <param name="accessedItem">The item accessed through reflection. This can be one of:
 		///   TypeDefinition, MethodDefinition, PropertyDefinition, FieldDefinition, EventDefinition, InterfaceImplementation.</param>
-		void RecognizedReflectionAccessPattern (MethodDefinition sourceMethod, Instruction reflectionMethodCall, IMetadataTokenProvider accessedItem);
+		void RecognizedReflectionAccessPattern (IMetadataTokenProvider source, Instruction sourceInstruction, IMetadataTokenProvider accessedItem);
 
 		/// <summary>
 		/// Called when the linker detected a reflection access but was not able to recognize the entire pattern.
 		/// </summary>
-		/// <param name="sourceMethod">The method which contains the reflection access code.</param>
-		/// <param name="reflectionMethodCall">The il instruction where the reflection method which is at the heart of the access code is called.</param>
+		/// <param name="source">The item which is the source of the reflection pattern. Typically this is the method in which the pattern is detected, but it can also be other things..</param>
+		/// <param name="instruction">The il instruction which is at the heart of the reflection access pattern. For example the call to the reflection API.
+		/// This can be null if there's no logical instruction to assign to the pattern.</param>
 		/// <param name="accessedItem">The item accessed through reflection. This can be one of:
 		///   TypeDefinition, MethodDefinition, PropertyDefinition, FieldDefinition, EventDefinition, InterfaceImplementation.</param>
 		/// <param name="message">Humanly readable message describing what failed during the pattern recognition.</param>
 		/// <remarks>This effectively means that there's a potential hole in the linker marking - some items which are accessed only through
 		/// reflection may not be marked correctly and thus may fail at runtime.</remarks>
-		void UnrecognizedReflectionAccessPattern (MethodDefinition sourceMethod, Instruction reflectionMethodCall, IMetadataTokenProvider accessedItem, string message);
+		void UnrecognizedReflectionAccessPattern (IMetadataTokenProvider source, Instruction sourceInstruction, IMetadataTokenProvider accessedItem, string message);
 	}
 }

--- a/src/linker/Linker/IReflectionPatternRecorder.cs
+++ b/src/linker/Linker/IReflectionPatternRecorder.cs
@@ -49,7 +49,7 @@ namespace Mono.Linker
 		/// This can be null if there's no logical instruction to assign to the pattern.</param>
 		/// <param name="accessedItem">The item accessed through reflection. This can be one of:
 		///   TypeDefinition, MethodDefinition, PropertyDefinition, FieldDefinition, EventDefinition, InterfaceImplementation.</param>
-		void RecognizedReflectionAccessPattern (IMetadataTokenProvider source, Instruction sourceInstruction, IMetadataTokenProvider accessedItem);
+		void RecognizedReflectionAccessPattern (IMemberDefinition source, Instruction sourceInstruction, IMetadataTokenProvider accessedItem);
 
 		/// <summary>
 		/// Called when the linker detected a reflection access but was not able to recognize the entire pattern.
@@ -62,6 +62,6 @@ namespace Mono.Linker
 		/// <param name="message">Humanly readable message describing what failed during the pattern recognition.</param>
 		/// <remarks>This effectively means that there's a potential hole in the linker marking - some items which are accessed only through
 		/// reflection may not be marked correctly and thus may fail at runtime.</remarks>
-		void UnrecognizedReflectionAccessPattern (IMetadataTokenProvider source, Instruction sourceInstruction, IMetadataTokenProvider accessedItem, string message);
+		void UnrecognizedReflectionAccessPattern (IMemberDefinition source, Instruction sourceInstruction, IMetadataTokenProvider accessedItem, string message);
 	}
 }

--- a/src/linker/Linker/LoggingReflectionPatternRecorder.cs
+++ b/src/linker/Linker/LoggingReflectionPatternRecorder.cs
@@ -37,27 +37,26 @@ namespace Mono.Linker
 			_context = context;
 		}
 
-		public void RecognizedReflectionAccessPattern (IMetadataTokenProvider source, Instruction sourceInstruction, IMetadataTokenProvider accessedItem)
+		public void RecognizedReflectionAccessPattern (IMemberDefinition source, Instruction sourceInstruction, IMetadataTokenProvider accessedItem)
 		{
 			// Do nothing - there's no logging for successfully recognized patterns
 		}
 
-		public void UnrecognizedReflectionAccessPattern (IMetadataTokenProvider source, Instruction sourceInstruction, IMetadataTokenProvider accessedItem, string message)
+		public void UnrecognizedReflectionAccessPattern (IMemberDefinition source, Instruction sourceInstruction, IMetadataTokenProvider accessedItem, string message)
 		{
-			MessageOrigin origin = new MessageOrigin ((IMemberDefinition)null);
+			MessageOrigin origin;
 			string location = string.Empty;
-			if (source is IMemberDefinition member) {
-				if (sourceInstruction != null && member is MethodDefinition method)
-					origin = MessageOrigin.TryGetOrigin(method, sourceInstruction.Offset);
-				else
-					origin = new MessageOrigin(member);
+			var method = source as MethodDefinition;
+			if (sourceInstruction != null && method != null)
+				origin = MessageOrigin.TryGetOrigin(method, sourceInstruction.Offset);
+			else
+				origin = new MessageOrigin(source);
 
-				if (origin.FileName == null) {
-					if (member is MethodDefinition methodDefinition)
-						location = methodDefinition.DeclaringType.FullName + "::" + GetSignature(methodDefinition) + ": ";
-					else
-						location = member.DeclaringType?.FullName + "::" + member.Name;
-				}
+			if (origin.FileName == null) {
+				if (method != null)
+					location = method.DeclaringType.FullName + "::" + GetSignature(method) + ": ";
+				else
+					location = source.DeclaringType?.FullName + "::" + source.Name;
 			}
 
 			_context.LogMessage (MessageContainer.CreateWarningMessage (_context, location + message, 2006, origin, "Unrecognized reflection pattern"));

--- a/src/linker/Linker/LoggingReflectionPatternRecorder.cs
+++ b/src/linker/Linker/LoggingReflectionPatternRecorder.cs
@@ -48,13 +48,13 @@ namespace Mono.Linker
 			string location = string.Empty;
 			var method = source as MethodDefinition;
 			if (sourceInstruction != null && method != null)
-				origin = MessageOrigin.TryGetOrigin(method, sourceInstruction.Offset);
+				origin = MessageOrigin.TryGetOrigin (method, sourceInstruction.Offset);
 			else
-				origin = new MessageOrigin(source);
+				origin = new MessageOrigin (source);
 
 			if (origin.FileName == null) {
 				if (method != null)
-					location = method.DeclaringType.FullName + "::" + GetSignature(method) + ": ";
+					location = method.DeclaringType.FullName + "::" + GetSignature (method) + ": ";
 				else
 					location = source.DeclaringType?.FullName + "::" + source.Name;
 			}

--- a/test/Mono.Linker.Tests/TestCasesRunner/LinkerCustomizations.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/LinkerCustomizations.cs
@@ -18,8 +18,6 @@ namespace Mono.Linker.Tests.TestCasesRunner
 		public void CustomizeLinkContext (LinkContext context)
 		{
 			CustomizeContext?.Invoke (context);
-			if (ReflectionPatternRecorder != null)
-				ReflectionPatternRecorder.Context = context;
 		}
 	}
 }

--- a/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -679,10 +679,14 @@ namespace Mono.Linker.Tests.TestCasesRunner
 						string expectedAccessedItem = GetFullMemberNameFromReflectionAccessPatternAttribute (attr, constructorArgumentsOffset: 3);
 
 						if (!reflectionPatternRecorder.RecognizedPatterns.Any (pattern => {
-							if (GetFullMemberNameFromDefinition (pattern.SourceMethod) != expectedSourceMethod)
+							if (GetFullMemberNameFromDefinition (pattern.Source) != expectedSourceMethod)
 								return false;
 
-							if (GetFullMemberNameFromDefinition (pattern.ReflectionMethodCall.Operand as IMetadataTokenProvider) != expectedReflectionMethod)
+							string actualAccessOperation = null;
+							if (pattern.SourceInstruction?.Operand is IMetadataTokenProvider sourceOperand)
+								actualAccessOperation = GetFullMemberNameFromDefinition (sourceOperand);
+
+							if (actualAccessOperation != expectedReflectionMethod)
 								return false;
 
 							if (GetFullMemberNameFromDefinition (pattern.AccessedItem) != expectedAccessedItem)
@@ -692,10 +696,10 @@ namespace Mono.Linker.Tests.TestCasesRunner
 							return true;
 						})) {
 							string sourceMethodCandidates = string.Join (Environment.NewLine, reflectionPatternRecorder.RecognizedPatterns
-								.Where (p => GetFullMemberNameFromDefinition (p.SourceMethod).ToLowerInvariant ().Contains (expectedSourceMethod.ToLowerInvariant ()))
+								.Where (p => GetFullMemberNameFromDefinition (p.Source)?.ToLowerInvariant ()?.Contains (expectedSourceMethod.ToLowerInvariant ()) == true)
 								.Select (p => "\t" + RecognizedReflectionAccessPatternToString (p)));
 							string reflectionMethodCandidates = string.Join (Environment.NewLine, reflectionPatternRecorder.RecognizedPatterns
-								.Where (p => GetFullMemberNameFromDefinition (p.ReflectionMethodCall.Operand as IMetadataTokenProvider).ToLowerInvariant ().Contains (expectedReflectionMethod.ToLowerInvariant ()))
+								.Where (p => GetFullMemberNameFromDefinition (p.SourceInstruction?.Operand as IMetadataTokenProvider)?.ToLowerInvariant ()?.Contains (expectedReflectionMethod.ToLowerInvariant ()) == true)
 								.Select (p => "\t" + RecognizedReflectionAccessPatternToString (p)));
 
 							Assert.Fail (
@@ -711,10 +715,16 @@ namespace Mono.Linker.Tests.TestCasesRunner
 						string expectedMessage = (string) attr.ConstructorArguments[3].Value;
 
 						if (!reflectionPatternRecorder.UnrecognizedPatterns.Any (pattern => {
-							if (GetFullMemberNameFromDefinition (pattern.SourceMethod) != expectedSourceMethod)
+							if (GetFullMemberNameFromDefinition (pattern.Source) != expectedSourceMethod)
 								return false;
 
-							if (GetFullMemberNameFromDefinition (pattern.ReflectionMethodCall != null ? pattern.ReflectionMethodCall.Operand as IMetadataTokenProvider : pattern.AccessedItem) != expectedReflectionMethod)
+							string actualAccessOperation = null;
+							if (pattern.SourceInstruction?.Operand is IMetadataTokenProvider sourceOperand)
+								actualAccessOperation = GetFullMemberNameFromDefinition (sourceOperand);
+							else
+								actualAccessOperation = GetFullMemberNameFromDefinition (pattern.AccessedItem);
+
+							if (actualAccessOperation != expectedReflectionMethod)
 								return false;
 
 							if (expectedMessage != null && pattern.Message != expectedMessage)
@@ -724,10 +734,10 @@ namespace Mono.Linker.Tests.TestCasesRunner
 							return true;
 						})) {
 							string sourceMethodCandidates = string.Join (Environment.NewLine, reflectionPatternRecorder.UnrecognizedPatterns
-								.Where (p => GetFullMemberNameFromDefinition (p.SourceMethod).ToLowerInvariant ().Contains (expectedSourceMethod.ToLowerInvariant ()))
+								.Where (p => GetFullMemberNameFromDefinition (p.Source)?.ToLowerInvariant ()?.Contains (expectedSourceMethod.ToLowerInvariant ()) == true)
 								.Select (p => "\t" + UnrecognizedReflectionAccessPatternToString (p)));
 							string reflectionMethodCandidates = string.Join (Environment.NewLine, reflectionPatternRecorder.UnrecognizedPatterns
-								.Where (p => GetFullMemberNameFromDefinition (p.ReflectionMethodCall != null ? p.ReflectionMethodCall.Operand as IMetadataTokenProvider : p.AccessedItem).ToLowerInvariant ().Contains (expectedReflectionMethod.ToLowerInvariant ()))
+								.Where (p => GetFullMemberNameFromDefinition (p.SourceInstruction != null ? p.SourceInstruction.Operand as IMetadataTokenProvider : p.AccessedItem)?.ToLowerInvariant ()?.Contains (expectedReflectionMethod.ToLowerInvariant ()) == true)
 								.Select (p => "\t" + UnrecognizedReflectionAccessPatternToString (p)));
 
 							Assert.Fail (
@@ -743,7 +753,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 					// Validate that there are no other reported unrecognized patterns on the method
 					string expectedSourceMethod = GetFullMemberNameFromDefinition (expectedSourceMethodDefinition);
 					var unrecognizedPatternsForSourceMethod = reflectionPatternRecorder.UnrecognizedPatterns.Where (pattern => {
-						if (GetFullMemberNameFromDefinition (pattern.SourceMethod) != expectedSourceMethod)
+						if (GetFullMemberNameFromDefinition (pattern.Source) != expectedSourceMethod)
 							return false;
 
 						return true;
@@ -767,9 +777,9 @@ namespace Mono.Linker.Tests.TestCasesRunner
 						// By now all verified recorded patterns were removed from the test recorder lists, so validate
 						// that there are no remaining patterns for this type.
 						var recognizedPatternsForType = reflectionPatternRecorder.RecognizedPatterns
-							.Where (pattern => pattern.SourceMethod.DeclaringType.FullName == typeToVerify.FullName);
+							.Where (pattern => (pattern.Source as IMemberDefinition)?.DeclaringType.FullName == typeToVerify.FullName);
 						var unrecognizedPatternsForType = reflectionPatternRecorder.UnrecognizedPatterns
-							.Where (pattern => pattern.SourceMethod.DeclaringType.FullName == typeToVerify.FullName);
+							.Where (pattern => (pattern.Source as IMemberDefinition)?.DeclaringType.FullName == typeToVerify.FullName);
 
 						if (recognizedPatternsForType.Any () || unrecognizedPatternsForType.Any ()) {
 							string recognizedPatterns = string.Join (Environment.NewLine, recognizedPatternsForType
@@ -821,6 +831,9 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			// as it would have to actually resolve the referenced method, which is very expensive and no necessary
 			// for the tests to work (the return types are redundant piece of information anyway).
 
+			if (member == null)
+				return null;
+
 			if (member is MemberReference memberReference)
 				member = memberReference.Resolve ();
 
@@ -849,14 +862,23 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 		static string RecognizedReflectionAccessPatternToString (TestReflectionPatternRecorder.ReflectionAccessPattern pattern)
 		{
-			return $"{GetFullMemberNameFromDefinition (pattern.SourceMethod)}: Call to {GetFullMemberNameFromDefinition (pattern.ReflectionMethodCall.Operand as IMetadataTokenProvider)} accessed {GetFullMemberNameFromDefinition (pattern.AccessedItem)}";
+			string operationDescription;
+			if (pattern.SourceInstruction?.Operand is IMetadataTokenProvider instructionOperand) {
+				operationDescription = "Usage of " + GetFullMemberNameFromDefinition (instructionOperand) + " accessed";
+			} else
+				operationDescription = "Accessed";
+			return $"{GetFullMemberNameFromDefinition (pattern.Source)}: {operationDescription} {GetFullMemberNameFromDefinition (pattern.AccessedItem)}";
 		}
 
 		static string UnrecognizedReflectionAccessPatternToString (TestReflectionPatternRecorder.ReflectionAccessPattern pattern)
 		{
-			return $"{GetFullMemberNameFromDefinition (pattern.SourceMethod)}: Call to {GetFullMemberNameFromDefinition (pattern.ReflectionMethodCall != null ? pattern.ReflectionMethodCall.Operand as IMetadataTokenProvider : pattern.AccessedItem)} unrecognized '{pattern.Message}'";
+			string operationDescription;
+			if (pattern.SourceInstruction?.Operand is IMetadataTokenProvider instructionOperand) {
+				operationDescription = "Usage of " + GetFullMemberNameFromDefinition (instructionOperand) + " unrecognized";
+			} else
+				operationDescription = "Usage of " + pattern.AccessedItem+ " unrecognized";
+			return $"{GetFullMemberNameFromDefinition (pattern.Source)}: {operationDescription} '{pattern.Message}'";
 		}
-
 
 		protected TypeDefinition GetOriginalTypeFromInAssemblyAttribute (CustomAttribute inAssemblyAttribute)
 		{

--- a/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -876,7 +876,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			if (pattern.SourceInstruction?.Operand is IMetadataTokenProvider instructionOperand) {
 				operationDescription = "Usage of " + GetFullMemberNameFromDefinition (instructionOperand) + " unrecognized";
 			} else
-				operationDescription = "Usage of " + pattern.AccessedItem+ " unrecognized";
+				operationDescription = "Usage of " + pattern.AccessedItem + " unrecognized";
 			return $"{GetFullMemberNameFromDefinition (pattern.Source)}: {operationDescription} '{pattern.Message}'";
 		}
 

--- a/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadaProvider.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadaProvider.cs
@@ -99,6 +99,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			if (ValidatesReflectionAccessPatterns (_testCaseTypeDefinition)) {
 				customizations.ReflectionPatternRecorder = new TestReflectionPatternRecorder ();
 				customizations.CustomizeContext += context => {
+					customizations.ReflectionPatternRecorder.PreviousRecorder = context.ReflectionPatternRecorder;
 					context.ReflectionPatternRecorder = customizations.ReflectionPatternRecorder;
 					context.LogMessages = true;
 				};

--- a/test/Mono.Linker.Tests/TestCasesRunner/TestReflectionPatternRecorder.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestReflectionPatternRecorder.cs
@@ -10,7 +10,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 		public struct ReflectionAccessPattern
 		{
-			public IMetadataTokenProvider Source;
+			public IMemberDefinition Source;
 			public Instruction SourceInstruction;
 			public IMetadataTokenProvider AccessedItem;
 			public string Message;
@@ -19,7 +19,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 		public List<ReflectionAccessPattern> RecognizedPatterns = new List<ReflectionAccessPattern> ();
 		public List<ReflectionAccessPattern> UnrecognizedPatterns = new List<ReflectionAccessPattern> ();
 
-		public void RecognizedReflectionAccessPattern (IMetadataTokenProvider source, Instruction sourceInstruction, IMetadataTokenProvider accessedItem)
+		public void RecognizedReflectionAccessPattern (IMemberDefinition source, Instruction sourceInstruction, IMetadataTokenProvider accessedItem)
 		{
 			PreviousRecorder?.RecognizedReflectionAccessPattern (source, sourceInstruction, accessedItem);
 			RecognizedPatterns.Add (new ReflectionAccessPattern {
@@ -29,7 +29,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			});
 		}
 
-		public void UnrecognizedReflectionAccessPattern (IMetadataTokenProvider source, Instruction sourceInstruction, IMetadataTokenProvider accessedItem, string message)
+		public void UnrecognizedReflectionAccessPattern (IMemberDefinition source, Instruction sourceInstruction, IMetadataTokenProvider accessedItem, string message)
 		{
 			PreviousRecorder?.UnrecognizedReflectionAccessPattern (source, sourceInstruction, accessedItem, message);
 			UnrecognizedPatterns.Add (new ReflectionAccessPattern {

--- a/test/Mono.Linker.Tests/TestCasesRunner/TestReflectionPatternRecorder.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestReflectionPatternRecorder.cs
@@ -1,24 +1,17 @@
 ﻿using Mono.Cecil;
 using Mono.Cecil.Cil;
-using System;
 using System.Collections.Generic;
 
 namespace Mono.Linker.Tests.TestCasesRunner
 {
 	public class TestReflectionPatternRecorder : IReflectionPatternRecorder
 	{
-		public LinkContext Context { private get; set; }
-
-		public Action<MessageContainer> LogMessage {
-			get {
-				return Context.LogMessage;
-			}
-		}
+		public IReflectionPatternRecorder PreviousRecorder = null;
 
 		public struct ReflectionAccessPattern
 		{
-			public MethodDefinition SourceMethod;
-			public Instruction ReflectionMethodCall;
+			public IMetadataTokenProvider Source;
+			public Instruction SourceInstruction;
 			public IMetadataTokenProvider AccessedItem;
 			public string Message;
 		}
@@ -26,23 +19,22 @@ namespace Mono.Linker.Tests.TestCasesRunner
 		public List<ReflectionAccessPattern> RecognizedPatterns = new List<ReflectionAccessPattern> ();
 		public List<ReflectionAccessPattern> UnrecognizedPatterns = new List<ReflectionAccessPattern> ();
 
-		public void RecognizedReflectionAccessPattern (MethodDefinition sourceMethod, Instruction reflectionMethodCall, IMetadataTokenProvider accessedItem)
+		public void RecognizedReflectionAccessPattern (IMetadataTokenProvider source, Instruction sourceInstruction, IMetadataTokenProvider accessedItem)
 		{
+			PreviousRecorder?.RecognizedReflectionAccessPattern (source, sourceInstruction, accessedItem);
 			RecognizedPatterns.Add (new ReflectionAccessPattern {
-				SourceMethod = sourceMethod,
-				ReflectionMethodCall = reflectionMethodCall,
+				Source = source,
+				SourceInstruction = sourceInstruction,
 				AccessedItem = accessedItem
 			});
 		}
 
-		public void UnrecognizedReflectionAccessPattern (MethodDefinition sourceMethod, Instruction reflectionMethodCall, IMetadataTokenProvider accessedItem, string message)
+		public void UnrecognizedReflectionAccessPattern (IMetadataTokenProvider source, Instruction sourceInstruction, IMetadataTokenProvider accessedItem, string message)
 		{
-			LogMessage (MessageContainer.CreateWarningMessage (Context, message, 2006,
-				reflectionMethodCall != null ? MessageOrigin.TryGetOrigin (sourceMethod, reflectionMethodCall.Offset) : new MessageOrigin (sourceMethod),
-				"Unrecognized reflection pattern"));
+			PreviousRecorder?.UnrecognizedReflectionAccessPattern (source, sourceInstruction, accessedItem, message);
 			UnrecognizedPatterns.Add (new ReflectionAccessPattern {
-				SourceMethod = sourceMethod,
-				ReflectionMethodCall = reflectionMethodCall,
+				Source = source,
+				SourceInstruction = sourceInstruction,
 				AccessedItem = accessedItem,
 				Message = message
 			});


### PR DESCRIPTION
With the upcoming support for DynamicallyAccessedMembersAttribute on generic parameters, the source of the access pattern will no longer be any code, but it can be a type declaration or field definition and so on. In such cases trying to point back to some line of code is complicated and in lot of cases confusing.

This change allows more values to be passed as the source of a reflection access pattern. Currently there's no use case for it. The one which comes close is attribute fields, but those make sense to use the attribute ctor as the source of the problem and use the field as the "accessed" item.

Corresponding changes to the test infra to allow for wider range of values and to handle missing values better.