### PR TITLE
Scope down PublicConstructors to DefaultConstructor if possible

### DIFF
--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -149,10 +149,18 @@ namespace Mono.Linker.Dataflow
 
 		protected override ValueNode GetFieldValue (MethodDefinition method, FieldDefinition field)
 		{
-			DynamicallyAccessedMemberTypes memberKinds = _flowAnnotations.GetFieldAnnotation (field);
-			return new LoadFieldValue (field, memberKinds) {
-				SourceContext = method
-			};
+			switch (field.Name) {
+			case "EmptyTypes" when field.DeclaringType.IsTypeOf ("System", "Type"): {
+					return new ArrayValue (new ConstIntValue (0));
+				}
+
+			default: {
+					DynamicallyAccessedMemberTypes memberKinds = _flowAnnotations.GetFieldAnnotation (field);
+					return new LoadFieldValue (field, memberKinds) {
+						SourceContext = method
+					};
+				}
+			}
 		}
 
 		protected override void HandleStoreField (MethodDefinition method, FieldDefinition field, Instruction operation, ValueNode valueToStore)
@@ -184,6 +192,7 @@ namespace Mono.Linker.Dataflow
 			Type_get_TypeHandle,
 			Object_GetType,
 			TypeDelegator_Ctor,
+			Array_Empty,
 
 			// Anything above this marker will require the method to be run through
 			// the reflection body scanner.
@@ -353,6 +362,9 @@ namespace Mono.Linker.Dataflow
 					&& calledMethod.HasParameterOfType (0, "System", "Type")
 					=> IntrinsicId.TypeDelegator_Ctor,
 
+				"Empty" when calledMethod.IsDeclaredOnType ("System", "Array")
+					=> IntrinsicId.Array_Empty,
+
 				// static System.Activator.CreateInstance (System.Type type)
 				// static System.Activator.CreateInstance (System.Type type, bool nonPublic)
 				// static System.Activator.CreateInstance (System.Type type, params object?[]? args)
@@ -466,6 +478,11 @@ namespace Mono.Linker.Dataflow
 				case IntrinsicId.TypeDelegator_Ctor: {
 						// This is an identity function for analysis purposes
 						methodReturnValue = methodParams[1];
+					}
+					break;
+
+				case IntrinsicId.Array_Empty: {
+						methodReturnValue = new ArrayValue (new ConstIntValue (0));
 					}
 					break;
 
@@ -741,6 +758,14 @@ namespace Mono.Linker.Dataflow
 							if (methodParams[1].AsConstInt () != null)
 								bindingFlags |= (BindingFlags) methodParams[1].AsConstInt ();
 						}
+						int ctorParameterCount = parameters.Count switch
+						{
+							1 => (methodParams[1] as ArrayValue)?.Size.AsConstInt () ?? -1,
+							2 => (methodParams[3] as ArrayValue)?.Size.AsConstInt () ?? -1,
+							5 => (methodParams[4] as ArrayValue)?.Size.AsConstInt () ?? -1,
+							_ => -1,
+						};
+
 						// Go over all types we've seen
 						foreach (var value in methodParams[0].UniqueValues ()) {
 							if (value is SystemTypeValue systemTypeValue) {
@@ -750,6 +775,9 @@ namespace Mono.Linker.Dataflow
 								// Otherwise fall back to the bitfield requirements
 								var requiredMemberKinds = bindingFlags.HasFlag (BindingFlags.Public) ? DynamicallyAccessedMemberTypes.PublicConstructors : DynamicallyAccessedMemberTypes.None;
 								requiredMemberKinds |= bindingFlags.HasFlag (BindingFlags.NonPublic) ? DynamicallyAccessedMemberTypes.NonPublicConstructors : DynamicallyAccessedMemberTypes.None;
+								// We can scope down the public constructors requirement if we know the number of parameters is 0
+								if (requiredMemberKinds == DynamicallyAccessedMemberTypes.PublicConstructors && ctorParameterCount == 0)
+									requiredMemberKinds = DynamicallyAccessedMemberTypes.DefaultConstructor;
 								RequireDynamicallyAccessedMembers (ref reflectionContext, requiredMemberKinds, value, calledMethodDefinition);
 							}
 						}

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -758,12 +758,12 @@ namespace Mono.Linker.Dataflow
 							if (methodParams[1].AsConstInt () != null)
 								bindingFlags |= (BindingFlags) methodParams[1].AsConstInt ();
 						}
