### PR TITLE
Implement data flow annotations on generic parameters

### DIFF
--- a/src/linker/Linker.Dataflow/FlowAnnotations.cs
+++ b/src/linker/Linker.Dataflow/FlowAnnotations.cs
@@ -79,13 +79,9 @@ namespace Mono.Linker.Dataflow
 			}
 
 			MethodDefinition declaringMethod = genericParameter.DeclaringMethod?.Resolve ();
-			if (declaringMethod != null) {
-				if (GetAnnotations (declaringMethod.DeclaringType).TryGetAnnotation (declaringMethod, out var methodAnnotations) &&
-					methodAnnotations.TryGetAnnotation (genericParameter, out var annotation))
-					return annotation.Annotation;
-
-				return DynamicallyAccessedMemberTypes.None;
-			}
+			if (declaringMethod != null && GetAnnotations (declaringMethod.DeclaringType).TryGetAnnotation (declaringMethod, out var methodTypeAnnotations) &&
+				methodTypeAnnotations.TryGetAnnotation (genericParameter, out var methodAnnotation))
+				return methodAnnotation.Annotation;
 
 			return DynamicallyAccessedMemberTypes.None;
 		}

--- a/src/linker/Linker.Dataflow/FlowAnnotations.cs
+++ b/src/linker/Linker.Dataflow/FlowAnnotations.cs
@@ -31,6 +31,11 @@ namespace Mono.Linker.Dataflow
 			return GetAnnotations (field.DeclaringType).TryGetAnnotation (field, out _);
 		}
 
+		public bool RequiresDataFlowAnalysis (GenericParameter genericParameter)
+		{
+			return GetGenericParameterAnnotation (genericParameter) != DynamicallyAccessedMemberTypes.None;
+		}
+
 		/// <summary>
 		/// Retrieves the annotations for the given parameter.
 		/// </summary>
@@ -58,6 +63,28 @@ namespace Mono.Linker.Dataflow
 		{
 			if (GetAnnotations (field.DeclaringType).TryGetAnnotation (field, out var annotation)) {
 				return annotation.Annotation;
+			}
+
+			return DynamicallyAccessedMemberTypes.None;
+		}
+
+		public DynamicallyAccessedMemberTypes GetGenericParameterAnnotation (GenericParameter genericParameter)
+		{
+			TypeDefinition declaringType = genericParameter.DeclaringType?.Resolve ();
+			if (declaringType != null) {
+				if (GetAnnotations (declaringType).TryGetAnnotation (genericParameter, out var annotation))
+					return annotation.Annotation;
+
+				return DynamicallyAccessedMemberTypes.None;
+			}
+
+			MethodDefinition declaringMethod = genericParameter.DeclaringMethod?.Resolve ();
+			if (declaringMethod != null) {
+				if (GetAnnotations (declaringMethod.DeclaringType).TryGetAnnotation (declaringMethod, out var methodAnnotations) &&
+					methodAnnotations.TryGetAnnotation (genericParameter, out var annotation))
+					return annotation.Annotation;
+
+				return DynamicallyAccessedMemberTypes.None;
 			}
 
 			return DynamicallyAccessedMemberTypes.None;
@@ -166,8 +193,18 @@ namespace Mono.Linker.Dataflow
 
 					DynamicallyAccessedMemberTypes returnAnnotation = IsTypeInterestingForDataflow (method.ReturnType) ?
 						GetMemberTypesForDynamicallyAccessedMemberAttribute (method.MethodReturnType, method) : DynamicallyAccessedMemberTypes.None;
-					if (returnAnnotation != DynamicallyAccessedMemberTypes.None || paramAnnotations != null) {
-						annotatedMethods.Add (new MethodAnnotations (method, paramAnnotations, returnAnnotation));
+
+					var annotatedMethodGenericParameters = new ArrayBuilder<GenericParameterAnnotation> ();
+					if (method.HasGenericParameters) {
+						foreach (var genericParameter in method.GenericParameters) {
+							var annotation = GetMemberTypesForDynamicallyAccessedMemberAttribute (genericParameter, method);
+							if (annotation != DynamicallyAccessedMemberTypes.None)
+								annotatedMethodGenericParameters.Add (new GenericParameterAnnotation (genericParameter, annotation));
+						}
+					}
+
+					if (returnAnnotation != DynamicallyAccessedMemberTypes.None || paramAnnotations != null || annotatedMethodGenericParameters.Count > 0) {
+						annotatedMethods.Add (new MethodAnnotations (method, paramAnnotations, returnAnnotation, annotatedMethodGenericParameters.ToArray ()));
 					}
 				}
 			}
@@ -220,7 +257,7 @@ namespace Mono.Linker.Dataflow
 							if (setMethod.Parameters.Count > 0) {
 								DynamicallyAccessedMemberTypes[] paramAnnotations = new DynamicallyAccessedMemberTypes[setMethod.Parameters.Count + offset];
 								paramAnnotations[offset] = annotation;
-								annotatedMethods.Add (new MethodAnnotations (setMethod, paramAnnotations, DynamicallyAccessedMemberTypes.None));
+								annotatedMethods.Add (new MethodAnnotations (setMethod, paramAnnotations, DynamicallyAccessedMemberTypes.None, null));
 							}
 						}
 					}
@@ -243,7 +280,7 @@ namespace Mono.Linker.Dataflow
 						if (annotatedMethods.Any (a => a.Method == getMethod)) {
 							_context.LogWarning ($"Trying to propagate DynamicallyAccessedMemberAttribute from property '{property.FullName}' to its getter '{getMethod}', but it already has such attribute on the return value.", 2043, getMethod);
 						} else {
-							annotatedMethods.Add (new MethodAnnotations (getMethod, null, annotation));
+							annotatedMethods.Add (new MethodAnnotations (getMethod, null, annotation, null));
 						}
 					}
 
@@ -266,7 +303,16 @@ namespace Mono.Linker.Dataflow
 				}
 			}
 
-			return new TypeAnnotations (annotatedMethods.ToArray (), annotatedFields.ToArray ());
+			var annotatedGenericParameters = new ArrayBuilder<GenericParameterAnnotation> ();
+			if (type.HasGenericParameters) {
+				foreach (var genericParameter in type.GenericParameters) {
+					var annotation = GetMemberTypesForDynamicallyAccessedMemberAttribute (genericParameter, type);
+					if (annotation != DynamicallyAccessedMemberTypes.None)
+						annotatedGenericParameters.Add (new GenericParameterAnnotation (genericParameter, annotation));
+				}
+			}
+
+			return new TypeAnnotations (annotatedMethods.ToArray (), annotatedFields.ToArray (), annotatedGenericParameters.ToArray ());
 		}
 
 		bool ScanMethodBodyForFieldAccess (MethodBody body, bool write, out FieldDefinition found)
@@ -338,9 +384,10 @@ namespace Mono.Linker.Dataflow
 		{
 			readonly MethodAnnotations[] _annotatedMethods;
 			readonly FieldAnnotation[] _annotatedFields;
+			readonly GenericParameterAnnotation[] _annotatedGenericParameters;
 
-			public TypeAnnotations (MethodAnnotations[] annotatedMethods, FieldAnnotation[] annotatedFields)
-				=> (_annotatedMethods, _annotatedFields) = (annotatedMethods, annotatedFields);
+			public TypeAnnotations (MethodAnnotations[] annotatedMethods, FieldAnnotation[] annotatedFields, GenericParameterAnnotation[] annotatedGenericParameters)
+				=> (_annotatedMethods, _annotatedFields, _annotatedGenericParameters) = (annotatedMethods, annotatedFields, annotatedGenericParameters);
 
 			public bool TryGetAnnotation (MethodDefinition method, out MethodAnnotations annotations)
 			{
@@ -377,6 +424,23 @@ namespace Mono.Linker.Dataflow
 
 				return false;
 			}
+
+			public bool TryGetAnnotation (GenericParameter genericParameter, out GenericParameterAnnotation annotation)
+			{
+				annotation = default;
+
+				if (_annotatedGenericParameters == null)
+					return false;
+
+				foreach (var g in _annotatedGenericParameters) {
+					if (g.GenericParameter == genericParameter) {
+						annotation = g;
+						return true;
+					}
+				}
+
+				return false;
+			}
 		}
 
 		readonly struct MethodAnnotations
@@ -384,9 +448,32 @@ namespace Mono.Linker.Dataflow
 			public readonly MethodDefinition Method;
 			public readonly DynamicallyAccessedMemberTypes[] ParameterAnnotations;
 			public readonly DynamicallyAccessedMemberTypes ReturnParameterAnnotation;
+			readonly GenericParameterAnnotation[] _annotatedGenericParameters;
 
-			public MethodAnnotations (MethodDefinition method, DynamicallyAccessedMemberTypes[] paramAnnotations, DynamicallyAccessedMemberTypes returnParamAnnotations)
-				=> (Method, ParameterAnnotations, ReturnParameterAnnotation) = (method, paramAnnotations, returnParamAnnotations);
+			public MethodAnnotations (
+				MethodDefinition method,
+				DynamicallyAccessedMemberTypes[] paramAnnotations,
+				DynamicallyAccessedMemberTypes returnParamAnnotations,
+				GenericParameterAnnotation[] annotatedGenericParameters)
+				=> (Method, ParameterAnnotations, ReturnParameterAnnotation, _annotatedGenericParameters) =
+					(method, paramAnnotations, returnParamAnnotations, annotatedGenericParameters);
+
+			public bool TryGetAnnotation (GenericParameter genericParameter, out GenericParameterAnnotation annotation)
+			{
+				annotation = default;
+
+				if (_annotatedGenericParameters == null)
+					return false;
+
+				foreach (var g in _annotatedGenericParameters) {
+					if (g.GenericParameter == genericParameter) {
+						annotation = g;
+						return true;
+					}
+				}
+
+				return false;
+			}
 		}
 
 		readonly struct FieldAnnotation
@@ -396,6 +483,15 @@ namespace Mono.Linker.Dataflow
 
 			public FieldAnnotation (FieldDefinition field, DynamicallyAccessedMemberTypes annotation)
 				=> (Field, Annotation) = (field, annotation);
+		}
+
+		readonly struct GenericParameterAnnotation
+		{
+			public readonly GenericParameter GenericParameter;
+			public readonly DynamicallyAccessedMemberTypes Annotation;
+
+			public GenericParameterAnnotation (GenericParameter genericParameter, DynamicallyAccessedMemberTypes annotation)
+				=> (GenericParameter, Annotation) = (genericParameter, annotation);
 		}
 	}
 }

--- a/src/linker/Linker.Dataflow/MethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/MethodBodyScanner.cs
@@ -697,7 +697,9 @@ namespace Mono.Linker.Dataflow
 				StackSlot slot = new StackSlot (new RuntimeTypeHandleForGenericParameterValue (genericParameter));
 				currentStack.Push (slot);
 				return;
