### PR TITLE
Add more warning suppression scenarios

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1445,8 +1445,8 @@ namespace Mono.Linker.Steps
 					l.Parameters.Count == 1 && l.Parameters[0].ParameterType.IsTypeOf ("System", "Type"),
 					provider);
 				return true;
-			} else if (dt.Name == "UnconditionalSuppressMessageAttribute" && dt.Namespace == "System.Diagnostics.CodeAnalysis") {
-				_context.Suppressions.AddLocalSuppression (ca, provider);
+			} else if (UnconditionalSuppressMessageAttributeState.TypeRefHasUnconditionalSuppressions (dt)) {
+				_context.Suppressions.AddSuppression (ca, provider);
 			}
 
 			return false;

--- a/src/linker/Linker/UnconditionalSuppressMessageAttributeState.cs
+++ b/src/linker/Linker/UnconditionalSuppressMessageAttributeState.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
+using System.Transactions;
 using Mono.Cecil;
 
 namespace Mono.Linker
@@ -7,6 +9,7 @@ namespace Mono.Linker
 	{
 		private readonly LinkContext _context;
 		private readonly Dictionary<ICustomAttributeProvider, Dictionary<int, SuppressMessageInfo>> _localSuppressions;
+		private GlobalSuppressions _globalSuppressions;
 
 		private bool HasLocalSuppressions {
 			get {
@@ -41,8 +44,15 @@ namespace Mono.Linker
 
 		public bool IsSuppressed (int id, MessageOrigin warningOrigin, out SuppressMessageInfo info)
 		{
+			if (IsGloballySuppressed (id, warningOrigin, out info))
+				return true;
+
 			if (HasLocalSuppressions && warningOrigin.MemberDefinition != null) {
 				IMemberDefinition memberDefinition = warningOrigin.MemberDefinition;
+				// Check if it's suppressed by a module level suppression.
+				if (IsLocallySuppressed (id, memberDefinition.DeclaringType.Module, out info))
+					return true;
+
 				while (memberDefinition != null) {
 					if (IsLocallySuppressed (id, memberDefinition, out info))
 						return true;
@@ -103,6 +113,71 @@ namespace Mono.Linker
 			info = default;
 			return _localSuppressions.TryGetValue (provider, out suppressions) &&
 				suppressions.TryGetValue (id, out info);
+		}
+
+		private bool IsGloballySuppressed (int id, MessageOrigin origin, out SuppressMessageInfo info)
+		{
+			DecodeGlobalSuppressMessageAttributes ();
+			// TODO
+			info = default;
+			return false;
+		}
+
+		private void DecodeGlobalSuppressMessageAttributes ()
+		{
+			if (_globalSuppressions == null) {
+				var suppressions = new GlobalSuppressions ();
+				HashSet<ModuleDefinition> modules = new HashSet<ModuleDefinition> ();
+				foreach (var assembly in _context.Resolver.AssemblyCache.Values) {
+					DecodeGlobalSuppressMessageAttributes (assembly, suppressions);
+					modules.Add (assembly.MainModule);
+				}
+
+				foreach (var module in modules)
+					DecodeGlobalSuppressMessageAttributes (module, suppressions);
+
+				_globalSuppressions = suppressions;
+			}
+		}
+
+		private void DecodeGlobalSuppressMessageAttributes (ICustomAttributeProvider provider, GlobalSuppressions globalSuppressions)
+		{
+			var attributes = provider.CustomAttributes.Where (a => a.AttributeType.Name == "UnconditionalSuppressMessageAttribute");
+			foreach (var instance in attributes) {
+				SuppressMessageInfo info;
+				if (!TryDecodeSuppressMessageAttributeData (instance, out info))
+					continue;
+
+				if (info.Target == null && (info.Scope == "module" || info.Scope == null)) {
+					if (provider is ModuleDefinition)
+						AddLocalSuppression (instance, provider);
+					else if (provider is AssemblyDefinition assembly)
+						AddLocalSuppression (instance, assembly.MainModule);
+
+					continue;
+				}
+
+				switch (info.Scope) {
+				case "module":
+				case "type":
+				case "method":
+				case "member":
+					// Integrate Sven's work here
+					break;
+				case "resource":
+					// TODO
+					break;
+				case "namespace":
+				case "namespaceanddescendants":
+					// TODO
+					break;
+				}
+			}
+		}
+
+		private class GlobalSuppressions
+		{
+
 		}
 	}
 }

--- a/src/linker/Linker/UnconditionalSuppressMessageAttributeState.cs
+++ b/src/linker/Linker/UnconditionalSuppressMessageAttributeState.cs
@@ -111,8 +111,7 @@ namespace Mono.Linker
 			if (provider == null)
 				return false;
 
-			Dictionary<int, SuppressMessageInfo> suppressions;
-			return _localSuppressions.TryGetValue (provider, out suppressions) &&
+			return _localSuppressions.TryGetValue (provider, out var suppressions) &&
 				suppressions.TryGetValue (id, out info);
 		}
 
@@ -213,7 +212,7 @@ namespace Mono.Linker
 				_globalSuppressions.Add (provider, _suppressions);
 			}
 
-			private void AddOrUpdate (SuppressMessageInfo info, IDictionary<int, SuppressMessageInfo> builder)
+			private static void AddOrUpdate (SuppressMessageInfo info, IDictionary<int, SuppressMessageInfo> builder)
 			{
 				if (builder.ContainsKey (info.Id))
 					builder[info.Id] = info;

--- a/test/Mono.Linker.Tests.Cases/WarningSuppression/SuppressWarningsInAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/WarningSuppression/SuppressWarningsInAssembly.cs
@@ -1,0 +1,25 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+
+[assembly: UnconditionalSuppressMessage ("Test", "IL2006:Suppress unrecognized reflection pattern warnings in this assembly")]
+
+namespace Mono.Linker.Tests.Cases.WarningSuppression
+{
+	[SkipKeptItemsValidation]
+	[LogDoesNotContain ("TriggerUnrecognizedPattern()")]
+	public class SuppressWarningsInAssembly
+	{
+		public static void Main ()
+		{
+			Expression.Call (TriggerUnrecognizedPattern (), "", Type.EmptyTypes);
+		}
+
+		public static Type TriggerUnrecognizedPattern ()
+		{
+			return typeof (SuppressWarningsInAssembly);
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/WarningSuppression/SuppressWarningsInMembersAndTypesUsingTarget.cs
+++ b/test/Mono.Linker.Tests.Cases/WarningSuppression/SuppressWarningsInMembersAndTypesUsingTarget.cs
@@ -1,0 +1,86 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using System.Text;
+
+[module: UnconditionalSuppressMessage ("Test", "IL2006", Scope = "type", Target = "T:Mono.Linker.Tests.Cases.WarningSuppression.WarningsInType")]
+[module: UnconditionalSuppressMessage ("Test", "IL2006", Scope = "member", Target = "M:Mono.Linker.Tests.Cases.WarningSuppression.WarningsInMembers.Method")]
+[module: UnconditionalSuppressMessage ("Test", "IL2006", Scope = "member", Target = "M:Mono.Linker.Tests.Cases.WarningSuppression.WarningsInMembers.get_Property")]
+
+namespace Mono.Linker.Tests.Cases.WarningSuppression
+{
+	[SkipKeptItemsValidation]
+	[LogDoesNotContain ("TriggerUnrecognizedPattern()")]
+	public class SuppressWarningsInMembersAndTypesUsingTarget
+	{
+		public static void Main ()
+		{
+			var warningsInType = new WarningsInType ();
+			warningsInType.Warning1 ();
+			warningsInType.Warning2 ();
+			var warningInNestedType = new WarningsInType.NestedType ();
+			warningInNestedType.Warning3 ();
+
+			var warningsInMembers = new WarningsInMembers ();
+			warningsInMembers.Method ();
+			int propertyThatTriggersWarning = warningsInMembers.Property;
+		}
+
+		public static Type TriggerUnrecognizedPattern ()
+		{
+			return typeof (SuppressWarningsInMembersAndTypesUsingTarget);
+		}
+
+		public class NestedType
+		{
+			public static void Warning ()
+			{
+				Expression.Call (TriggerUnrecognizedPattern (), "", Type.EmptyTypes);
+			}
+		}
+	}
+
+	public class WarningsInType
+	{
+		public void Warning1 ()
+		{
+			Expression.Call (SuppressWarningsInMembersAndTypesUsingTarget.TriggerUnrecognizedPattern (), "", Type.EmptyTypes);
+		}
+
+		public void Warning2 ()
+		{
+			Expression.Call (SuppressWarningsInMembersAndTypesUsingTarget.TriggerUnrecognizedPattern (), "", Type.EmptyTypes);
+		}
+
+		public class NestedType
+		{
+			public void Warning3 ()
+			{
+				void Warning4 ()
+				{
+					Expression.Call (SuppressWarningsInMembersAndTypesUsingTarget.TriggerUnrecognizedPattern (), "", Type.EmptyTypes);
+				}
+
+				SuppressWarningsInMembersAndTypesUsingTarget.TriggerUnrecognizedPattern ();
+				Warning4 ();
+			}
+		}
+	}
+
+	public class WarningsInMembers
+	{
+		public void Method ()
+		{
+			Expression.Call (SuppressWarningsInMembersAndTypesUsingTarget.TriggerUnrecognizedPattern (), "", Type.EmptyTypes);
+		}
+
+		public int Property {
+			get {
+				Expression.Call (SuppressWarningsInMembersAndTypesUsingTarget.TriggerUnrecognizedPattern (), "", Type.EmptyTypes);
+				return 0;
+			}
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/WarningSuppression/SuppressWarningsInModule.cs
+++ b/test/Mono.Linker.Tests.Cases/WarningSuppression/SuppressWarningsInModule.cs
@@ -1,0 +1,25 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+
+[module: UnconditionalSuppressMessage ("Test", "IL2006:Suppress unrecognized reflection pattern warnings in this module")]
+
+namespace Mono.Linker.Tests.Cases.WarningSuppression
+{
+	[SkipKeptItemsValidation]
+	[LogDoesNotContain ("TriggerUnrecognizedPattern()")]
+	public class SuppressWarningsInModule
+	{
+		public static void Main ()
+		{
+			Expression.Call (TriggerUnrecognizedPattern (), "", Type.EmptyTypes);
+		}
+
+		public static Type TriggerUnrecognizedPattern ()
+		{
+			return typeof (SuppressWarningsInModule);
+		}
+	}
+}


### PR DESCRIPTION
Continuing with the work of https://github.com/mono/linker/pull/1185 this PR adds the ability to suppress warnings throughout a module or assembly. It also adds support for using the `Target` and `Scope` properties for global suppression on types and members.