### PR TITLE
Update option names and docs

### DIFF
--- a/docs/illink-tasks.md
+++ b/docs/illink-tasks.md
@@ -62,13 +62,10 @@ The linker default behavior depends on the SDK, because each SDK uses linker set
 By default, only framework assemblies are trimmed, and they are trimmed in a conservative
 assembly-level mode (`copyused` action). Third-party libraries and the app will be analyzed but not trimmed.
 
-By default, the linker will operate in assembly-level mode (`copyused` action) for all framework or
-core managed assemblies. The 3rd party libraries or final app will be analyzed but not trimmed.
-
 ### Blazor SDK
 
 By default, framework assemblies are trimmed in an aggressive member-level mode (`link` action). ASP.NET assemblies
-use type-level trimming (achieved by custom root descriptors, not `TrimMode`), and third-party libraries are analyzed
+use type-level trimming (achieved by using custom root descriptors with the global `TrimMode` `link`), and third-party libraries are analyzed
 but not trimmed.
 
 ## Customizing Linking Behavior

--- a/docs/illink-tasks.md
+++ b/docs/illink-tasks.md
@@ -55,18 +55,7 @@ The linker can be invoked as an MSBuild task, `ILLink`. We recommend not using t
 
 ## Default Linking Behavior
 
-The linker default behavior depends on the SDK, because each SDK uses linker settings appropriate for the target form factor.
-
-### .NET Core SDK
-
-By default, only framework assemblies are trimmed, and they are trimmed in a conservative
-assembly-level mode (`copyused` action). Third-party libraries and the app will be analyzed but not trimmed.
-
-### Blazor SDK
-
-By default, framework assemblies are trimmed in an aggressive member-level mode (`link` action). ASP.NET assemblies
-use type-level trimming (achieved by using custom root descriptors with the global `TrimMode` `link`), and third-party libraries are analyzed
-but not trimmed.
+The default in the .NET Core SDK is to trim framework assemblies only, in a conservative assembly-level mode (`copyused` action). Third-party libraries and the app will be analyzed but not trimmed. Other SDKs may modify these defaults.
 
 ## Customizing Linking Behavior
 

