### PR TITLE
Recognize Type.AssemblyQualifiedName as intrinsic

### DIFF
--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -205,6 +205,7 @@ namespace Mono.Linker.Dataflow
 			Type_GetProperty,
 			Type_GetEvent,
 			Type_GetNestedType,
+			Type_get_AssemblyQualifiedName,
 			Expression_Call,
 			Expression_Field,
 			Expression_Property,
@@ -341,6 +342,12 @@ namespace Mono.Linker.Dataflow
 					&& calledMethod.HasParameterOfType (0, "System", "String")
 					&& calledMethod.HasThis
 					=> IntrinsicId.Type_GetNestedType,
+
+				// System.Type.AssemblyQualifiedName
+				"get_AssemblyQualifiedName" when calledMethod.IsDeclaredOnType ("System", "Type")
+					&& !calledMethod.HasParameters
+					&& calledMethod.HasThis
+					=> IntrinsicId.Type_get_AssemblyQualifiedName,
 
 				// System.Type.GetProperty (string)
 				// System.Type.GetProperty (string, BindingFlags)
@@ -860,6 +867,27 @@ namespace Mono.Linker.Dataflow
 								// Otherwise fall back to the bitfield requirements
 								RequireDynamicallyAccessedMembers (ref reflectionContext, requiredMemberKinds, value, calledMethodDefinition);
 							}
+						}
+					}
+					break;
+
+				//
+				// AssemblyQualifiedName
+				//
+				case IntrinsicId.Type_get_AssemblyQualifiedName: {
+
+						ValueNode transformedResult = null;
+						foreach (var value in methodParams[0].UniqueValues ()) {
+							if (value is LeafValueWithDynamicallyAccessedMemberNode dynamicallyAccessedThing) {
+								var annotatedString = new AnnotatedStringValue (dynamicallyAccessedThing.DynamicallyAccessedMemberKinds);
+								transformedResult = MergePointValue.MergeValues (transformedResult, annotatedString);
+							} else {
+								transformedResult = null;
+							}
+						}
+
+						if (transformedResult != null) {
+							methodReturnValue = transformedResult;
 						}
 					}
 					break;

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -883,6 +883,7 @@ namespace Mono.Linker.Dataflow
 								transformedResult = MergePointValue.MergeValues (transformedResult, annotatedString);
 							} else {
 								transformedResult = null;
+								break;
 							}
 						}
 

--- a/src/linker/Linker.Dataflow/ValueNode.cs
+++ b/src/linker/Linker.Dataflow/ValueNode.cs
@@ -24,6 +24,7 @@ namespace Mono.Linker.Dataflow
 		RuntimeTypeHandle,              // known value - TypeRepresented
 		KnownString,                    // known value - Contents
 		ConstInt,                       // known value - Int32
+		AnnotatedString,                // string with known annotation
 
 		MethodParameter,                // symbolic placeholder
 		MethodReturn,                   // symbolic placeholder
@@ -366,6 +367,7 @@ namespace Mono.Linker.Dataflow
 			case ValueNodeKind.SystemType:
 			case ValueNodeKind.RuntimeTypeHandle:
 			case ValueNodeKind.KnownString:
+			case ValueNodeKind.AnnotatedString:
 			case ValueNodeKind.ConstInt:
 			case ValueNodeKind.MethodParameter:
 			case ValueNodeKind.LoadField:
@@ -679,6 +681,39 @@ namespace Mono.Linker.Dataflow
 		protected override string NodeToString ()
 		{
 			return ValueNodeDump.ValueNodeToString (this, ParameterIndex, DynamicallyAccessedMemberKinds);
+		}
+	}
+
+	/// <summary>
+	/// String with a known annotation.
+	/// </summary>
+	class AnnotatedStringValue : LeafValueWithDynamicallyAccessedMemberNode
+	{
+		public AnnotatedStringValue (DynamicallyAccessedMemberTypes dynamicallyAccessedMemberKinds)
+		{
+			Kind = ValueNodeKind.AnnotatedString;
+			DynamicallyAccessedMemberKinds = dynamicallyAccessedMemberKinds;
+		}
+
+		public override bool Equals (ValueNode other)
+		{
+			if (other == null)
+				return false;
+			if (this.Kind != other.Kind)
+				return false;
+
+			var otherValue = (AnnotatedStringValue) other;
+			return this.DynamicallyAccessedMemberKinds == otherValue.DynamicallyAccessedMemberKinds;
+		}
+
+		public override int GetHashCode ()
+		{
+			return HashCode.Combine (Kind, DynamicallyAccessedMemberKinds);
+		}
+
+		protected override string NodeToString ()
+		{
+			return ValueNodeDump.ValueNodeToString (this, DynamicallyAccessedMemberKinds);
 		}
 	}
 

