### PR TITLE
Don't warn on duplicate preserve for types

### DIFF
--- a/src/linker/Linker.Steps/ResolveFromXmlStep.cs
+++ b/src/linker/Linker.Steps/ResolveFromXmlStep.cs
@@ -274,7 +274,6 @@ namespace Mono.Linker.Steps
 
 			if (Annotations.IsMarked (type)) {
 				var duplicateLevel = preserve != TypePreserve.Nothing ? preserve : nav.HasChildren ? TypePreserve.Nothing : TypePreserve.All;
-				Context.LogWarning ($"Duplicate preserve of '{type.FullName}' in '{_xmlDocumentLocation}'", 2025, _xmlDocumentLocation);
 			}
 
 			Annotations.Mark (type, new DependencyInfo (DependencyKind.XmlDescriptor, _xmlDocumentLocation));


### PR DESCRIPTION
Related to #1289. Whenever we mark a member with `ResolveFromXmlStep` we also have to mark its declaring type. Because there can be multiple calls to this step, each marking a different member from the same declaring type, there's a chance that the linker will output this warning multiple times without having the possibility to resolve it.