### PR TITLE
Fix a crash processing DebuggerDisplayAttribute

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1455,6 +1455,14 @@ namespace Mono.Linker.Steps {
 
 					if (realMatch.EndsWith ("()")) {
 						string methodName = realMatch.Substring (0, realMatch.Length - 2);
+
+						// It's a call to a method on some member.  Handling this scenario robustly would be complicated and a decent bit of work.
+						// 
+						// We could implement support for this at some point, but for now it's important to make sure at least we don't crash trying to find some
+						// method on the current type when it exists on some other type
+						if (methodName.Contains ("."))
+							continue;
+
 						MethodDefinition method = GetMethodWithNoParameters (type, methodName);
 						if (method != null) {
 							MarkMethod (method, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute));

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayOnTypeWithCallToExtensionMethodOnFieldType.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayOnTypeWithCallToExtensionMethodOnFieldType.cs
@@ -1,0 +1,49 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+[assembly: KeptAttributeAttribute (typeof (ExtensionAttribute))]
+
+namespace Mono.Linker.Tests.Cases.Attributes.Debugger.KeepDebugMembers
+{
+	[SetupLinkerKeepDebugMembers ("true")]
+	public class DebuggerDisplayOnTypeWithCallToExtensionMethodOnFieldType
+	{
+		public static void Main ()
+		{
+			var foo = new Foo ();
+			foo.Field = new Bar ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptAttributeAttribute (typeof (DebuggerDisplayAttribute))]
+		// Calling extension methods on members from DebuggerDisplay doesn't seem to work so in this case we shouldn't mark `Field.Count()`
+		[DebuggerDisplay ("Count = {Field.Count()}")]
+		class Foo
+		{
+			[Kept]
+			public Bar Field;
+
+			public int Count ()
+			{
+				return 1;
+			}
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		public class Bar
+		{
+		}
+	}
+
+	public static class DebuggerDisplayOnTypeWithCallToExtensionMethodOnFieldTypeExtensions
+	{
+		public static int Count (this DebuggerDisplayOnTypeWithCallToExtensionMethodOnFieldType.Bar b)
+		{
+			return 1;
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayOnTypeWithCallToMethodOnFieldType.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayOnTypeWithCallToMethodOnFieldType.cs
@@ -1,0 +1,45 @@
+using System.Diagnostics;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Attributes.Debugger.KeepDebugMembers
+{
+	[SetupLinkerKeepDebugMembers ("true")]
+	public class DebuggerDisplayOnTypeWithCallToMethodOnFieldType
+	{
+		public static void Main ()
+		{
+			var foo = new Foo ();
+			foo.Field = new Bar ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptAttributeAttribute (typeof (DebuggerDisplayAttribute))]
+
+		//TODO : DebuggerDisplay supports calling methods on members.
+		//However, robustly handling this case in the linker would require some non-trivial work.
+		//For now let's at least make sure that the linker doesn't crash.
+		[DebuggerDisplay ("Count = {Field.Count()}")]
+		class Foo
+		{
+			[Kept]
+			public Bar Field;
+
+			public int Count ()
+			{
+				return 1;
+			}
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		public class Bar
+		{
+			public int Count ()
+			{
+				return 1;
+			}
+		}
+	}
+}


### PR DESCRIPTION
This  change fixes a crash that would occur if the linker tried to process a DebuggerDisplayAttribute that referred to a method on a member. 

Robustly handling this scenario doesn't seem worth the effort.  This bug has gone unnoticed for a couple years in Unity which implies this isn't a particularly common thing to do.  Much less to also have zero usages of that member appear in a used code path.

The full exception stack was 
```
Mono.Linker.MarkException : Error processing method: 'System.Void Mono.Linker.Tests.Cases.Attributes.Debugger.KeepDebugMembers.DebuggerDisplayOnTypeWithCallToExtensionMethodOnFieldType::Main()' in assembly: 'test.exe'
  ----> System.NullReferenceException : Object reference not set to an instance of an object.


   at Mono.Linker.Steps.MarkStep.ProcessQueue() in D:\Unity\dev\unity-monolinker-1\src\linker\Linker.Steps\MarkStep.cs:line 353
   at Mono.Linker.Steps.MarkStep.ProcessPrimaryQueue() in D:\Unity\dev\unity-monolinker-1\src\linker\Linker.Steps\MarkStep.cs:line 336
   at Mono.Linker.Steps.MarkStep.Process() in D:\Unity\dev\unity-monolinker-1\src\linker\Linker.Steps\MarkStep.cs:line 303
   at Mono.Linker.Steps.MarkStep.Process(LinkContext context) in D:\Unity\dev\unity-monolinker-1\src\linker\Linker.Steps\MarkStep.cs:line 159
   at Mono.Linker.Pipeline.ProcessStep(LinkContext context, IStep step) in D:\Unity\dev\unity-monolinker-1\src\linker\Linker\Pipeline.cs:line 133
   at Mono.Linker.Pipeline.Process(LinkContext context) in D:\Unity\dev\unity-monolinker-1\src\linker\Linker\Pipeline.cs:line 126
   at Mono.Linker.Driver.Run(ILogger customLogger) in D:\Unity\dev\unity-monolinker-1\src\linker\Linker\Driver.cs:line 588
   at Mono.Linker.Tests.TestCasesRunner.LinkerDriver.Link(String[] args, LinkerCustomizations customizations, ILogger logger) in D:\Unity\dev\unity-monolinker-1\test\Mono.Linker.Tests\TestCasesRunner\LinkerDriver.cs:line 25
   at Mono.Linker.Tests.TestCasesRunner.TestRunner.Link(TestCase testCase, TestCaseSandbox sandbox, ManagedCompilationResult compilationResult, TestCaseMetadaProvider metadataProvider) in D:\Unity\dev\unity-monolinker-1\test\Mono.Linker.Tests\TestCasesRunner\TestRunner.cs:line 101
   at Mono.Linker.Tests.TestCasesRunner.TestRunner.Run(TestCase testCase) in D:\Unity\dev\unity-monolinker-1\test\Mono.Linker.Tests\TestCasesRunner\TestRunner.cs:line 29
   at Mono.Linker.Tests.TestCases.All.Run(TestCase testCase) in D:\Unity\dev\unity-monolinker-1\test\Mono.Linker.Tests\TestCases\TestSuites.cs:line 205
   at Mono.Linker.Tests.TestCases.All.AttributesDebuggerTests(TestCase testCase) in D:\Unity\dev\unity-monolinker-1\test\Mono.Linker.Tests\TestCases\TestSuites.cs:line 37
--NullReferenceException
   at Mono.Linker.Steps.MarkStep.GetMethodWithNoParameters(TypeDefinition type, String methodname) in D:\Unity\dev\unity-monolinker-1\src\linker\Linker.Steps\MarkStep.cs:line 896
   at Mono.Linker.Steps.MarkStep.MarkTypeWithDebuggerDisplayAttribute(TypeDefinition type, CustomAttribute attribute) in D:\Unity\dev\unity-monolinker-1\src\linker\Linker.Steps\MarkStep.cs:line 1466
   at Mono.Linker.Steps.MarkStep.MarkTypeSpecialCustomAttributes(TypeDefinition type) in D:\Unity\dev\unity-monolinker-1\src\linker\Linker.Steps\MarkStep.cs:line 1356
   at Mono.Linker.Steps.MarkStep.MarkType(TypeReference reference, DependencyInfo reason) in D:\Unity\dev\unity-monolinker-1\src\linker\Linker.Steps\MarkStep.cs:line 1227
   at Mono.Linker.Steps.MarkStep.MarkMethodBody(MethodBody body) in D:\Unity\dev\unity-monolinker-1\src\linker\Linker.Steps\MarkStep.cs:line 2414
   at Mono.Linker.Steps.MarkStep.ProcessMethod(MethodDefinition method, DependencyInfo& reason) in D:\Unity\dev\unity-monolinker-1\src\linker\Linker.Steps\MarkStep.cs:line 2174
   at Mono.Linker.Steps.MarkStep.ProcessQueue() in D:\Unity\dev\unity-monolinker-1\src\linker\Linker.Steps\MarkStep.cs:line 351
```