### PR TITLE
Warn if DynamicallyAccessedMembersAttribute is used directly on a method

### DIFF
--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -217,3 +217,7 @@ error and warning codes.
 #### `IL2040`: Could not find embedded resource 'resource' to remove in assembly 'assembly'.
 
 - The resource name in a substitution file could not be found in the specified assembly. Ensure that the resource name matches the name of an embedded resource in the assembly.
+
+#### `IL2041`: DynamicallyAccessedMembersAttribute is specified on method 'method'. The DynamicallyAccessedMembersAttribute is only allowed on method parameters, return value or generic parameters.
+
+- Method 'method' has the DynamicallyAccessedMembersAttribute directly on the method itself. This is only allowed for instance methods on System.Type and similar classes. Usually this means the attribute should be placed on the return value of the method (or one of its parameters).

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MethodThisDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MethodThisDataFlow.cs
@@ -20,6 +20,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			PropagateToThis ();
 			PropagateToThisWithGetters ();
 			PropagateToThisWithSetters ();
+
+			TestAnnotationOnNonTypeMethod ();
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (TypeTest), nameof (TypeTest.RequireThisPublicMethods), new Type[] { },
@@ -79,6 +81,33 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		static TypeTest GetWithNonPublicMethods ()
 		{
 			return null;
+		}
+
+		[RecognizedReflectionAccessPattern]
+		static void TestAnnotationOnNonTypeMethod ()
+		{
+			var t = new NonTypeType ();
+			t.GetMethod ("foo");
+		}
+
+		class NonTypeType
+		{
+			[LogContains ("warning IL2041: DynamicallyAccessedMembersAttribute is specified " +
+				"on method 'System.Reflection.MethodInfo Mono.Linker.Tests.Cases.DataFlow.MethodThisDataFlow/NonTypeType::GetMethod(System.String)'. " +
+				"The DynamicallyAccessedMembersAttribute is only allowed on method parameters, return value or generic parameters.")]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+			public MethodInfo GetMethod (string name)
+			{
+				return null;
+			}
+
+			[LogContains ("warning IL2041: DynamicallyAccessedMembersAttribute is specified " +
+				"on method 'System.Void Mono.Linker.Tests.Cases.DataFlow.MethodThisDataFlow/NonTypeType::StaticMethod()'. " +
+				"The DynamicallyAccessedMembersAttribute is only allowed on method parameters, return value or generic parameters.")]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+			public static void StaticMethod ()
+			{
+			}
 		}
 	}
 }


### PR DESCRIPTION
We had to allow the attribute on a method so that we could annotate System.Type instance methods. In that case the attribute on the method means "annotate the this parameter with this".

But using the attribute anywhere else is not allowed. Linker should warn about this.