### PR TITLE
Remove unnecessary asserts

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -964,8 +964,6 @@ namespace Mono.Linker.Steps
 				if (property != null)
 					return property;
 
-				// This would neglect to mark parameters for generic instances.
-				Debug.Assert (!(type.BaseType is GenericInstanceType));
 				type = type.BaseType?.Resolve ();
 			}
 
@@ -1002,8 +1000,6 @@ namespace Mono.Linker.Steps
 				if (field != null)
 					return field;
 
-				// This would neglect to mark parameters for generic instances.
-				Debug.Assert (!(type.BaseType is GenericInstanceType));
 				type = type.BaseType?.Resolve ();
 			}
 
@@ -1017,8 +1013,6 @@ namespace Mono.Linker.Steps
 				if (method != null)
 					return method;
 
-				// This would neglect to mark parameters for generic instances.
-				Debug.Assert (!(type.BaseType is GenericInstanceType));
 				type = type.BaseType.Resolve ();
 			}
 

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerDisplayAttributeOnGenerics.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerDisplayAttributeOnGenerics.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Attributes.Debugger
+{
+	[SetupLinkerCoreAction ("link")]
+	[SetupLinkerKeepDebugMembers ("true")]
+
+	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168
+	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
+	public class DebuggerDisplayAttributeOnGenerics
+	{
+		public static void Main ()
+		{
+			_ = new GenericDerivedWithField<TestType> ();
+			_ = new GenericDerivedWithProperty<TestType> ();
+		}
+
+		[KeptMember (".ctor()")]
+		class GenericBase<T>
+		{
+			[Kept]
+			public T FieldOnBase;
+
+			[Kept]
+			[KeptBackingField]
+			public T PropertyOnBase { [Kept] get; [Kept] set; }
+
+			public void MethodOnBase () { }
+		}
+
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof (GenericBase<>), "T")]
+		[KeptAttributeAttribute (typeof (DebuggerDisplayAttribute))]
+		[DebuggerDisplay ("F = {FieldOnBase}")]
+		class GenericDerivedWithField<T> : GenericBase<T>
+		{
+		}
+
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof (GenericBase<>), "T")]
+		[KeptAttributeAttribute (typeof (DebuggerDisplayAttribute))]
+		[DebuggerDisplay ("P = {PropertyOnBase}")]
+		class GenericDerivedWithProperty<T> : GenericBase<T>
+		{
+		}
+
+		[Kept]
+		class TestType
+		{
+		}
+	}
+}


### PR DESCRIPTION
I added these asserts because these methods retrieve members on
resolved base TypeDefinitions - uninstantiated types, in the case of
generics - losing information about generic arguments. I was concerned
that we might leave some of the generic argument types unmarked as a
result.

Inspecting the callers of these methods, I am now pretty sure that we
can only get to these helpers along code paths that also mark the base
TypeReference.

For example, MarkType usually gets called on the declaring type, and
MarkType will mark the unresolved base type. In other cases,
MarkEntireType is called on the declaring type, and this calls into
helpers to mark members which then call MarkType on the unresolved
base type. When marking custom attributes, we mark the constructor
which marks the unresolved base type, etc... If I missed any cases they are
probably pretty obscure or IL-only.

Not marking TypeReferences here means that the dependency trace
records uninstantiated field types for the fields marked on these
paths. There might be room for cleanup here, but I don't think there
is something worth changing right now.

Closes https://github.com/mono/linker/issues/1264