### PR TITLE
This allows linker to propagate constant return values higher up the callstack

### DIFF
--- a/src/linker/Linker.Steps/RemoveUnreachableBlocksStep.cs
+++ b/src/linker/Linker.Steps/RemoveUnreachableBlocksStep.cs
@@ -139,10 +139,11 @@ namespace Mono.Linker.Steps
 			// produce folded branches. When it finds them the unreachable
 			// branch is replaced with nops.
 			//
-			if (!reducer.RewriteBody ())
-				return;
+			if (reducer.RewriteBody ())
+				Context.LogMessage ($"Reduced '{reducer.InstructionsReplaced}' instructions in conditional branches for [{method.DeclaringType.Module.Assembly.Name}] method {method.FullName}");
 
-			Context.LogMessage ($"Reduced '{reducer.InstructionsReplaced}' instructions in conditional branches for [{method.DeclaringType.Module.Assembly.Name}] method {method.FullName}");
+			// Even if the rewriter doesn't find any branches to fold the inlining above may have changed the method enough
+			// such that we can now deduce its return value.
 
 			if (method.ReturnType.MetadataType == MetadataType.Void)
 				return;

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/BodiesWithSubstitutions.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/BodiesWithSubstitutions.cs
@@ -84,22 +84,22 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 		}
 
 		[Kept]
+		[ExpectBodyModified]
 		static void TestPropagation ()
 		{
 			// We don't propagate return values across method calls
 			if (PropagateProperty != 3)
-				Propagation_Reached1 ();
+				Propagation_NeverReached ();
 			else
-				Propagation_Reached2 ();
+				Propagation_Reached ();
 		}
 
-		[Kept]
-		static void Propagation_Reached1 ()
+		static void Propagation_NeverReached ()
 		{
 		}
 
 		[Kept]
-		static void Propagation_Reached2 ()
+		static void Propagation_Reached ()
 		{
 		}
 	}


### PR DESCRIPTION
This was probably a "bug" as the code is designed to do this and it will work for methods with multiple branches, but it doesn't work for methods which simply return a value from another method (no branching).

This has small impact - in CoreLib this actually only kicks in about 4 times.