### PR TITLE
Remove TryGetOrigin from MessageOrigin

### DIFF
--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -186,7 +186,7 @@ error and warning codes.
 
 - The number of arguments correspond to a certain type constructor, but the type of arguments specified in the xml does not match the type of arguments in the constructor.
 
-#### `IL2033`: Deprecated PreserveDependencyAttribute on 'member'. Use DynamicDependencyAttribute instead.
+#### `IL2033`: PreserveDependencyAttribute is deprecated. Use DynamicDependencyAttribute instead.
 
 - PreserveDependencyAttribute was an internal attribute that was never officially supported. Instead, use the similar DynamicDependencyAttribute.
 
@@ -202,7 +202,7 @@ error and warning codes.
 
 - The type in a DynamicDependencyAttribute constructor could not be resolved. Ensure that the argument specifies a valid type name or type reference, that the type exists in the specified assembly, and that the assembly is available to the linker.
 
-### `IL2037`: No members were resolved for 'memberSignature/memberTypes' in DynamicDependencyAttribute on 'member'
+### `IL2037`: No members were resolved for 'memberSignature/memberTypes'.
 
 - The member signature or DynamicallyAccessedMemberTypes in a DynamicDependencyAttribute constructor did not resolve to any members on the type. If you using a signature, ensure that it refers to an existing member, and that it uses the format defined at https://github.com/dotnet/csharplang/blob/master/spec/documentation-comments.md#id-string-format. If using DynamicallyAccessedMemberTypes, ensure that the type contains members of the specified member types.
 
@@ -218,9 +218,9 @@ error and warning codes.
 
 - The resource name in a substitution file could not be found in the specified assembly. Ensure that the resource name matches the name of an embedded resource in the assembly.
 
-#### `IL2041`: DynamicallyAccessedMembersAttribute is specified on method 'method'. The DynamicallyAccessedMembersAttribute is only allowed on method parameters, return value or generic parameters.
+#### `IL2041`: DynamicallyAccessedMembersAttribute is only allowed on method parameters, return value or generic parameters.
 
-- Method 'method' has the DynamicallyAccessedMembersAttribute directly on the method itself. This is only allowed for instance methods on System.Type and similar classes. Usually this means the attribute should be placed on the return value of the method (or one of its parameters).
+- DynamicallyAccessedMembersAttribute was put directly on the member itself. This is only allowed for instance methods on System.Type and similar classes. Usually this means the attribute should be placed on the return value of the method (or one of its parameters).
 
 #### `IL2042`: Could not find a unique backing field for property 'property' to propagate DynamicallyAccessedMembersAttribute
 

--- a/src/linker/Linker.Dataflow/FlowAnnotations.cs
+++ b/src/linker/Linker.Dataflow/FlowAnnotations.cs
@@ -141,12 +141,12 @@ namespace Mono.Linker.Dataflow
 								paramAnnotations[0] = methodMemberTypes;
 							}
 						} else if (methodMemberTypes != DynamicallyAccessedMemberTypes.None) {
-							_context.LogWarning ($"DynamicallyAccessedMembersAttribute is specified on method '{method}'. The DynamicallyAccessedMembersAttribute is only allowed on method parameters, return value or generic parameters.", 2041, method);
+							_context.LogWarning ($"The DynamicallyAccessedMembersAttribute is only allowed on method parameters, return value or generic parameters.", 2041, method);
 						}
 					} else {
 						offset = 0;
 						if (methodMemberTypes != DynamicallyAccessedMemberTypes.None) {
-							_context.LogWarning ($"DynamicallyAccessedMembersAttribute is specified on method '{method}'. The DynamicallyAccessedMembersAttribute is only allowed on method parameters, return value or generic parameters.", 2041, method);
+							_context.LogWarning ($"The DynamicallyAccessedMembersAttribute is only allowed on method parameters, return value or generic parameters.", 2041, method);
 						}
 					}
 

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -1168,7 +1168,7 @@ namespace Mono.Linker.Dataflow
 							message += " " + requiresUnreferencedCode.Url;
 						}
 
-						_context.LogWarning (message, 2026, MessageOrigin.TryGetOrigin (callingMethodBody.Method, operation.Offset));
+						_context.LogWarning (message, 2026, callingMethodBody.Method, operation.Offset);
 					}
 
 					// To get good reporting of errors we need to track the origin of the value for all method calls

--- a/src/linker/Linker.Steps/DynamicDependencyLookupStep.cs
+++ b/src/linker/Linker.Steps/DynamicDependencyLookupStep.cs
@@ -59,7 +59,7 @@ namespace Mono.Linker.Steps
 				if (!IsPreserveDependencyAttribute (ca.AttributeType))
 					continue;
 #if FEATURE_ILLINK
-				Context.LogWarning ($"Deprecated PreserveDependencyAttribute on '{member}'. Use DynamicDependencyAttribute instead.", 2033, MessageOrigin.TryGetOrigin (member));
+				Context.LogWarning ($"Deprecated PreserveDependencyAttribute on '{member}'. Use DynamicDependencyAttribute instead.", 2033, member);
 #endif
 				if (ca.ConstructorArguments.Count != 3)
 					continue;
