### PR TITLE
RequiresUnreferencedCode should not suppress reflection analysis

### DIFF
--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -55,14 +55,9 @@ namespace Mono.Linker.Dataflow
 			return false;
 		}
 
-		public static bool AutomaticallySuppressReflectionMethodBodyScannerForMethod (LinkContext context, MethodReference method)
+		private bool ShouldEnableReflectionPatternReporting (MethodDefinition method)
 		{
-			MethodDefinition methodDefinition = method.Resolve ();
-			if (methodDefinition != null) {
-				return context.Annotations.HasLinkerAttribute<RequiresUnreferencedCodeAttribute> (methodDefinition);
-			}
-
-			return false;
+			return !_context.Annotations.HasLinkerAttribute<RequiresUnreferencedCodeAttribute> (method);
 		}
 
 		public ReflectionMethodBodyScanner (LinkContext context, MarkStep parent, FlowAnnotations flowAnnotations)
@@ -77,11 +72,12 @@ namespace Mono.Linker.Dataflow
 			Scan (methodBody);
 
 			if (MethodReturnValue != null) {
-				var requiredMemberKinds = _flowAnnotations.GetReturnParameterAnnotation (methodBody.Method);
+				var method = methodBody.Method;
+				var requiredMemberKinds = _flowAnnotations.GetReturnParameterAnnotation (method);
 				if (requiredMemberKinds != 0) {
-					var reflectionContext = new ReflectionPatternContext (_context, methodBody.Method, methodBody.Method.MethodReturnType);
+					var reflectionContext = new ReflectionPatternContext (_context, ShouldEnableReflectionPatternReporting (method), method, method.MethodReturnType);
 					reflectionContext.AnalyzingPattern ();
-					RequireDynamicallyAccessedMembers (ref reflectionContext, requiredMemberKinds, MethodReturnValue, methodBody.Method.MethodReturnType);
+					RequireDynamicallyAccessedMembers (ref reflectionContext, requiredMemberKinds, MethodReturnValue, method.MethodReturnType);
 				}
 			}
 		}
@@ -95,7 +91,7 @@ namespace Mono.Linker.Dataflow
 				if (annotation != DynamicallyAccessedMemberTypes.None) {
 					ValueNode valueNode = GetValueNodeForCustomAttributeArgument (arguments[i]);
 					if (valueNode != null) {
-						var reflectionContext = new ReflectionPatternContext (_context, source, method.Parameters[i]);
+						var reflectionContext = new ReflectionPatternContext (_context, true, source, method.Parameters[i]);
 						reflectionContext.AnalyzingPattern ();
 						RequireDynamicallyAccessedMembers (ref reflectionContext, annotation, valueNode, method);
 					}
@@ -110,7 +106,7 @@ namespace Mono.Linker.Dataflow
 
 			ValueNode valueNode = GetValueNodeForCustomAttributeArgument (value);
 			if (valueNode != null) {
-				var reflectionContext = new ReflectionPatternContext (_context, field.DeclaringType.Methods[0], field);
+				var reflectionContext = new ReflectionPatternContext (_context, true, field.DeclaringType.Methods[0], field);
 				reflectionContext.AnalyzingPattern ();
 				RequireDynamicallyAccessedMembers (ref reflectionContext, annotation, valueNode, field);
 			}
@@ -152,7 +148,10 @@ namespace Mono.Linker.Dataflow
 			}
 
 			if (valueNode != null) {
-				var reflectionContext = new ReflectionPatternContext (_context, source, genericParameter);
+				bool enableReflectionPatternReporting = (source is MethodDefinition sourceMethod) ? 
+					ShouldEnableReflectionPatternReporting (sourceMethod) : true;
+
+				var reflectionContext = new ReflectionPatternContext (_context, enableReflectionPatternReporting, source, genericParameter);
 				reflectionContext.AnalyzingPattern ();
 				RequireDynamicallyAccessedMembers (ref reflectionContext, annotation, valueNode, genericParameter);
 			}