-						int ctorParameterCount = parameters.Count switch
+						int? ctorParameterCount = parameters.Count switch
 						{
-							1 => (methodParams[1] as ArrayValue)?.Size.AsConstInt () ?? -1,
-							2 => (methodParams[3] as ArrayValue)?.Size.AsConstInt () ?? -1,
-							5 => (methodParams[4] as ArrayValue)?.Size.AsConstInt () ?? -1,
-							_ => -1,
+							1 => (methodParams[1] as ArrayValue)?.Size.AsConstInt (),
+							2 => (methodParams[3] as ArrayValue)?.Size.AsConstInt (),
+							5 => (methodParams[4] as ArrayValue)?.Size.AsConstInt (),
+							_ => null,
 						};
 
 						// Go over all types we've seen

--- a/test/Mono.Linker.Tests.Cases/DataFlow/EmptyArrayIntrinsicsDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/EmptyArrayIntrinsicsDataFlow.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Text;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.DataFlow
+{
+	// Note: this test's goal is to validate that the product correctly reports unrecognized patterns
+	//   - so the main validation is done by the UnrecognizedReflectionAccessPattern attributes.
+	[SkipKeptItemsValidation]
+	class EmptyArrayIntrinsicsDataFlow
+	{
+		static void Main ()
+		{
+			TestGetPublicParameterlessConstructorWithEmptyTypes ();
+			TestGetPublicParameterlessConstructorWithArrayEmpty ();
+			TestGetPublicParameterlessConstructorWithUnknownArray ();
+		}
+
+		[UnrecognizedReflectionAccessPattern (typeof (Type), nameof (Type.GetMethod), new Type[] { typeof (string) })]
+		static void TestGetPublicParameterlessConstructorWithEmptyTypes ()
+		{
+			s_typeWithKeptDefaultConstructor.GetConstructor (Type.EmptyTypes);
+			s_typeWithKeptDefaultConstructor.GetMethod ("Foo");
+		}
+
+		[UnrecognizedReflectionAccessPattern (typeof (Type), nameof (Type.GetMethod), new Type[] { typeof (string) })]
+		static void TestGetPublicParameterlessConstructorWithArrayEmpty ()
+		{
+			s_typeWithKeptDefaultConstructor.GetConstructor (Array.Empty<Type> ());
+			s_typeWithKeptDefaultConstructor.GetMethod ("Foo");
+		}
+
+		[UnrecognizedReflectionAccessPattern (typeof (Type), nameof (Type.GetConstructor), new Type[] { typeof (Type[]) })]
+		static void TestGetPublicParameterlessConstructorWithUnknownArray ()
+		{
+			s_typeWithKeptDefaultConstructor.GetConstructor (s_localEmptyArrayInvisibleToAnalysis);
+		}
+
+		static Type[] s_localEmptyArrayInvisibleToAnalysis = Type.EmptyTypes;
+
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
+		static Type s_typeWithKeptDefaultConstructor = typeof (EmptyArrayIntrinsicsDataFlow);
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Reflection/ConstructorUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ConstructorUsedViaReflection.cs
@@ -64,8 +64,8 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		[UnrecognizedReflectionAccessPattern (
 			typeof (Type), nameof (Type.GetConstructor), new Type[] { typeof (Type[]) },
 			"The return value of method 'System.Type Mono.Linker.Tests.Cases.Reflection.ConstructorUsedViaReflection::FindType()' with dynamically accessed member kinds 'None' " +
-			"is passed into the implicit 'this' parameter of method 'System.Reflection.ConstructorInfo System.Type::GetConstructor(System.Type[])' which requires dynamically accessed member kinds 'PublicConstructors'. " +
-			"To fix this add DynamicallyAccessedMembersAttribute to it and specify at least these member kinds 'PublicConstructors'.")]
+			"is passed into the implicit 'this' parameter of method 'System.Reflection.ConstructorInfo System.Type::GetConstructor(System.Type[])' which requires dynamically accessed member kinds 'DefaultConstructor'. " +
+			"To fix this add DynamicallyAccessedMembersAttribute to it and specify at least these member kinds 'DefaultConstructor'.")]
 		[Kept]
 		static void TestDataFlowType ()
 		{


### PR DESCRIPTION
Also recognize `Type.EmptyTypes` and `Array.Empty<Type>`.

Fixes #1222.