@@ -82,7 +82,7 @@ namespace Mono.Linker.Steps
 
 				var assembly = Context.Resolve (new AssemblyNameReference (dynamicDependency.AssemblyName, new Version ()));
 				if (assembly == null) {
-					Context.LogWarning ($"Unresolved assembly '{dynamicDependency.AssemblyName}' in DynamicDependencyAttribute on '{member}'", 2035, MessageOrigin.TryGetOrigin (member));
+					Context.LogWarning ($"Unresolved assembly '{dynamicDependency.AssemblyName}' in DynamicDependencyAttribute on '{member}'", 2035, member);
 					continue;
 				}
 

--- a/src/linker/Linker.Steps/DynamicDependencyLookupStep.cs
+++ b/src/linker/Linker.Steps/DynamicDependencyLookupStep.cs
@@ -59,7 +59,7 @@ namespace Mono.Linker.Steps
 				if (!IsPreserveDependencyAttribute (ca.AttributeType))
 					continue;
 #if FEATURE_ILLINK
-				Context.LogWarning ($"Deprecated PreserveDependencyAttribute on '{member}'. Use DynamicDependencyAttribute instead.", 2033, member);
+				Context.LogWarning ($"PreserveDependencyAttribute is deprecated. Use DynamicDependencyAttribute instead.", 2033, member);
 #endif
 				if (ca.ConstructorArguments.Count != 3)
 					continue;

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -615,14 +615,14 @@ namespace Mono.Linker.Steps
 			if (dynamicDependency.MemberSignature is string memberSignature) {
 				members = DocumentationSignatureParser.GetMembersByDocumentationSignature (type, memberSignature);
 				if (!members.Any ()) {
-					_context.LogWarning ($"No members were resolved for '{memberSignature}' in DynamicDependencyAttribute on '{context}'", 2037, context.Resolve ());
+					_context.LogWarning ($"No members were resolved for '{memberSignature}'.", 2037, context.Resolve ());
 					return;
 				}
 			} else {
 				var memberTypes = dynamicDependency.MemberTypes;
 				members = DynamicallyAccessedMembersBinder.GetDynamicallyAccessedMembers (type, memberTypes);
 				if (!members.Any ()) {
-					_context.LogWarning ($"No members were resolved for '{memberTypes}' in DynamicDependencyAttribute on '{context}'", 2037, context.Resolve ());
+					_context.LogWarning ($"No members were resolved for '{memberTypes}'.", 2037, context.Resolve ());
 					return;
 				}
 			}

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -378,7 +378,7 @@ namespace Mono.Linker.Steps
 				} catch (Exception e) when (!(e is LinkerFatalErrorException)) {
 					throw new LinkerFatalErrorException (
 						MessageContainer.CreateErrorMessage ($"Error processing method '{method.FullName}' in assembly '{method.Module.Name}'", 1005,
-						origin: MessageOrigin.TryGetOrigin (method)), e);
+						origin: new MessageOrigin (method)), e);
 				}
 			}
 		}