-			} else if (operation.Operand is TypeReference typeReference) {
+			}
+
+			if (operation.Operand is TypeReference typeReference) {
 				var resolvedReference = typeReference.Resolve ();
 				if (resolvedReference != null) {
 					StackSlot slot = new StackSlot (new RuntimeTypeHandleValue (resolvedReference));

--- a/src/linker/Linker.Dataflow/MethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/MethodBodyScanner.cs
@@ -2,12 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Mono.Cecil;
-using Mono.Cecil.Cil;
-using Mono.Collections.Generic;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Mono.Collections.Generic;
 
 namespace Mono.Linker.Dataflow
 {
@@ -693,7 +693,11 @@ namespace Mono.Linker.Dataflow
 			MethodDefinition thisMethod,
 			MethodBody methodBody)
 		{
-			if (operation.Operand is TypeReference typeReference) {
+			if (operation.Operand is GenericParameter genericParameter) {
+				StackSlot slot = new StackSlot (new RuntimeTypeHandleForGenericParameterValue (genericParameter));
+				currentStack.Push (slot);
+				return;
+			} else if (operation.Operand is TypeReference typeReference) {
 				var resolvedReference = typeReference.Resolve ();
 				if (resolvedReference != null) {
 					StackSlot slot = new StackSlot (new RuntimeTypeHandleValue (resolvedReference));
@@ -838,7 +842,7 @@ namespace Mono.Linker.Dataflow
 
 			ValueNode newObjValue = null;
 			ValueNodeList methodParams = PopCallArguments (currentStack, calledMethod, callingMethodBody, isNewObj,
-														  operation.Offset, out newObjValue);
+														   operation.Offset, out newObjValue);
 
 			ValueNode methodReturnValue = null;
 			bool handledFunction = HandleCall (

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -938,7 +938,7 @@ namespace Mono.Linker.Dataflow
 						ValueNode transformedResult = null;
 						foreach (var value in methodParams[0].UniqueValues ()) {
 							if (value is LeafValueWithDynamicallyAccessedMemberNode dynamicallyAccessedThing) {
-								var annotatedString = new AnnotatedStringValue (dynamicallyAccessedThing.DynamicallyAccessedMemberKinds);
+								var annotatedString = new AnnotatedStringValue (dynamicallyAccessedThing.DynamicallyAccessedMemberTypes);
 								transformedResult = MergePointValue.MergeValues (transformedResult, annotatedString);
 							} else {
 								transformedResult = null;

--- a/src/linker/Linker.Dataflow/ValueNode.cs
+++ b/src/linker/Linker.Dataflow/ValueNode.cs
@@ -10,6 +10,7 @@ using System.Text;
 
 using TypeDefinition = Mono.Cecil.TypeDefinition;
 using FieldDefinition = Mono.Cecil.FieldDefinition;
+using GenericParameter = Mono.Cecil.GenericParameter;
 
 namespace Mono.Linker.Dataflow
 {
@@ -28,6 +29,9 @@ namespace Mono.Linker.Dataflow
 
 		MethodParameter,                // symbolic placeholder
 		MethodReturn,                   // symbolic placeholder
+
+		RuntimeTypeHandleForGenericParameter, // symbolic placeholder for generic parameter
+		SystemTypeForGenericParameter,        // symbolic placeholder for generic parameter
 
 		MergePoint,                     // structural, multiplexer - Values
 		GetTypeFromString,              // structural, could be known value - KnownString
@@ -578,7 +582,7 @@ namespace Mono.Linker.Dataflow
 			TypeRepresented = typeRepresented;
 		}
 
-		public TypeDefinition TypeRepresented { get; private set; }
+		public TypeDefinition TypeRepresented { get; }
 
 		public override bool Equals (ValueNode other)
 		{
@@ -598,6 +602,77 @@ namespace Mono.Linker.Dataflow
 		protected override string NodeToString ()
 		{
 			return ValueNodeDump.ValueNodeToString (this, TypeRepresented);
+		}
+	}
+
+	/// <summary>
+	/// This is a System.Type value which reprensents generic parameter (basically result of typeof(T))
+	/// Its actual type is unknown, but it can have annotations.
+	/// </summary>
+	class SystemTypeForGenericParameterValue : LeafValueWithDynamicallyAccessedMemberNode
+	{
+		public SystemTypeForGenericParameterValue (GenericParameter genericParameter, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
+		{
+			Kind = ValueNodeKind.SystemTypeForGenericParameter;
+			GenericParameter = genericParameter;
+			DynamicallyAccessedMemberTypes = dynamicallyAccessedMemberTypes;
+		}
+
+		public GenericParameter GenericParameter { get; }
+
+		public override bool Equals (ValueNode other)
+		{
+			if (other == null)
+				return false;
+			if (this.Kind != other.Kind)
+				return false;
+
+			var otherValue = (SystemTypeForGenericParameterValue) other;
+			return this.GenericParameter == otherValue.GenericParameter && this.DynamicallyAccessedMemberTypes == otherValue.DynamicallyAccessedMemberTypes;
+		}
+
+		public override int GetHashCode ()
+		{
+			return HashCode.Combine (Kind, GenericParameter, DynamicallyAccessedMemberTypes);
+		}
+
+		protected override string NodeToString ()
+		{
+			return ValueNodeDump.ValueNodeToString (this, GenericParameter, DynamicallyAccessedMemberTypes);
+		}
+	}
+
+	/// <summary>
+	/// This is the System.RuntimeTypeHandle equivalent to a <see cref="SystemTypeForGenericParameterValue"/> node.
+	/// </summary>
+	class RuntimeTypeHandleForGenericParameterValue : LeafValueNode
+	{
+		public RuntimeTypeHandleForGenericParameterValue (GenericParameter genericParameter)
+		{
+			Kind = ValueNodeKind.RuntimeTypeHandleForGenericParameter;
+			GenericParameter = genericParameter;
+		}
+
+		public GenericParameter GenericParameter { get; }
+
+		public override bool Equals (ValueNode other)
+		{
+			if (other == null)
+				return false;
+			if (this.Kind != other.Kind)
+				return false;
+
+			return Equals (this.GenericParameter, ((RuntimeTypeHandleForGenericParameterValue) other).GenericParameter);
+		}
+
+		public override int GetHashCode ()
+		{
+			return HashCode.Combine (Kind, GenericParameter);
+		}
+
+		protected override string NodeToString ()
+		{
+			return ValueNodeDump.ValueNodeToString (this, GenericParameter);
 		}
 	}
 
@@ -643,9 +718,9 @@ namespace Mono.Linker.Dataflow
 		public object SourceContext { get; set; }
 
 		/// <summary>
-		/// The bitfield of dynamically accessed member kinds the node guarantees
+		/// The bitfield of dynamically accessed member types the node guarantees
 		/// </summary>
-		public DynamicallyAccessedMemberTypes DynamicallyAccessedMemberKinds { get; protected set; }
+		public DynamicallyAccessedMemberTypes DynamicallyAccessedMemberTypes { get; protected set; }
 	}
 
 	/// <summary>
@@ -653,11 +728,11 @@ namespace Mono.Linker.Dataflow
 	/// </summary>
 	class MethodParameterValue : LeafValueWithDynamicallyAccessedMemberNode
 	{
-		public MethodParameterValue (int parameterIndex, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberKinds)
+		public MethodParameterValue (int parameterIndex, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
 		{
 			Kind = ValueNodeKind.MethodParameter;
 			ParameterIndex = parameterIndex;
-			DynamicallyAccessedMemberKinds = dynamicallyAccessedMemberKinds;
+			DynamicallyAccessedMemberTypes = dynamicallyAccessedMemberTypes;
 		}
 
 		public int ParameterIndex { get; }
@@ -670,17 +745,17 @@ namespace Mono.Linker.Dataflow
 				return false;
 
 			var otherValue = (MethodParameterValue) other;
-			return this.ParameterIndex == otherValue.ParameterIndex && this.DynamicallyAccessedMemberKinds == otherValue.DynamicallyAccessedMemberKinds;
+			return this.ParameterIndex == otherValue.ParameterIndex && this.DynamicallyAccessedMemberTypes == otherValue.DynamicallyAccessedMemberTypes;
 		}
 
 		public override int GetHashCode ()
 		{
-			return HashCode.Combine (Kind, ParameterIndex, DynamicallyAccessedMemberKinds);
+			return HashCode.Combine (Kind, ParameterIndex, DynamicallyAccessedMemberTypes);
 		}
 
 		protected override string NodeToString ()
 		{
-			return ValueNodeDump.ValueNodeToString (this, ParameterIndex, DynamicallyAccessedMemberKinds);
+			return ValueNodeDump.ValueNodeToString (this, ParameterIndex, DynamicallyAccessedMemberTypes);
 		}
 	}
 
@@ -722,10 +797,10 @@ namespace Mono.Linker.Dataflow
 	/// </summary>
 	class MethodReturnValue : LeafValueWithDynamicallyAccessedMemberNode
 	{
-		public MethodReturnValue (DynamicallyAccessedMemberTypes dynamicallyAccessedMemberKinds)
+		public MethodReturnValue (DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
 		{
 			Kind = ValueNodeKind.MethodReturn;
-			DynamicallyAccessedMemberKinds = dynamicallyAccessedMemberKinds;
+			DynamicallyAccessedMemberTypes = dynamicallyAccessedMemberTypes;
 		}
 
 		public override bool Equals (ValueNode other)
@@ -736,17 +811,17 @@ namespace Mono.Linker.Dataflow
 				return false;
 
 			var otherValue = (MethodReturnValue) other;
-			return this.DynamicallyAccessedMemberKinds == otherValue.DynamicallyAccessedMemberKinds;
+			return this.DynamicallyAccessedMemberTypes == otherValue.DynamicallyAccessedMemberTypes;
 		}
 
 		public override int GetHashCode ()
 		{
-			return HashCode.Combine (Kind, DynamicallyAccessedMemberKinds);
+			return HashCode.Combine (Kind, DynamicallyAccessedMemberTypes);
 		}
 
 		protected override string NodeToString ()
 		{
-			return ValueNodeDump.ValueNodeToString (this, DynamicallyAccessedMemberKinds);
+			return ValueNodeDump.ValueNodeToString (this, DynamicallyAccessedMemberTypes);
 		}
 	}
 
@@ -962,11 +1037,11 @@ namespace Mono.Linker.Dataflow
 	/// </summary>
 	class LoadFieldValue : LeafValueWithDynamicallyAccessedMemberNode
 	{
-		public LoadFieldValue (FieldDefinition fieldToLoad, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberKinds)
+		public LoadFieldValue (FieldDefinition fieldToLoad, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
 		{
 			Kind = ValueNodeKind.LoadField;
 			Field = fieldToLoad;
-			DynamicallyAccessedMemberKinds = dynamicallyAccessedMemberKinds;
+			DynamicallyAccessedMemberTypes = dynamicallyAccessedMemberTypes;
 		}
 
 		public FieldDefinition Field { get; private set; }
@@ -982,17 +1057,17 @@ namespace Mono.Linker.Dataflow
 			if (!Equals (this.Field, otherLfv.Field))
 				return false;
 
-			return this.DynamicallyAccessedMemberKinds == otherLfv.DynamicallyAccessedMemberKinds;
+			return this.DynamicallyAccessedMemberTypes == otherLfv.DynamicallyAccessedMemberTypes;
 		}
 
 		public override int GetHashCode ()
 		{
-			return HashCode.Combine (Kind, Field, DynamicallyAccessedMemberKinds);
+			return HashCode.Combine (Kind, Field, DynamicallyAccessedMemberTypes);
 		}
 
 		protected override string NodeToString ()
 		{
-			return ValueNodeDump.ValueNodeToString (this, Field, DynamicallyAccessedMemberKinds);
+			return ValueNodeDump.ValueNodeToString (this, Field, DynamicallyAccessedMemberTypes);
 		}
 	}
 

--- a/src/linker/Linker.Dataflow/ValueNode.cs
+++ b/src/linker/Linker.Dataflow/ValueNode.cs
@@ -767,10 +767,10 @@ namespace Mono.Linker.Dataflow
 	/// </summary>
 	class AnnotatedStringValue : LeafValueWithDynamicallyAccessedMemberNode
 	{
-		public AnnotatedStringValue (DynamicallyAccessedMemberTypes dynamicallyAccessedMemberKinds)
+		public AnnotatedStringValue (DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
 		{
 			Kind = ValueNodeKind.AnnotatedString;
-			DynamicallyAccessedMemberKinds = dynamicallyAccessedMemberKinds;
+			DynamicallyAccessedMemberTypes = dynamicallyAccessedMemberTypes;
 		}
 
 		public override bool Equals (ValueNode other)
@@ -781,17 +781,17 @@ namespace Mono.Linker.Dataflow
 				return false;
 
 			var otherValue = (AnnotatedStringValue) other;
-			return this.DynamicallyAccessedMemberKinds == otherValue.DynamicallyAccessedMemberKinds;
+			return this.DynamicallyAccessedMemberTypes == otherValue.DynamicallyAccessedMemberTypes;
 		}
 
 		public override int GetHashCode ()
 		{
-			return HashCode.Combine (Kind, DynamicallyAccessedMemberKinds);
+			return HashCode.Combine (Kind, DynamicallyAccessedMemberTypes);
 		}
 
 		protected override string NodeToString ()
 		{
-			return ValueNodeDump.ValueNodeToString (this, DynamicallyAccessedMemberKinds);
+			return ValueNodeDump.ValueNodeToString (this, DynamicallyAccessedMemberTypes);
 		}
 	}
 

--- a/src/linker/Linker.Dataflow/ValueNode.cs
+++ b/src/linker/Linker.Dataflow/ValueNode.cs
@@ -374,6 +374,9 @@ namespace Mono.Linker.Dataflow
 			case ValueNodeKind.AnnotatedString:
 			case ValueNodeKind.ConstInt:
 			case ValueNodeKind.MethodParameter:
+			case ValueNodeKind.MethodReturn:
+			case ValueNodeKind.SystemTypeForGenericParameter:
+			case ValueNodeKind.RuntimeTypeHandleForGenericParameter:
 			case ValueNodeKind.LoadField:
 				break;
 

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1410,7 +1410,7 @@ namespace Mono.Linker.Steps
 
 #if !FEATURE_ILLINK
 				if (_context.IsFeatureExcluded ("deserialization")) {
-					MarkMethodsIf (type.Methods, HasOnSerializeAttribute, new DependencyInfo (DependencyKind.SerializationMethodForType, type));
+					MarkMethodsIf (type.Methods, HasOnSerializeAttribute, new DependencyInfo (DependencyKind.SerializationMethodForType, type), type);
 				} else
 #endif
 				{

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -48,7 +48,7 @@ namespace Mono.Linker.Steps
 		protected Queue<(MethodDefinition, DependencyInfo)> _methods;
 		protected List<MethodDefinition> _virtual_methods;
 		protected Queue<AttributeProviderPair> _assemblyLevelAttributes;
-		protected Queue<(AttributeProviderPair, DependencyInfo)> _lateMarkedAttributes;
+		protected Queue<(AttributeProviderPair, DependencyInfo, IMemberDefinition)> _lateMarkedAttributes;
 		protected List<TypeDefinition> _typesWithInterfaces;
 		protected List<MethodBody> _unreachableBodies;
 
@@ -161,7 +161,7 @@ namespace Mono.Linker.Steps
 			_methods = new Queue<(MethodDefinition, DependencyInfo)> ();
 			_virtual_methods = new List<MethodDefinition> ();
 			_assemblyLevelAttributes = new Queue<AttributeProviderPair> ();
-			_lateMarkedAttributes = new Queue<(AttributeProviderPair, DependencyInfo)> ();
+			_lateMarkedAttributes = new Queue<(AttributeProviderPair, DependencyInfo, IMemberDefinition)> ();
 			_typesWithInterfaces = new List<TypeDefinition> ();
 			_unreachableBodies = new List<MethodBody> ();
 		}
@@ -226,7 +226,7 @@ namespace Mono.Linker.Steps
 			// We may get here for a type marked by an earlier step, or by a type
 			// marked indirectly as the result of some other InitializeType call.
 			// Just track this as already marked, and don't include a new source.
-			MarkType (type, DependencyInfo.AlreadyMarked);
+			MarkType (type, DependencyInfo.AlreadyMarked, type);
 
 			if (type.HasFields)
 				InitializeFields (type);
@@ -265,7 +265,7 @@ namespace Mono.Linker.Steps
 					EnqueueMethod (method, DependencyInfo.AlreadyMarked);
 		}
 
-		internal void MarkEntireType (TypeDefinition type, bool includeBaseTypes, in DependencyInfo reason)
+		internal void MarkEntireType (TypeDefinition type, bool includeBaseTypes, in DependencyInfo reason, IMemberDefinition sourceLocationMember)
 		{
 #if DEBUG
 			if (!_entireTypeReasons.Contains (reason.Kind))
@@ -274,15 +274,15 @@ namespace Mono.Linker.Steps
 
 			if (type.HasNestedTypes) {
 				foreach (TypeDefinition nested in type.NestedTypes)
-					MarkEntireType (nested, includeBaseTypes, new DependencyInfo (DependencyKind.NestedType, type));
+					MarkEntireType (nested, includeBaseTypes, new DependencyInfo (DependencyKind.NestedType, type), type);
 			}
 
 			Annotations.Mark (type, reason);
 			var baseTypeDefinition = type.BaseType?.Resolve ();
 			if (includeBaseTypes && baseTypeDefinition != null) {
-				MarkEntireType (baseTypeDefinition, includeBaseTypes: true, new DependencyInfo (DependencyKind.BaseType, type));
+				MarkEntireType (baseTypeDefinition, includeBaseTypes: true, new DependencyInfo (DependencyKind.BaseType, type), type);
 			}
-			MarkCustomAttributes (type, new DependencyInfo (DependencyKind.CustomAttribute, type));
+			MarkCustomAttributes (type, new DependencyInfo (DependencyKind.CustomAttribute, type), type);
 			MarkTypeSpecialCustomAttributes (type);
 
 			if (type.HasInterfaces) {
@@ -291,7 +291,7 @@ namespace Mono.Linker.Steps
 				}
 			}
 
-			MarkGenericParameterProvider (type);
+			MarkGenericParameterProvider (type, sourceLocationMember);
 
 			if (type.HasFields) {
 				foreach (FieldDefinition field in type.Fields) {
@@ -462,11 +462,11 @@ namespace Mono.Linker.Steps
 			// Only track instantiations if override removal is enabled and the type is instantiated.
 			// If it's disabled, all overrides are kept, so there's no instantiation site to blame.
 			if (_context.IsOptimizationEnabled (CodeOptimizations.OverrideRemoval, method) && isInstantiated) {
-				MarkMethod (method, new DependencyInfo (DependencyKind.OverrideOnInstantiatedType, method.DeclaringType));
+				MarkMethod (method, new DependencyInfo (DependencyKind.OverrideOnInstantiatedType, method.DeclaringType), method.DeclaringType);
 			} else {
 				// If the optimization is disabled or it's an abstract type, we just mark it as a normal override.
 				Debug.Assert (!_context.IsOptimizationEnabled (CodeOptimizations.OverrideRemoval, method) || @base.IsAbstract);
-				MarkMethod (method, new DependencyInfo (DependencyKind.Override, @base));
+				MarkMethod (method, new DependencyInfo (DependencyKind.Override, @base), @base);
 			}
 
 			ProcessVirtualMethod (method);
@@ -513,16 +513,16 @@ namespace Mono.Linker.Steps
 			return false;
 		}
 
-		void MarkMarshalSpec (IMarshalInfoProvider spec, in DependencyInfo reason)
+		void MarkMarshalSpec (IMarshalInfoProvider spec, in DependencyInfo reason, IMemberDefinition sourceLocationMember)
 		{
 			if (!spec.HasMarshalInfo)
 				return;
 
 			if (spec.MarshalInfo is CustomMarshalInfo marshaler)
-				MarkType (marshaler.ManagedType, reason);
+				MarkType (marshaler.ManagedType, reason, sourceLocationMember);
 		}
 
-		void MarkCustomAttributes (ICustomAttributeProvider provider, in DependencyInfo reason)
+		void MarkCustomAttributes (ICustomAttributeProvider provider, in DependencyInfo reason, IMemberDefinition sourceLocationMember)
 		{
 			if (!provider.HasCustomAttributes)
 				return;
@@ -530,16 +530,16 @@ namespace Mono.Linker.Steps
 			bool markOnUse = _context.KeepUsedAttributeTypesOnly && Annotations.GetAction (GetAssemblyFromCustomAttributeProvider (provider)) == AssemblyAction.Link;
 
 			foreach (CustomAttribute ca in provider.CustomAttributes) {
-				if (ProcessLinkerSpecialAttribute (ca, provider, reason))
+				if (ProcessLinkerSpecialAttribute (ca, provider, reason, sourceLocationMember))
 					continue;
 
 				if (markOnUse) {
-					_lateMarkedAttributes.Enqueue ((new AttributeProviderPair (ca, provider), reason));
+					_lateMarkedAttributes.Enqueue ((new AttributeProviderPair (ca, provider), reason, sourceLocationMember));
 					continue;
 				}
 
-				MarkCustomAttribute (ca, reason);
-				MarkSpecialCustomAttributeDependencies (ca, provider);
+				MarkCustomAttribute (ca, reason, sourceLocationMember);
+				MarkSpecialCustomAttributeDependencies (ca, provider, sourceLocationMember);
 			}
 
 			if (!(provider is MethodDefinition || provider is FieldDefinition))
@@ -548,10 +548,10 @@ namespace Mono.Linker.Steps
 			var dynamicDependencies = _context.Annotations.GetLinkerAttributes<DynamicDependency> ((IMemberDefinition) provider);
 
 			foreach (var dynamicDependency in dynamicDependencies)
-				MarkDynamicDependency (dynamicDependency, (MemberReference) provider);
+				MarkDynamicDependency (dynamicDependency, (IMemberDefinition) provider);
 		}
 
-		protected virtual bool ProcessLinkerSpecialAttribute (CustomAttribute ca, ICustomAttributeProvider provider, in DependencyInfo reason)
+		protected virtual bool ProcessLinkerSpecialAttribute (CustomAttribute ca, ICustomAttributeProvider provider, in DependencyInfo reason, IMemberDefinition sourceLocationMember)
 		{
 			var isPreserveDependency = IsUserDependencyMarker (ca.AttributeType);
 			var isDynamicDependency = ca.AttributeType.IsTypeOf<DynamicDependencyAttribute> ();
@@ -560,10 +560,10 @@ namespace Mono.Linker.Steps
 				return false;
 
 			if (isPreserveDependency)
-				MarkUserDependency (mr, ca);
+				MarkUserDependency (mr, ca, sourceLocationMember);
 
 			if (_context.KeepDependencyAttributes || Annotations.GetAction (mr.Module.Assembly) != AssemblyAction.Link) {
-				MarkCustomAttribute (ca, reason);
+				MarkCustomAttribute (ca, reason, sourceLocationMember);
 			} else {
 				// Record the custom attribute so that it has a reason, without actually marking it.
 				Tracer.AddDirectDependency (ca, reason, marked: false);
@@ -572,18 +572,18 @@ namespace Mono.Linker.Steps
 			return true;
 		}
 
-		void MarkDynamicDependency (DynamicDependency dynamicDependency, MemberReference context)
+		void MarkDynamicDependency (DynamicDependency dynamicDependency, IMemberDefinition context)
 		{
 			Debug.Assert (context is MethodDefinition || context is FieldDefinition);
 			AssemblyDefinition assembly;
 			if (dynamicDependency.AssemblyName != null) {
 				assembly = _context.GetLoadedAssembly (dynamicDependency.AssemblyName);
 				if (assembly == null) {
-					_context.LogWarning ($"Unresolved assembly '{dynamicDependency.AssemblyName}' in DynamicDependencyAttribute on '{context}'", 2035, context.Resolve ());
+					_context.LogWarning ($"Unresolved assembly '{dynamicDependency.AssemblyName}' in DynamicDependencyAttribute on '{context}'", 2035, context);
 					return;
 				}
 			} else {
-				assembly = context.Module.Assembly;
+				assembly = context.DeclaringType.Module.Assembly;
 				Debug.Assert (assembly != null);
 			}
 
@@ -591,19 +591,19 @@ namespace Mono.Linker.Steps
 			if (dynamicDependency.TypeName is string typeName) {
 				type = DocumentationSignatureParser.GetTypeByDocumentationSignature (assembly, typeName);
 				if (type == null) {
-					_context.LogWarning ($"Unresolved type '{typeName}' in DynamicDependencyAttribute on '{context}'", 2036, context.Resolve ());
+					_context.LogWarning ($"Unresolved type '{typeName}' in DynamicDependencyAttribute on '{context}'", 2036, context);
 					return;
 				}
 			} else if (dynamicDependency.Type is TypeReference typeReference) {
 				type = typeReference.Resolve ();
 				if (type == null) {
-					_context.LogWarning ($"Unresolved type '{typeReference}' in DynamicDependencyAtribute on '{context}'", 2036, context.Resolve ());
+					_context.LogWarning ($"Unresolved type '{typeReference}' in DynamicDependencyAtribute on '{context}'", 2036, context);
 					return;
 				}
 			} else {
 				type = context.DeclaringType.Resolve ();
 				if (type == null) {
-					_context.LogWarning ($"Unresolved type '{context.DeclaringType}' in DynamicDependencyAttribute on '{context}'", 2036, context.Resolve ());
+					_context.LogWarning ($"Unresolved type '{context.DeclaringType}' in DynamicDependencyAttribute on '{context}'", 2036, context);
 					return;
 				}
 			}
@@ -612,46 +612,46 @@ namespace Mono.Linker.Steps
 			if (dynamicDependency.MemberSignature is string memberSignature) {
 				members = DocumentationSignatureParser.GetMembersByDocumentationSignature (type, memberSignature, acceptName: true);
 				if (!members.Any ()) {
-					_context.LogWarning ($"No members were resolved for '{memberSignature}'.", 2037, context.Resolve ());
+					_context.LogWarning ($"No members were resolved for '{memberSignature}'.", 2037, context);
 					return;
 				}
 			} else {
 				var memberTypes = dynamicDependency.MemberTypes;
 				members = DynamicallyAccessedMembersBinder.GetDynamicallyAccessedMembers (type, memberTypes);
 				if (!members.Any ()) {
-					_context.LogWarning ($"No members were resolved for '{memberTypes}'.", 2037, context.Resolve ());
+					_context.LogWarning ($"No members were resolved for '{memberTypes}'.", 2037, context);
 					return;
 				}
 			}
 
-			MarkMembers (type, members, new DependencyInfo (DependencyKind.DynamicDependency, dynamicDependency.OriginalAttribute));
+			MarkMembers (type, members, new DependencyInfo (DependencyKind.DynamicDependency, dynamicDependency.OriginalAttribute), context);
 		}
 
-		void MarkMembers (TypeDefinition typeDefinition, IEnumerable<IMemberDefinition> members, DependencyInfo reason)
+		void MarkMembers (TypeDefinition typeDefinition, IEnumerable<IMemberDefinition> members, DependencyInfo reason, IMemberDefinition sourceLocationMember)
 		{
 			foreach (var member in members) {
 				switch (member) {
 				case TypeDefinition type:
-					MarkType (type, reason);
+					MarkType (type, reason, sourceLocationMember);
 					break;
 				case MethodDefinition method:
-					MarkMethod (method, reason);
+					MarkMethod (method, reason, sourceLocationMember);
 					break;
 				case FieldDefinition field:
 					MarkField (field, reason);
 					break;
 				case PropertyDefinition property:
 					MarkProperty (property, reason);
-					MarkMethodIfNotNull (property.GetMethod, reason);
-					MarkMethodIfNotNull (property.SetMethod, reason);
-					MarkMethodsIf (property.OtherMethods, m => true, reason);
+					MarkMethodIfNotNull (property.GetMethod, reason, sourceLocationMember);
+					MarkMethodIfNotNull (property.SetMethod, reason, sourceLocationMember);
+					MarkMethodsIf (property.OtherMethods, m => true, reason, sourceLocationMember);
 					break;
 				case EventDefinition @event:
 					MarkEvent (@event, reason);
-					MarkMethodsIf (@event.OtherMethods, m => true, reason);
+					MarkMethodsIf (@event.OtherMethods, m => true, reason, sourceLocationMember);
 					break;
 				case null:
-					MarkEntireType (typeDefinition, includeBaseTypes: true, reason);
+					MarkEntireType (typeDefinition, includeBaseTypes: true, reason, sourceLocationMember);
 					break;
 				}
 			}
@@ -677,7 +677,7 @@ namespace Mono.Linker.Steps
 			return DynamicDependencyLookupStep.IsPreserveDependencyAttribute (type);
 		}
 
-		protected virtual void MarkUserDependency (MemberReference context, CustomAttribute ca)
+		protected virtual void MarkUserDependency (MemberReference context, CustomAttribute ca, IMemberDefinition sourceLocationMember)
 		{
 			if (!DynamicDependency.ShouldProcess (_context, ca))
 				return;
@@ -724,11 +724,11 @@ namespace Mono.Linker.Steps
 			}
 
 			if (member == "*") {
-				MarkEntireType (td, includeBaseTypes: false, new DependencyInfo (DependencyKind.PreservedDependency, ca));
+				MarkEntireType (td, includeBaseTypes: false, new DependencyInfo (DependencyKind.PreservedDependency, ca), sourceLocationMember);
 				return;
 			}
 
-			if (MarkDependencyMethod (td, member, signature, new DependencyInfo (DependencyKind.PreservedDependency, ca)))
+			if (MarkDependencyMethod (td, member, signature, new DependencyInfo (DependencyKind.PreservedDependency, ca), sourceLocationMember))
 				return;
 
 			if (MarkDependencyField (td, member, new DependencyInfo (DependencyKind.PreservedDependency, ca)))
@@ -738,7 +738,7 @@ namespace Mono.Linker.Steps
 				$"Could not resolve dependency member '{member}' declared in type '{td.FullName}' specified in a `PreserveDependency` attribute that targets method '{context.FullName}'", 2005, td);
 		}
 
-		bool MarkDependencyMethod (TypeDefinition type, string name, string[] signature, in DependencyInfo reason)
+		bool MarkDependencyMethod (TypeDefinition type, string name, string[] signature, in DependencyInfo reason, IMemberDefinition sourceLocationMember)
 		{
 			bool marked = false;
 
@@ -757,7 +757,7 @@ namespace Mono.Linker.Steps
 					continue;
 
 				if (signature == null) {
-					MarkIndirectlyCalledMethod (m, reason);
+					MarkIndirectlyCalledMethod (m, reason, sourceLocationMember);
 					marked = true;
 					continue;
 				}
@@ -777,7 +777,7 @@ namespace Mono.Linker.Steps
 				if (i < 0)
 					continue;
 
-				MarkIndirectlyCalledMethod (m, reason);
+				MarkIndirectlyCalledMethod (m, reason, sourceLocationMember);
 				marked = true;
 			}
 
@@ -805,12 +805,12 @@ namespace Mono.Linker.Steps
 				_assemblyLevelAttributes.Enqueue (new AttributeProviderPair (ca, module));
 		}
 
-		protected virtual void MarkCustomAttribute (CustomAttribute ca, in DependencyInfo reason)
+		protected virtual void MarkCustomAttribute (CustomAttribute ca, in DependencyInfo reason, IMemberDefinition source)
 		{
 			Annotations.Mark (ca, reason);
-			MarkMethod (ca.Constructor, new DependencyInfo (DependencyKind.AttributeConstructor, ca));
+			MarkMethod (ca.Constructor, new DependencyInfo (DependencyKind.AttributeConstructor, ca), source);
 
-			MarkCustomAttributeArguments (reason.Source as MethodDefinition, ca);
+			MarkCustomAttributeArguments (source, ca);
 
 			TypeReference constructor_type = ca.Constructor.DeclaringType;
 			TypeDefinition type = constructor_type.Resolve ();
@@ -820,8 +820,8 @@ namespace Mono.Linker.Steps
 				return;
 			}
 
-			MarkCustomAttributeProperties (ca, type);
-			MarkCustomAttributeFields (ca, type);
+			MarkCustomAttributeProperties (ca, type, source);
+			MarkCustomAttributeFields (ca, type, source);
 		}
 
 		protected virtual bool ShouldMarkCustomAttribute (CustomAttribute ca, ICustomAttributeProvider provider)
@@ -862,9 +862,9 @@ namespace Mono.Linker.Steps
 			return true;
 		}
 
-		internal protected void MarkStaticConstructor (TypeDefinition type, in DependencyInfo reason)
+		internal protected void MarkStaticConstructor (TypeDefinition type, in DependencyInfo reason, IMemberDefinition sourceLocationMember)
 		{
-			if (MarkMethodIf (type.Methods, IsNonEmptyStaticConstructor, reason) != null)
+			if (MarkMethodIf (type.Methods, IsNonEmptyStaticConstructor, reason, sourceLocationMember) != null)
 				Annotations.SetPreservedStaticCtor (type);
 		}
 
@@ -894,7 +894,7 @@ namespace Mono.Linker.Steps
 			return true;
 		}
 
-		protected void MarkSecurityDeclarations (ISecurityDeclarationProvider provider, in DependencyInfo reason)
+		protected void MarkSecurityDeclarations (ISecurityDeclarationProvider provider, in DependencyInfo reason, IMemberDefinition sourceLocationMember)
 		{
 			// most security declarations are removed (if linked) but user code might still have some
 			// and if the attributes references types then they need to be marked too
@@ -902,19 +902,19 @@ namespace Mono.Linker.Steps
 				return;
 
 			foreach (var sd in provider.SecurityDeclarations)
-				MarkSecurityDeclaration (sd, reason);
+				MarkSecurityDeclaration (sd, reason, sourceLocationMember);
 		}
 
-		protected virtual void MarkSecurityDeclaration (SecurityDeclaration sd, in DependencyInfo reason)
+		protected virtual void MarkSecurityDeclaration (SecurityDeclaration sd, in DependencyInfo reason, IMemberDefinition sourceLocationMember)
 		{
 			if (!sd.HasSecurityAttributes)
 				return;
 
 			foreach (var sa in sd.SecurityAttributes)
-				MarkSecurityAttribute (sa, reason);
+				MarkSecurityAttribute (sa, reason, sourceLocationMember);
 		}
 
-		protected virtual void MarkSecurityAttribute (SecurityAttribute sa, in DependencyInfo reason)
+		protected virtual void MarkSecurityAttribute (SecurityAttribute sa, in DependencyInfo reason, IMemberDefinition sourceLocationMember)
 		{
 			TypeReference security_type = sa.AttributeType;
 			TypeDefinition type = security_type.Resolve ();
@@ -925,27 +925,27 @@ namespace Mono.Linker.Steps
 
 			// Security attributes participate in inference logic without being marked.
 			Tracer.AddDirectDependency (sa, reason, marked: false);
-			MarkType (security_type, new DependencyInfo (DependencyKind.AttributeType, sa));
-			MarkCustomAttributeProperties (sa, type);
-			MarkCustomAttributeFields (sa, type);
+			MarkType (security_type, new DependencyInfo (DependencyKind.AttributeType, sa), sourceLocationMember);
+			MarkCustomAttributeProperties (sa, type, sourceLocationMember);
+			MarkCustomAttributeFields (sa, type, sourceLocationMember);
 		}
 
-		protected void MarkCustomAttributeProperties (ICustomAttribute ca, TypeDefinition attribute)
+		protected void MarkCustomAttributeProperties (ICustomAttribute ca, TypeDefinition attribute, IMemberDefinition sourceLocationMember)
 		{
 			if (!ca.HasProperties)
 				return;
 
 			foreach (var named_argument in ca.Properties)
-				MarkCustomAttributeProperty (named_argument, attribute, ca, new DependencyInfo (DependencyKind.AttributeProperty, ca));
+				MarkCustomAttributeProperty (named_argument, attribute, ca, new DependencyInfo (DependencyKind.AttributeProperty, ca), sourceLocationMember);
 		}
 
-		protected void MarkCustomAttributeProperty (CustomAttributeNamedArgument namedArgument, TypeDefinition attribute, ICustomAttribute ca, in DependencyInfo reason)
+		protected void MarkCustomAttributeProperty (CustomAttributeNamedArgument namedArgument, TypeDefinition attribute, ICustomAttribute ca, in DependencyInfo reason, IMemberDefinition sourceLocationMember)
 		{
 			PropertyDefinition property = GetProperty (attribute, namedArgument.Name);
 			if (property != null)
-				MarkMethod (property.SetMethod, reason);
+				MarkMethod (property.SetMethod, reason, sourceLocationMember);
 
-			MarkCustomAttributeArgument (namedArgument.Argument, ca);
+			MarkCustomAttributeArgument (namedArgument.Argument, ca, sourceLocationMember);
 
 			if (property != null && _flowAnnotations.RequiresDataFlowAnalysis (property.SetMethod)) {
 				var scanner = new ReflectionMethodBodyScanner (_context, this, _flowAnnotations);
@@ -967,22 +967,22 @@ namespace Mono.Linker.Steps
 			return null;
 		}
 
-		protected void MarkCustomAttributeFields (ICustomAttribute ca, TypeDefinition attribute)
+		protected void MarkCustomAttributeFields (ICustomAttribute ca, TypeDefinition attribute, IMemberDefinition sourceLocationMember)
 		{
 			if (!ca.HasFields)
 				return;
 
 			foreach (var named_argument in ca.Fields)
-				MarkCustomAttributeField (named_argument, attribute, ca);
+				MarkCustomAttributeField (named_argument, attribute, ca, sourceLocationMember);
 		}
 
-		protected void MarkCustomAttributeField (CustomAttributeNamedArgument namedArgument, TypeDefinition attribute, ICustomAttribute ca)
+		protected void MarkCustomAttributeField (CustomAttributeNamedArgument namedArgument, TypeDefinition attribute, ICustomAttribute ca, IMemberDefinition sourceLocationMember)
 		{
 			FieldDefinition field = GetField (attribute, namedArgument.Name);
 			if (field != null)
 				MarkField (field, new DependencyInfo (DependencyKind.CustomAttributeField, ca));
 
-			MarkCustomAttributeArgument (namedArgument.Argument, ca);
+			MarkCustomAttributeArgument (namedArgument.Argument, ca, sourceLocationMember);
 
 			if (field != null && _flowAnnotations.RequiresDataFlowAnalysis (field)) {
 				var scanner = new ReflectionMethodBodyScanner (_context, this, _flowAnnotations);
@@ -1016,13 +1016,13 @@ namespace Mono.Linker.Steps
 			return null;
 		}
 
-		void MarkCustomAttributeArguments (MethodDefinition source, CustomAttribute ca)
+		void MarkCustomAttributeArguments (IMemberDefinition source, CustomAttribute ca)
 		{
 			if (!ca.HasConstructorArguments)
 				return;
 
 			foreach (var argument in ca.ConstructorArguments)
-				MarkCustomAttributeArgument (argument, ca);
+				MarkCustomAttributeArgument (argument, ca, source);
 
 			var resolvedConstructor = ca.Constructor.Resolve ();
 			if (resolvedConstructor != null && _flowAnnotations.RequiresDataFlowAnalysis (resolvedConstructor)) {
@@ -1031,21 +1031,21 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void MarkCustomAttributeArgument (CustomAttributeArgument argument, ICustomAttribute ca)
+		void MarkCustomAttributeArgument (CustomAttributeArgument argument, ICustomAttribute ca, IMemberDefinition sourceLocationMember)
 		{
 			var at = argument.Type;
 
 			if (at.IsArray) {
 				var et = at.GetElementType ();
 
-				MarkType (et, new DependencyInfo (DependencyKind.CustomAttributeArgumentType, ca));
+				MarkType (et, new DependencyInfo (DependencyKind.CustomAttributeArgumentType, ca), sourceLocationMember);
 				if (argument.Value == null)
 					return;
 
 				// Array arguments are modeled as a CustomAttributeArgument [], and will mark the
 				// Type once for each element in the array.
 				foreach (var caa in (CustomAttributeArgument[]) argument.Value)
-					MarkCustomAttributeArgument (caa, ca);
+					MarkCustomAttributeArgument (caa, ca, sourceLocationMember);
 
 				return;
 			}
@@ -1053,14 +1053,14 @@ namespace Mono.Linker.Steps
 			if (at.Namespace == "System") {
 				switch (at.Name) {
 				case "Type":
-					MarkType (argument.Type, new DependencyInfo (DependencyKind.CustomAttributeArgumentType, ca));
-					MarkType ((TypeReference) argument.Value, new DependencyInfo (DependencyKind.CustomAttributeArgumentValue, ca));
+					MarkType (argument.Type, new DependencyInfo (DependencyKind.CustomAttributeArgumentType, ca), sourceLocationMember);
+					MarkType ((TypeReference) argument.Value, new DependencyInfo (DependencyKind.CustomAttributeArgumentValue, ca), sourceLocationMember);
 					return;
 
 				case "Object":
 					var boxed_value = (CustomAttributeArgument) argument.Value;
-					MarkType (boxed_value.Type, new DependencyInfo (DependencyKind.CustomAttributeArgumentType, ca));
-					MarkCustomAttributeArgument (boxed_value, ca);
+					MarkType (boxed_value.Type, new DependencyInfo (DependencyKind.CustomAttributeArgumentType, ca), sourceLocationMember);
+					MarkCustomAttributeArgument (boxed_value, ca, sourceLocationMember);
 					return;
 				}
 			}
@@ -1084,7 +1084,7 @@ namespace Mono.Linker.Steps
 
 			MarkAssemblyCustomAttributes (assembly);
 
-			MarkSecurityDeclarations (assembly, new DependencyInfo (DependencyKind.AssemblyOrModuleAttribute, assembly));
+			MarkSecurityDeclarations (assembly, new DependencyInfo (DependencyKind.AssemblyOrModuleAttribute, assembly), null);
 
 			foreach (ModuleDefinition module in assembly.Modules)
 				LazyMarkCustomAttributes (module, module);
@@ -1092,15 +1092,15 @@ namespace Mono.Linker.Steps
 
 		void MarkEntireAssembly (AssemblyDefinition assembly)
 		{
-			MarkCustomAttributes (assembly, new DependencyInfo (DependencyKind.AssemblyOrModuleAttribute, assembly));
-			MarkCustomAttributes (assembly.MainModule, new DependencyInfo (DependencyKind.AssemblyOrModuleAttribute, assembly.MainModule));
+			MarkCustomAttributes (assembly, new DependencyInfo (DependencyKind.AssemblyOrModuleAttribute, assembly), null);
+			MarkCustomAttributes (assembly.MainModule, new DependencyInfo (DependencyKind.AssemblyOrModuleAttribute, assembly.MainModule), null);
 
 			if (assembly.MainModule.HasExportedTypes) {
 				// TODO: This needs more work accross all steps
 			}
 
 			foreach (TypeDefinition type in assembly.MainModule.Types)
-				MarkEntireType (type, includeBaseTypes: false, new DependencyInfo (DependencyKind.TypeInAssembly, assembly));
+				MarkEntireType (type, includeBaseTypes: false, new DependencyInfo (DependencyKind.TypeInAssembly, assembly), null);
 		}
 
 		void ProcessModule (AssemblyDefinition assembly)
@@ -1109,7 +1109,7 @@ namespace Mono.Linker.Steps
 			// at assembly load time
 			foreach (TypeDefinition type in assembly.MainModule.Types) {
 				if (type.Name == "<Module>" && type.HasMethods) {
-					MarkType (type, new DependencyInfo (DependencyKind.TypeInAssembly, assembly));
+					MarkType (type, new DependencyInfo (DependencyKind.TypeInAssembly, assembly), null);
 					break;
 				}
 			}
@@ -1144,7 +1144,7 @@ namespace Mono.Linker.Steps
 
 
 				markOccurred = true;
-				MarkCustomAttribute (customAttribute, new DependencyInfo (DependencyKind.AssemblyOrModuleAttribute, assemblyLevelAttribute.Provider));
+				MarkCustomAttribute (customAttribute, new DependencyInfo (DependencyKind.AssemblyOrModuleAttribute, assemblyLevelAttribute.Provider), null);
 
 				string attributeFullName = customAttribute.Constructor.DeclaringType.FullName;
 				switch (attributeFullName) {
@@ -1170,11 +1170,11 @@ namespace Mono.Linker.Steps
 			if (startingQueueCount == 0)
 				return false;
 
-			var skippedItems = new List<(AttributeProviderPair, DependencyInfo)> ();
+			var skippedItems = new List<(AttributeProviderPair, DependencyInfo, IMemberDefinition)> ();
 			var markOccurred = false;
 
 			while (_lateMarkedAttributes.Count != 0) {
-				var (attributeProviderPair, reason) = _lateMarkedAttributes.Dequeue ();
+				var (attributeProviderPair, reason, sourceLocationMember) = _lateMarkedAttributes.Dequeue ();
 				var customAttribute = attributeProviderPair.Attribute;
 				var provider = attributeProviderPair.Provider;
 
@@ -1185,13 +1185,13 @@ namespace Mono.Linker.Steps
 				}
 
 				if (!ShouldMarkCustomAttribute (customAttribute, provider)) {
-					skippedItems.Add ((attributeProviderPair, reason));
+					skippedItems.Add ((attributeProviderPair, reason, sourceLocationMember));
 					continue;
 				}
 
 				markOccurred = true;
-				MarkCustomAttribute (customAttribute, reason);
-				MarkSpecialCustomAttributeDependencies (customAttribute, provider);
+				MarkCustomAttribute (customAttribute, reason, sourceLocationMember);
+				MarkSpecialCustomAttributeDependencies (customAttribute, provider, sourceLocationMember);
 			}
 
 			// requeue the items we skipped in case we need to make another pass
@@ -1207,7 +1207,7 @@ namespace Mono.Linker.Steps
 				Debug.Assert (reason.Kind == DependencyKind.FieldAccess || reason.Kind == DependencyKind.Ldtoken);
 				// Blame the field reference (without actually marking) on the original reason.
 				Tracer.AddDirectDependency (reference, reason, marked: false);
-				MarkType (reference.DeclaringType, new DependencyInfo (DependencyKind.DeclaringType, reference));
+				MarkType (reference.DeclaringType, new DependencyInfo (DependencyKind.DeclaringType, reference), reference.Resolve ());
 
 				// Blame the field definition that we will resolve on the field reference.
 				reason = new DependencyInfo (DependencyKind.FieldOnGenericInstance, reference);
@@ -1233,10 +1233,10 @@ namespace Mono.Linker.Steps
 			if (CheckProcessed (field))
 				return;
 
-			MarkType (field.DeclaringType, new DependencyInfo (DependencyKind.DeclaringType, field));
-			MarkType (field.FieldType, new DependencyInfo (DependencyKind.FieldType, field));
-			MarkCustomAttributes (field, new DependencyInfo (DependencyKind.CustomAttribute, field));
-			MarkMarshalSpec (field, new DependencyInfo (DependencyKind.FieldMarshalSpec, field));
+			MarkType (field.DeclaringType, new DependencyInfo (DependencyKind.DeclaringType, field), field);
+			MarkType (field.FieldType, new DependencyInfo (DependencyKind.FieldType, field), field);
+			MarkCustomAttributes (field, new DependencyInfo (DependencyKind.CustomAttribute, field), field);
+			MarkMarshalSpec (field, new DependencyInfo (DependencyKind.FieldMarshalSpec, field), field);
 			DoAdditionalFieldProcessing (field);
 
 			var parent = field.DeclaringType;
@@ -1247,7 +1247,7 @@ namespace Mono.Linker.Steps
 					DependencyKind.FieldAccess => new DependencyInfo (DependencyKind.TriggersCctorThroughFieldAccess, reason.Source),
 					_ => new DependencyInfo (DependencyKind.CctorForField, field)
 				};
-				MarkStaticConstructor (parent, cctorReason);
+				MarkStaticConstructor (parent, cctorReason, field);
 			}
 
 			if (Annotations.HasSubstitutedInit (field)) {
@@ -1277,12 +1277,12 @@ namespace Mono.Linker.Steps
 		protected virtual void MarkSerializable (TypeDefinition type)
 		{
 			// Keep default ctor for XmlSerializer support. See https://github.com/mono/linker/issues/957
-			MarkDefaultConstructor (type, new DependencyInfo (DependencyKind.SerializationMethodForType, type));
+			MarkDefaultConstructor (type, new DependencyInfo (DependencyKind.SerializationMethodForType, type), type);
 #if !FEATURE_ILLINK
 			if (_context.IsFeatureExcluded ("deserialization"))
 				return;
 #endif
-			MarkMethodsIf (type.Methods, IsSpecialSerializationConstructor, new DependencyInfo (DependencyKind.SerializationMethodForType, type));
+			MarkMethodsIf (type.Methods, IsSpecialSerializationConstructor, new DependencyInfo (DependencyKind.SerializationMethodForType, type), type);
 		}
 
 		/// <summary>
@@ -1291,11 +1291,10 @@ namespace Mono.Linker.Steps
 		/// <param name="reference">The type reference to mark.</param>
 		/// <param name="reason">The reason why the marking is occuring</param>
 		/// <param name="sourceLocationMember">The member which is the "source location" for the marking.
-		/// For example if the type is marked due to an instruction in a method's body, this should be the method which body it is.
-		/// Can be null if the source location is not mappable to a specific member.</param>
+		/// For example if the type is marked due to an instruction in a method's body, this should be the method which body it is.</param>
 		/// <returns>The resolved type definition if the reference can be resolved and if the call ended up actually marking.
 		/// If the type definition was already marked, the method returns null.</returns>
-		internal protected virtual TypeDefinition MarkType (TypeReference reference, DependencyInfo reason, IMemberDefinition sourceLocationMember = null)
+		internal protected virtual TypeDefinition MarkType (TypeReference reference, DependencyInfo reason, IMemberDefinition sourceLocationMember)
 		{
 #if DEBUG
 			if (!_typeReasons.Contains (reason.Kind))
@@ -1334,23 +1333,23 @@ namespace Mono.Linker.Steps
 
 			// Treat cctors triggered by a called method specially and mark this case up-front.
 			if (type.HasMethods && ShouldMarkTypeStaticConstructor (type) && reason.Kind == DependencyKind.DeclaringTypeOfCalledMethod)
-				MarkStaticConstructor (type, new DependencyInfo (DependencyKind.TriggersCctorForCalledMethod, reason.Source));
+				MarkStaticConstructor (type, new DependencyInfo (DependencyKind.TriggersCctorForCalledMethod, reason.Source), type);
 
 			if (CheckProcessed (type))
 				return null;
 
 			MarkScope (type.Scope, type);
-			MarkType (type.BaseType, new DependencyInfo (DependencyKind.BaseType, type));
-			MarkType (type.DeclaringType, new DependencyInfo (DependencyKind.DeclaringType, type));
-			MarkCustomAttributes (type, new DependencyInfo (DependencyKind.CustomAttribute, type));
-			MarkSecurityDeclarations (type, new DependencyInfo (DependencyKind.CustomAttribute, type));
+			MarkType (type.BaseType, new DependencyInfo (DependencyKind.BaseType, type), type);
+			MarkType (type.DeclaringType, new DependencyInfo (DependencyKind.DeclaringType, type), type);
+			MarkCustomAttributes (type, new DependencyInfo (DependencyKind.CustomAttribute, type), type);
+			MarkSecurityDeclarations (type, new DependencyInfo (DependencyKind.CustomAttribute, type), type);
 
 			if (type.IsMulticastDelegate ()) {
 				MarkMulticastDelegate (type);
 			}
 
 			if (type.IsClass && type.BaseType == null && type.Name == "Object")
-				MarkMethodIf (type.Methods, m => m.Name == "Finalize", new DependencyInfo (DependencyKind.MethodForSpecialType, type));
+				MarkMethodIf (type.Methods, m => m.Name == "Finalize", new DependencyInfo (DependencyKind.MethodForSpecialType, type), type);
 
 			if (type.IsSerializable ())
 				MarkSerializable (type);
@@ -1369,7 +1368,7 @@ namespace Mono.Linker.Steps
 			// This marks properties for [EventData] types as well as other attribute dependencies.
 			MarkTypeSpecialCustomAttributes (type);
 
-			MarkGenericParameterProvider (type);
+			MarkGenericParameterProvider (type, sourceLocationMember);
 
 			// keep fields for value-types and for classes with LayoutKind.Sequential or Explicit
 			if (type.IsValueType || !type.IsAutoLayout)
@@ -1405,9 +1404,9 @@ namespace Mono.Linker.Steps
 
 			if (type.HasMethods) {
 				// For virtuals that must be preserved, blame the declaring type.
-				MarkMethodsIf (type.Methods, IsVirtualNeededByTypeDueToPreservedScope, new DependencyInfo (DependencyKind.VirtualNeededDueToPreservedScope, type));
+				MarkMethodsIf (type.Methods, IsVirtualNeededByTypeDueToPreservedScope, new DependencyInfo (DependencyKind.VirtualNeededDueToPreservedScope, type), type);
 				if (ShouldMarkTypeStaticConstructor (type) && reason.Kind != DependencyKind.TriggersCctorForCalledMethod)
-					MarkStaticConstructor (type, new DependencyInfo (DependencyKind.CctorForType, type));
+					MarkStaticConstructor (type, new DependencyInfo (DependencyKind.CctorForType, type), type);
 
 #if !FEATURE_ILLINK
 				if (_context.IsFeatureExcluded ("deserialization")) {
@@ -1415,7 +1414,7 @@ namespace Mono.Linker.Steps
 				} else
 #endif
 				{
-					MarkMethodsIf (type.Methods, HasOnSerializeOrDeserializeAttribute, new DependencyInfo (DependencyKind.SerializationMethodForType, type));
+					MarkMethodsIf (type.Methods, HasOnSerializeOrDeserializeAttribute, new DependencyInfo (DependencyKind.SerializationMethodForType, type), type);
 				}
 			}
 
@@ -1506,11 +1505,11 @@ namespace Mono.Linker.Steps
 					MarkTypeWithDebuggerTypeProxyAttribute (type, attribute);
 					break;
 				case "EventDataAttribute" when attrType.Namespace == "System.Diagnostics.Tracing":
-					if (MarkMethodsIf (type.Methods, MethodDefinitionExtensions.IsPublicInstancePropertyMethod, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, type)))
+					if (MarkMethodsIf (type.Methods, MethodDefinitionExtensions.IsPublicInstancePropertyMethod, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, type), type))
 						Tracer.AddDirectDependency (attribute, new DependencyInfo (DependencyKind.CustomAttribute, type), marked: false);
 					break;
 				case "TypeDescriptionProviderAttribute" when attrType.Namespace == "System.ComponentModel":
-					MarkTypeConverterLikeDependency (attribute, l => l.IsDefaultConstructor (), type);
+					MarkTypeConverterLikeDependency (attribute, l => l.IsDefaultConstructor (), type, type);
 					break;
 				}
 			}
@@ -1519,14 +1518,15 @@ namespace Mono.Linker.Steps
 		//
 		// Used for known framework attributes which can be applied to any element
 		//
-		bool MarkSpecialCustomAttributeDependencies (CustomAttribute ca, ICustomAttributeProvider provider)
+		bool MarkSpecialCustomAttributeDependencies (CustomAttribute ca, ICustomAttributeProvider provider, IMemberDefinition sourceLocationMember)
 		{
 			var dt = ca.Constructor.DeclaringType;
 			if (dt.Name == "TypeConverterAttribute" && dt.Namespace == "System.ComponentModel") {
 				MarkTypeConverterLikeDependency (ca, l =>
 					l.IsDefaultConstructor () ||
 					l.Parameters.Count == 1 && l.Parameters[0].ParameterType.IsTypeOf ("System", "Type"),
-					provider);
+					provider,
+					sourceLocationMember);
 				return true;
 			} else if (UnconditionalSuppressMessageAttributeState.TypeRefHasUnconditionalSuppressions (dt)) {
 				_context.Suppressions.AddSuppression (ca, provider);
@@ -1553,11 +1553,11 @@ namespace Mono.Linker.Steps
 		{
 			if (TryGetStringArgument (attribute, out string name)) {
 				Tracer.AddDirectDependency (attribute, new DependencyInfo (DependencyKind.CustomAttribute, type), marked: false);
-				MarkNamedMethod (type, name, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute));
+				MarkNamedMethod (type, name, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute), type);
 			}
 		}
 
-		protected virtual void MarkTypeConverterLikeDependency (CustomAttribute attribute, Func<MethodDefinition, bool> predicate, ICustomAttributeProvider provider)
+		protected virtual void MarkTypeConverterLikeDependency (CustomAttribute attribute, Func<MethodDefinition, bool> predicate, ICustomAttributeProvider provider, IMemberDefinition sourceLocationMember)
 		{
 			var args = attribute.ConstructorArguments;
 			if (args.Count < 1)
@@ -1577,7 +1577,7 @@ namespace Mono.Linker.Steps
 				return;
 
 			Tracer.AddDirectDependency (attribute, new DependencyInfo (DependencyKind.CustomAttribute, provider), marked: false);
-			MarkMethodsIf (tdef.Methods, predicate, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute));
+			MarkMethodsIf (tdef.Methods, predicate, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute), sourceLocationMember);
 		}
 
 		void MarkTypeWithDebuggerDisplayAttribute (TypeDefinition type, CustomAttribute attribute)
@@ -1614,7 +1614,7 @@ namespace Mono.Linker.Steps
 
 						MethodDefinition method = GetMethodWithNoParameters (type, methodName);
 						if (method != null) {
-							MarkMethod (method, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute));
+							MarkMethod (method, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute), type);
 							continue;
 						}
 					} else {
@@ -1627,10 +1627,10 @@ namespace Mono.Linker.Steps
 						PropertyDefinition property = GetProperty (type, realMatch);
 						if (property != null) {
 							if (property.GetMethod != null) {
-								MarkMethod (property.GetMethod, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute));
+								MarkMethod (property.GetMethod, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute), type);
 							}
 							if (property.SetMethod != null) {
-								MarkMethod (property.SetMethod, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute));
+								MarkMethod (property.SetMethod, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute), type);
 							}
 							continue;
 						}
