### PR TITLE
Warnings during propagation of data flow annotations in properties

### DIFF
--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -221,3 +221,11 @@ error and warning codes.
 #### `IL2041`: DynamicallyAccessedMembersAttribute is specified on method 'method'. The DynamicallyAccessedMembersAttribute is only allowed on method parameters, return value or generic parameters.
 
 - Method 'method' has the DynamicallyAccessedMembersAttribute directly on the method itself. This is only allowed for instance methods on System.Type and similar classes. Usually this means the attribute should be placed on the return value of the method (or one of its parameters).
+
+#### `IL2042`: Could not find a unique backing field for property 'property' to propagate DynamicallyAccessedMembersAttribute
+
+- The property 'property' has DynamicallyAccessedMembersAttribute on it, but the linker could not determine the backing fields for the property to propagate the attribute to the field.
+
+#### `IL2043`: Trying to propagate DynamicallyAccessedMemberAttribute from property 'property' to its getter 'method', but it already has such attribute.
+
+- Propagating DynamicallyAccessedMembersAttribute from property 'property' to its getter 'method' found that the getter already has such an attribute. The existing attribute will be used.

--- a/src/linker/Linker.Dataflow/FlowAnnotations.cs
+++ b/src/linker/Linker.Dataflow/FlowAnnotations.cs
@@ -208,8 +208,11 @@ namespace Mono.Linker.Dataflow
 
 						// TODO: Handle abstract properties - can't do any propagation on the base property, should rely on validation
 						//  that overrides also correctly annotate.