@@ -582,7 +582,7 @@ namespace Mono.Linker.Steps
 			if (dynamicDependency.AssemblyName != null) {
 				assembly = _context.GetLoadedAssembly (dynamicDependency.AssemblyName);
 				if (assembly == null) {
-					_context.LogWarning ($"Unresolved assembly '{dynamicDependency.AssemblyName}' in DynamicDependencyAttribute on '{context}'", 2035, MessageOrigin.TryGetOrigin (context.Resolve ()));
+					_context.LogWarning ($"Unresolved assembly '{dynamicDependency.AssemblyName}' in DynamicDependencyAttribute on '{context}'", 2035, context.Resolve ());
 					return;
 				}
 			} else {
@@ -594,19 +594,19 @@ namespace Mono.Linker.Steps
 			if (dynamicDependency.TypeName is string typeName) {
 				type = DocumentationSignatureParser.GetTypeByDocumentationSignature (assembly, typeName);
 				if (type == null) {
-					_context.LogWarning ($"Unresolved type '{typeName}' in DynamicDependencyAttribute on '{context}'", 2036, MessageOrigin.TryGetOrigin (context.Resolve ()));
+					_context.LogWarning ($"Unresolved type '{typeName}' in DynamicDependencyAttribute on '{context}'", 2036, context.Resolve ());
 					return;
 				}
 			} else if (dynamicDependency.Type is TypeReference typeReference) {
 				type = typeReference.Resolve ();
 				if (type == null) {
-					_context.LogWarning ($"Unresolved type '{typeReference}' in DynamicDependencyAtribute on '{context}'", 2036, MessageOrigin.TryGetOrigin (context.Resolve ()));
+					_context.LogWarning ($"Unresolved type '{typeReference}' in DynamicDependencyAtribute on '{context}'", 2036, context.Resolve ());
 					return;
 				}
 			} else {
 				type = context.DeclaringType.Resolve ();
 				if (type == null) {
-					_context.LogWarning ($"Unresolved type '{context.DeclaringType}' in DynamicDependencyAttribute on '{context}'", 2036, MessageOrigin.TryGetOrigin (context.Resolve ()));
+					_context.LogWarning ($"Unresolved type '{context.DeclaringType}' in DynamicDependencyAttribute on '{context}'", 2036, context.Resolve ());
 					return;
 				}
 			}
@@ -615,14 +615,14 @@ namespace Mono.Linker.Steps
 			if (dynamicDependency.MemberSignature is string memberSignature) {
 				members = DocumentationSignatureParser.GetMembersByDocumentationSignature (type, memberSignature);
 				if (!members.Any ()) {
-					_context.LogWarning ($"No members were resolved for '{memberSignature}' in DynamicDependencyAttribute on '{context}'", 2037, MessageOrigin.TryGetOrigin (context.Resolve ()));
+					_context.LogWarning ($"No members were resolved for '{memberSignature}' in DynamicDependencyAttribute on '{context}'", 2037, context.Resolve ());
 					return;
 				}
 			} else {
 				var memberTypes = dynamicDependency.MemberTypes;
 				members = DynamicallyAccessedMembersBinder.GetDynamicallyAccessedMembers (type, memberTypes);
 				if (!members.Any ()) {
-					_context.LogWarning ($"No members were resolved for '{memberTypes}' in DynamicDependencyAttribute on '{context}'", 2037, MessageOrigin.TryGetOrigin (context.Resolve ()));
+					_context.LogWarning ($"No members were resolved for '{memberTypes}' in DynamicDependencyAttribute on '{context}'", 2037, context.Resolve ());
 					return;
 				}
 			}
@@ -2376,7 +2376,7 @@ namespace Mono.Linker.Steps
 				var baseType = method.DeclaringType.BaseType.Resolve ();
 				if (!MarkDefaultConstructor (baseType, new DependencyInfo (DependencyKind.BaseDefaultCtorForStubbedMethod, method)))
 					throw new LinkerFatalErrorException (MessageContainer.CreateErrorMessage ($"Cannot stub constructor on '{method.DeclaringType}' when base type does not have default constructor",
-						1006, origin: MessageOrigin.TryGetOrigin (method)));
+						1006, origin: new MessageOrigin (method)));
 
 				break;
 

--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -460,7 +460,7 @@ namespace Mono.Linker
 		{
 			var attributes = GetLinkerAttributes<T> (member);
 			if (attributes.Count () > 1) {
-				context.LogWarning ($"Attribute '{typeof (T).FullName}' should only be used once on '{member}'.", 2027, MessageOrigin.TryGetOrigin (member));
+				context.LogWarning ($"Attribute '{typeof (T).FullName}' should only be used once on '{member}'.", 2027, member);
 			}
 
 			Debug.Assert (attributes.Count () <= 1);

--- a/src/linker/Linker/DynamicDependency.cs
+++ b/src/linker/Linker/DynamicDependency.cs
@@ -75,7 +75,7 @@ namespace Mono.Linker
 			if (dynamicDependency != null)
 				return dynamicDependency;
 
-			context.LogWarning ($"Invalid DynamicDependencyAttribute on '{member}'", 2030, MessageOrigin.TryGetOrigin (member));
+			context.LogWarning ($"Invalid DynamicDependencyAttribute on '{member}'", 2030, member);
 			return null;
 		}
 

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -514,7 +514,7 @@ namespace Mono.Linker
 		/// <param name="subcategory">Optionally, further categorize this warning</param>
 		public void LogWarning (string text, int code, IMemberDefinition origin, int? ilOffset = null, string subcategory = MessageSubCategory.None)
 		{
-			MessageOrigin _origin = new MessageOrigin (origin);
+			MessageOrigin _origin = new MessageOrigin (origin, ilOffset);
 			LogWarning (text, code, _origin, subcategory);
 		}
 

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -512,7 +512,7 @@ namespace Mono.Linker
 		/// <param name="code">Unique warning ID. Please see https://github.com/mono/linker/blob/master/doc/error-codes.md for the list of warnings and possibly add a new one</param>
 		/// <param name="origin">Type or member where the warning is coming from</param>
 		/// <param name="subcategory">Optionally, further categorize this warning</param>
-		public void LogWarning (string text, int code, IMemberDefinition origin, string subcategory = MessageSubCategory.None)
+		public void LogWarning (string text, int code, IMemberDefinition origin, int? ilOffset = null, string subcategory = MessageSubCategory.None)
 		{
 			MessageOrigin _origin = new MessageOrigin (origin);
 			LogWarning (text, code, _origin, subcategory);

--- a/src/linker/Linker/LinkerAttributesInformation.cs
+++ b/src/linker/Linker/LinkerAttributesInformation.cs
@@ -83,8 +83,7 @@ namespace Mono.Linker
 				return new RequiresUnreferencedCodeAttribute (message) { Url = url };
 			}
 
-			context.LogWarning ($"Attribute '{typeof (RequiresUnreferencedCodeAttribute).FullName}' on '{method}' doesn't have a required constructor argument.",
-				2028, MessageOrigin.TryGetOrigin (method));
+			context.LogWarning ($"Attribute '{typeof (RequiresUnreferencedCodeAttribute).FullName}' on '{method}' doesn't have a required constructor argument.", 2028, method);
 			return null;
 		}
 	}

