### PR TITLE
Fix edge case in signature parser

### DIFF
--- a/test/Mono.Linker.Tests/Tests/DocumentationSignatureParserTests.cs
+++ b/test/Mono.Linker.Tests/Tests/DocumentationSignatureParserTests.cs
@@ -576,6 +576,14 @@ namespace Mono.Linker.Tests
 			{
 			}
 
+			public class GenericType<T, U>
+			{
+				[ExpectUnresolvedDocumentationSignature ("T:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.GenericType`2.TypeWithMethodGenericParameters``1")]
+				public class TypeWithMethodGenericParameters
+				{
+				}
+			}
+
 			// our parser won't match fields with `, unlike roslyn.
 			[ExpectUnresolvedDocumentationSignature ("F:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.field`gibberish")]
 			public int field;

--- a/test/Mono.Linker.Tests/Tests/DocumentationSignatureParserTests.cs
+++ b/test/Mono.Linker.Tests/Tests/DocumentationSignatureParserTests.cs
@@ -571,6 +571,11 @@ namespace Mono.Linker.Tests
 			{
 			}
 
+			[ExpectUnresolvedDocumentationSignature ("T:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.TypeWithMethodGenericParameters``1")]
+			public class TypeWithMethodGenericParameters
+			{
+			}
+
 			// our parser won't match fields with `, unlike roslyn.
 			[ExpectUnresolvedDocumentationSignature ("F:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.field`gibberish")]
 			public int field;


### PR DESCRIPTION
Because generic methods don't have mangled names, a generic method
signature could match a type if we don't check its arity.