### PR TITLE
Match DynamicDependency members by name

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -613,7 +613,7 @@ namespace Mono.Linker.Steps
 
 			IEnumerable<IMemberDefinition> members;
 			if (dynamicDependency.MemberSignature is string memberSignature) {
-				members = DocumentationSignatureParser.GetMembersByDocumentationSignature (type, memberSignature);
+				members = DocumentationSignatureParser.GetMembersByDocumentationSignature (type, memberSignature, acceptName: true);
 				if (!members.Any ()) {
 					_context.LogWarning ($"No members were resolved for '{memberSignature}' in DynamicDependencyAttribute on '{context}'", 2037, MessageOrigin.TryGetOrigin (context.Resolve ()));
 					return;

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMethod.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMethod.cs
@@ -36,12 +36,15 @@ namespace Mono.Linker.Tests.Cases.DynamicDependencies
 			[Kept]
 			[DynamicDependency ("Dependency1()", typeof (C))]
 			[DynamicDependency ("Dependency2``1(``0[],System.Int32", typeof (C))]
+			[DynamicDependency ("Dependency3", typeof (C))]
+			[DynamicDependency ("RecursiveDependency", typeof (C))]
 			[DynamicDependency ("#ctor()", typeof (C))] // To avoid lazy body marking stubbing
 			[DynamicDependency ("field", typeof (C))]
 			[DynamicDependency ("NextOne(Mono.Linker.Tests.Cases.DynamicDependencies.DynamicDependencyMethod.Nested@)", typeof (Nested))]
 			[DynamicDependency ("#cctor()", typeof (Nested))]
 			// Dependency on a property itself should be expressed as a dependency on one or both accessor methods
 			[DynamicDependency ("get_Property()", typeof (C))]
+			[DynamicDependency ("get_Property2", typeof (C))]
 			[DynamicDependency ("M``1(Mono.Linker.Tests.Cases.DynamicDependencies.DynamicDependencyMethod.Complex.S{" +
 				"Mono.Linker.Tests.Cases.DynamicDependencies.DynamicDependencyMethod.Complex.G{" +
 					"Mono.Linker.Tests.Cases.DynamicDependencies.DynamicDependencyMethod.Complex.A,``0}}" +
@@ -135,8 +138,28 @@ namespace Mono.Linker.Tests.Cases.DynamicDependencies
 		}
 
 		[Kept]
+		internal void Dependency3 (string str)
+		{
+		}
+
+		[Kept]
+		[DynamicDependency ("#ctor", typeof (NestedInC))]
+		internal void RecursiveDependency ()
+		{
+		}
+
+		[KeptMember (".ctor()")]
+		class NestedInC
+		{
+		}
+
+		[Kept]
 		[KeptBackingField]
 		internal string Property { [Kept] get; set; }
+
+		[Kept]
+		[KeptBackingField]
+		internal string Property2 { [Kept] get; set; }
 
 		// For now, Condition has no effect: https://github.com/mono/linker/issues/1231
 		[Kept]

--- a/test/Mono.Linker.Tests/Tests/DocumentationSignatureParserTests.cs
+++ b/test/Mono.Linker.Tests/Tests/DocumentationSignatureParserTests.cs
@@ -368,6 +368,10 @@ namespace Mono.Linker.Tests
 			[ExpectGeneratedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.op_Addition(Mono.Linker.Tests.DocumentationSignatureParserTests.A,Mono.Linker.Tests.DocumentationSignatureParserTests.A)")]
 			[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.op_Addition(Mono.Linker.Tests.DocumentationSignatureParserTests.A,Mono.Linker.Tests.DocumentationSignatureParserTests.A)")]
 			public static A operator + (A left, A right) => null;
+
+			[ExpectGeneratedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.MWithReturnType")]
+			[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.MWithReturnType~System.Boolean")]
+			public static bool MWithReturnType () => false;
 		}
 
 		public struct S<T>


### PR DESCRIPTION
The signature parser allows a name to match different member types (method/field, etc.) with the same string, and it also allows specifying a parameterless method by name alone. This change also allows it to match methods/properties with any number of parameters by name alone.

I thought this was already the case, but didn't notice that the parser still checks parameters when it doesn't see parentheses, and didn't hit it when testing.

I noticed this while turning it on for dotnet/runtime. There we use it to pull in `GetSourceLineInfo` by name: https://github.com/dotnet/runtime/blob/144e5145453ac3885ac20bc1f1f2641523c6fcea/src/coreclr/src/System.Private.CoreLib/src/System/Diagnostics/StackFrameHelper.cs#L91.

`GetSourceLineInfo` has a lot of parameters, so we probably wouldn't want to put the full signature in the attribute: https://github.com/dotnet/runtime/blob/144e5145453ac3885ac20bc1f1f2641523c6fcea/src/libraries/System.Diagnostics.StackTrace/src/System/Diagnostics/StackTraceSymbols.cs#L53.