### PR TITLE
Accept default constructor annotation in CreateInstance<T>

### DIFF
--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -1126,7 +1126,7 @@ namespace Mono.Linker.Dataflow
 								break;
 							}
 
-							if ((_flowAnnotations.GetGenericParameterAnnotation(genericParameter) & DynamicallyAccessedMemberTypes.DefaultConstructor) != 0) {
+							if ((_flowAnnotations.GetGenericParameterAnnotation (genericParameter) & DynamicallyAccessedMemberTypes.DefaultConstructor) != 0) {
 								// Also safe, the linker would have marked the default .ctor already
 								reflectionContext.RecordHandledPattern ();
 								break;

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -1125,6 +1125,12 @@ namespace Mono.Linker.Dataflow
 								reflectionContext.RecordHandledPattern ();
 								break;
 							}
+
+							if ((_flowAnnotations.GetGenericParameterAnnotation(genericParameter) & DynamicallyAccessedMemberTypes.DefaultConstructor) != 0) {
+								// Also safe, the linker would have marked the default .ctor already
+								reflectionContext.RecordHandledPattern ();
+								break;
+							}
 						}
 
 						// Not yet supported in any combination

--- a/test/Mono.Linker.Tests.Cases/Reflection/ActivatorCreateInstance.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ActivatorCreateInstance.cs
@@ -47,6 +47,8 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
 			TestCreateInstanceOfTWithNewConstraint<TestCreateInstanceOfTWithNewConstraintType> ();
 			TestCreateInstanceOfTWithNoConstraint<TestCreateInstanceOfTWithNoConstraintType> ();
+
+			TestCreateInstanceOfTWithDataflow<TestCreateInstanceOfTWithDataflowType> ();
 		}
 
 		[Kept]
@@ -403,6 +405,28 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		[Kept]
 		[UnrecognizedReflectionAccessPattern (typeof (Activator), nameof (Activator.CreateInstance) + "<T>", new Type[0])]
 		private static void TestCreateInstanceOfTWithNoConstraint<T> ()
+		{
+			Activator.CreateInstance<T> ();
+		}
+
+		[Kept]
+		class TestCreateInstanceOfTWithDataflowType
+		{
+			[Kept]
+			public TestCreateInstanceOfTWithDataflowType ()
+			{
+			}
+
+			public TestCreateInstanceOfTWithDataflowType (int i)
+			{
+			}
+		}
+
+		[Kept]
+		[RecognizedReflectionAccessPattern]
+		private static void TestCreateInstanceOfTWithDataflow<
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor),
+			KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))] T> ()
 		{
 			Activator.CreateInstance<T> ();
 		}


### PR DESCRIPTION
If `CreateInstance<T>` is used with a generic parameter that is annotated to keep the public parameterless ctor, the use is safe.