--- a/src/linker/Linker/LoggingReflectionPatternRecorder.cs
+++ b/src/linker/Linker/LoggingReflectionPatternRecorder.cs
@@ -44,10 +44,8 @@ namespace Mono.Linker
 
 		public void UnrecognizedReflectionAccessPattern (IMemberDefinition source, Instruction sourceInstruction, IMetadataTokenProvider accessedItem, string message)
 		{
-			string location = string.Empty;
-			var method = source as MethodDefinition;
-			var origin = new MessageOrigin (method, sourceInstruction?.Offset);
-			_context.LogWarning (location + message, 2006, origin, "Unrecognized reflection pattern");
+			var origin = new MessageOrigin (source, sourceInstruction?.Offset);
+			_context.LogWarning (message, 2006, origin, "Unrecognized reflection pattern");
 		}
 	}
 }

--- a/src/linker/Linker/LoggingReflectionPatternRecorder.cs
+++ b/src/linker/Linker/LoggingReflectionPatternRecorder.cs
@@ -44,14 +44,10 @@ namespace Mono.Linker
 
 		public void UnrecognizedReflectionAccessPattern (IMemberDefinition source, Instruction sourceInstruction, IMetadataTokenProvider accessedItem, string message)
 		{
-			MessageOrigin origin;
 			string location = string.Empty;
 			var method = source as MethodDefinition;
-			if (sourceInstruction != null && method != null)
-				origin = MessageOrigin.TryGetOrigin (method, sourceInstruction.Offset);
-			else
-				origin = new MessageOrigin (source);
-
+			var origin = new MessageOrigin (method, sourceInstruction?.Offset);
+			origin.TryGetSourceInfo ();
 			if (origin.FileName == null) {
 				if (method != null)
 					location = method.DeclaringType.FullName + "::" + GetSignature (method) + ": ";

--- a/src/linker/Linker/LoggingReflectionPatternRecorder.cs
+++ b/src/linker/Linker/LoggingReflectionPatternRecorder.cs
@@ -47,43 +47,7 @@ namespace Mono.Linker
 			string location = string.Empty;
 			var method = source as MethodDefinition;
 			var origin = new MessageOrigin (method, sourceInstruction?.Offset);
-			origin.TryGetSourceInfo ();
-			if (origin.FileName == null) {
-				if (method != null)
-					location = method.DeclaringType.FullName + "::" + GetSignature (method) + ": ";
-				else
-					location = source.DeclaringType?.FullName + "::" + source.Name;
-			}
-
 			_context.LogWarning (location + message, 2006, origin, "Unrecognized reflection pattern");
-		}
-
-		static string GetSignature (MethodDefinition method)
-		{
-			var builder = new System.Text.StringBuilder ();
-			builder.Append (method.Name);
-			if (method.HasGenericParameters) {
-				builder.Append ('<');
-
-				for (int i = 0; i < method.GenericParameters.Count - 1; i++)
-					builder.Append ($"{method.GenericParameters[i]},");
-
-				builder.Append ($"{method.GenericParameters[method.GenericParameters.Count - 1]}>");
-			}
-
-			builder.Append ("(");
-
-			if (method.HasParameters) {
-				for (int i = 0; i < method.Parameters.Count - 1; i++) {
-					builder.Append ($"{method.Parameters[i].ParameterType},");
-				}
-
-				builder.Append (method.Parameters[method.Parameters.Count - 1].ParameterType);
-			}
-
-			builder.Append (")");
-
-			return builder.ToString ();
 		}
 	}
 }

--- a/src/linker/Linker/MessageContainer.cs
+++ b/src/linker/Linker/MessageContainer.cs
@@ -70,6 +70,12 @@ namespace Mono.Linker
 			if (context.IsWarningSuppressed (code, origin))
 				return Empty;
 
+			origin.TryGetSourceInfo ();
+			if (subcategory == "Unrecognized reflection pattern" && origin.FileName == null) {
+				if (origin.MemberDefinition != null && origin.MemberDefinition is MethodDefinition method)
+					text = string.Format ("{0}: {1}", method.GetDisplayName (), text);
+			}
+
 			return new MessageContainer (MessageCategory.Warning, text, code, subcategory, origin);
 		}
 

--- a/src/linker/Linker/MessageContainer.cs
+++ b/src/linker/Linker/MessageContainer.cs
@@ -49,6 +49,7 @@ namespace Mono.Linker
 			if (!(code >= 1000 && code <= 2000))
 				throw new ArgumentException ($"The provided code '{code}' does not fall into the error category, which is in the range of 1000 to 2000 (inclusive).");
 
+			origin?.TryGetSourceInfo ();
 			return new MessageContainer (MessageCategory.Error, text, code, subcategory, origin);
 		}
 
@@ -71,9 +72,11 @@ namespace Mono.Linker
 				return Empty;
 
 			origin.TryGetSourceInfo ();
