### PR TITLE
Clean up clearinitlocals handling

### DIFF
--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -55,10 +55,6 @@ error and warning codes.
 
 - There was an error processing 'XML document location' xml file. The most likely reason for this is that the descriptor file has syntactical errors.
 
-#### `IL1014`: Clearinitlocals is not supported for copy assembly 'assembly'.
-
-- The clearinitlocals rewrites assemblies, and so only operates on 'link' assemblies. Either disable the optimization for this assembly, or change the assembly action to 'link'.
-
 ----
 ## Warning Codes
 

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -55,6 +55,9 @@ error and warning codes.
 
 - There was an error processing 'XML document location' xml file. The most likely reason for this is that the descriptor file has syntactical errors.
 
+#### `IL1014`: Clearinitlocals is not supported for copy assembly 'assembly'.
+
+- The clearinitlocals rewrites assemblies, and so only operates on 'link' assemblies. Either disable the optimization for this assembly, or change the assembly action to 'link'.
 
 ----
 ## Warning Codes

--- a/src/ILLink.Tasks/LinkTask.cs
+++ b/src/ILLink.Tasks/LinkTask.cs
@@ -132,13 +132,6 @@ namespace ILLink.Tasks
 		};
 
 		/// <summary>
-		///   A comma-separated list of assemblies whose methods
-		///   should have initlocals flag cleared if ClearInitLocals is true.
-		///   Maps to '-m ClearInitLocalsAssemblies <list>'
-		/// </summary>
-		public string ClearInitLocalsAssemblies { get; set; }
-
-		/// <summary>
 		///   Custom data key-value pairs to pass to the linker.
 		///   The name of the item is the key, and the required "Value"
 		///   metadata is the value. Maps to '--custom-data key=value'.
@@ -322,8 +315,6 @@ namespace ILLink.Tasks
 
 			if (_clearInitLocals is bool clearInitLocals) {
 				SetOpt (args, "clearinitlocals", clearInitLocals);
-			} else {
-				clearInitLocals = false;
 			}
 
 			if (_unusedInterfaces is bool unusedInterfaces)
@@ -343,10 +334,6 @@ namespace ILLink.Tasks
 						throw new ArgumentException ("custom data requires \"Value\" metadata");
 					args.Append ("--custom-data ").Append (" ").Append (key).Append ("=").AppendLine (Quote (value));
 				}
-			}
-
-			if (clearInitLocals && ClearInitLocalsAssemblies?.Length > 0) {
-				args.AppendFormat ($"--custom-data ClearInitLocalsAssemblies={ClearInitLocalsAssemblies} ");
 			}
 
 			if (FeatureSettings != null) {

--- a/src/linker/Linker.Steps/ClearInitLocals.cs
+++ b/src/linker/Linker.Steps/ClearInitLocals.cs
@@ -6,15 +6,6 @@ namespace Mono.Linker.Steps
 {
 	public class ClearInitLocalsStep : BaseStep
 	{
-		HashSet<string> _assemblies;
-
-		protected override void Process ()
-		{
-			if (Context.TryGetCustomData ("ClearInitLocalsAssemblies", out string parameter)) {
-				_assemblies = new HashSet<string> (parameter.Split (','), StringComparer.OrdinalIgnoreCase);
-			}
-		}
-
 		private static IEnumerable<TypeDefinition> EnumerateTypesAndNestedTypes (IEnumerable<TypeDefinition> types)
 		{
 			// Recursively (depth-first) yield each element in 'types' and all nested types under each element.
@@ -30,12 +21,13 @@ namespace Mono.Linker.Steps
 
 		protected override void ProcessAssembly (AssemblyDefinition assembly)
 		{
-			if (!Context.IsOptimizationEnabled (CodeOptimizations.ClearInitLocals, assembly) &&
-				_assemblies?.Contains (assembly.Name.Name) != true) {
+			if (!Context.IsOptimizationEnabled (CodeOptimizations.ClearInitLocals, assembly))
+				return;
+
+			if (Annotations.GetAction (assembly) != AssemblyAction.Link) {
+				Context.LogMessage (MessageContainer.CreateErrorMessage ($"Clearinitlocals is not supported for copy assembly '{assembly.Name.Name}'.", 1014));
 				return;
 			}
-
-			bool changed = false;
 
 			foreach (ModuleDefinition module in assembly.Modules) {
 				foreach (TypeDefinition type in EnumerateTypesAndNestedTypes (module.Types)) {
@@ -43,15 +35,11 @@ namespace Mono.Linker.Steps
 						if (method.Body != null) {
 							if (method.Body.InitLocals) {
 								method.Body.InitLocals = false;
-								changed = true;
 							}
 						}
 					}
 				}
 			}
-
-			if (changed && (Annotations.GetAction (assembly) == AssemblyAction.Copy))
-				Annotations.SetAction (assembly, AssemblyAction.Save);
 		}
 	}
 }

--- a/src/linker/Linker.Steps/ClearInitLocals.cs
+++ b/src/linker/Linker.Steps/ClearInitLocals.cs
@@ -24,10 +24,8 @@ namespace Mono.Linker.Steps
 			if (!Context.IsOptimizationEnabled (CodeOptimizations.ClearInitLocals, assembly))
 				return;
 
-			if (Annotations.GetAction (assembly) != AssemblyAction.Link) {
-				Context.LogMessage (MessageContainer.CreateErrorMessage ($"Clearinitlocals is not supported for copy assembly '{assembly.Name.Name}'.", 1014));
+			if (Annotations.GetAction (assembly) != AssemblyAction.Link)
 				return;
-			}
 
 			foreach (ModuleDefinition module in assembly.Modules) {
 				foreach (TypeDefinition type in EnumerateTypesAndNestedTypes (module.Types)) {

--- a/test/ILLink.Tasks.Tests/ILLink.Tasks.Tests.cs
+++ b/test/ILLink.Tasks.Tests/ILLink.Tasks.Tests.cs
@@ -287,25 +287,6 @@ namespace ILLink.Tasks.Tests
 			}
 		}
 
-		[Theory]
-		[InlineData ("Assembly1,Assembly2,Assembly3")]
-		public void TestClearInitLocalsAssemblies (string assemblyNames)
-		{
-			var task = new MockTask () {
-				ClearInitLocalsAssemblies = assemblyNames,
-				// This task parameter ClearInitLocalsAssemblies currently only is applied if ClearInitLocals is also true,
-				// which turns the optimization on globally. This is redundant behavior that we might want to fix.
-				// For now, at least test the existing behavior.
-				ClearInitLocals = true
-			};
-			using (var driver = task.CreateDriver ()) {
-				var expectedAssemblies = assemblyNames.Split (',');
-				Assert.True (driver.Context.TryGetCustomData ("ClearInitLocalsAssemblies", out var value));
-				var actualAssemblies = value.Split (',');
-				Assert.Equal (expectedAssemblies.OrderBy (a => a), actualAssemblies.OrderBy (a => a));
-			}
-		}
-
 		public static IEnumerable<object[]> CustomDataCases => new List<object[]> {
 			new object [] {
 				new ITaskItem [] {


### PR DESCRIPTION
- Avoids changing assembly action
- Uses assembly optimizations instead of custom data
- Fixes https://github.com/mono/linker/issues/1129