--- a/docs/illink-tasks.md
+++ b/docs/illink-tasks.md
@@ -53,20 +53,33 @@ The linker can be invoked as an MSBuild task, `ILLink`. We recommend not using t
         ExtraArgs="-t -c link" />
 ```
 
-## Default Linking Behaviour
+## Default Linking Behavior
 
-### .NET 5.0
+The linker default behavior depends on the SDK, because each SDK uses linker settings appropriate for the target form factor.
 
-By default, the linker will operate in a full linking mode for all framework or 
-core managed assemblies. The 3rd party libraries or final app will be analyzed but not linked.
-This setting can be altered by setting `_TrimmerDefaultAction` property to different
-linker action mode.
+### .NET Core SDK
 
-### .NET 3.x
+By default, only framework assemblies are trimmed, and they are trimmed in a conservative
+assembly-level mode (`copyused` action). Third-party libraries and the app will be analyzed but not trimmed.
 
-By default, the linker will operate in a conservative mode that keeps
-all managed assemblies that aren't part of the framework (they are
-kept intact, and the linker simply copies them).
+By default, the linker will operate in assembly-level mode (`copyused` action) for all framework or
+core managed assemblies. The 3rd party libraries or final app will be analyzed but not trimmed.
+
+### Blazor SDK
+
+By default, framework assemblies are trimmed in an aggressive member-level mode (`link` action). ASP.NET assemblies
+use type-level trimming (achieved by custom root descriptors, not `TrimMode`), and third-party libraries are analyzed
+but not trimmed.
+
+## Customizing Linking Behavior
+
+`TrimMode` can be used to set the trimming behavior for framework assemblies. Additional assemblies can be given
+metadata `IsTrimmable` and they will also be trimmed using this mode, or they can have per-assembly `TrimMode` which
+takes precedence over the global `TrimMode`.
+
+## Reflection
+
+Note: this section is out-of-date. New versions of the linker can understand some of these reflection patterns.
 
 Applications or frameworks (including ASP<span />.NET Core and WPF) that use reflection or related dynamic features will often break when trimmed, because the linker does not know about this dynamic behavior, and can not determine in general which framework types will be required for reflection at runtime. To trim such apps, you will need to tell the linker about any types needed by reflection in your code, and in packages or frameworks that you depend on. Be sure to test your apps after trimming.
 

--- a/src/ILLink.Tasks/LinkTask.cs
+++ b/src/ILLink.Tasks/LinkTask.cs
@@ -14,7 +14,7 @@ namespace ILLink.Tasks
 		///   Paths to the assembly files that should be considered as
 		///   input to the linker.
 		///   Optional metadata:
-		///       Action ("copy", "link", etc...): sets the illink action to take for this assembly.
+		///       TrimMode ("copy", "link", etc...): sets the illink action to take for this assembly.
 		///   There is an optional metadata for each optimization that can be set to "True" or "False" to
 		///   enable or disable it per-assembly:
 		///       BeforeFieldInit
@@ -159,7 +159,7 @@ namespace ILLink.Tasks
 		///   Sets the default action for assemblies.
 		///   Maps to '-c' and '-u'.
 		/// </summary>
-		public string DefaultAction { get; set; }
+		public string TrimMode { get; set; }
 
 		/// <summary>
 		///   A list of custom steps to insert into the linker pipeline.
@@ -261,10 +261,10 @@ namespace ILLink.Tasks
 
 				args.Append ("-reference ").AppendLine (Quote (assemblyPath));
 
-				string action = assembly.GetMetadata ("Action");
-				if (!String.IsNullOrEmpty (action)) {
+				string trimMode = assembly.GetMetadata ("TrimMode");
+				if (!String.IsNullOrEmpty (trimMode)) {
 					args.Append ("-p ");
-					args.Append (action);
+					args.Append (trimMode);
 					args.Append (" ").AppendLine (Quote (assemblyName));
 				}
 
@@ -349,8 +349,8 @@ namespace ILLink.Tasks
 			if (LinkSymbols)
 				args.AppendLine ("-b");
 
-			if (DefaultAction != null)
-				args.Append ("-c ").Append (DefaultAction).Append (" -u ").AppendLine (DefaultAction);
+			if (TrimMode != null)
+				args.Append ("-c ").Append (TrimMode).Append (" -u ").AppendLine (TrimMode);
 
 			if (CustomSteps != null) {
 				foreach (var customStep in CustomSteps) {

--- a/test/ILLink.Tasks.Tests/ILLink.Tasks.Tests.cs
+++ b/test/ILLink.Tasks.Tests/ILLink.Tasks.Tests.cs
@@ -21,12 +21,12 @@ namespace ILLink.Tasks.Tests
 		public static IEnumerable<object[]> AssemblyPathsCases => new List<object[]> {
 			new object [] {
 				new ITaskItem [] {
-					new TaskItem ("Assembly.dll", new Dictionary<string, string> { { "action", "copy" } })
+					new TaskItem ("Assembly.dll", new Dictionary<string, string> { { "trimmode", "copy" } })
 				}
 			},
 			new object [] {
 				new ITaskItem [] {
-					new TaskItem ("Assembly.dll", new Dictionary<string, string> { { "Action", "Copy" } })
+					new TaskItem ("Assembly.dll", new Dictionary<string, string> { { "TrimMode", "Copy" } })
 				}
 			},
 			new object [] {
@@ -75,10 +75,10 @@ namespace ILLink.Tasks.Tests
 
 				foreach (var item in assemblyPaths) {
 					var assemblyPath = item.ItemSpec;
-					var action = item.GetMetadata ("action");
-					if (String.IsNullOrEmpty (action))
+					var trimMode = item.GetMetadata ("TrimMode");
+					if (String.IsNullOrEmpty (trimMode))
 						continue;
-					AssemblyAction expectedAction = (AssemblyAction) Enum.Parse (typeof (AssemblyAction), action, ignoreCase: true);
+					AssemblyAction expectedAction = (AssemblyAction) Enum.Parse (typeof (AssemblyAction), trimMode, ignoreCase: true);
 					AssemblyAction actualAction = (AssemblyAction) context.Actions[Path.GetFileNameWithoutExtension (assemblyPath)];
 					Assert.Equal (expectedAction, actualAction);
 				}
@@ -89,7 +89,7 @@ namespace ILLink.Tasks.Tests
 		public void TestAssemblyPathsWithInvalidAction ()
 		{
 			var task = new MockTask () {
-				AssemblyPaths = new ITaskItem[] { new TaskItem ("Assembly.dll", new Dictionary<string, string> { { "action", "invalid" } }) }
+				AssemblyPaths = new ITaskItem[] { new TaskItem ("Assembly.dll", new Dictionary<string, string> { { "TrimMode", "invalid" } }) }
 			};
 			Assert.Throws<ArgumentException> (() => task.CreateDriver ());
 		}
@@ -379,12 +379,12 @@ namespace ILLink.Tasks.Tests
 		public void TestExtraArgs ()
 		{
 			var task = new MockTask () {
-				DefaultAction = "copy",
+				TrimMode = "copy",
 				ExtraArgs = "-c link"
 			};
 			using (var driver = task.CreateDriver ()) {
 				Assert.Equal (AssemblyAction.Copy, driver.Context.UserAction);
-				// Check that ExtraArgs can override DefaultAction
+				// Check that ExtraArgs can override TrimMode
 				Assert.Equal (AssemblyAction.Link, driver.Context.CoreAction);
 			}
 		}
@@ -419,13 +419,13 @@ namespace ILLink.Tasks.Tests
 		[InlineData ("copy")]
 		[InlineData ("link")]
 		[InlineData ("copyused")]
-		public void TestDefaultAction (string defaultAction)
+		public void TestGlobalTrimMode (string trimMode)
 		{
 			var task = new MockTask () {
-				DefaultAction = defaultAction
+				TrimMode = trimMode
 			};
 			using (var driver = task.CreateDriver ()) {
-				var expectedAction = (AssemblyAction) Enum.Parse (typeof (AssemblyAction), defaultAction, ignoreCase: true);
+				var expectedAction = (AssemblyAction) Enum.Parse (typeof (AssemblyAction), trimMode, ignoreCase: true);
 				Assert.Equal (expectedAction, driver.Context.CoreAction);
 				Assert.Equal (expectedAction, driver.Context.UserAction);
 			}
@@ -435,7 +435,7 @@ namespace ILLink.Tasks.Tests
 		public void TestInvalidDefaultAction ()
 		{
 			var task = new MockTask () {
-				DefaultAction = "invalid"
+				TrimMode = "invalid"
 			};
 			Assert.Throws<ArgumentException> (() => task.CreateDriver ());
 		}


### PR DESCRIPTION
`Action` and `DefaultAction` become `TrimMode`, and updates documentation to match.
The documentation needs more work, but this at least replaces some incorrect information.

Part of https://github.com/dotnet/sdk/issues/12035. The SDK side of this is implemented in https://github.com/dotnet/sdk/pull/12116. Once the SDK part is in, I will update the SDK here to get the integration tests working with the change.