-						if (!setMethod.HasBody || !ScanMethodBodyForFieldAccess (setMethod.Body, write: true, out backingFieldFromSetter)) {
-							_context.LogWarning ($"Could not find a unique backing field for property '{property.FullName}' to propagate DynamicallyAccessedMembersAttribute. The property setter is either abstract or not a compiler generated setter.", 2042, property);
+						if (setMethod.HasBody) {
+							// Look for the compiler generated backing field. If it doesn't work out simply move on. In such case we would still
+							// propagate the annotation to the setter/getter and later on when analyzing the setter/getter we will warn
+							// that the field (which ever it is) must be annotated as well.
+							ScanMethodBodyForFieldAccess (setMethod.Body, write: true, out backingFieldFromSetter);
 						}
 
 						if (annotatedMethods.Any (a => a.Method == setMethod)) {
@@ -232,8 +235,11 @@ namespace Mono.Linker.Dataflow
 
 						// TODO: Handle abstract properties - can't do any propagation on the base property, should rely on validation
 						//  that overrides also correctly annotate.
-						if (!getMethod.HasBody || !ScanMethodBodyForFieldAccess (getMethod.Body, write: false, out backingFieldFromGetter)) {
-							_context.LogWarning ($"Could not find a unique backing field for property '{property.FullName}' to propagate DynamicallyAccessedMembersAttribute. The property getter is either abstract or not a compiler generated getter.", 2042, property);
+						if (getMethod.HasBody) {
+							// Look for the compiler generated backing field. If it doesn't work out simply move on. In such case we would still
+							// propagate the annotation to the setter/getter and later on when analyzing the setter/getter we will warn
+							// that the field (which ever it is) must be annotated as well.
+							ScanMethodBodyForFieldAccess (getMethod.Body, write: false, out backingFieldFromGetter);
 						}
 
 						if (annotatedMethods.Any (a => a.Method == getMethod)) {

--- a/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
@@ -32,6 +33,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			instance.PropertyDefaultConstructorWithExplicitAccessors = null;
 			instance.PropertyPublicConstructorsWithExplicitAccessors = null;
 			instance.PropertyNonPublicConstructorsWithExplicitAccessors = null;
+
+			TestAutomaticPropagation ();
 		}
 
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)]
@@ -123,6 +126,136 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[param: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicConstructors)]
 			set {
 				_fieldWithPublicConstructors = value;
+			}
+		}
+
+		static void TestAutomaticPropagation ()
+		{
+			var instance = new TestAutomaticPropagationType ();
+			instance.TestImplicitProperty ();
+			instance.TestPropertyWithSimpleGetter ();
+			instance.TestPropertyWhichLooksLikeCompilerGenerated ();
+			instance.TestInstancePropertyWithStaticField ();
+			instance.TestPropertyWithDifferentBackingFields ();
+			instance.TestPropertyWithExistingAttributes ();
+		}
+
+		class TestAutomaticPropagationType
+ 		{
+			// Fully implicit property should work
+			[UnrecognizedReflectionAccessPattern (typeof (TestAutomaticPropagationType), "set_" + nameof (ImplicitProperty), new Type[] { typeof (Type) })]
+			public void TestImplicitProperty ()
+			{
+				RequirePublicConstructors (ImplicitProperty);
+				ImplicitProperty = GetTypeWithDefaultConstructor (); // This will warn since the setter requires public .ctors
+			}
+
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)]
+			static Type ImplicitProperty {
+				get; set;
+			}
+
+			// Simple getter is not enough - we do detect the field, but we require the field to be compiler generated for this to work
+			[UnrecognizedReflectionAccessPattern (typeof (PropertyDataFlow), nameof (RequirePublicConstructors), new Type[] { typeof (Type) })]
+			[LogContains("Could not find a unique backing field for property 'System.Type Mono.Linker.Tests.Cases.DataFlow.PropertyDataFlow/TestAutomaticPropagationType::PropertyWithSimpleGetter()' " +
+				"to propagate DynamicallyAccessedMembersAttribute. The property getter is either abstract or not a compiler generated getter.")]
+			public void TestPropertyWithSimpleGetter ()
+			{
+				_ = PropertyWithSimpleGetter;
+				RequirePublicConstructors (PropertyWithSimpleGetter_Field);
+			}
+
+			static Type PropertyWithSimpleGetter_Field;
+
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)]
+			static Type PropertyWithSimpleGetter {
+				get {
+					return PropertyWithSimpleGetter_Field;
+				}
+			}
+
+			[RecognizedReflectionAccessPattern]
+			public void TestPropertyWhichLooksLikeCompilerGenerated ()
+			{
+				// If the property was correctly recognized both the property getter and the backing field should get the annotation.
+				RequirePublicConstructors (PropertyWhichLooksLikeCompilerGenerated);
+				RequirePublicConstructors (PropertyWhichLooksLikeCompilerGenerated_Field);
+			}
+
+			[CompilerGenerated]
+			private static Type PropertyWhichLooksLikeCompilerGenerated_Field;
+
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)]
+			static Type PropertyWhichLooksLikeCompilerGenerated {
+				get {
+					return PropertyWhichLooksLikeCompilerGenerated_Field;
+				}
+			}
+
+			[UnrecognizedReflectionAccessPattern (typeof (PropertyDataFlow), nameof (RequirePublicConstructors), new Type[] { typeof (Type) })]
+			[LogContains ("Could not find a unique backing field for property 'System.Type Mono.Linker.Tests.Cases.DataFlow.PropertyDataFlow/TestAutomaticPropagationType::InstancePropertyWithStaticField()' " +
+				"to propagate DynamicallyAccessedMembersAttribute. The property setter is either abstract or not a compiler generated setter.")]
+			public void TestInstancePropertyWithStaticField ()
+			{
+				InstancePropertyWithStaticField = null;
+				RequirePublicConstructors (InstancePropertyWithStaticField_Field);
+			}
+
+			[CompilerGenerated]
+			private static Type InstancePropertyWithStaticField_Field;
+
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)]
+			Type InstancePropertyWithStaticField {
+				set {
+					InstancePropertyWithStaticField_Field = value;
+				}
+			}
+
+			[LogContains ("Could not find a unique backing field for property 'System.Type Mono.Linker.Tests.Cases.DataFlow.PropertyDataFlow/TestAutomaticPropagationType::PropertyWithDifferentBackingFields()' " +
+				"to propagate DynamicallyAccessedMembersAttribute. " +
+				"The backing fields from getter 'System.Type Mono.Linker.Tests.Cases.DataFlow.PropertyDataFlow/TestAutomaticPropagationType::PropertyWithDifferentBackingFields_GetterField' " +
+				"and setter 'System.Type Mono.Linker.Tests.Cases.DataFlow.PropertyDataFlow/TestAutomaticPropagationType::PropertyWithDifferentBackingFields_SetterField' are not the same.")]
+			public void TestPropertyWithDifferentBackingFields ()
+			{
+				_ = PropertyWithDifferentBackingFields;
+			}
+
+			[CompilerGenerated]
+			private Type PropertyWithDifferentBackingFields_GetterField;
+
+			[CompilerGenerated]
+			private Type PropertyWithDifferentBackingFields_SetterField;
+
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)]
+			Type PropertyWithDifferentBackingFields {
+				get {
+					return PropertyWithDifferentBackingFields_GetterField;
+				}
+
+				set {
+					PropertyWithDifferentBackingFields_SetterField = value;
+				}
+			}
+
+			[LogContains ("Trying to propagate DynamicallyAccessedMemberAttribute from property 'System.Type Mono.Linker.Tests.Cases.DataFlow.PropertyDataFlow/TestAutomaticPropagationType::PropertyWithExistingAttributes()' to its field 'System.Type Mono.Linker.Tests.Cases.DataFlow.PropertyDataFlow/TestAutomaticPropagationType::PropertyWithExistingAttributes_Field', but it already has such attribute.")]
+			[LogContains ("Trying to propagate DynamicallyAccessedMemberAttribute from property 'System.Type Mono.Linker.Tests.Cases.DataFlow.PropertyDataFlow/TestAutomaticPropagationType::PropertyWithExistingAttributes()' to its setter 'System.Void Mono.Linker.Tests.Cases.DataFlow.PropertyDataFlow/TestAutomaticPropagationType::set_PropertyWithExistingAttributes(System.Type)', but it already has such attribute on the 'value' parameter.")]
+			[LogContains ("Trying to propagate DynamicallyAccessedMemberAttribute from property 'System.Type Mono.Linker.Tests.Cases.DataFlow.PropertyDataFlow/TestAutomaticPropagationType::PropertyWithExistingAttributes()' to its getter 'System.Type Mono.Linker.Tests.Cases.DataFlow.PropertyDataFlow/TestAutomaticPropagationType::get_PropertyWithExistingAttributes()', but it already has such attribute on the return value.")]
+			public void TestPropertyWithExistingAttributes ()
+			{
+				_ = PropertyWithExistingAttributes;
+				PropertyWithExistingAttributes = null;
+			}
+
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)]
+			[CompilerGenerated]
+			Type PropertyWithExistingAttributes_Field;
+
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)]
+			Type PropertyWithExistingAttributes {
+				[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)]
+				get { return PropertyWithExistingAttributes_Field; }
+				[param: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)]
+				set { PropertyWithExistingAttributes_Field = value; }
 			}
 		}
 