-			if (subcategory == "Unrecognized reflection pattern" && origin.FileName == null) {
-				if (origin.MemberDefinition != null && origin.MemberDefinition is MethodDefinition method)
+			if (origin.FileName == null) {
+				if (origin.MemberDefinition is MethodDefinition method)
 					text = string.Format ("{0}: {1}", method.GetDisplayName (), text);
+				else
+					text = string.Format ("{0}: {1}", origin.MemberDefinition.FullName, text);
 			}
 
 			return new MessageContainer (MessageCategory.Warning, text, code, subcategory, origin);

--- a/src/linker/Linker/MessageOrigin.cs
+++ b/src/linker/Linker/MessageOrigin.cs
@@ -59,7 +59,6 @@ namespace Mono.Linker
 
 		public override string ToString ()
 		{
-			TryGetSourceInfo ();
 			if (FileName == null)
 				return null;
 

--- a/src/linker/Linker/MessageOrigin.cs
+++ b/src/linker/Linker/MessageOrigin.cs
@@ -43,10 +43,10 @@ namespace Mono.Linker
 				return;
 
 			var sourceMethod = MemberDefinition as MethodDefinition;
-			var offeset = ILOffset ?? 0;
+			var offset = ILOffset ?? 0;
 			if (sourceMethod.DebugInformation.HasSequencePoints) {
 				SequencePoint correspondingSequencePoint = sourceMethod.DebugInformation.SequencePoints
-					.Where (s => s.Offset <= offeset)?.Last ();
+					.Where (s => s.Offset <= offset)?.Last ();
 				if (correspondingSequencePoint == null)
 					return;
 

--- a/src/linker/Linker/MessageOrigin.cs
+++ b/src/linker/Linker/MessageOrigin.cs
@@ -41,16 +41,15 @@ namespace Mono.Linker
 		{
 			int sourceLine = SourceLine, sourceColumn = SourceColumn;
 			string fileName = FileName;
-			if (MemberDefinition != null && MemberDefinition is MethodDefinition method) {
-				if (method.DebugInformation.HasSequencePoints) {
-					var offset = ILOffset ?? 0;
-					SequencePoint correspondingSequencePoint = method.DebugInformation.SequencePoints
-						.Where (s => s.Offset <= offset)?.Last ();
-					if (correspondingSequencePoint != null) {
-						fileName = correspondingSequencePoint.Document.Url;
-						sourceLine = correspondingSequencePoint.StartLine;
-						sourceColumn = correspondingSequencePoint.StartColumn;
-					}
+			if (MemberDefinition is MethodDefinition method &&
+				method.DebugInformation.HasSequencePoints) {
+				var offset = ILOffset ?? 0;
+				SequencePoint correspondingSequencePoint = method.DebugInformation.SequencePoints
+					.Where (s => s.Offset <= offset)?.Last ();
+				if (correspondingSequencePoint != null) {
+					fileName = correspondingSequencePoint.Document.Url;
+					sourceLine = correspondingSequencePoint.StartLine;
+					sourceColumn = correspondingSequencePoint.StartColumn;
 				}
 			}
 

--- a/src/linker/Linker/MethodReferenceExtensions.cs
+++ b/src/linker/Linker/MethodReferenceExtensions.cs
@@ -8,6 +8,40 @@ namespace Mono.Linker
 {
 	public static class MethodReferenceExtensions
 	{
+		public static string GetDisplayName (this MethodReference method)
+		{
+			var builder = new System.Text.StringBuilder ();
+			builder.Append (method.DeclaringType.FullName);
+			builder.Append ("::");
+			if (method.Name == ".ctor")
+				builder.Append (method.DeclaringType.Name);
+			else
+				builder.Append (method.Name);
+			
+			if (method.HasGenericParameters) {
+				builder.Append ('<');
+
+				for (int i = 0; i < method.GenericParameters.Count - 1; i++)
+					builder.Append ($"{method.GenericParameters[i]},");
+
+				builder.Append ($"{method.GenericParameters[method.GenericParameters.Count - 1]}>");
+			}
+
+			builder.Append ("(");
+
+			if (method.HasParameters) {
+				for (int i = 0; i < method.Parameters.Count - 1; i++) {
+					builder.Append ($"{method.Parameters[i].ParameterType},");
+				}
+
+				builder.Append (method.Parameters[method.Parameters.Count - 1].ParameterType);
+			}
+
+			builder.Append (")");
+
+			return builder.ToString ();
+		}
+
 		public static TypeReference GetReturnType (this MethodReference method)
 		{
 			if (method.DeclaringType is GenericInstanceType genericInstance)

--- a/src/linker/Linker/MethodReferenceExtensions.cs
+++ b/src/linker/Linker/MethodReferenceExtensions.cs
@@ -17,7 +17,7 @@ namespace Mono.Linker
 				builder.Append (method.DeclaringType.Name);
 			else
 				builder.Append (method.Name);
-			
+
 			if (method.HasGenericParameters) {
 				builder.Append ('<');
 

--- a/src/linker/ref/Linker/MessageOrigin.cs
+++ b/src/linker/ref/Linker/MessageOrigin.cs
@@ -4,7 +4,7 @@
 
 namespace Mono.Linker
 {
-	public struct MessageOrigin
+	public readonly struct MessageOrigin
 	{
 		public MessageOrigin (string fileName, int sourceLine = 0, int sourceColumn = 0)
 		{

--- a/src/linker/ref/Linker/MessageOrigin.cs
+++ b/src/linker/ref/Linker/MessageOrigin.cs
@@ -4,7 +4,7 @@
 
 namespace Mono.Linker
 {
-	public readonly struct MessageOrigin
+	public struct MessageOrigin
 	{
 		public MessageOrigin (string fileName, int sourceLine = 0, int sourceColumn = 0)
 		{

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MethodThisDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MethodThisDataFlow.cs
@@ -92,8 +92,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		class NonTypeType
 		{
-			[LogContains ("warning IL2041: DynamicallyAccessedMembersAttribute is specified " +
-				"on method 'System.Reflection.MethodInfo Mono.Linker.Tests.Cases.DataFlow.MethodThisDataFlow/NonTypeType::GetMethod(System.String)'. " +
+			[LogContains ("warning IL2041: Mono.Linker.Tests.Cases.DataFlow.MethodThisDataFlow/NonTypeType::GetMethod(System.String): " +
 				"The DynamicallyAccessedMembersAttribute is only allowed on method parameters, return value or generic parameters.")]
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
 			public MethodInfo GetMethod (string name)
@@ -101,8 +100,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				return null;
 			}
 
-			[LogContains ("warning IL2041: DynamicallyAccessedMembersAttribute is specified " +
-				"on method 'System.Void Mono.Linker.Tests.Cases.DataFlow.MethodThisDataFlow/NonTypeType::StaticMethod()'. " +
+			[LogContains ("warning IL2041: Mono.Linker.Tests.Cases.DataFlow.MethodThisDataFlow/NonTypeType::StaticMethod(): " +
 				"The DynamicallyAccessedMembersAttribute is only allowed on method parameters, return value or generic parameters.")]
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
 			public static void StaticMethod ()

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMemberSignatureWildcard.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMemberSignatureWildcard.cs
@@ -5,7 +5,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.DynamicDependencies
 {
-	[LogContains ("IL2037: No members were resolved for '*' in DynamicDependencyAttribute on 'System.Void Mono.Linker.Tests.Cases.DynamicDependencies.DynamicDependencyMemberSignatureWildcard::Dependency()'")]
+	[LogContains ("IL2037: Mono.Linker.Tests.Cases.DynamicDependencies.DynamicDependencyMemberSignatureWildcard::Dependency(): No members were resolved for '*'.")]
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/DynamicDependencyMethodInAssemblyLibrary.cs" })]
 	public class DynamicDependencyMemberSignatureWildcard
 	{

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMethod.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMethod.cs
@@ -5,10 +5,10 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.DynamicDependencies
 {
-	[LogContains ("IL2037: No members were resolved for 'MissingMethod' in DynamicDependencyAttribute on 'System.Void Mono.Linker.Tests.Cases.DynamicDependencies.DynamicDependencyMethod/B::Broken()'")]
-	[LogContains ("IL2037: No members were resolved for 'Dependency2``1(``0,System.Int32,System.Object)' in DynamicDependencyAttribute on 'System.Void Mono.Linker.Tests.Cases.DynamicDependencies.DynamicDependencyMethod/B::Broken()'")]
-	[LogContains ("IL2037: No members were resolved for '#ctor()' in DynamicDependencyAttribute on 'System.Void Mono.Linker.Tests.Cases.DynamicDependencies.DynamicDependencyMethod/B::Broken()'")]
-	[LogContains ("IL2037: No members were resolved for '#cctor()' in DynamicDependencyAttribute on 'System.Void Mono.Linker.Tests.Cases.DynamicDependencies.DynamicDependencyMethod/B::Broken()'")]
+	[LogContains ("IL2037: Mono.Linker.Tests.Cases.DynamicDependencies.DynamicDependencyMethod/B::Broken(): No members were resolved for 'MissingMethod'.")]
+	[LogContains ("IL2037: Mono.Linker.Tests.Cases.DynamicDependencies.DynamicDependencyMethod/B::Broken(): No members were resolved for 'Dependency2``1(``0,System.Int32,System.Object)'.")]
+	[LogContains ("IL2037: Mono.Linker.Tests.Cases.DynamicDependencies.DynamicDependencyMethod/B::Broken(): No members were resolved for '#ctor()'.")]
+	[LogContains ("IL2037: Mono.Linker.Tests.Cases.DynamicDependencies.DynamicDependencyMethod/B::Broken(): No members were resolved for '#cctor()'.")]
 	class DynamicDependencyMethod
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/Logging/SourceLines.cs
+++ b/test/Mono.Linker.Tests.Cases/Logging/SourceLines.cs
@@ -9,10 +9,12 @@ namespace Mono.Linker.Tests.Cases.Logging
 	[SkipKeptItemsValidation]
 	[SetupCompileBefore ("FakeSystemAssembly.dll", new[] { "../PreserveDependencies/Dependencies/PreserveDependencyAttribute.cs" })]
 	[SetupCompileArgument ("/debug:full")]
-	[LogContains ("(35,4): Unrecognized reflection pattern warning IL2006: The return value of method 'System.Type Mono.Linker.Tests.Cases.Logging.SourceLines::GetUnknownType()' " +
+	[LogContains ("(37,4): Unrecognized reflection pattern warning IL2006: Mono.Linker.Tests.Cases.Logging.SourceLines::UnrecognizedReflectionPattern(): " +
+		"The return value of method 'System.Type Mono.Linker.Tests.Cases.Logging.SourceLines::GetUnknownType()' " +
 		"with dynamically accessed member kinds 'None' is passed into the field 'System.Type Mono.Linker.Tests.Cases.Logging.SourceLines::type' which requires dynamically " +
 		"accessed member kinds 'PublicConstructors'. To fix this add DynamicallyAccessedMembersAttribute to it and specify at least these member kinds 'PublicConstructors'.")]
-	[LogContains ("(36,4): Unrecognized reflection pattern warning IL2006: The return value of method 'System.Type Mono.Linker.Tests.Cases.Logging.SourceLines::GetUnknownType()' " +
+	[LogContains ("(38,4): Unrecognized reflection pattern warning IL2006: Mono.Linker.Tests.Cases.Logging.SourceLines::UnrecognizedReflectionPattern(): " +
+		"The return value of method 'System.Type Mono.Linker.Tests.Cases.Logging.SourceLines::GetUnknownType()' " +
 		"with dynamically accessed member kinds 'None' is passed into the field 'System.Type Mono.Linker.Tests.Cases.Logging.SourceLines::type' which requires dynamically " +
 		"accessed member kinds 'PublicConstructors'. To fix this add DynamicallyAccessedMembersAttribute to it and specify at least these member kinds 'PublicConstructors'.")]
 	public class SourceLines

--- a/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyDeprecated.cs
+++ b/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyDeprecated.cs
@@ -8,10 +8,10 @@ namespace Mono.Linker.Tests.Cases.PreserveDependencies
 	[IgnoreTestCase ("This test checks that PreserveDependency correctly issues a warning on .NET Core where it is deprecated.")]
 #endif
 	[SetupCompileBefore ("FakeSystemAssembly.dll", new[] { "Dependencies/PreserveDependencyAttribute.cs" })]
-	[LogContains ("IL2033: Deprecated PreserveDependencyAttribute on 'System.Void Mono.Linker.Tests.Cases.PreserveDependencies.PreserveDependencyDeprecated/B::Method()'. Use DynamicDependencyAttribute instead.")]
-	[LogContains ("IL2033: Deprecated PreserveDependencyAttribute on 'System.Void Mono.Linker.Tests.Cases.PreserveDependencies.PreserveDependencyDeprecated/B::SameContext()'. Use DynamicDependencyAttribute instead.")]
-	[LogContains ("IL2033: Deprecated PreserveDependencyAttribute on 'System.Void Mono.Linker.Tests.Cases.PreserveDependencies.PreserveDependencyDeprecated/B::Broken()'. Use DynamicDependencyAttribute instead.")]
-	[LogContains ("IL2033: Deprecated PreserveDependencyAttribute on 'System.Void Mono.Linker.Tests.Cases.PreserveDependencies.PreserveDependencyDeprecated/B::Conditional()'. Use DynamicDependencyAttribute instead.")]
+	[LogContains ("IL2033: Mono.Linker.Tests.Cases.PreserveDependencies.PreserveDependencyDeprecated/B::Method(): PreserveDependencyAttribute is deprecated. Use DynamicDependencyAttribute instead.")]
+	[LogContains ("IL2033: Mono.Linker.Tests.Cases.PreserveDependencies.PreserveDependencyDeprecated/B::SameContext(): PreserveDependencyAttribute is deprecated. Use DynamicDependencyAttribute instead.")]
+	[LogContains ("IL2033: Mono.Linker.Tests.Cases.PreserveDependencies.PreserveDependencyDeprecated/B::Broken(): PreserveDependencyAttribute is deprecated. Use DynamicDependencyAttribute instead.")]
+	[LogContains ("IL2033: Mono.Linker.Tests.Cases.PreserveDependencies.PreserveDependencyDeprecated/B::Conditional(): PreserveDependencyAttribute is deprecated. Use DynamicDependencyAttribute instead.")]
 	class PreserveDependencyDeprecated
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
@@ -23,7 +23,9 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		}
 
 		[LogContains (
-			"warning IL2026: Calling 'System.Void Mono.Linker.Tests.Cases.RequiresCapability.RequiresUnreferencedCodeCapability::RequiresWithMessageOnly()' which has `RequiresUnreferencedCodeAttribute` can break functionality when trimming application code. " +
+			"warning IL2026: Mono.Linker.Tests.Cases.RequiresCapability.RequiresUnreferencedCodeCapability::TestRequiresWithMessageOnlyOnMethod(): " +
+			"Calling 'System.Void Mono.Linker.Tests.Cases.RequiresCapability.RequiresUnreferencedCodeCapability::RequiresWithMessageOnly()' " +
+			"which has `RequiresUnreferencedCodeAttribute` can break functionality when trimming application code. " +
 			"Message for --RequiresWithMessageOnly--.")]
 		static void TestRequiresWithMessageOnlyOnMethod ()
 		{
@@ -36,7 +38,9 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		}
 
 		[LogContains (
-			"warning IL2026: Calling 'System.Void Mono.Linker.Tests.Cases.RequiresCapability.RequiresUnreferencedCodeCapability::RequiresWithMessageAndUrl()' which has `RequiresUnreferencedCodeAttribute` can break functionality when trimming application code. " +
+			"warning IL2026: Mono.Linker.Tests.Cases.RequiresCapability.RequiresUnreferencedCodeCapability::TestRequiresWithMessageAndUrlOnMethod(): " +
+			"Calling 'System.Void Mono.Linker.Tests.Cases.RequiresCapability.RequiresUnreferencedCodeCapability::RequiresWithMessageAndUrl()' " +
+			"which has `RequiresUnreferencedCodeAttribute` can break functionality when trimming application code. " +
 			"Message for --RequiresWithMessageAndUrl--. " +
 			"https://helpurl")]
 		static void TestRequiresWithMessageAndUrlOnMethod ()
@@ -50,7 +54,9 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		}
 
 		[LogContains (
-			"warning IL2026: Calling 'System.Void Mono.Linker.Tests.Cases.RequiresCapability.RequiresUnreferencedCodeCapability/ConstructorRequires::.ctor()' which has `RequiresUnreferencedCodeAttribute` can break functionality when trimming application code. " +
+			"warning IL2026: Mono.Linker.Tests.Cases.RequiresCapability.RequiresUnreferencedCodeCapability::TestRequiresOnConstructor(): " +
+			"Calling 'System.Void Mono.Linker.Tests.Cases.RequiresCapability.RequiresUnreferencedCodeCapability/ConstructorRequires::.ctor()' " +
+			"which has `RequiresUnreferencedCodeAttribute` can break functionality when trimming application code. " +
 			"Message for --ConstructorRequires--.")]
 		static void TestRequiresOnConstructor ()
 		{
@@ -66,10 +72,14 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		}
 
 		[LogContains (
-			"warning IL2026: Calling 'System.Int32 Mono.Linker.Tests.Cases.RequiresCapability.RequiresUnreferencedCodeCapability::get_PropertyRequires()' which has `RequiresUnreferencedCodeAttribute` can break functionality when trimming application code. " +
+			"warning IL2026: Mono.Linker.Tests.Cases.RequiresCapability.RequiresUnreferencedCodeCapability::TestRequiresOnPropertyGetterAndSetter(): " +
+			"Calling 'System.Int32 Mono.Linker.Tests.Cases.RequiresCapability.RequiresUnreferencedCodeCapability::get_PropertyRequires()' " +
+			"which has `RequiresUnreferencedCodeAttribute` can break functionality when trimming application code. " +
 			"Message for --getter PropertyRequires--.")]
 		[LogContains (
-			"warning IL2026: Calling 'System.Void Mono.Linker.Tests.Cases.RequiresCapability.RequiresUnreferencedCodeCapability::set_PropertyRequires(System.Int32)' which has `RequiresUnreferencedCodeAttribute` can break functionality when trimming application code. " +
+			"warning IL2026: Mono.Linker.Tests.Cases.RequiresCapability.RequiresUnreferencedCodeCapability::TestRequiresOnPropertyGetterAndSetter(): " +
+			"Calling 'System.Void Mono.Linker.Tests.Cases.RequiresCapability.RequiresUnreferencedCodeCapability::set_PropertyRequires(System.Int32)' " +
+			"which has `RequiresUnreferencedCodeAttribute` can break functionality when trimming application code. " +
 			"Message for --setter PropertyRequires--.")]
 		static void TestRequiresOnPropertyGetterAndSetter ()
 		{
@@ -86,7 +96,9 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		}
 
 		[LogContains (
-			"warning IL2026: Calling 'System.Void Mono.Linker.Tests.Cases.RequiresCapability.RequiresUnreferencedCodeCapability::RequiresAndCallsOtherRequiresMethods()' which has `RequiresUnreferencedCodeAttribute` can break functionality when trimming application code. " +
+			"warning IL2026: Mono.Linker.Tests.Cases.RequiresCapability.RequiresUnreferencedCodeCapability::TestRequiresSuppressesReflectionAnalysis(): " +
+			"Calling 'System.Void Mono.Linker.Tests.Cases.RequiresCapability.RequiresUnreferencedCodeCapability::RequiresAndCallsOtherRequiresMethods()' " +
+			"which has `RequiresUnreferencedCodeAttribute` can break functionality when trimming application code. " +
 			"Message for --RequiresAndCallsOtherRequiresMethods--.")]
 		static void TestRequiresSuppressesReflectionAnalysis ()
 		{


### PR DESCRIPTION
I'm moving the optional `ilOffset` parameter that was originally passed to `TryGetOrigin` to `LogWarning`, so that we can delay the retrieval of the source information for warnings until it's needed (i.e., after we're sure that the warning isn't suppressed).

Solves https://github.com/mono/linker/issues/1221