@@ -1638,7 +1638,7 @@ namespace Mono.Linker.Steps
 
 					while (type != null) {
 						// TODO: Non-understood DebuggerDisplayAttribute causes us to keep everything. Should this be a warning?
-						MarkMethods (type, new DependencyInfo (DependencyKind.KeptForSpecialAttribute, attribute));
+						MarkMethods (type, new DependencyInfo (DependencyKind.KeptForSpecialAttribute, attribute), type);
 						MarkFields (type, includeStatic: true, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute));
 						// This logic would miss generic parameters used in methods/fields for generic types
 						Debug.Assert (!(type.BaseType is GenericInstanceType));
@@ -1665,11 +1665,11 @@ namespace Mono.Linker.Steps
 				}
 
 				Tracer.AddDirectDependency (attribute, new DependencyInfo (DependencyKind.CustomAttribute, type), marked: false);
-				MarkType (proxyTypeReference, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute));
+				MarkType (proxyTypeReference, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute), type);
 
 				TypeDefinition proxyType = proxyTypeReference.Resolve ();
 				if (proxyType != null) {
-					MarkMethods (proxyType, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute));
+					MarkMethods (proxyType, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute), type);
 					MarkFields (proxyType, includeStatic: true, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute));
 				}
 			}