--- a/test/Mono.Linker.Tests.Cases/DataFlow/AssemblyQualifiedNameDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/AssemblyQualifiedNameDataflow.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.DataFlow
+{
+	// Note: this test's goal is to validate that the product correctly reports unrecognized patterns
+	//   - so the main validation is done by the UnrecognizedReflectionAccessPattern attributes.
+	[SkipKeptItemsValidation]
+	class AssemblyQualifiedNameDataflow
+	{
+		static void Main ()
+		{
+			TestDefaultConstructor ();
+			TestPublicConstructors ();
+			TestConstructors ();
+		}
+
+		[UnrecognizedReflectionAccessPattern (typeof (AssemblyQualifiedNameDataflow), nameof (RequirePublicConstructors), new Type[] { typeof (string) })]
+		[UnrecognizedReflectionAccessPattern (typeof (AssemblyQualifiedNameDataflow), nameof (RequireNonPublicConstructors), new Type[] { typeof (string) })]
+		static void TestDefaultConstructor ()
+		{
+			string type = GetTypeWithDefaultConstructor ().AssemblyQualifiedName;
+			RequireDefaultConstructor (type);
+			RequirePublicConstructors (type);
+			RequireNonPublicConstructors (type);
+			RequireNothing (type);
+		}
+
+		[UnrecognizedReflectionAccessPattern (typeof (AssemblyQualifiedNameDataflow), nameof (RequireNonPublicConstructors), new Type[] { typeof (string) })]
+		static void TestPublicConstructors ()
+		{
+			string type = GetTypeWithPublicConstructors ().AssemblyQualifiedName;
+			RequireDefaultConstructor (type);
+			RequirePublicConstructors (type);
+			RequireNonPublicConstructors (type);
+			RequireNothing (type);
+		}
+
+		[UnrecognizedReflectionAccessPattern (typeof (AssemblyQualifiedNameDataflow), nameof (RequireDefaultConstructor), new Type[] { typeof (string) })]
+		[UnrecognizedReflectionAccessPattern (typeof (AssemblyQualifiedNameDataflow), nameof (RequirePublicConstructors), new Type[] { typeof (string) })]
+		static void TestConstructors ()
+		{
+			string type = GetTypeWithNonPublicConstructors ().AssemblyQualifiedName;
+			RequireDefaultConstructor (type);
+			RequirePublicConstructors (type);
+			RequireNonPublicConstructors (type);
+			RequireNothing (type);
+		}
+
+		private static void RequireDefaultConstructor (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.DefaultConstructor)]
+			string type)
+		{
+		}
+
+		private static void RequirePublicConstructors (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+			string type)
+		{
+		}
+
+		private static void RequireNonPublicConstructors (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+			string type)
+		{
+		}
+
+		private static void RequireNothing (string type)
+		{
+		}
+
+
+		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
+		private static Type GetTypeWithDefaultConstructor ()
+		{
+			return null;
+		}
+
+		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)]
+		private static Type GetTypeWithPublicConstructors ()
+		{
+			return null;
+		}
+
+		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+		private static Type GetTypeWithNonPublicConstructors ()
+		{
+			return null;
+		}
+
+	}
+}


### PR DESCRIPTION
This will propagate whatever annotations there are on the type to the string.

Makes it possible to recognize the pattern used by ComponentModel/TypeDescriptionProviderAttribute as safe (the pattern is to accept both a `string` and a `Type`, store the value as a `string`, and `Type.GetType` the type out of that string, before passing it to `Activator`).