### PR TITLE
Allow inlining of return values of instance methods which are explicitly substituted

### DIFF
--- a/src/linker/Linker.Steps/RemoveUnreachableBlocksStep.cs
+++ b/src/linker/Linker.Steps/RemoveUnreachableBlocksStep.cs
@@ -116,9 +116,6 @@ namespace Mono.Linker.Steps
 						continue;
 					}
 
-					if (method.Name == "NewId")
-						Debug.WriteLine ("");
-
 					RewriteBody (method);
 				}
 

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/BodiesWithSubstitutions.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/BodiesWithSubstitutions.cs
@@ -23,6 +23,7 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 			TestProperty_int_1 ();
 			TestField_int_1 ();
 			NoInlining ();
+			TestPropagation ();
 		}
 
 		[Kept]
@@ -71,6 +72,34 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 
 		[Kept]
 		static void Reached_1 ()
+		{
+		}
+
+		[Kept]
+		static int PropagateProperty {
+			[Kept]
+			get {
+				return Property;
+			}
+		}
+
+		[Kept]
+		static void TestPropagation ()
+		{
+			// We don't propagate return values across method calls
+			if (PropagateProperty != 3)
+				Propagation_Reached1 ();
+			else
+				Propagation_Reached2 ();
+		}
+
+		[Kept]
+		static void Propagation_Reached1 ()
+		{
+		}
+
+		[Kept]
+		static void Propagation_Reached2 ()
 		{
 		}
 	}

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/InstanceMethodSubstitutions.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/InstanceMethodSubstitutions.cs
@@ -1,0 +1,173 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.UnreachableBlock
+{
+	[SetupLinkerSubstitutionFile ("InstanceMethodSubstitutions.xml")]
+	[SetupCSharpCompilerToUse ("csc")]
+	[SetupCompileArgument ("/optimize+")]
+	[SetupLinkerArgument ("--enable-opt", "ipconstprop")]
+	public class InstanceMethodSubstitutions
+	{
+		[Kept]
+		private InstanceMethodSubstitutions ()
+		{
+		}
+
+		public static void Main ()
+		{
+			var instance = new InstanceMethodSubstitutions ();
+			instance.TestSimpleCallsite ();
+			instance.TestCallOnInstance ();
+			instance.TestInstanceMethodWithoutSubstitution ();
+			instance.TestPropagation ();
+			instance.TestVirtualMethod ();
+		}
+
+		bool _isEnabledField;
+
+		[Kept]
+		[ExpectBodyModified]
+		bool IsEnabled ()
+		{
+			return _isEnabledField;
+		}
+
+		[Kept]
+		InstanceMethodSubstitutions GetInstance()
+		{
+			return null;
+		}
+
+		[Kept]
+		[ExpectBodyModified]
+		void TestCallOnInstance ()
+		{
+			
+			if (GetInstance().IsEnabled ())
+				CallOnInstance_NeverReached ();
+			else
+				CallOnInstance_Reached ();
+		}
+
+		void CallOnInstance_NeverReached ()
+		{
+		}
+
+		[Kept]
+		void CallOnInstance_Reached ()
+		{
+		}
+
+		[Kept]
+		[ExpectBodyModified]
+		void TestSimpleCallsite ()
+		{
+			if (IsEnabled ())
+				SimpleCallsite_NeverReached ();
+			else
+				SimpleCallsite_Reached ();
+		}
+
+		void SimpleCallsite_NeverReached ()
+		{
+		}
+
+		[Kept]
+		void SimpleCallsite_Reached ()
+		{
+		}
+
+		[Kept]
+		void TestInstanceMethodWithoutSubstitution ()
+		{
+			if (InstanceMethodWithoutSubstitution ())
+				InstanceMethodWithoutSubstitution_Reached1 ();
+			else
+				InstanceMethodWithoutSubstitution_Reached2 ();
+		}
+
+		[Kept]
+		bool InstanceMethodWithoutSubstitution ()
+		{
+			return true;
+		}
+
+		[Kept]
+		void InstanceMethodWithoutSubstitution_Reached1 ()
+		{
+		}
+
+		[Kept]
+		void InstanceMethodWithoutSubstitution_Reached2 ()
+		{
+		}
+
+		[Kept]
+		void TestPropagation ()
+		{
+			if (PropagateIsEnabled ())
+				Propagation_Reached1 ();
+			else
+				Propagation_Reached2 ();
+		}
+
+		[Kept]
+		bool PropagateIsEnabled ()
+		{
+			return IsEnabled ();
+		}
+
+		[Kept]
+		void Propagation_Reached1 ()
+		{
+		}
+
+		[Kept]
+		void Propagation_Reached2 ()
+		{
+		}
+
+		[Kept]
+		void TestVirtualMethod ()
+		{
+			TestVirtualMethodBase instance = new TestVirtualMethodType ();
+			if (instance.IsEnabled ())
+				VirtualMethod_Reached1 ();
+			else
+				VirtualMethod_Reached2 ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		class TestVirtualMethodBase
+		{
+			[Kept]
+			[ExpectBodyModified]
+			public virtual bool IsEnabled () { return false; }
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptBaseType (typeof (TestVirtualMethodBase))]
+		class TestVirtualMethodType : TestVirtualMethodBase
+		{
+			[Kept]
+			[ExpectBodyModified]
+			public override bool IsEnabled () { return false; }
+		}
+
+		[Kept]
+		void VirtualMethod_Reached1 ()
+		{
+		}
+
+		[Kept]
+		void VirtualMethod_Reached2 ()
+		{
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/InstanceMethodSubstitutions.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/InstanceMethodSubstitutions.cs
@@ -37,7 +37,7 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 		}
 
 		[Kept]
-		InstanceMethodSubstitutions GetInstance()
+		InstanceMethodSubstitutions GetInstance ()
 		{
 			return null;
 		}
@@ -46,8 +46,8 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 		[ExpectBodyModified]
 		void TestCallOnInstance ()
 		{
-			
-			if (GetInstance().IsEnabled ())
+
+			if (GetInstance ().IsEnabled ())
 				CallOnInstance_NeverReached ();
 			else
 				CallOnInstance_Reached ();

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/InstanceMethodSubstitutions.xml
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/InstanceMethodSubstitutions.xml
@@ -1,0 +1,16 @@
+﻿<linker>
+  <assembly fullname="test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+    <type fullname="Mono.Linker.Tests.Cases.UnreachableBlock.InstanceMethodSubstitutions">
+      <method signature="System.Boolean IsEnabled()" body="stub" value="false">
+      </method>
+    </type>
+    <type fullname="Mono.Linker.Tests.Cases.UnreachableBlock.InstanceMethodSubstitutions/TestVirtualMethodBase">
+      <method signature="System.Boolean IsEnabled()" body="stub" value="true">
+      </method>
+    </type>
+    <type fullname="Mono.Linker.Tests.Cases.UnreachableBlock.InstanceMethodSubstitutions/TestVirtualMethodType">
+      <method signature="System.Boolean IsEnabled()" body="stub" value="true">
+      </method>
+    </type>
+  </assembly>
+</linker>


### PR DESCRIPTION
So far we only allowed inlining of return values for methods which are static, with this change we also allow it on an instance method which is explicitly substituted.