@@ -1687,7 +1687,7 @@ namespace Mono.Linker.Steps
 			return argument != null;
 		}
 
-		protected int MarkNamedMethod (TypeDefinition type, string method_name, in DependencyInfo reason)
+		protected int MarkNamedMethod (TypeDefinition type, string method_name, in DependencyInfo reason, IMemberDefinition sourceLocationMember)
 		{
 			if (!type.HasMethods)
 				return 0;
@@ -1697,7 +1697,7 @@ namespace Mono.Linker.Steps
 				if (method.Name != method_name)
 					continue;
 
-				MarkMethod (method, reason);
+				MarkMethod (method, reason, sourceLocationMember);
 				count++;
 			}
 
@@ -1737,8 +1737,8 @@ namespace Mono.Linker.Steps
 					continue;
 
 				// This marks methods directly without reporting the property.
-				MarkMethod (property.GetMethod, reason);
-				MarkMethod (property.SetMethod, reason);
+				MarkMethod (property.GetMethod, reason, property);
+				MarkMethod (property.SetMethod, reason, property);
 			}
 		}
 
@@ -1761,24 +1761,24 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void MarkGenericParameterProvider (IGenericParameterProvider provider)
+		void MarkGenericParameterProvider (IGenericParameterProvider provider, IMemberDefinition sourceLocationMember)
 		{
 			if (!provider.HasGenericParameters)
 				return;
 
 			foreach (GenericParameter parameter in provider.GenericParameters)
-				MarkGenericParameter (parameter);
+				MarkGenericParameter (parameter, sourceLocationMember);
 		}
 
-		void MarkGenericParameter (GenericParameter parameter)
+		void MarkGenericParameter (GenericParameter parameter, IMemberDefinition sourceLocationMember)
 		{
-			MarkCustomAttributes (parameter, new DependencyInfo (DependencyKind.GenericParameterCustomAttribute, parameter.Owner));
+			MarkCustomAttributes (parameter, new DependencyInfo (DependencyKind.GenericParameterCustomAttribute, parameter.Owner), sourceLocationMember);
 			if (!parameter.HasConstraints)
 				return;
 
 			foreach (var constraint in parameter.Constraints) {
-				MarkCustomAttributes (constraint, new DependencyInfo (DependencyKind.GenericParameterConstraintCustomAttribute, parameter.Owner));
-				MarkType (constraint.ConstraintType, new DependencyInfo (DependencyKind.GenericParameterConstraintType, parameter.Owner));
+				MarkCustomAttributes (constraint, new DependencyInfo (DependencyKind.GenericParameterConstraintCustomAttribute, parameter.Owner), sourceLocationMember);
+				MarkType (constraint.ConstraintType, new DependencyInfo (DependencyKind.GenericParameterConstraintType, parameter.Owner), sourceLocationMember);
 			}
 		}
 
@@ -1846,35 +1846,35 @@ namespace Mono.Linker.Steps
 				parameters[1].ParameterType.Name == "StreamingContext";
 		}
 
-		internal protected bool MarkMethodsIf (Collection<MethodDefinition> methods, Func<MethodDefinition, bool> predicate, in DependencyInfo reason)
+		internal protected bool MarkMethodsIf (Collection<MethodDefinition> methods, Func<MethodDefinition, bool> predicate, in DependencyInfo reason, IMemberDefinition sourceLocationMember)
 		{
 			bool marked = false;
 			foreach (MethodDefinition method in methods) {
 				if (predicate (method)) {
-					MarkMethod (method, reason);
+					MarkMethod (method, reason, sourceLocationMember);
 					marked = true;
 				}
 			}
 			return marked;
 		}
 