--- a/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
@@ -157,8 +157,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 			// Simple getter is not enough - we do detect the field, but we require the field to be compiler generated for this to work
 			[UnrecognizedReflectionAccessPattern (typeof (PropertyDataFlow), nameof (RequirePublicConstructors), new Type[] { typeof (Type) })]
-			[LogContains("Could not find a unique backing field for property 'System.Type Mono.Linker.Tests.Cases.DataFlow.PropertyDataFlow/TestAutomaticPropagationType::PropertyWithSimpleGetter()' " +
-				"to propagate DynamicallyAccessedMembersAttribute. The property getter is either abstract or not a compiler generated getter.")]
+			// Make sure we don't warn about the field in context of property annotation propagation.
+			[LogDoesNotContain("Could not find a unique backing field for property 'System.Type Mono.Linker.Tests.Cases.DataFlow.PropertyDataFlow/TestAutomaticPropagationType::PropertyWithSimpleGetter()'")]
 			public void TestPropertyWithSimpleGetter ()
 			{
 				_ = PropertyWithSimpleGetter;
@@ -169,6 +169,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)]
 			static Type PropertyWithSimpleGetter {
+				[UnrecognizedReflectionAccessPattern (typeof (TestAutomaticPropagationType), "get_" + nameof (PropertyWithSimpleGetter), new Type[] { }, returnType: typeof (Type))]
 				get {
 					return PropertyWithSimpleGetter_Field;
 				}
@@ -193,8 +194,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			}
 
 			[UnrecognizedReflectionAccessPattern (typeof (PropertyDataFlow), nameof (RequirePublicConstructors), new Type[] { typeof (Type) })]