@@ -193,7 +192,7 @@ namespace Mono.Linker.Dataflow
 		{
 			var requiredMemberKinds = _flowAnnotations.GetFieldAnnotation (field);
 			if (requiredMemberKinds != 0) {
-				var reflectionContext = new ReflectionPatternContext (_context, method, field, operation);
+				var reflectionContext = new ReflectionPatternContext (_context, ShouldEnableReflectionPatternReporting (method), method, field, operation);
 				reflectionContext.AnalyzingPattern ();
 				RequireDynamicallyAccessedMembers (ref reflectionContext, requiredMemberKinds, valueToStore, field);
 			}
@@ -204,7 +203,7 @@ namespace Mono.Linker.Dataflow
 			var requiredMemberKinds = _flowAnnotations.GetParameterAnnotation (method, index);
 			if (requiredMemberKinds != 0) {
 				ParameterDefinition parameter = method.Parameters[index - (method.HasImplicitThis () ? 1 : 0)];
-				var reflectionContext = new ReflectionPatternContext (_context, method, parameter, operation);
+				var reflectionContext = new ReflectionPatternContext (_context, ShouldEnableReflectionPatternReporting (method), method, parameter, operation);
 				reflectionContext.AnalyzingPattern ();
 				RequireDynamicallyAccessedMembers (ref reflectionContext, requiredMemberKinds, valueToStore, parameter);
 			}
@@ -490,7 +489,9 @@ namespace Mono.Linker.Dataflow
 
 		public override bool HandleCall (MethodBody callingMethodBody, MethodReference calledMethod, Instruction operation, ValueNodeList methodParams, out ValueNode methodReturnValue)
 		{
-			var reflectionContext = new ReflectionPatternContext (_context, callingMethodBody.Method, calledMethod.Resolve (), operation);
+			var callingMethodDefinition = callingMethodBody.Method;
+			bool shouldEnableReflectionWarnings = ShouldEnableReflectionPatternReporting (callingMethodDefinition);
+			var reflectionContext = new ReflectionPatternContext (_context, shouldEnableReflectionWarnings, callingMethodDefinition, calledMethod.Resolve (), operation);
 
 			DynamicallyAccessedMemberTypes returnValueDynamicallyAccessedMemberKinds = 0;
 
@@ -599,7 +600,7 @@ namespace Mono.Linker.Dataflow
 							IntrinsicId.RuntimeReflectionExtensions_GetRuntimeField => DynamicallyAccessedMemberTypes.PublicFields,
 							IntrinsicId.RuntimeReflectionExtensions_GetRuntimeMethod => DynamicallyAccessedMemberTypes.PublicMethods,
 							IntrinsicId.RuntimeReflectionExtensions_GetRuntimeProperty => DynamicallyAccessedMemberTypes.PublicProperties,
-							_ => throw new InternalErrorException ($"Reflection call '{calledMethod.FullName}' inside '{callingMethodBody.Method.FullName}' is of unexpected member type."),
+							_ => throw new InternalErrorException ($"Reflection call '{calledMethod.FullName}' inside '{callingMethodDefinition.FullName}' is of unexpected member type."),
 						};
 
 						foreach (var value in methodParams[0].UniqueValues ()) {
@@ -624,7 +625,7 @@ namespace Mono.Linker.Dataflow
 											reflectionContext.RecordHandledPattern ();
 											break;
 										default:
-											throw new InternalErrorException ($"Error processing reflection call '{calledMethod.FullName}' inside {callingMethodBody.Method.FullName}. Unexpected member kind.");
+											throw new InternalErrorException ($"Error processing reflection call '{calledMethod.FullName}' inside {callingMethodDefinition.FullName}. Unexpected member kind.");
 										}
 									} else {
 										RequireDynamicallyAccessedMembers (ref reflectionContext, requiredMemberTypes, value, calledMethod.Parameters[0]);
@@ -738,14 +739,14 @@ namespace Mono.Linker.Dataflow
 						// Right now, this can only analyze a couple cases for which we have static information for.
 						TypeDefinition staticType = null;
 						if (methodParams[0] is MethodParameterValue methodParam) {
-							if (callingMethodBody.Method.HasThis) {
+							if (callingMethodDefinition.HasThis) {
 								if (methodParam.ParameterIndex == 0) {
-									staticType = callingMethodBody.Method.DeclaringType;
+									staticType = callingMethodDefinition.DeclaringType;
 								} else {
-									staticType = callingMethodBody.Method.Parameters[methodParam.ParameterIndex - 1].ParameterType.Resolve ();
+									staticType = callingMethodDefinition.Parameters[methodParam.ParameterIndex - 1].ParameterType.Resolve ();
 								}
 							} else {
-								staticType = callingMethodBody.Method.Parameters[methodParam.ParameterIndex].ParameterType.Resolve ();
+								staticType = callingMethodDefinition.Parameters[methodParam.ParameterIndex].ParameterType.Resolve ();
 							}
 						} else if (methodParams[0] is LoadFieldValue loadedField) {
 							staticType = loadedField.Field.FieldType.Resolve ();
@@ -789,8 +790,7 @@ namespace Mono.Linker.Dataflow
 									// Intentionally ignore - it's not wrong for code to call Type.GetType on non-existing name, the code might expect null/exception back.
 									reflectionContext.RecordHandledPattern ();
 								} else {
-									var methodCalling = callingMethodBody.Method;
-									reflectionContext.RecordRecognizedPattern (foundType, () => _markStep.MarkType (foundType, new DependencyInfo (DependencyKind.AccessedViaReflection, methodCalling), methodCalling));
+									reflectionContext.RecordRecognizedPattern (foundType, () => _markStep.MarkType (foundType, new DependencyInfo (DependencyKind.AccessedViaReflection, callingMethodDefinition), callingMethodDefinition));
 									methodReturnValue = MergePointValue.MergeValues (methodReturnValue, new SystemTypeValue (foundType));
 								}
 							} else if (typeNameValue == NullValue.Instance) {
@@ -982,7 +982,7 @@ namespace Mono.Linker.Dataflow
 							IntrinsicId.Type_GetEvent => GetDynamicallyAccessedMemberTypesFromBindingFlagsForEvents (bindingFlags),
 							IntrinsicId.Type_GetField => GetDynamicallyAccessedMemberTypesFromBindingFlagsForFields (bindingFlags),
 							IntrinsicId.Type_GetProperty => GetDynamicallyAccessedMemberTypesFromBindingFlagsForProperties (bindingFlags),
-							_ => throw new ArgumentException ($"Reflection call '{calledMethod.FullName}' inside '{callingMethodBody.Method.FullName}' is of unexpected member type."),
+							_ => throw new ArgumentException ($"Reflection call '{calledMethod.FullName}' inside '{callingMethodDefinition.FullName}' is of unexpected member type."),
 						};
 
 						foreach (var value in methodParams[0].UniqueValues ()) {
@@ -1238,7 +1238,8 @@ namespace Mono.Linker.Dataflow
 						reflectionContext.RecordHandledPattern ();
 					}
 
-					if (_context.Annotations.TryGetLinkerAttribute (calledMethodDefinition, out RequiresUnreferencedCodeAttribute requiresUnreferencedCode)) {
+					if (shouldEnableReflectionWarnings &&
+						_context.Annotations.TryGetLinkerAttribute (calledMethodDefinition, out RequiresUnreferencedCodeAttribute requiresUnreferencedCode)) {
 						string message =
 							$"Calling '{calledMethodDefinition}' which has `RequiresUnreferencedCodeAttribute` can break functionality when trimming application code. " +
 							$"{requiresUnreferencedCode.Message}.";
@@ -1247,7 +1248,7 @@ namespace Mono.Linker.Dataflow
 							message += " " + requiresUnreferencedCode.Url;
 						}
 
-						_context.LogWarning (message, 2026, callingMethodBody.Method, operation.Offset);
+						_context.LogWarning (message, 2026, callingMethodDefinition, operation.Offset);
 					}
 
 					// To get good reporting of errors we need to track the origin of the value for all method calls
@@ -1281,12 +1282,12 @@ namespace Mono.Linker.Dataflow
 			if (returnValueDynamicallyAccessedMemberKinds != 0 && methodReturnValue != null) {
 				if (methodReturnValue is LeafValueWithDynamicallyAccessedMemberNode methodReturnValueWithMemberKinds) {
 					if (!methodReturnValueWithMemberKinds.DynamicallyAccessedMemberTypes.HasFlag (returnValueDynamicallyAccessedMemberKinds))
-						throw new InvalidOperationException ($"Internal linker error: processing of call from {callingMethodBody.Method} to {calledMethod} returned value which is not correctly annotated with the expected dynamic member access kinds.");
+						throw new InvalidOperationException ($"Internal linker error: processing of call from {callingMethodDefinition} to {calledMethod} returned value which is not correctly annotated with the expected dynamic member access kinds.");
 				} else if (methodReturnValue is SystemTypeValue) {
 					// SystemTypeValue can fullfill any requirement, so it's always valid
 					// The requirements will be applied at the point where it's consumed (passed as a method parameter, set as field value, returned from the method)
 				} else {
-					throw new InvalidOperationException ($"Internal linker error: processing of call from {callingMethodBody.Method} to {calledMethod} returned value which is not correctly annotated with the expected dynamic member access kinds.");
+					throw new InvalidOperationException ($"Internal linker error: processing of call from {callingMethodDefinition} to {calledMethod} returned value which is not correctly annotated with the expected dynamic member access kinds.");
 				}
 			}
 

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -148,7 +148,7 @@ namespace Mono.Linker.Dataflow
 			}
 
 			if (valueNode != null) {
-				bool enableReflectionPatternReporting = (source is MethodDefinition sourceMethod) ? 
+				bool enableReflectionPatternReporting = (source is MethodDefinition sourceMethod) ?
 					ShouldEnableReflectionPatternReporting (sourceMethod) : true;
 
 				var reflectionContext = new ReflectionPatternContext (_context, enableReflectionPatternReporting, source, genericParameter);

--- a/src/linker/Linker.Dataflow/ReflectionPatternContext.cs
+++ b/src/linker/Linker.Dataflow/ReflectionPatternContext.cs
@@ -28,11 +28,17 @@ namespace Mono.Linker.Dataflow
 		public IMemberDefinition Source { get; private set; }
 		public IMetadataTokenProvider MemberWithRequirements { get; private set; }
 		public Instruction Instruction { get; private set; }
+		public bool ReportingEnabled { get; private set; }
 
-		public ReflectionPatternContext (LinkContext context, IMemberDefinition source, IMetadataTokenProvider memberWithRequirements,
+		public ReflectionPatternContext (
+			LinkContext context,
+			bool reportingEnabled,
+			IMemberDefinition source,
+			IMetadataTokenProvider memberWithRequirements,
 			Instruction instruction = null)
 		{
 			_context = context;
+			ReportingEnabled = reportingEnabled;
 			Source = source;
 			MemberWithRequirements = memberWithRequirements;
 			Instruction = instruction;
@@ -70,7 +76,9 @@ namespace Mono.Linker.Dataflow
 #endif
 
 			mark ();
-			_context.ReflectionPatternRecorder.RecognizedReflectionAccessPattern (Source, Instruction, accessedItem);
+
+			if (ReportingEnabled)
+				_context.ReflectionPatternRecorder.RecognizedReflectionAccessPattern (Source, Instruction, accessedItem);
 		}
 
 		public void RecordUnrecognizedPattern (string message)
@@ -81,7 +89,9 @@ namespace Mono.Linker.Dataflow
 
 			_patternReported = true;
 #endif
-			_context.ReflectionPatternRecorder.UnrecognizedReflectionAccessPattern (Source, Instruction, MemberWithRequirements, message);
+
+			if (ReportingEnabled)
+				_context.ReflectionPatternRecorder.UnrecognizedReflectionAccessPattern (Source, Instruction, MemberWithRequirements, message);
 		}
 
 		public void Dispose ()

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2571,9 +2571,6 @@ namespace Mono.Linker.Steps
 			foreach (Instruction instruction in body.Instructions)
 				MarkInstruction (instruction, body.Method, ref requiresReflectionMethodBodyScanner);
 
-			if (ReflectionMethodBodyScanner.AutomaticallySuppressReflectionMethodBodyScannerForMethod (_context, body.Method))
-				requiresReflectionMethodBodyScanner = false;
-
 			MarkInterfacesNeededByBodyStack (body);
 
 			MarkReflectionLikeDependencies (body, requiresReflectionMethodBodyScanner);

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
@@ -136,7 +136,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			return null;
 		}
 