-		protected MethodDefinition MarkMethodIf (Collection<MethodDefinition> methods, Func<MethodDefinition, bool> predicate, in DependencyInfo reason)
+		protected MethodDefinition MarkMethodIf (Collection<MethodDefinition> methods, Func<MethodDefinition, bool> predicate, in DependencyInfo reason, IMemberDefinition sourceLocationMember)
 		{
 			foreach (MethodDefinition method in methods) {
 				if (predicate (method)) {
-					return MarkMethod (method, reason);
+					return MarkMethod (method, reason, sourceLocationMember);
 				}
 			}
 
 			return null;
 		}
 
-		protected bool MarkDefaultConstructor (TypeDefinition type, in DependencyInfo reason)
+		protected bool MarkDefaultConstructor (TypeDefinition type, in DependencyInfo reason, IMemberDefinition sourceLocationMember)
 		{
 			if (type?.HasMethods != true)
 				return false;
 
-			return MarkMethodIf (type.Methods, MethodDefinitionExtensions.IsDefaultConstructor, reason) != null;
+			return MarkMethodIf (type.Methods, MethodDefinitionExtensions.IsDefaultConstructor, reason, sourceLocationMember) != null;
 		}
 
 		static bool IsNonEmptyStaticConstructor (MethodDefinition method)
@@ -1955,23 +1955,23 @@ namespace Mono.Linker.Steps
 
 		protected virtual void MarkMulticastDelegate (TypeDefinition type)
 		{
-			MarkMethodCollection (type.Methods, new DependencyInfo (DependencyKind.MethodForSpecialType, type));
+			MarkMethodCollection (type.Methods, new DependencyInfo (DependencyKind.MethodForSpecialType, type), type);
 		}
 
 		protected (TypeReference, DependencyInfo) GetOriginalType (TypeReference type, DependencyInfo reason, IMemberDefinition sourceLocationMember)
 		{
 			while (type is TypeSpecification specification) {
 				if (type is GenericInstanceType git) {
-					MarkGenericArguments (git, sourceLocationMember ?? (reason.Source as IMemberDefinition) ?? (reason.Source as MemberReference)?.Resolve ());
+					MarkGenericArguments (git, sourceLocationMember);
 					Debug.Assert (!(specification.ElementType is TypeSpecification));
 				}
 
 				if (type is IModifierType mod)
-					MarkModifierType (mod);
+					MarkModifierType (mod, sourceLocationMember);
 
 				if (type is FunctionPointerType fnptr) {
-					MarkParameters (fnptr);
-					MarkType (fnptr.ReturnType, new DependencyInfo (DependencyKind.ReturnType, fnptr));
+					MarkParameters (fnptr, sourceLocationMember);
+					MarkType (fnptr.ReturnType, new DependencyInfo (DependencyKind.ReturnType, fnptr), sourceLocationMember);
 					break; // FunctionPointerType is the original type
 				}
 
@@ -1984,19 +1984,19 @@ namespace Mono.Linker.Steps
 			return (type, reason);
 		}
 
-		void MarkParameters (FunctionPointerType fnptr)
+		void MarkParameters (FunctionPointerType fnptr, IMemberDefinition sourceLocationMember)
 		{
 			if (!fnptr.HasParameters)
 				return;
 
 			for (int i = 0; i < fnptr.Parameters.Count; i++) {
-				MarkType (fnptr.Parameters[i].ParameterType, new DependencyInfo (DependencyKind.ParameterType, fnptr));
+				MarkType (fnptr.Parameters[i].ParameterType, new DependencyInfo (DependencyKind.ParameterType, fnptr), sourceLocationMember);
 			}
 		}
 
-		void MarkModifierType (IModifierType mod)
+		void MarkModifierType (IModifierType mod, IMemberDefinition sourceLocationMember)
 		{
-			MarkType (mod.ModifierType, new DependencyInfo (DependencyKind.ModifierType, mod));
+			MarkType (mod.ModifierType, new DependencyInfo (DependencyKind.ModifierType, mod), sourceLocationMember);
 		}
 
 		void MarkGenericArguments (IGenericInstance instance, IMemberDefinition sourceLocationMember)
@@ -2036,7 +2036,7 @@ namespace Mono.Linker.Steps
 					continue;
 
 				var argument_definition = argument.Resolve ();
-				MarkDefaultConstructor (argument_definition, new DependencyInfo (DependencyKind.DefaultCtorForNewConstrainedGenericArgument, instance));
+				MarkDefaultConstructor (argument_definition, new DependencyInfo (DependencyKind.DefaultCtorForNewConstrainedGenericArgument, instance), sourceLocationMember);
 			}
 		}
 
@@ -2063,14 +2063,14 @@ namespace Mono.Linker.Steps
 				// TODO: it seems like PreserveAll on a type won't necessarily keep nested types,
 				// but PreserveAll on an assembly will. Is this correct?
 				MarkFields (type, true, new DependencyInfo (DependencyKind.TypePreserve, type));
-				MarkMethods (type, new DependencyInfo (DependencyKind.TypePreserve, type));
+				MarkMethods (type, new DependencyInfo (DependencyKind.TypePreserve, type), type);
 				break;
 			case TypePreserve.Fields:
 				if (!MarkFields (type, true, new DependencyInfo (DependencyKind.TypePreserve, type), true))
 					_context.LogWarning ($"Type {type.FullName} has no fields to preserve", 2001, type);
 				break;
 			case TypePreserve.Methods:
-				if (!MarkMethods (type, new DependencyInfo (DependencyKind.TypePreserve, type)))
+				if (!MarkMethods (type, new DependencyInfo (DependencyKind.TypePreserve, type), type))
 					_context.LogWarning ($"Type {type.FullName} has no methods to preserve", 2002, type);
 				break;
 			}
@@ -2082,7 +2082,7 @@ namespace Mono.Linker.Steps
 			if (list == null)
 				return;
 
-			MarkMethodCollection (list, new DependencyInfo (DependencyKind.PreservedMethod, type));
+			MarkMethodCollection (list, new DependencyInfo (DependencyKind.PreservedMethod, type), type);
 		}
 
 		void ApplyPreserveMethods (MethodDefinition method)
@@ -2091,7 +2091,7 @@ namespace Mono.Linker.Steps
 			if (list == null)
 				return;
 
-			MarkMethodCollection (list, new DependencyInfo (DependencyKind.PreservedMethod, method));
+			MarkMethodCollection (list, new DependencyInfo (DependencyKind.PreservedMethod, method), method);
 		}
 
 		protected bool MarkFields (TypeDefinition type, bool includeStatic, in DependencyInfo reason, bool markBackingFieldsOnlyIfPropertyMarked = false)
@@ -2148,30 +2148,30 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		protected virtual bool MarkMethods (TypeDefinition type, in DependencyInfo reason)
+		protected virtual bool MarkMethods (TypeDefinition type, in DependencyInfo reason, IMemberDefinition sourceLocationMember)
 		{
 			if (!type.HasMethods)
 				return false;
 
-			MarkMethodCollection (type.Methods, reason);
+			MarkMethodCollection (type.Methods, reason, sourceLocationMember);
 			return true;
 		}
 
-		void MarkMethodCollection (IList<MethodDefinition> methods, in DependencyInfo reason)
+		void MarkMethodCollection (IList<MethodDefinition> methods, in DependencyInfo reason, IMemberDefinition sourceLocationMember)
 		{
 			foreach (MethodDefinition method in methods)
-				MarkMethod (method, reason);
+				MarkMethod (method, reason, sourceLocationMember);
 		}
 
-		internal protected void MarkIndirectlyCalledMethod (MethodDefinition method, in DependencyInfo reason)
+		internal protected void MarkIndirectlyCalledMethod (MethodDefinition method, in DependencyInfo reason, IMemberDefinition sourceLocationMember)
 		{
-			MarkMethod (method, reason);
+			MarkMethod (method, reason, sourceLocationMember);
 			Annotations.MarkIndirectlyCalledMethod (method);
 		}
 
-		protected virtual MethodDefinition MarkMethod (MethodReference reference, DependencyInfo reason)
+		protected virtual MethodDefinition MarkMethod (MethodReference reference, DependencyInfo reason, IMemberDefinition sourceLocationMember)
 		{
-			(reference, reason) = GetOriginalMethod (reference, reason);
+			(reference, reason) = GetOriginalMethod (reference, reason, sourceLocationMember);
 
 			if (reference.DeclaringType is ArrayType)
 				return null;
@@ -2179,7 +2179,7 @@ namespace Mono.Linker.Steps
 			if (reference.DeclaringType is GenericInstanceType) {
 				// Blame the method reference on the original reason without marking it.
 				Tracer.AddDirectDependency (reference, reason, marked: false);
-				MarkType (reference.DeclaringType, new DependencyInfo (DependencyKind.DeclaringType, reference), (reason.Source as IMemberDefinition) ?? (reason.Source as MemberReference)?.Resolve ());
+				MarkType (reference.DeclaringType, new DependencyInfo (DependencyKind.DeclaringType, reference), sourceLocationMember);
 				// Mark the resolved method definition as a dependency of the reference.
 				reason = new DependencyInfo (DependencyKind.MethodOnGenericInstance, reference);
 			}
@@ -2209,14 +2209,14 @@ namespace Mono.Linker.Steps
 			return assembly;
 		}
 
-		protected (MethodReference, DependencyInfo) GetOriginalMethod (MethodReference method, DependencyInfo reason)
+		protected (MethodReference, DependencyInfo) GetOriginalMethod (MethodReference method, DependencyInfo reason, IMemberDefinition sourceLocationMember)
 		{
 			while (method is MethodSpecification specification) {
 				// Blame the method reference (which isn't marked) on the original reason.
 				Tracer.AddDirectDependency (specification, reason, marked: false);
 				// Blame the outgoing element method on the specification.
 				if (method is GenericInstanceMethod gim)
-					MarkGenericArguments (gim, (reason.Source as IMemberDefinition) ?? (reason.Source as MemberReference)?.Resolve ());
+					MarkGenericArguments (gim, sourceLocationMember);
 
 				(method, reason) = (specification.ElementMethod, new DependencyInfo (DependencyKind.ElementMethod, specification));
 				Debug.Assert (!(method is MethodSpecification));
@@ -2251,18 +2251,18 @@ namespace Mono.Linker.Steps
 			if (markedForCall) {
 				// Record declaring type of a called method up-front as a special case so that we may
 				// track at least some method calls that trigger a cctor.
-				MarkType (method.DeclaringType, new DependencyInfo (DependencyKind.DeclaringTypeOfCalledMethod, method));
+				MarkType (method.DeclaringType, new DependencyInfo (DependencyKind.DeclaringTypeOfCalledMethod, method), method);
 			}
 
 			if (CheckProcessed (method))
 				return;
 
 			if (!markedForCall)
-				MarkType (method.DeclaringType, new DependencyInfo (DependencyKind.DeclaringType, method));
-			MarkCustomAttributes (method, new DependencyInfo (DependencyKind.CustomAttribute, method));
-			MarkSecurityDeclarations (method, new DependencyInfo (DependencyKind.CustomAttribute, method));
+				MarkType (method.DeclaringType, new DependencyInfo (DependencyKind.DeclaringType, method), method);
+			MarkCustomAttributes (method, new DependencyInfo (DependencyKind.CustomAttribute, method), method);
+			MarkSecurityDeclarations (method, new DependencyInfo (DependencyKind.CustomAttribute, method), method);
 
-			MarkGenericParameterProvider (method);
+			MarkGenericParameterProvider (method, method);
 
 			if (method.IsInstanceConstructor ()) {
 				MarkRequirementsForInstantiatedTypes (method.DeclaringType);
@@ -2279,15 +2279,15 @@ namespace Mono.Linker.Steps
 
 			if (method.HasParameters) {
 				foreach (ParameterDefinition pd in method.Parameters) {
-					MarkType (pd.ParameterType, new DependencyInfo (DependencyKind.ParameterType, method));
-					MarkCustomAttributes (pd, new DependencyInfo (DependencyKind.ParameterAttribute, method));
-					MarkMarshalSpec (pd, new DependencyInfo (DependencyKind.ParameterMarshalSpec, method));
+					MarkType (pd.ParameterType, new DependencyInfo (DependencyKind.ParameterType, method), method);
+					MarkCustomAttributes (pd, new DependencyInfo (DependencyKind.ParameterAttribute, method), method);
+					MarkMarshalSpec (pd, new DependencyInfo (DependencyKind.ParameterMarshalSpec, method), method);
 				}
 			}
 
 			if (method.HasOverrides) {
 				foreach (MethodReference ov in method.Overrides) {
-					MarkMethod (ov, new DependencyInfo (DependencyKind.MethodImplOverride, method));
+					MarkMethod (ov, new DependencyInfo (DependencyKind.MethodImplOverride, method), method);
 					MarkExplicitInterfaceImplementation (method, ov);
 				}
 			}
@@ -2301,9 +2301,9 @@ namespace Mono.Linker.Steps
 
 			MarkBaseMethods (method);
 
-			MarkType (method.ReturnType, new DependencyInfo (DependencyKind.ReturnType, method));
-			MarkCustomAttributes (method.MethodReturnType, new DependencyInfo (DependencyKind.ReturnTypeAttribute, method));
-			MarkMarshalSpec (method.MethodReturnType, new DependencyInfo (DependencyKind.ReturnTypeMarshalSpec, method));
+			MarkType (method.ReturnType, new DependencyInfo (DependencyKind.ReturnType, method), method);
+			MarkCustomAttributes (method.MethodReturnType, new DependencyInfo (DependencyKind.ReturnTypeAttribute, method), method);
+			MarkMarshalSpec (method.MethodReturnType, new DependencyInfo (DependencyKind.ReturnTypeMarshalSpec, method), method);
 
 			if (method.IsPInvokeImpl || method.IsInternalCall) {
 				ProcessInteropMethod (method);
@@ -2332,7 +2332,7 @@ namespace Mono.Linker.Steps
 			MarkInterfaceImplementations (type);
 
 			foreach (var method in GetRequiredMethodsForInstantiatedType (type))
-				MarkMethod (method, new DependencyInfo (DependencyKind.MethodForInstantiatedType, type));
+				MarkMethod (method, new DependencyInfo (DependencyKind.MethodForInstantiatedType, type), type);
 
 			DoAdditionalInstantiatedTypeProcessing (type);
 		}
@@ -2385,19 +2385,19 @@ namespace Mono.Linker.Steps
 					return;
 
 				var baseType = method.DeclaringType.BaseType.Resolve ();
-				if (!MarkDefaultConstructor (baseType, new DependencyInfo (DependencyKind.BaseDefaultCtorForStubbedMethod, method)))
+				if (!MarkDefaultConstructor (baseType, new DependencyInfo (DependencyKind.BaseDefaultCtorForStubbedMethod, method), method))
 					throw new LinkerFatalErrorException (MessageContainer.CreateErrorMessage ($"Cannot stub constructor on '{method.DeclaringType}' when base type does not have default constructor",
 						1006, origin: new MessageOrigin (method)));
 
 				break;
 
 			case MethodAction.ConvertToThrow:
-				MarkAndCacheConvertToThrowExceptionCtor (new DependencyInfo (DependencyKind.UnreachableBodyRequirement, method));
+				MarkAndCacheConvertToThrowExceptionCtor (new DependencyInfo (DependencyKind.UnreachableBodyRequirement, method), method);
 				break;
 			}
 		}
 
-		protected virtual void MarkAndCacheConvertToThrowExceptionCtor (DependencyInfo reason)
+		protected virtual void MarkAndCacheConvertToThrowExceptionCtor (DependencyInfo reason, IMemberDefinition sourceLocationMember)
 		{
 			if (_context.MarkedKnownMembers.NotSupportedExceptionCtorString != null)
 				return;
@@ -2406,9 +2406,9 @@ namespace Mono.Linker.Steps
 			if (nse == null)
 				throw new LinkerFatalErrorException (MessageContainer.CreateErrorMessage ("Missing predefined 'System.NotSupportedException' type", 1007));
 
-			MarkType (nse, reason);
+			MarkType (nse, reason, sourceLocationMember);
 
-			var nseCtor = MarkMethodIf (nse.Methods, KnownMembers.IsNotSupportedExceptionCtorString, reason);
+			var nseCtor = MarkMethodIf (nse.Methods, KnownMembers.IsNotSupportedExceptionCtorString, reason, sourceLocationMember);
 			_context.MarkedKnownMembers.NotSupportedExceptionCtorString = nseCtor ??
 				throw new LinkerFatalErrorException (MessageContainer.CreateErrorMessage ($"Could not find constructor on '{nse.FullName}'", 1008));
 
@@ -2416,9 +2416,9 @@ namespace Mono.Linker.Steps
 			if (objectType == null)
 				throw new NotSupportedException ("Missing predefined 'System.Object' type");
 
-			MarkType (objectType, reason);
+			MarkType (objectType, reason, sourceLocationMember);
 
-			var objectCtor = MarkMethodIf (objectType.Methods, MethodDefinitionExtensions.IsDefaultConstructor, reason);
+			var objectCtor = MarkMethodIf (objectType.Methods, MethodDefinitionExtensions.IsDefaultConstructor, reason, sourceLocationMember);
 			_context.MarkedKnownMembers.ObjectCtor = objectCtor ??
 				throw new LinkerFatalErrorException (MessageContainer.CreateErrorMessage ($"Could not find constructor on '{objectType.FullName}'", 1008));
 		}
@@ -2432,9 +2432,9 @@ namespace Mono.Linker.Steps
 			if (disablePrivateReflection == null)
 				throw new LinkerFatalErrorException (MessageContainer.CreateErrorMessage ("Missing predefined 'System.Runtime.CompilerServices.DisablePrivateReflectionAttribute' type", 1007));
 
-			MarkType (disablePrivateReflection, DependencyInfo.DisablePrivateReflectionRequirement);
+			MarkType (disablePrivateReflection, DependencyInfo.DisablePrivateReflectionRequirement, null);
 
-			var ctor = MarkMethodIf (disablePrivateReflection.Methods, MethodDefinitionExtensions.IsDefaultConstructor, new DependencyInfo (DependencyKind.DisablePrivateReflectionRequirement, disablePrivateReflection));
+			var ctor = MarkMethodIf (disablePrivateReflection.Methods, MethodDefinitionExtensions.IsDefaultConstructor, new DependencyInfo (DependencyKind.DisablePrivateReflectionRequirement, disablePrivateReflection), disablePrivateReflection);
 			_context.MarkedKnownMembers.DisablePrivateReflectionAttributeCtor = ctor ??
 				throw new LinkerFatalErrorException (MessageContainer.CreateErrorMessage ($"Could not find constructor on '{disablePrivateReflection.FullName}'", 1010));
 
@@ -2451,7 +2451,7 @@ namespace Mono.Linker.Steps
 				if (base_method.DeclaringType.IsInterface && !method.DeclaringType.IsInterface)
 					continue;
 
-				MarkMethod (base_method, new DependencyInfo (DependencyKind.BaseMethod, method));
+				MarkMethod (base_method, new DependencyInfo (DependencyKind.BaseMethod, method), method);
 				MarkBaseMethods (base_method);
 			}
 		}