-			[LogContains ("Could not find a unique backing field for property 'System.Type Mono.Linker.Tests.Cases.DataFlow.PropertyDataFlow/TestAutomaticPropagationType::InstancePropertyWithStaticField()' " +
-				"to propagate DynamicallyAccessedMembersAttribute. The property setter is either abstract or not a compiler generated setter.")]
+			// Make sure we don't warn about the field in context of property annotation propagation.
+			[LogDoesNotContain ("Could not find a unique backing field for property 'System.Type Mono.Linker.Tests.Cases.DataFlow.PropertyDataFlow/TestAutomaticPropagationType::InstancePropertyWithStaticField()'")]
 			public void TestInstancePropertyWithStaticField ()
 			{
 				InstancePropertyWithStaticField = null;
@@ -206,6 +207,9 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)]
 			Type InstancePropertyWithStaticField {
+				// Nothing to warn about - the "value" is annotated with PublicConstructors and we're assigning
+				// it to unannotated field - that's a perfectly valid operation.
+				[RecognizedReflectionAccessPattern]
 				set {
 					InstancePropertyWithStaticField_Field = value;
 				}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
@@ -141,7 +141,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		class TestAutomaticPropagationType
- 		{
+		{
 			// Fully implicit property should work
 			[UnrecognizedReflectionAccessPattern (typeof (TestAutomaticPropagationType), "set_" + nameof (ImplicitProperty), new Type[] { typeof (Type) })]
 			public void TestImplicitProperty ()
@@ -158,7 +158,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			// Simple getter is not enough - we do detect the field, but we require the field to be compiler generated for this to work
 			[UnrecognizedReflectionAccessPattern (typeof (PropertyDataFlow), nameof (RequirePublicConstructors), new Type[] { typeof (Type) })]
 			// Make sure we don't warn about the field in context of property annotation propagation.
-			[LogDoesNotContain("Could not find a unique backing field for property 'System.Type Mono.Linker.Tests.Cases.DataFlow.PropertyDataFlow/TestAutomaticPropagationType::PropertyWithSimpleGetter()'")]
+			[LogDoesNotContain ("Could not find a unique backing field for property 'System.Type Mono.Linker.Tests.Cases.DataFlow.PropertyDataFlow/TestAutomaticPropagationType::PropertyWithSimpleGetter()'")]
 			public void TestPropertyWithSimpleGetter ()
 			{
 				_ = PropertyWithSimpleGetter;

--- a/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -876,7 +876,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			if (pattern.SourceInstruction?.Operand is IMetadataTokenProvider instructionOperand) {
 				operationDescription = "Usage of " + GetFullMemberNameFromDefinition (instructionOperand) + " unrecognized";
 			} else
-				operationDescription = "Usage of " + pattern.AccessedItem + " unrecognized";
+				operationDescription = "Usage of " + GetFullMemberNameFromDefinition (pattern.AccessedItem) + " unrecognized";
 			return $"{GetFullMemberNameFromDefinition (pattern.Source)}: {operationDescription} '{pattern.Message}'";
 		}
 


### PR DESCRIPTION
When we propagate data flow annotations from the property to its getter/setter/backing field there are cases which the code doesn't handle. This change will issue warnings for most of those cases:
- If we can't detect backing field
- If there already is a data flow annotation in a place where we would try to apply it

Added tests for these cases