### PR TITLE
Update log methods

### DIFF
--- a/src/linker/Linker/LoggingReflectionPatternRecorder.cs
+++ b/src/linker/Linker/LoggingReflectionPatternRecorder.cs
@@ -59,7 +59,7 @@ namespace Mono.Linker
 					location = source.DeclaringType?.FullName + "::" + source.Name;
 			}
 
-			_context.LogMessage (MessageContainer.CreateWarningMessage (_context, location + message, 2006, origin, "Unrecognized reflection pattern"));
+			_context.LogWarning (location + message, 2006, origin, "Unrecognized reflection pattern");
 		}
 
 		static string GetSignature (MethodDefinition method)

--- a/src/linker/Linker/UnconditionalSuppressMessageAttributeState.cs
+++ b/src/linker/Linker/UnconditionalSuppressMessageAttributeState.cs
@@ -169,7 +169,7 @@ namespace Mono.Linker
 
 					break;
 				default:
-					_context.LogMessage (MessageContainer.CreateInfoMessage ($"Scope `{info.Scope}` used in `UnconditionalSuppressMessage` is currently not supported."));
+					_context.LogMessage ($"Scope `{info.Scope}` used in `UnconditionalSuppressMessage` is currently not supported.");
 					break;
 				}
 			}


### PR DESCRIPTION
Nit: use the new logging methods instead of passing a `MessageContainer` directly.