@@ -2476,7 +2476,7 @@ namespace Mono.Linker.Steps
 
 			const bool includeStaticFields = false;
 			if (returnTypeDefinition != null && !returnTypeDefinition.IsImport) {
-				MarkDefaultConstructor (returnTypeDefinition, new DependencyInfo (DependencyKind.InteropMethodDependency, method));
+				MarkDefaultConstructor (returnTypeDefinition, new DependencyInfo (DependencyKind.InteropMethodDependency, method), method);
 				MarkFields (returnTypeDefinition, includeStaticFields, new DependencyInfo (DependencyKind.InteropMethodDependency, method));
 			}
 
@@ -2493,7 +2493,7 @@ namespace Mono.Linker.Steps
 				if (paramTypeDefinition != null && !paramTypeDefinition.IsImport) {
 					MarkFields (paramTypeDefinition, includeStaticFields, new DependencyInfo (DependencyKind.InteropMethodDependency, method));
 					if (pd.ParameterType.IsByReference) {
-						MarkDefaultConstructor (paramTypeDefinition, new DependencyInfo (DependencyKind.InteropMethodDependency, method));
+						MarkDefaultConstructor (paramTypeDefinition, new DependencyInfo (DependencyKind.InteropMethodDependency, method), method);
 					}
 				}
 			}
@@ -2528,7 +2528,7 @@ namespace Mono.Linker.Steps
 		{
 			Tracer.AddDirectDependency (prop, reason, marked: false);
 			// Consider making this more similar to MarkEvent method?
-			MarkCustomAttributes (prop, new DependencyInfo (DependencyKind.CustomAttribute, prop));
+			MarkCustomAttributes (prop, new DependencyInfo (DependencyKind.CustomAttribute, prop), prop);
 			DoAdditionalPropertyProcessing (prop);
 		}
 
@@ -2536,35 +2536,35 @@ namespace Mono.Linker.Steps
 		{
 			// Record the event without marking it in Annotations.
 			Tracer.AddDirectDependency (evt, reason, marked: false);
-			MarkCustomAttributes (evt, new DependencyInfo (DependencyKind.CustomAttribute, evt));
-			MarkMethodIfNotNull (evt.AddMethod, new DependencyInfo (DependencyKind.EventMethod, evt));
-			MarkMethodIfNotNull (evt.InvokeMethod, new DependencyInfo (DependencyKind.EventMethod, evt));
-			MarkMethodIfNotNull (evt.RemoveMethod, new DependencyInfo (DependencyKind.EventMethod, evt));
+			MarkCustomAttributes (evt, new DependencyInfo (DependencyKind.CustomAttribute, evt), evt);
+			MarkMethodIfNotNull (evt.AddMethod, new DependencyInfo (DependencyKind.EventMethod, evt), evt);
+			MarkMethodIfNotNull (evt.InvokeMethod, new DependencyInfo (DependencyKind.EventMethod, evt), evt);
+			MarkMethodIfNotNull (evt.RemoveMethod, new DependencyInfo (DependencyKind.EventMethod, evt), evt);
 			DoAdditionalEventProcessing (evt);
 		}
 
-		internal void MarkMethodIfNotNull (MethodReference method, in DependencyInfo reason)
+		internal void MarkMethodIfNotNull (MethodReference method, in DependencyInfo reason, IMemberDefinition sourceLocationMember)
 		{
 			if (method == null)
 				return;
 
-			MarkMethod (method, reason);
+			MarkMethod (method, reason, sourceLocationMember);
 		}
 
 		protected virtual void MarkMethodBody (MethodBody body)
 		{
 			if (_context.IsOptimizationEnabled (CodeOptimizations.UnreachableBodies, body.Method) && IsUnreachableBody (body)) {
-				MarkAndCacheConvertToThrowExceptionCtor (new DependencyInfo (DependencyKind.UnreachableBodyRequirement, body.Method));
+				MarkAndCacheConvertToThrowExceptionCtor (new DependencyInfo (DependencyKind.UnreachableBodyRequirement, body.Method), body.Method);
 				_unreachableBodies.Add (body);
 				return;
 			}
 
 			foreach (VariableDefinition var in body.Variables)
-				MarkType (var.VariableType, new DependencyInfo (DependencyKind.VariableType, body.Method));
+				MarkType (var.VariableType, new DependencyInfo (DependencyKind.VariableType, body.Method), body.Method);
 
 			foreach (ExceptionHandler eh in body.ExceptionHandlers)
 				if (eh.HandlerType == ExceptionHandlerType.Catch)
-					MarkType (eh.CatchType, new DependencyInfo (DependencyKind.CatchType, body.Method));
+					MarkType (eh.CatchType, new DependencyInfo (DependencyKind.CatchType, body.Method), body.Method);
 
 			bool requiresReflectionMethodBodyScanner =
 				ReflectionMethodBodyScanner.RequiresReflectionMethodBodyScannerForMethodBody (_flowAnnotations, body.Method);
@@ -2636,7 +2636,7 @@ namespace Mono.Linker.Steps
 					};
 					requiresReflectionMethodBodyScanner |=
 						ReflectionMethodBodyScanner.RequiresReflectionMethodBodyScannerForCallSite (_context, _flowAnnotations, (MethodReference) instruction.Operand);
-					MarkMethod ((MethodReference) instruction.Operand, new DependencyInfo (dependencyKind, method));
+					MarkMethod ((MethodReference) instruction.Operand, new DependencyInfo (dependencyKind, method), method);
 					break;
 				}
 
@@ -2645,9 +2645,9 @@ namespace Mono.Linker.Steps
 					Debug.Assert (instruction.OpCode.Code == Code.Ldtoken);
 					var reason = new DependencyInfo (DependencyKind.Ldtoken, method);
 					if (token is TypeReference typeReference) {
-						MarkType (typeReference, reason);
+						MarkType (typeReference, reason, method);
 					} else if (token is MethodReference methodReference) {
-						MarkMethod (methodReference, reason);
+						MarkMethod (methodReference, reason, method);
 					} else {
 						MarkField ((FieldReference) token, reason);
 					}
@@ -2655,7 +2655,7 @@ namespace Mono.Linker.Steps
 				}
 
 			case OperandType.InlineType:
-				MarkType ((TypeReference) instruction.Operand, new DependencyInfo (DependencyKind.InstructionTypeRef, method));
+				MarkType ((TypeReference) instruction.Operand, new DependencyInfo (DependencyKind.InstructionTypeRef, method), method);
 				break;
 			default:
 				break;