-		class TypeRequiresPublicFields <[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T>
+		class TypeRequiresPublicFields<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T>
 		{
 			public static void Method () { }
 		}

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
@@ -19,7 +19,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			TestRequiresWithMessageAndUrlOnMethod ();
 			TestRequiresOnConstructor ();
 			TestRequiresOnPropertyGetterAndSetter ();
-			TestRequiresSuppressesReflectionAnalysis ();
+			TestRequiresSuppressesWarningsFromReflectionAnalysis ();
 		}
 
 		[LogContains (
@@ -96,25 +96,29 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		}
 
 		[LogContains (
-			"warning IL2026: Mono.Linker.Tests.Cases.RequiresCapability.RequiresUnreferencedCodeCapability::TestRequiresSuppressesReflectionAnalysis(): " +
+			"warning IL2026: Mono.Linker.Tests.Cases.RequiresCapability.RequiresUnreferencedCodeCapability::TestRequiresSuppressesWarningsFromReflectionAnalysis(): " +
 			"Calling 'System.Void Mono.Linker.Tests.Cases.RequiresCapability.RequiresUnreferencedCodeCapability::RequiresAndCallsOtherRequiresMethods()' " +
 			"which has `RequiresUnreferencedCodeAttribute` can break functionality when trimming application code. " +
 			"Message for --RequiresAndCallsOtherRequiresMethods--.")]
-		static void TestRequiresSuppressesReflectionAnalysis ()
+		static void TestRequiresSuppressesWarningsFromReflectionAnalysis ()
 		{
-			RequiresAndCallsOtherRequiresMethods ();
+			RequiresAndCallsOtherRequiresMethods<TestType> ();
 		}
 
 		[RequiresUnreferencedCode ("Message for --RequiresAndCallsOtherRequiresMethods--")]
 		[LogDoesNotContain ("Message for --RequiresUnreferencedCodeMethod--")]
 		[RecognizedReflectionAccessPattern]
-		static void RequiresAndCallsOtherRequiresMethods ()
+		static void RequiresAndCallsOtherRequiresMethods<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] TPublicMethods> ()
 		{
 			// Normally this would warn, but with the attribute on this method it should be auto-suppressed
 			RequiresUnreferencedCodeMethod ();
 
 			// Normally this would warn due to incompatible annotations, but with the attribute on this method it should be auto-suppressed
 			RequiresPublicFields (GetTypeWithPublicMethods ());
+
+			TypeRequiresPublicFields<TPublicMethods>.Method ();
+
+			MethodRequiresPublicFields<TPublicMethods> ();
 		}
 
 		[RequiresUnreferencedCode ("Message for --RequiresUnreferencedCodeMethod--")]