@@ -2705,7 +2705,7 @@ namespace Mono.Linker.Steps
 		protected virtual void MarkInterfaceImplementation (InterfaceImplementation iface, TypeDefinition type)
 		{
 			// Blame the type that has the interfaceimpl, expecting the type itself to get marked for other reasons.
-			MarkCustomAttributes (iface, new DependencyInfo (DependencyKind.CustomAttribute, iface));
+			MarkCustomAttributes (iface, new DependencyInfo (DependencyKind.CustomAttribute, iface), type);
 			// Blame the interface type on the interfaceimpl itself.
 			MarkType (iface.InterfaceType, new DependencyInfo (DependencyKind.InterfaceImplementationInterfaceType, iface), type);
 			Annotations.Mark (iface, new DependencyInfo (DependencyKind.InterfaceImplementationOnType, type));

--- a/test/Mono.Linker.Tests.Cases.Expectations/Assertions/RecognizedReflectionAccessPatternAttribute.cs
+++ b/test/Mono.Linker.Tests.Cases.Expectations/Assertions/RecognizedReflectionAccessPatternAttribute.cs
@@ -6,7 +6,14 @@ using System;
 
 namespace Mono.Linker.Tests.Cases.Expectations.Assertions
 {
-	[AttributeUsage (AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+	[AttributeUsage (
+		AttributeTargets.Method |
+		AttributeTargets.Constructor |
+		AttributeTargets.Class |
+		AttributeTargets.Field |
+		AttributeTargets.Property,
+		AllowMultiple = true,
+		Inherited = false)]
 	public class RecognizedReflectionAccessPatternAttribute : BaseExpectedLinkedBehaviorAttribute
 	{
 		// The default .ctor has a special meaning - don't validate any specifically recognized reflection access patterns

--- a/test/Mono.Linker.Tests.Cases.Expectations/Assertions/UnrecognizedReflectionAccessPatternAttribute.cs
+++ b/test/Mono.Linker.Tests.Cases.Expectations/Assertions/UnrecognizedReflectionAccessPatternAttribute.cs
@@ -6,7 +6,14 @@ using System;
 
 namespace Mono.Linker.Tests.Cases.Expectations.Assertions
 {
-	[AttributeUsage (AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+	[AttributeUsage (
+		AttributeTargets.Method |
+		AttributeTargets.Constructor |
+		AttributeTargets.Class |
+		AttributeTargets.Field |
+		AttributeTargets.Property,
+		AllowMultiple = true,
+		Inherited = false)]
 	public class UnrecognizedReflectionAccessPatternAttribute : BaseExpectedLinkedBehaviorAttribute
 	{
 		public UnrecognizedReflectionAccessPatternAttribute (Type reflectionMethodType, string reflectionMethodName, Type[] reflectionMethodParameters,

--- a/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
@@ -1,0 +1,637 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Policy;
+using System.Text;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.DataFlow
+{
+	[SkipKeptItemsValidation]
+	public class GenericParameterDataFlow
+	{
+		public static void Main ()
+		{
+			TestSingleGenericParameterOnType ();
+			TestMultipleGenericParametersOnType ();
+			TestBaseTypeGenericRequirements ();
+			TestInterfaceTypeGenericRequirements ();
+			TestTypeGenericRequirementsOnMembers ();
+			TestPartialInstantiationTypes ();
+
+			TestSingleGenericParameterOnMethod ();
+			TestMultipleGenericParametersOnMethod ();
+			TestMethodGenericParametersViaInheritance ();
+		}
+
+		static void TestSingleGenericParameterOnType ()
+		{
+			TypeRequiresNothing<TestType>.Test ();
+			TypeRequiresPublicFields<TestType>.Test ();
+			TypeRequiresPublicMethods<TestType>.Test ();
+			TypeRequiresPublicFieldsPassThrough<TestType>.Test ();
+			TypeRequiresNothingPassThrough<TestType>.Test ();
+		}
+
+		class TypeRequiresPublicFields<
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T>
+		{
+			[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (RequiresPublicMethods), new Type[] { typeof (Type) })]
+			public static void Test ()
+			{
+				RequiresPublicFields (typeof (T));
+				RequiresPublicMethods (typeof (T));
+				RequiresNothing (typeof (T));
+			}
+		}
+
+		class TypeRequiresPublicMethods<
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] T>
+		{
+			[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (RequiresPublicFields), new Type[] { typeof (Type) })]
+			public static void Test ()
+			{
+				RequiresPublicFields (typeof (T));
+				RequiresPublicMethods (typeof (T));
+				RequiresNothing (typeof (T));
+			}
+		}
+
+		class TypeRequiresNothing<T>
+		{
+			[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (RequiresPublicFields), new Type[] { typeof (Type) })]
+			[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (RequiresPublicMethods), new Type[] { typeof (Type) })]
+			public static void Test ()
+			{
+				RequiresPublicFields (typeof (T));
+				RequiresPublicMethods (typeof (T));
+				RequiresNothing (typeof (T));
+			}
+		}
+
+		class TypeRequiresPublicFieldsPassThrough<
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T>
+		{
+			[UnrecognizedReflectionAccessPattern (typeof (TypeRequiresPublicMethods<>), "T",
+				message: "The generic parameter 'T' from 'Mono.Linker.Tests.Cases.DataFlow.GenericParameterDataFlow/TypeRequiresPublicFieldsPassThrough`1' " +
+				"with dynamically accessed member kinds 'PublicFields' " +
+				"is passed into the generic parameter 'T' from 'Mono.Linker.Tests.Cases.DataFlow.GenericParameterDataFlow/TypeRequiresPublicMethods`1' " +
+				"which requires dynamically accessed member kinds 'PublicMethods'. To fix this add DynamicallyAccessedMembersAttribute to it and specify at least these member kinds 'PublicMethods'.")]
+			public static void Test ()
+			{
+				TypeRequiresPublicFields<T>.Test ();
+				TypeRequiresPublicMethods<T>.Test ();
+				TypeRequiresNothing<T>.Test ();
+			}
+		}
+
+		class TypeRequiresNothingPassThrough<T>
+		{
+			[UnrecognizedReflectionAccessPattern (typeof (TypeRequiresPublicFields<>), "T")]
+			[UnrecognizedReflectionAccessPattern (typeof (TypeRequiresPublicMethods<>), "T")]
+			public static void Test ()
+			{
+				TypeRequiresPublicFields<T>.Test ();
+				TypeRequiresPublicMethods<T>.Test ();
+				TypeRequiresNothing<T>.Test ();
+			}
+		}
+
+		static void TestMultipleGenericParametersOnType ()
+		{
+			MultipleTypesWithDifferentRequirements<TestType, TestType, TestType, TestType>.TestMultiple ();
+			MultipleTypesWithDifferentRequirements<TestType, TestType, TestType, TestType>.TestFields ();
+			MultipleTypesWithDifferentRequirements<TestType, TestType, TestType, TestType>.TestMethods ();
+			MultipleTypesWithDifferentRequirements<TestType, TestType, TestType, TestType>.TestBoth ();
+			MultipleTypesWithDifferentRequirements<TestType, TestType, TestType, TestType>.TestNothing ();
+		}
+
+		class MultipleTypesWithDifferentRequirements<
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] TFields,
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] TMethods,
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicMethods)] TBoth,
+			TNothing>
+		{
+			[RecognizedReflectionAccessPattern]
+			public static void TestMultiple ()
+			{
+				RequiresPublicFields (typeof (TFields));
+				RequiresPublicMethods (typeof (TMethods));
+				RequiresPublicFields (typeof (TBoth));
+				RequiresPublicMethods (typeof (TBoth));
+				RequiresNothing (typeof (TFields));
+				RequiresNothing (typeof (TMethods));
+				RequiresNothing (typeof (TBoth));
+				RequiresNothing (typeof (TNothing));
+			}
+
+			[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (RequiresPublicMethods), new Type[] { typeof (Type) })]
+			public static void TestFields ()
+			{
+				RequiresPublicFields (typeof (TFields));
+				RequiresPublicMethods (typeof (TFields));
+				RequiresNothing (typeof (TFields));
+			}
+
+			[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (RequiresPublicFields), new Type[] { typeof (Type) })]
+			public static void TestMethods ()
+			{
+				RequiresPublicFields (typeof (TMethods));
+				RequiresPublicMethods (typeof (TMethods));
+				RequiresNothing (typeof (TMethods));
+			}
+
+			[RecognizedReflectionAccessPattern]
+			public static void TestBoth ()
+			{
+				RequiresPublicFields (typeof (TBoth));
+				RequiresPublicMethods (typeof (TBoth));
+				RequiresNothing (typeof (TBoth));
+			}
+
+			[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (RequiresPublicFields), new Type[] { typeof (Type) })]
+			[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (RequiresPublicMethods), new Type[] { typeof (Type) })]
+			public static void TestNothing ()
+			{
+				RequiresPublicFields (typeof (TNothing));
+				RequiresPublicMethods (typeof (TNothing));
+				RequiresNothing (typeof (TNothing));
+			}
+		}
+
+		static void TestBaseTypeGenericRequirements ()
+		{
+			new DerivedTypeWithInstantiatedGenericOnBase ();
+			new DerivedTypeWithOpenGenericOnBase<TestType> ();
+			new DerivedTypeWithOpenGenericOnBaseWithRequirements<TestType> ();
+		}
+
+		class GenericBaseTypeWithRequirements<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T>
+		{
+			[RecognizedReflectionAccessPattern]
+			public GenericBaseTypeWithRequirements ()
+			{
+				RequiresPublicFields (typeof (T));
+			}
+		}
+
+		[RecognizedReflectionAccessPattern]
+		class DerivedTypeWithInstantiatedGenericOnBase : GenericBaseTypeWithRequirements<TestType>
+		{
+		}
+
+		[UnrecognizedReflectionAccessPattern (typeof (GenericBaseTypeWithRequirements<>), "T")]
+		class DerivedTypeWithOpenGenericOnBase<T> : GenericBaseTypeWithRequirements<T>
+		{
+		}
+
+		[RecognizedReflectionAccessPattern]
+		class DerivedTypeWithOpenGenericOnBaseWithRequirements<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T>
+			: GenericBaseTypeWithRequirements<T>
+		{
+		}
+
+		static void TestInterfaceTypeGenericRequirements ()
+		{
+			IGenericInterfaceTypeWithRequirements<TestType> instance = new InterfaceImplementationTypeWithInstantiatedGenericOnBase ();
+			new InterfaceImplementationTypeWithOpenGenericOnBase<TestType> ();
+			new InterfaceImplementationTypeWithOpenGenericOnBaseWithRequirements<TestType> ();
+		}
+
+		interface IGenericInterfaceTypeWithRequirements<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T>
+		{
+		}
+
+		[RecognizedReflectionAccessPattern]
+		class InterfaceImplementationTypeWithInstantiatedGenericOnBase : IGenericInterfaceTypeWithRequirements<TestType>
+		{
+		}
+
+		[UnrecognizedReflectionAccessPattern (typeof (IGenericInterfaceTypeWithRequirements<>), "T")]
+		class InterfaceImplementationTypeWithOpenGenericOnBase<T> : IGenericInterfaceTypeWithRequirements<T>
+		{
+		}
+
+		[RecognizedReflectionAccessPattern]
+		class InterfaceImplementationTypeWithOpenGenericOnBaseWithRequirements<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T>
+			: IGenericInterfaceTypeWithRequirements<T>
+		{
+		}
+
+		[RecognizedReflectionAccessPattern]
+		static void TestTypeGenericRequirementsOnMembers ()
+		{
+			// Basically just root everything we need to test
+			var instance = new TypeGenericRequirementsOnMembers<TestType> ();
+
+			_ = instance.PublicFieldsField;
+			_ = instance.PublicMethodsField;
+
+			_ = instance.PublicFieldsProperty;
+			instance.PublicFieldsProperty = null;
+			_ = instance.PublicMethodsProperty;
+			instance.PublicMethodsProperty = null;
+
+			instance.PublicFieldsMethodParameter (null);
+			instance.PublicMethodsMethodParameter (null);
+
+			instance.PublicFieldsMethodReturnValue ();
+			instance.PublicMethodsMethodReturnValue ();
+
+			instance.PublicFieldsMethodLocalVariable ();
+			instance.PublicMethodsMethodLocalVariable ();
+		}
+
+		class TypeGenericRequirementsOnMembers<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] TOuter>
+		{
+			[RecognizedReflectionAccessPattern]
+			public TypeRequiresPublicFields<TOuter> PublicFieldsField;
+
+			[UnrecognizedReflectionAccessPattern (typeof (TypeRequiresPublicMethods<>), "T")]
+			public TypeRequiresPublicMethods<TOuter> PublicMethodsField;
+
+			public TypeRequiresPublicFields<TOuter> PublicFieldsProperty {
+				[RecognizedReflectionAccessPattern]
+				get;
+				[RecognizedReflectionAccessPattern]
+				set;
+			}
+			public TypeRequiresPublicMethods<TOuter> PublicMethodsProperty {
+				[UnrecognizedReflectionAccessPattern (typeof (TypeRequiresPublicMethods<>), "T")]
+				get;
+				[UnrecognizedReflectionAccessPattern (typeof (TypeRequiresPublicMethods<>), "T")]
+				set;
+			}
+
+			[RecognizedReflectionAccessPattern]
+			public void PublicFieldsMethodParameter (TypeRequiresPublicFields<TOuter> param) { }
+			[UnrecognizedReflectionAccessPattern (typeof (TypeRequiresPublicMethods<>), "T")]
+			public void PublicMethodsMethodParameter (TypeRequiresPublicMethods<TOuter> param) { }
+
+			[RecognizedReflectionAccessPattern]
+			public TypeRequiresPublicFields<TOuter> PublicFieldsMethodReturnValue () { return null; }
+			[UnrecognizedReflectionAccessPattern (typeof (TypeRequiresPublicMethods<>), "T")] // Return value
+			[UnrecognizedReflectionAccessPattern (typeof (TypeRequiresPublicMethods<>), "T")] // Compiler generated local variable
+			public TypeRequiresPublicMethods<TOuter> PublicMethodsMethodReturnValue () { return null; }
+
+			[RecognizedReflectionAccessPattern]
+			public void PublicFieldsMethodLocalVariable ()
+			{
+				TypeRequiresPublicFields<TOuter> t = null;
+			}
+			[UnrecognizedReflectionAccessPattern (typeof (TypeRequiresPublicMethods<>), "T")]
+			public void PublicMethodsMethodLocalVariable ()
+			{
+				TypeRequiresPublicMethods<TOuter> t = null;
+			}
+		}
+
+		[RecognizedReflectionAccessPattern]
+		static void TestPartialInstantiationTypes ()
+		{
+			_ = new PartialyInstantiatedFields<TestType> ();
+			_ = new FullyInstantiatedOverPartiallyInstantiatedFields ();
+			_ = new PartialyInstantiatedMethods<TestType> ();
+			_ = new FullyInstantiatedOverPartiallyInstantiatedMethods ();
+		}
+
+		class BaseForPartialInstantiation<
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] TFields,
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] TMethods>
+		{
+		}
+
+		[RecognizedReflectionAccessPattern]
+		class PartialyInstantiatedFields<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] TOuter>
+			: BaseForPartialInstantiation<TOuter, TestType>
+		{
+		}
+
+		[RecognizedReflectionAccessPattern]
+		class FullyInstantiatedOverPartiallyInstantiatedFields
+			: PartialyInstantiatedFields<TestType>
+		{
+		}
+
+		[UnrecognizedReflectionAccessPattern (typeof (BaseForPartialInstantiation<,>), "TMethods")]
+		class PartialyInstantiatedMethods<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] TOuter>
+			: BaseForPartialInstantiation<TestType, TOuter>
+		{
+		}
+
+		[RecognizedReflectionAccessPattern]
+		class FullyInstantiatedOverPartiallyInstantiatedMethods
+			: PartialyInstantiatedMethods<TestType>
+		{
+		}
+
+		static void TestSingleGenericParameterOnMethod ()
+		{
+			MethodRequiresPublicFields<TestType> ();
+			MethodRequiresPublicMethods<TestType> ();
+			MethodRequiresNothing<TestType> ();
+			MethodRequiresPublicFieldsPassThrough<TestType> ();
+			MethodRequiresNothingPassThrough<TestType> ();
+		}
+
+		[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (RequiresPublicMethods), new Type[] { typeof (Type) })]
+		static void MethodRequiresPublicFields<
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T> ()
+		{
+			RequiresPublicFields (typeof (T));
+			RequiresPublicMethods (typeof (T));
+			RequiresNothing (typeof (T));
+		}
+
+		[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (RequiresPublicFields), new Type[] { typeof (Type) })]
+		static void MethodRequiresPublicMethods<
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] T> ()
+		{
+			RequiresPublicFields (typeof (T));
+			RequiresPublicMethods (typeof (T));
+			RequiresNothing (typeof (T));
+		}
+
+		[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (RequiresPublicFields), new Type[] { typeof (Type) })]
+		[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (RequiresPublicMethods), new Type[] { typeof (Type) })]
+		static void MethodRequiresNothing<T> ()
+		{
+			RequiresPublicFields (typeof (T));
+			RequiresPublicMethods (typeof (T));
+			RequiresNothing (typeof (T));
+		}
+
+		[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (MethodRequiresPublicMethods) + "<T>()::T")]
+		static void MethodRequiresPublicFieldsPassThrough<
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T> ()
+		{
+			MethodRequiresPublicFields<T> ();
+			MethodRequiresPublicMethods<T> ();
+			MethodRequiresNothing<T> ();
+		}
+
+		[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (MethodRequiresPublicFields) + "<T>()::T")]
+		[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (MethodRequiresPublicMethods) + "<T>()::T")]
+		static void MethodRequiresNothingPassThrough<T> ()
+		{
+			MethodRequiresPublicFields<T> ();
+			MethodRequiresPublicMethods<T> ();
+			MethodRequiresNothing<T> ();
+		}
+
+		static void TestMethodGenericParametersViaInheritance ()
+		{
+			TypeWithInstantiatedGenericMethodViaGenericParameter<TestType>.StaticRequiresPublicFields<TestType> ();
+			TypeWithInstantiatedGenericMethodViaGenericParameter<TestType>.StaticRequiresPublicFieldsNonGeneric ();
+
+			TypeWithInstantiatedGenericMethodViaGenericParameter<TestType>.StaticPartialInstantiation ();
+			TypeWithInstantiatedGenericMethodViaGenericParameter<TestType>.StaticPartialInstantiationUnrecognized ();
+
+			var instance = new TypeWithInstantiatedGenericMethodViaGenericParameter<TestType> ();
+
+			instance.InstanceRequiresPublicFields<TestType> ();
+			instance.InstanceRequiresPublicFieldsNonGeneric ();
+
+			instance.VirtualRequiresPublicFields<TestType> ();
+			instance.VirtualRequiresPublicMethods<TestType> ();
+
+			instance.CallInterface ();
+
+			IInterfaceWithGenericMethod interfaceInstance = (IInterfaceWithGenericMethod) instance;
+			interfaceInstance.InterfaceRequiresPublicFields<TestType> ();
+			interfaceInstance.InterfaceRequiresPublicMethods<TestType> ();
+		}
+
+		class BaseTypeWithGenericMethod
+		{
+			[RecognizedReflectionAccessPattern]
+			public static void StaticRequiresPublicFields<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T> ()
+				=> RequiresPublicFields (typeof (T));
+			[RecognizedReflectionAccessPattern]
+			public void InstanceRequiresPublicFields<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T> ()
+				=> RequiresPublicFields (typeof (T));
+			[RecognizedReflectionAccessPattern]
+			public virtual void VirtualRequiresPublicFields<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T> ()
+				=> RequiresPublicFields (typeof (T));
+
+			[RecognizedReflectionAccessPattern]
+			public static void StaticRequiresPublicMethods<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] T> ()
+				=> RequiresPublicMethods (typeof (T));
+			[RecognizedReflectionAccessPattern]
+			public void InstanceRequiresPublicMethods<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]T> ()
+				=> RequiresPublicMethods (typeof (T));
+			[RecognizedReflectionAccessPattern]
+			public virtual void VirtualRequiresPublicMethods<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]T> ()
+				=> RequiresPublicMethods (typeof (T));
+
+			[RecognizedReflectionAccessPattern]
+			public static void StaticRequiresMultipleGenericParams<
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] TFields,
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] TMethods> ()
+			{
+				RequiresPublicFields (typeof (TFields));
+				RequiresPublicMethods (typeof (TMethods));
+			}
+		}
+
+		interface IInterfaceWithGenericMethod
+		{
+			void InterfaceRequiresPublicFields<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T> ();
+			void InterfaceRequiresPublicMethods<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] T> ();
+		}
+
+		class TypeWithInstantiatedGenericMethodViaGenericParameter<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] TOuter>
+			: BaseTypeWithGenericMethod, IInterfaceWithGenericMethod
+		{
+			[UnrecognizedReflectionAccessPattern (typeof (BaseTypeWithGenericMethod), nameof (BaseTypeWithGenericMethod.StaticRequiresPublicMethods) + "<T>()::T",
+				message: "The generic parameter 'TInner' from 'System.Void Mono.Linker.Tests.Cases.DataFlow.GenericParameterDataFlow/TypeWithInstantiatedGenericMethodViaGenericParameter`1::StaticRequiresPublicFields()' " +
+				"with dynamically accessed member kinds 'PublicFields' " +
+				"is passed into the generic parameter 'T' from 'System.Void Mono.Linker.Tests.Cases.DataFlow.GenericParameterDataFlow/BaseTypeWithGenericMethod::StaticRequiresPublicMethods()' which requires dynamically accessed member kinds 'PublicMethods'. " +
+				"To fix this add DynamicallyAccessedMembersAttribute to it and specify at least these member kinds 'PublicMethods'.")]
+			public static void StaticRequiresPublicFields<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] TInner> ()
+			{
+				StaticRequiresPublicFields<TInner> ();
+				StaticRequiresPublicMethods<TInner> ();
+			}
+
+			[UnrecognizedReflectionAccessPattern (typeof (BaseTypeWithGenericMethod), nameof (BaseTypeWithGenericMethod.StaticRequiresPublicMethods) + "<T>()::T",
+				message: "The generic parameter 'TOuter' from 'Mono.Linker.Tests.Cases.DataFlow.GenericParameterDataFlow/TypeWithInstantiatedGenericMethodViaGenericParameter`1' " +
+				"with dynamically accessed member kinds 'PublicFields' " +
+				"is passed into the generic parameter 'T' from 'System.Void Mono.Linker.Tests.Cases.DataFlow.GenericParameterDataFlow/BaseTypeWithGenericMethod::StaticRequiresPublicMethods()' which requires dynamically accessed member kinds 'PublicMethods'. " +
+				"To fix this add DynamicallyAccessedMembersAttribute to it and specify at least these member kinds 'PublicMethods'.")]
+			public static void StaticRequiresPublicFieldsNonGeneric ()
+			{
+				StaticRequiresPublicFields<TOuter> ();
+				StaticRequiresPublicMethods<TOuter> ();
+			}
+
+			[RecognizedReflectionAccessPattern]
+			public static void StaticPartialInstantiation ()
+			{
+				StaticRequiresMultipleGenericParams<TOuter, TestType> ();
+			}
+
+			[UnrecognizedReflectionAccessPattern (typeof (BaseTypeWithGenericMethod), nameof (BaseTypeWithGenericMethod.StaticRequiresMultipleGenericParams) + "<TFields,TMethods>()::TMethods",
+				message: "The generic parameter 'TOuter' from 'Mono.Linker.Tests.Cases.DataFlow.GenericParameterDataFlow/TypeWithInstantiatedGenericMethodViaGenericParameter`1' " +
+				"with dynamically accessed member kinds 'PublicFields' " +
+				"is passed into the generic parameter 'TMethods' from 'System.Void Mono.Linker.Tests.Cases.DataFlow.GenericParameterDataFlow/BaseTypeWithGenericMethod::StaticRequiresMultipleGenericParams()' " +
+				"which requires dynamically accessed member kinds 'PublicMethods'. To fix this add DynamicallyAccessedMembersAttribute to it and specify at least these member kinds 'PublicMethods'.")]
+			public static void StaticPartialInstantiationUnrecognized ()
+			{
+				StaticRequiresMultipleGenericParams<TestType, TOuter> ();
+			}
+
+			[UnrecognizedReflectionAccessPattern (typeof (BaseTypeWithGenericMethod), nameof (BaseTypeWithGenericMethod.InstanceRequiresPublicMethods) + "<T>()::T",
+				message: "The generic parameter 'TInner' from 'System.Void Mono.Linker.Tests.Cases.DataFlow.GenericParameterDataFlow/TypeWithInstantiatedGenericMethodViaGenericParameter`1::InstanceRequiresPublicFields()' " +
+				"with dynamically accessed member kinds 'PublicFields' " +
+				"is passed into the generic parameter 'T' from 'System.Void Mono.Linker.Tests.Cases.DataFlow.GenericParameterDataFlow/BaseTypeWithGenericMethod::InstanceRequiresPublicMethods()' which requires dynamically accessed member kinds 'PublicMethods'. " +
+				"To fix this add DynamicallyAccessedMembersAttribute to it and specify at least these member kinds 'PublicMethods'.")]
+			public void InstanceRequiresPublicFields<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] TInner> ()
+			{
+				InstanceRequiresPublicFields<TInner> ();
+				InstanceRequiresPublicMethods<TInner> ();
+			}
+
+			[UnrecognizedReflectionAccessPattern (typeof (BaseTypeWithGenericMethod), nameof (BaseTypeWithGenericMethod.InstanceRequiresPublicMethods) + "<T>()::T",
+				message: "The generic parameter 'TOuter' from 'Mono.Linker.Tests.Cases.DataFlow.GenericParameterDataFlow/TypeWithInstantiatedGenericMethodViaGenericParameter`1' " +
+				"with dynamically accessed member kinds 'PublicFields' " +
+				"is passed into the generic parameter 'T' from 'System.Void Mono.Linker.Tests.Cases.DataFlow.GenericParameterDataFlow/BaseTypeWithGenericMethod::InstanceRequiresPublicMethods()' which requires dynamically accessed member kinds 'PublicMethods'. " +
+				"To fix this add DynamicallyAccessedMembersAttribute to it and specify at least these member kinds 'PublicMethods'.")]
+			public void InstanceRequiresPublicFieldsNonGeneric ()
+			{
+				InstanceRequiresPublicFields<TOuter> ();
+				InstanceRequiresPublicMethods<TOuter> ();
+			}
+
+			[RecognizedReflectionAccessPattern]
+			public override void VirtualRequiresPublicFields<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T> ()
+			{
+				RequiresPublicFields (typeof (T));
+			}
+
+			[RecognizedReflectionAccessPattern]
+			public override void VirtualRequiresPublicMethods<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] T> ()
+			{
+				RequiresPublicMethods (typeof (T));
+			}
+
+			[RecognizedReflectionAccessPattern]
+			public void InterfaceRequiresPublicFields<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T> ()
+			{
+				RequiresPublicFields (typeof (T));
+			}
+
+			[RecognizedReflectionAccessPattern]
+			public void InterfaceRequiresPublicMethods<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] T> ()
+			{
+				RequiresPublicMethods (typeof (T));
+			}
+
+			[UnrecognizedReflectionAccessPattern (typeof (IInterfaceWithGenericMethod), nameof (IInterfaceWithGenericMethod.InterfaceRequiresPublicMethods) + "<T>()::T",
+				message: "The generic parameter 'TOuter' from 'Mono.Linker.Tests.Cases.DataFlow.GenericParameterDataFlow/TypeWithInstantiatedGenericMethodViaGenericParameter`1' " +
+				"with dynamically accessed member kinds 'PublicFields' " +
+				"is passed into the generic parameter 'T' from 'System.Void Mono.Linker.Tests.Cases.DataFlow.GenericParameterDataFlow/IInterfaceWithGenericMethod::InterfaceRequiresPublicMethods()' " +
+				"which requires dynamically accessed member kinds 'PublicMethods'. To fix this add DynamicallyAccessedMembersAttribute to it and specify at least these member kinds 'PublicMethods'.")]
+			public void CallInterface ()
+			{
+				IInterfaceWithGenericMethod interfaceInstance = (IInterfaceWithGenericMethod) this;
+				interfaceInstance.InterfaceRequiresPublicFields<TOuter> ();
+				interfaceInstance.InterfaceRequiresPublicMethods<TOuter> ();
+			}
+		}
+
+
+		static void TestMultipleGenericParametersOnMethod ()
+		{
+			MethodMultipleWithDifferentRequirements_TestMultiple<TestType, TestType, TestType, TestType> ();
+			MethodMultipleWithDifferentRequirements_TestFields<TestType, TestType, TestType, TestType> ();
+			MethodMultipleWithDifferentRequirements_TestMethods<TestType, TestType, TestType, TestType> ();
+			MethodMultipleWithDifferentRequirements_TestBoth<TestType, TestType, TestType, TestType> ();
+			MethodMultipleWithDifferentRequirements_TestNothing<TestType, TestType, TestType, TestType> ();
+		}
+
+		[RecognizedReflectionAccessPattern]
+		static void MethodMultipleWithDifferentRequirements_TestMultiple<
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] TFields,
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] TMethods,
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicMethods)] TBoth,
+			TNothing> ()
+		{
+			RequiresPublicFields (typeof (TFields));
+			RequiresPublicMethods (typeof (TMethods));
+			RequiresPublicFields (typeof (TBoth));
+			RequiresPublicMethods (typeof (TBoth));
+			RequiresNothing (typeof (TFields));
+			RequiresNothing (typeof (TMethods));
+			RequiresNothing (typeof (TBoth));
+			RequiresNothing (typeof (TNothing));
+		}
+
+		[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (RequiresPublicMethods), new Type[] { typeof (Type) })]
+		static void MethodMultipleWithDifferentRequirements_TestFields<
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] TFields,
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] TMethods,
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicMethods)] TBoth,
+			TNothing> ()
+		{
+			RequiresPublicFields (typeof (TFields));
+			RequiresPublicMethods (typeof (TFields));
+			RequiresNothing (typeof (TFields));
+		}
+
+		[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (RequiresPublicFields), new Type[] { typeof (Type) })]
+		static void MethodMultipleWithDifferentRequirements_TestMethods<
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] TFields,
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] TMethods,
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicMethods)] TBoth,
+			TNothing> ()
+		{
+			RequiresPublicFields (typeof (TMethods));
+			RequiresPublicMethods (typeof (TMethods));
+			RequiresNothing (typeof (TMethods));
+		}
+
+		static void MethodMultipleWithDifferentRequirements_TestBoth<
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] TFields,
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] TMethods,
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicMethods)] TBoth,
+			TNothing> ()
+		{
+			RequiresPublicFields (typeof (TBoth));
+			RequiresPublicMethods (typeof (TBoth));
+			RequiresNothing (typeof (TBoth));
+		}
+
+		[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (RequiresPublicFields), new Type[] { typeof (Type) })]
+		[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (RequiresPublicMethods), new Type[] { typeof (Type) })]
+		static void MethodMultipleWithDifferentRequirements_TestNothing<
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] TFields,
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] TMethods,
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicMethods)] TBoth,
+			TNothing> ()
+		{
+			RequiresPublicFields (typeof (TNothing));
+			RequiresPublicMethods (typeof (TNothing));
+			RequiresNothing (typeof (TNothing));
+		}
+
+
+		static void RequiresPublicFields (
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] Type type)
+		{
+		}
+
+		static void RequiresPublicMethods (
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] Type type)
+		{
+		}
+
+		static void RequiresNothing (Type type)
+		{
+		}
+
+		public class TestType
+		{
+		}
+	}
+}

--- a/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -733,9 +733,6 @@ namespace Mono.Linker.Tests.TestCasesRunner
 							else
 								actualAccessOperation = GetFullMemberNameFromDefinition (pattern.AccessedItem);
 
-							if (actualAccessOperation.Contains ("CreateInstance<"))
-								Debug.WriteLine ("");
-
 							if (actualAccessOperation != expectedReflectionMember)
 								return false;
 

--- a/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -661,11 +662,18 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			}
 		}
 
+		static void RemoveFromList<T> (List<T> list, IEnumerable<T> itemsToRemove)
+		{
+			foreach (var item in itemsToRemove.ToList ()) {
+				list.Remove (item);
+			}
+		}
+
 		void VerifyRecordedReflectionPatterns (AssemblyDefinition original, TestReflectionPatternRecorder reflectionPatternRecorder)
 		{
-			foreach (var expectedSourceMethodDefinition in original.MainModule.AllDefinedTypes ().SelectMany (t => t.AllMethods ()).Distinct ()) {
+			foreach (var expectedSourceMemberDefinition in original.MainModule.AllDefinedTypes ().SelectMany (t => t.AllMembers ().Append (t)).Distinct ()) {
 				bool foundAttributesToVerify = false;
-				foreach (var attr in expectedSourceMethodDefinition.CustomAttributes) {
+				foreach (var attr in expectedSourceMemberDefinition.CustomAttributes) {
 					if (attr.AttributeType.Resolve ().Name == nameof (RecognizedReflectionAccessPatternAttribute)) {
 						foundAttributesToVerify = true;
 
@@ -674,19 +682,19 @@ namespace Mono.Linker.Tests.TestCasesRunner
 						if (attr.ConstructorArguments.Count == 0)
 							continue;
 
-						string expectedSourceMethod = GetFullMemberNameFromDefinition (expectedSourceMethodDefinition);
-						string expectedReflectionMethod = GetFullMemberNameFromReflectionAccessPatternAttribute (attr, constructorArgumentsOffset: 0);
+						string expectedSourceMember = GetFullMemberNameFromDefinition (expectedSourceMemberDefinition);
+						string expectedReflectionMember = GetFullMemberNameFromReflectionAccessPatternAttribute (attr, constructorArgumentsOffset: 0);
 						string expectedAccessedItem = GetFullMemberNameFromReflectionAccessPatternAttribute (attr, constructorArgumentsOffset: 3);
 
 						if (!reflectionPatternRecorder.RecognizedPatterns.Any (pattern => {
-							if (GetFullMemberNameFromDefinition (pattern.Source) != expectedSourceMethod)
+							if (GetFullMemberNameFromDefinition (pattern.Source) != expectedSourceMember)
 								return false;
 
 							string actualAccessOperation = null;
 							if (pattern.SourceInstruction?.Operand is IMetadataTokenProvider sourceOperand)
 								actualAccessOperation = GetFullMemberNameFromDefinition (sourceOperand);
 
-							if (actualAccessOperation != expectedReflectionMethod)
+							if (actualAccessOperation != expectedReflectionMember)
 								return false;
 
 							if (GetFullMemberNameFromDefinition (pattern.AccessedItem) != expectedAccessedItem)
@@ -695,27 +703,28 @@ namespace Mono.Linker.Tests.TestCasesRunner
 							reflectionPatternRecorder.RecognizedPatterns.Remove (pattern);
 							return true;
 						})) {
-							string sourceMethodCandidates = string.Join (Environment.NewLine, reflectionPatternRecorder.RecognizedPatterns
-								.Where (p => GetFullMemberNameFromDefinition (p.Source)?.ToLowerInvariant ()?.Contains (expectedSourceMethod.ToLowerInvariant ()) == true)
+							string sourceMemberCandidates = string.Join (Environment.NewLine, reflectionPatternRecorder.RecognizedPatterns
+								.Where (p => GetFullMemberNameFromDefinition (p.Source)?.ToLowerInvariant ()?.Contains (expectedReflectionMember.ToLowerInvariant ()) == true)
 								.Select (p => "\t" + RecognizedReflectionAccessPatternToString (p)));
-							string reflectionMethodCandidates = string.Join (Environment.NewLine, reflectionPatternRecorder.RecognizedPatterns
-								.Where (p => GetFullMemberNameFromDefinition (p.SourceInstruction?.Operand as IMetadataTokenProvider)?.ToLowerInvariant ()?.Contains (expectedReflectionMethod.ToLowerInvariant ()) == true)
+							string reflectionMemberCandidates = string.Join (Environment.NewLine, reflectionPatternRecorder.RecognizedPatterns
+								.Where (p => GetFullMemberNameFromDefinition (p.SourceInstruction?.Operand as IMetadataTokenProvider)?.ToLowerInvariant ()?.Contains (expectedReflectionMember.ToLowerInvariant ()) == true)
 								.Select (p => "\t" + RecognizedReflectionAccessPatternToString (p)));
 
 							Assert.Fail (
-								$"Expected to find recognized reflection access pattern '{expectedSourceMethod}: Call to {expectedReflectionMethod} accessed {expectedAccessedItem}'{Environment.NewLine}" +
-								$"Potential patterns matching the source method: {Environment.NewLine}{sourceMethodCandidates}{Environment.NewLine}" +
-								$"Potential patterns matching the reflection method: {Environment.NewLine}{reflectionMethodCandidates}{Environment.NewLine}" +
-								$"If there's no matches, try to specify just a part of the source method or reflection method name and rerun the test to get potential matches.");
+								$"Expected to find recognized reflection access pattern '{expectedSourceMember}: Usage of {expectedReflectionMember} accessed {expectedAccessedItem}'{Environment.NewLine}" +
+								$"Potential patterns matching the source member: {Environment.NewLine}{sourceMemberCandidates}{Environment.NewLine}" +
+								$"Potential patterns matching the reflection member: {Environment.NewLine}{reflectionMemberCandidates}{Environment.NewLine}" +
+								$"If there's no matches, try to specify just a part of the source member or reflection member name and rerun the test to get potential matches.");
 						}
-					} else if (attr.AttributeType.Resolve ().Name == nameof (UnrecognizedReflectionAccessPatternAttribute)) {
+					} else if (attr.AttributeType.Resolve ().Name == nameof (UnrecognizedReflectionAccessPatternAttribute) &&
+						attr.ConstructorArguments[0].Type.MetadataType != MetadataType.String) {
 						foundAttributesToVerify = true;
-						string expectedSourceMethod = GetFullMemberNameFromDefinition (expectedSourceMethodDefinition);
-						string expectedReflectionMethod = GetFullMemberNameFromReflectionAccessPatternAttribute (attr, constructorArgumentsOffset: 0);
+						string expectedSourceMember = GetFullMemberNameFromDefinition (expectedSourceMemberDefinition);
+						string expectedReflectionMember = GetFullMemberNameFromReflectionAccessPatternAttribute (attr, constructorArgumentsOffset: 0);
 						string expectedMessage = (string) attr.ConstructorArguments[3].Value;
 
 						if (!reflectionPatternRecorder.UnrecognizedPatterns.Any (pattern => {
-							if (GetFullMemberNameFromDefinition (pattern.Source) != expectedSourceMethod)
+							if (GetFullMemberNameFromDefinition (pattern.Source) != expectedSourceMember)
 								return false;
 
 							string actualAccessOperation = null;
@@ -724,7 +733,10 @@ namespace Mono.Linker.Tests.TestCasesRunner
 							else
 								actualAccessOperation = GetFullMemberNameFromDefinition (pattern.AccessedItem);
 
-							if (actualAccessOperation != expectedReflectionMethod)
+							if (actualAccessOperation.Contains ("CreateInstance<"))
+								Debug.WriteLine ("");
+
+							if (actualAccessOperation != expectedReflectionMember)
 								return false;
 
 							if (expectedMessage != null && pattern.Message != expectedMessage)
@@ -733,38 +745,38 @@ namespace Mono.Linker.Tests.TestCasesRunner
 							reflectionPatternRecorder.UnrecognizedPatterns.Remove (pattern);
 							return true;
 						})) {
-							string sourceMethodCandidates = string.Join (Environment.NewLine, reflectionPatternRecorder.UnrecognizedPatterns
-								.Where (p => GetFullMemberNameFromDefinition (p.Source)?.ToLowerInvariant ()?.Contains (expectedSourceMethod.ToLowerInvariant ()) == true)
+							string sourceMemberCandidates = string.Join (Environment.NewLine, reflectionPatternRecorder.UnrecognizedPatterns
+								.Where (p => GetFullMemberNameFromDefinition (p.Source)?.ToLowerInvariant ()?.Contains (expectedSourceMember.ToLowerInvariant ()) == true)
 								.Select (p => "\t" + UnrecognizedReflectionAccessPatternToString (p)));
-							string reflectionMethodCandidates = string.Join (Environment.NewLine, reflectionPatternRecorder.UnrecognizedPatterns
-								.Where (p => GetFullMemberNameFromDefinition (p.SourceInstruction != null ? p.SourceInstruction.Operand as IMetadataTokenProvider : p.AccessedItem)?.ToLowerInvariant ()?.Contains (expectedReflectionMethod.ToLowerInvariant ()) == true)
+							string reflectionMemberCandidates = string.Join (Environment.NewLine, reflectionPatternRecorder.UnrecognizedPatterns
+								.Where (p => GetFullMemberNameFromDefinition (p.SourceInstruction != null ? p.SourceInstruction.Operand as IMetadataTokenProvider : p.AccessedItem)?.ToLowerInvariant ()?.Contains (expectedReflectionMember.ToLowerInvariant ()) == true)
 								.Select (p => "\t" + UnrecognizedReflectionAccessPatternToString (p)));
 
 							Assert.Fail (
-								$"Expected to find unrecognized reflection access pattern '{expectedSourceMethod}: Call to {expectedReflectionMethod} unrecognized '{expectedMessage ?? string.Empty}''{Environment.NewLine}" +
-								$"Potential patterns matching the source method: {Environment.NewLine}{sourceMethodCandidates}{Environment.NewLine}" +
-								$"Potential patterns matching the reflection method: {Environment.NewLine}{reflectionMethodCandidates}{Environment.NewLine}" +
-								$"If there's no matches, try to specify just a part of the source method or reflection method name and rerun the test to get potential matches.");
+								$"Expected to find unrecognized reflection access pattern '{expectedSourceMember}: Usage of {expectedReflectionMember} unrecognized '{expectedMessage ?? string.Empty}''{Environment.NewLine}" +
+								$"Potential patterns matching the source member: {Environment.NewLine}{sourceMemberCandidates}{Environment.NewLine}" +
+								$"Potential patterns matching the reflection member: {Environment.NewLine}{reflectionMemberCandidates}{Environment.NewLine}" +
+								$"If there's no matches, try to specify just a part of the source member or reflection member name and rerun the test to get potential matches.");
 						}
 					}
 				}
 
 				if (foundAttributesToVerify) {
-					// Validate that there are no other reported unrecognized patterns on the method
-					string expectedSourceMethod = GetFullMemberNameFromDefinition (expectedSourceMethodDefinition);
-					var unrecognizedPatternsForSourceMethod = reflectionPatternRecorder.UnrecognizedPatterns.Where (pattern => {
-						if (GetFullMemberNameFromDefinition (pattern.Source) != expectedSourceMethod)
+					// Validate that there are no other reported unrecognized patterns on the member
+					string expectedSourceMember = GetFullMemberNameFromDefinition (expectedSourceMemberDefinition);
+					var unrecognizedPatternsForSourceMember = reflectionPatternRecorder.UnrecognizedPatterns.Where (pattern => {
+						if (GetFullMemberNameFromDefinition (pattern.Source) != expectedSourceMember)
 							return false;
 
 						return true;
 					});
 
-					if (unrecognizedPatternsForSourceMethod.Any ()) {
-						string unrecognizedPatterns = string.Join (Environment.NewLine, unrecognizedPatternsForSourceMethod
+					if (unrecognizedPatternsForSourceMember.Any ()) {
+						string unrecognizedPatterns = string.Join (Environment.NewLine, unrecognizedPatternsForSourceMember
 							.Select (p => "\t" + UnrecognizedReflectionAccessPatternToString (p)));
 
 						Assert.Fail (
-							$"Method {expectedSourceMethod} has either {nameof (RecognizedReflectionAccessPatternAttribute)} or {nameof (UnrecognizedReflectionAccessPatternAttribute)} attributes.{Environment.NewLine}" +
+							$"Member {expectedSourceMember} has either {nameof (RecognizedReflectionAccessPatternAttribute)} or {nameof (UnrecognizedReflectionAccessPatternAttribute)} attributes.{Environment.NewLine}" +
 							$"Some reported unrecognized patterns are not expected by the test (there's no matching attribute for them):{Environment.NewLine}" +
 							$"{unrecognizedPatterns}");
 					}
@@ -777,9 +789,9 @@ namespace Mono.Linker.Tests.TestCasesRunner
 						// By now all verified recorded patterns were removed from the test recorder lists, so validate
 						// that there are no remaining patterns for this type.
 						var recognizedPatternsForType = reflectionPatternRecorder.RecognizedPatterns
-							.Where (pattern => (pattern.Source as IMemberDefinition)?.DeclaringType.FullName == typeToVerify.FullName);
+							.Where (pattern => pattern.Source.DeclaringType.FullName == typeToVerify.FullName);
 						var unrecognizedPatternsForType = reflectionPatternRecorder.UnrecognizedPatterns
-							.Where (pattern => (pattern.Source as IMemberDefinition)?.DeclaringType.FullName == typeToVerify.FullName);
+							.Where (pattern => pattern.Source.DeclaringType.FullName == typeToVerify.FullName);
 
 						if (recognizedPatternsForType.Any () || unrecognizedPatternsForType.Any ()) {
 							string recognizedPatterns = string.Join (Environment.NewLine, recognizedPatternsForType
@@ -828,13 +840,28 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			// Method which basically returns the same as member.ToString() but without the return type
 			// of a method (if it's a method).
 			// We need this as the GetFullMemberNameFromReflectionAccessPatternAttribute can't guess the return type
-			// as it would have to actually resolve the referenced method, which is very expensive and no necessary
+			// as it would have to actually resolve the referenced method, which is very expensive and unnecessary
 			// for the tests to work (the return types are redundant piece of information anyway).
 
 			if (member == null)
 				return null;
+			else if (member is TypeSpecification typeSpecification)
+				return typeSpecification.FullName;
+			else if (member is MethodSpecification methodSpecification)
+				member = methodSpecification.ElementMethod.Resolve ();
+			else if (member is GenericParameter genericParameter) {
+				var declaringType = genericParameter.DeclaringType?.Resolve ();
+				if (declaringType != null) {
+					return declaringType.FullName + "::" + genericParameter.FullName;
+				}
 
-			if (member is MemberReference memberReference)
+				var declaringMethod = genericParameter.DeclaringMethod?.Resolve ();
+				if (declaringMethod != null) {
+					return GetFullMemberNameFromDefinition (declaringMethod) + "::" + genericParameter.FullName;
+				}
+
+				return genericParameter.FullName;
+			} else if (member is MemberReference memberReference)
 				member = memberReference.Resolve ();
 
 			if (member is IMemberDefinition memberDefinition) {

--- a/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadaProvider.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadaProvider.cs
@@ -126,9 +126,9 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 			if (testCaseTypeDefinition.CustomAttributes.Any (attr =>
 					attr.AttributeType.Name == nameof (VerifyAllReflectionAccessPatternsAreValidatedAttribute))
-				|| testCaseTypeDefinition.AllMethods ().Any (method => method.CustomAttributes.Any (attr =>
-					attr.AttributeType.Name == nameof (RecognizedReflectionAccessPatternAttribute) ||
-					attr.AttributeType.Name == nameof (UnrecognizedReflectionAccessPatternAttribute))))
+				|| testCaseTypeDefinition.AllMembers ().Concat (testCaseTypeDefinition.AllDefinedTypes ()).Any (m => m.CustomAttributes.Any (attr =>
+					  attr.AttributeType.Name == nameof (RecognizedReflectionAccessPatternAttribute) ||
+					  attr.AttributeType.Name == nameof (UnrecognizedReflectionAccessPatternAttribute))))
 				return true;
 
 			return false;


### PR DESCRIPTION
The checks are done when linker calls `MarkType(TypeReference)` or `MarkMethod(MethodReference)`. The check itself is straightforward as it uses existing functionality.

Added annotations in `FlowAnnotations` for generic parameters.

Added one parameter to `MarkType` to better track the location where the type reference comes from. This enables much more precise reporting of warnings.

On test side this makes the recognized/unrecognized attributes applicable to many more things as warnings can come from types, fields and so on.

Fixes #1086 