@@ -131,5 +135,14 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		{
 			return null;
 		}
+
+		class TypeRequiresPublicFields <[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T>
+		{
+			public static void Method () { }
+		}
+
+		static void MethodRequiresPublicFields<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T> () { }
+
+		class TestType { }
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapabilityReflectionAnalysisEnabled.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapabilityReflectionAnalysisEnabled.cs
@@ -74,10 +74,10 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		}
 
 		[Kept]
-		class TypeRequiresPublicFields <
+		class TypeRequiresPublicFields<
 			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
-			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)]
-			T>
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)]
+		T>
 		{
 			[Kept]
 			public static void Method () { }
@@ -93,10 +93,10 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		}
 
 		[Kept]
-		static void MethodRequiresPublicFields <
+		static void MethodRequiresPublicFields<
 			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
-			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)]
-			T> ()
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)]
+		T> ()
 		{
 		}
 

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapabilityReflectionAnalysisEnabled.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapabilityReflectionAnalysisEnabled.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.RequiresCapability
+{
+	public class RequiresUnreferencedCodeCapabilityReflectionAnalysisEnabled
+	{
+		[LogContains ("-- DynamicallyAccessedMembersEnabled --")]
+		[LogContains ("-- ReflectionPattern --")]
+		[LogContains ("-- DynamicallyAccessedMembersOnGenericsEnabled --")]
+		public static void Main ()
+		{
+			TestRequiresUnreferencedCodeAttributeWithDynamicallyAccessedMembersEnabled ();
+			TestRequiresUnreferencedCodeAttributeWithReflectionPattern ();
+			TestRequiresUnreferencedCodeAttributeWithDynamicallyAccessedMembersOnGenericsEnabled ();
+		}
+
+		[Kept]
+		[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+		[RequiresUnreferencedCode ("-- DynamicallyAccessedMembersEnabled --")]
+		[RecognizedReflectionAccessPattern]
+		static void TestRequiresUnreferencedCodeAttributeWithDynamicallyAccessedMembersEnabled ()
+		{
+			RequiresPublicFields (typeof (TypeWithPublicFieldsAccessed));
+		}
+
+		[Kept]
+		static void RequiresPublicFields (
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)]
+			Type type)
+		{
+		}
+
+		[Kept]
+		class TypeWithPublicFieldsAccessed
+		{
+			[Kept]
+			public int _publicField;
+
+			private int _privateField;
+		}
+
+		[Kept]
+		[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+		[RequiresUnreferencedCode ("-- ReflectionPattern --")]
+		[RecognizedReflectionAccessPattern]
+		static void TestRequiresUnreferencedCodeAttributeWithReflectionPattern ()
+		{
+			typeof (TypeWithMethodAccessed).GetMethod ("PublicMethod");
+		}
+
+		[Kept]
+		class TypeWithMethodAccessed
+		{
+			[Kept]
+			public void PublicMethod () { }
+
+			public void PublicMethod2 () { }
+		}
+
+		[Kept]
+		[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+		[RequiresUnreferencedCode ("-- DynamicallyAccessedMembersOnGenericsEnabled --")]
+		[RecognizedReflectionAccessPattern]
+		static void TestRequiresUnreferencedCodeAttributeWithDynamicallyAccessedMembersOnGenericsEnabled ()
+		{
+			TypeRequiresPublicFields<TypeWithPublicFieldsForGenericType>.Method ();
+			MethodRequiresPublicFields<TypeWithPublicFieldsForGenericMethod> ();
+		}
+
+		[Kept]
+		class TypeRequiresPublicFields <
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)]
+			T>
+		{
+			[Kept]
+			public static void Method () { }
+		}
+
+		[Kept]
+		class TypeWithPublicFieldsForGenericType
+		{
+			[Kept]
+			public int _publicField;
+
+			private int _privateField;
+		}
+
+		[Kept]
+		static void MethodRequiresPublicFields <
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)]
+			T> ()
+		{
+		}
+
+		[Kept]
+		class TypeWithPublicFieldsForGenericMethod
+		{
+			[Kept]
+			public int _publicField;
+
+			private int _privateField;
+		}
+	}
+}


### PR DESCRIPTION
RequiresUnreferencedCode attribute should only suppress reflection analysis warnings for a given method, but reflection analysis should still run.

Should basically fix https://github.com/mono/linker/issues/1167.