### PR TITLE
Support propagation of constant return value from methods with parameters

### DIFF
--- a/src/linker/Linker.Steps/CodeRewriterStep.cs
+++ b/src/linker/Linker.Steps/CodeRewriterStep.cs
@@ -149,7 +149,7 @@ namespace Mono.Linker.Steps
 			var body = new MethodBody (method);
 
 			if (method.HasParameters && method.Parameters.Any (l => l.IsOut))
-				throw new NotImplementedException ();
+				throw new NotSupportedException ($"Cannot replace body of method '{method.GetDisplayName ()}' because it has an out parameter.");
 
 			var il = body.GetILProcessor ();
 			if (method.IsInstanceConstructor () && !method.DeclaringType.IsValueType) {

--- a/src/linker/Linker.Steps/RemoveUnreachableBlocksStep.cs
+++ b/src/linker/Linker.Steps/RemoveUnreachableBlocksStep.cs
@@ -193,13 +193,11 @@ namespace Mono.Linker.Steps
 						if (!explicitlyAnnotated)
 							break;
 
-						bool hasByRefOrOutParameter = false;
-						for (int paramIndex = 0; paramIndex < md.Parameters.Count; paramIndex++) {
-							var param = md.Parameters[paramIndex];
-							hasByRefOrOutParameter |= param.ParameterType.IsByReference || param.IsOut;
-						}
+						bool hasByRefParameter = false;
+						foreach (var param in md.Parameters)
+							hasByRefParameter |= param.ParameterType.IsByReference;
 
-						if (hasByRefOrOutParameter || md.CallingConvention == MethodCallingConvention.VarArg)
+						if (hasByRefParameter || md.CallingConvention == MethodCallingConvention.VarArg)
 							break;
 					}
 

--- a/src/linker/Linker.Steps/RemoveUnreachableBlocksStep.cs
+++ b/src/linker/Linker.Steps/RemoveUnreachableBlocksStep.cs
@@ -194,8 +194,12 @@ namespace Mono.Linker.Steps
 							break;
 
 						bool hasByRefParameter = false;
-						foreach (var param in md.Parameters)
-							hasByRefParameter |= param.ParameterType.IsByReference;
+						foreach (var param in md.Parameters) {
+							if (param.ParameterType.IsByReference) {
+								hasByRefParameter = true;
+								break;
+							}
+						}
 
 						if (hasByRefParameter || md.CallingConvention == MethodCallingConvention.VarArg)
 							break;

--- a/src/linker/Linker.Steps/RemoveUnreachableBlocksStep.cs
+++ b/src/linker/Linker.Steps/RemoveUnreachableBlocksStep.cs
@@ -199,7 +199,7 @@ namespace Mono.Linker.Steps
 							hasByRefOrOutParameter |= param.ParameterType.IsByReference || param.IsOut;
 						}
 
-						if (hasByRefOrOutParameter)
+						if (hasByRefOrOutParameter || md.CallingConvention == MethodCallingConvention.VarArg)
 							break;
 					}
 

--- a/src/linker/Linker.Steps/RemoveUnreachableBlocksStep.cs
+++ b/src/linker/Linker.Steps/RemoveUnreachableBlocksStep.cs
@@ -177,6 +177,9 @@ namespace Mono.Linker.Steps
 					if (!constExprMethods.TryGetValue (md, out targetResult))
 						break;
 
+					if (md.CallingConvention == MethodCallingConvention.VarArg)
+						break;
+
 					bool explicitlyAnnotated = Annotations.GetAction (md) == MethodAction.ConvertToStub;
 
 					// Allow inlining results of instance methods which are explicitly annotated
@@ -201,7 +204,7 @@ namespace Mono.Linker.Steps
 							}
 						}
 
-						if (hasByRefParameter || md.CallingConvention == MethodCallingConvention.VarArg)
+						if (hasByRefParameter)
 							break;
 					}
 

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/InstanceMethodSubstitutions.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/InstanceMethodSubstitutions.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.UnreachableBlock
@@ -24,6 +21,7 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 			instance.TestCallOnInstance ();
 			instance.TestInstanceMethodWithoutSubstitution ();
 			instance.TestPropagation ();
+			instance.TestStaticPropagation ();
 			instance.TestVirtualMethod ();
 		}
 
@@ -109,6 +107,8 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 		[Kept]
 		void TestPropagation ()
 		{
+			// Propagation of return value across instance method is not supported
+			// (propagation of return value from a method which has call in the body is not supported)
 			if (PropagateIsEnabled ())
 				Propagation_Reached1 ();
 			else
@@ -132,9 +132,40 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 		}
 
 		[Kept]
+		void TestStaticPropagation ()
+		{
+			// Propagation of return value across static method is not supported
+			// (propagation of return value from a method which has call in the body is not supported)
+			if (PropagateStaticIsEnabled ())
+				StaticPropagation_Reached1 ();
+			else
+				StaticPropagation_Reached2 ();
+		}
+
+		[Kept]
+		private static InstanceMethodSubstitutions _staticInstance;
+
+		[Kept]
+		static bool PropagateStaticIsEnabled ()
+		{
+			return _staticInstance.IsEnabled ();
+		}
+
+		[Kept]
+		void StaticPropagation_Reached1 ()
+		{
+		}
+
+		[Kept]
+		void StaticPropagation_Reached2 ()
+		{
+		}
+
+		[Kept]
 		void TestVirtualMethod ()
 		{
 			TestVirtualMethodBase instance = new TestVirtualMethodType ();
+			// Virtual method return value inlining not supported
 			if (instance.IsEnabled ())
 				VirtualMethod_Reached1 ();
 			else

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/MethodWithParametersSubstitutions.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/MethodWithParametersSubstitutions.cs
@@ -1,0 +1,196 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.UnreachableBlock
+{
+	[SetupLinkerSubstitutionFile ("MethodWithParametersSubstitutions.xml")]
+	[SetupCSharpCompilerToUse ("csc")]
+	[SetupCompileArgument ("/optimize+")]
+	[SetupLinkerArgument ("--enable-opt", "ipconstprop")]
+	class MethodWithParametersSubstitutions
+	{
+		[Kept] MethodWithParametersSubstitutions () { }
+
+		public static void Main ()
+		{
+			var instance = new MethodWithParametersSubstitutions ();
+
+			TestMethodWithValueParam ();
+			TestMethodWithReferenceParam ();
+			instance.TestMethodWithMultipleInParamsInstance ();
+			// TestMethodWithOutParam ();
+			TestMethodWithRefParam ();
+			TestMethodWithMultipleRefParams ();
+			TestMethodWithValueParamAndConstReturn_NoSubstitutions ();
+		}
+
+		static bool _isEnabledField;
+
+		[Kept]
+		[ExpectBodyModified]
+		static bool IsEnabledWithValueParam (int param)
+		{
+			return _isEnabledField;
+		}
+ 
+		[Kept]
+		[ExpectBodyModified]
+		static void TestMethodWithValueParam ()
+		{
+			if (IsEnabledWithValueParam (0))
+				MethodWithValueParam_Reached ();
+			else
+				MethodWithValueParam_NeverReached ();
+		}
+
+		[Kept] static void MethodWithValueParam_Reached () { }
+		static void MethodWithValueParam_NeverReached () { }
+
+		[Kept]
+		[ExpectBodyModified]
+		static bool IsEnabledWithReferenceParam (string param)
+		{
+			return _isEnabledField;
+		}
+
+		[Kept]
+		[ExpectBodyModified]
+		static void TestMethodWithReferenceParam ()
+		{
+			if (IsEnabledWithReferenceParam (""))
+				MethodWithReferenceParam_Reached ();
+			else
+				MethodWithReferenceParam_NeverReached ();
+		}
+
+		[Kept] static void MethodWithReferenceParam_Reached () { }
+		static void MethodWithReferenceParam_NeverReached () { }
+
+		[Kept]
+		[ExpectBodyModified]
+		bool IsEnabledWithMultipleInParamsInstance (int p1, string p2, TestClass p3, TestStruct p4, TestEnum p5)
+		{
+			return _isEnabledField;
+		}
+
+		[Kept]
+		[ExpectBodyModified]
+		void TestMethodWithMultipleInParamsInstance ()
+		{
+			if (IsEnabledWithMultipleInParamsInstance (0, "", new TestClass (), new TestStruct (), TestEnum.None))
+				MethodWithMultipleInParamsInstance_Reached ();
+			else
+				MethodWithMultipleInParamsInstance_NeverReached ();
+		}
+
+		[Kept] void MethodWithMultipleInParamsInstance_Reached () { }
+		void MethodWithMultipleInParamsInstance_NeverReached () { }
+
+		// CodeRewriterStep actually fails when asked to rewrite method body with an out parameter.
+		// So no point in testing that the substitution works or not.
+		//[Kept] static bool _isEnabledWithOutParamField;
+
+		//[Kept]
+		//static bool IsEnabledWithOutParam (out int param)
+		//{
+		//	param = 0;
+		//	return _isEnabledWithOutParamField;
+		//}
+
+		//[Kept]
+		//[LogDoesNotContain("IsEnabledWithOutParam")]
+		//static void TestMethodWithOutParam ()
+		//{
+		//	if (IsEnabledWithOutParam (out var _))
+		//		MethodWithOutParam_Reached1 ();
+		//	else
+		//		MethodWithOutParam_Reached2 ();
+		//}
+
+		//[Kept] static void MethodWithOutParam_Reached1 () { }
+		//[Kept] static void MethodWithOutParam_Reached2 () { }
+
+		static bool _isEnabledWithRefParamField;
+
+		[Kept]
+		[ExpectBodyModified]
+		static bool IsEnabledWithRefParam (ref int param)
+		{
+			param = 0;
+			return _isEnabledWithRefParamField;
+		}
+
+		[Kept]
+		[LogDoesNotContain ("IsEnabledWithRefParam")]
+		static void TestMethodWithRefParam ()
+		{
+			int p = 0;
+			if (IsEnabledWithRefParam (ref p))
+				MethodWithRefParam_Reached1 ();
+			else
+				MethodWithRefParam_Reached2 ();
+		}
+
+		[Kept] static void MethodWithRefParam_Reached1 () { }
+		[Kept] static void MethodWithRefParam_Reached2 () { }
+
+		static bool _isEnabledWithMultipleRefParamsField;
+
+		[Kept]
+		[ExpectBodyModified]
+		static bool IsEnabledWithMultipleRefParams (int p1, ref int p2, ref TestStruct p3, string p4)
+		{
+			p2 = 0;
+			return _isEnabledWithMultipleRefParamsField;
+		}
+
+		[Kept]
+		[LogDoesNotContain ("IsEnabledWithMultipleRefParams")]
+		static void TestMethodWithMultipleRefParams ()
+		{
+			int p = 0;
+			TestStruct p2 = new TestStruct ();
+			if (IsEnabledWithMultipleRefParams (0, ref p, ref p2, ""))
+				MethodWithMultipleRefParams_Reached1 ();
+			else
+				MethodWithMultipleRefParams_Reached2 ();
+		}
+
+		[Kept] static void MethodWithMultipleRefParams_Reached1 () { }
+		[Kept] static void MethodWithMultipleRefParams_Reached2 () { }
+
+		[Kept]
+		static bool IsEnabledWithValueParamAndConstReturn_NoSubstitutions (int param)
+		{
+			return true;
+		}
+
+		[Kept]
+		static void TestMethodWithValueParamAndConstReturn_NoSubstitutions ()
+		{
+			// The return value inlining for methods with params only works on explicitly substituted methods.
+			// Linker will not do this implicitly.
+			if (IsEnabledWithValueParamAndConstReturn_NoSubstitutions (0))
+				MethodWithValueParamAndConstReturn_NoSubstitutions_Reached1 ();
+			else
+				MethodWithValueParamAndConstReturn_NoSubstitutions_Reached2 ();
+		}
+
+		[Kept] static void MethodWithValueParamAndConstReturn_NoSubstitutions_Reached1 () { }
+		[Kept] static void MethodWithValueParamAndConstReturn_NoSubstitutions_Reached2 () { }
+
+
+		[Kept] [KeptMember (".ctor()")] class TestClass { }
+		[Kept] struct TestStruct { }
+
+		[Kept]
+		[KeptMember ("value__")]
+		[KeptBaseType (typeof (Enum))]
+		enum TestEnum
+		{
+			[Kept]
+			None
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/MethodWithParametersSubstitutions.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/MethodWithParametersSubstitutions.cs
@@ -196,7 +196,7 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 		[LogDoesNotContain ("IsEnabledWithVarArgs")]
 		static void TestMethodWithVarArgs ()
 		{
-			if (IsEnabledWithVarArgs (__arglist(1)))
+			if (IsEnabledWithVarArgs (__arglist (1)))
 				MethodWithVarArgs_Reached1 ();
 			else
 				MethodWithVarArgs_Reached2 ();

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/MethodWithParametersSubstitutions.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/MethodWithParametersSubstitutions.cs
@@ -23,6 +23,7 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 			TestMethodWithRefParam ();
 			TestMethodWithMultipleRefParams ();
 			TestMethodWithValueParamAndConstReturn_NoSubstitutions ();
+			TestMethodWithVarArgs ();
 		}
 
 		static bool _isEnabledField;
@@ -179,6 +180,30 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 
 		[Kept] static void MethodWithValueParamAndConstReturn_NoSubstitutions_Reached1 () { }
 		[Kept] static void MethodWithValueParamAndConstReturn_NoSubstitutions_Reached2 () { }
+
+
+		static bool _isEnabledWithVarArgsField;
+
+		[Kept]
+		[ExpectBodyModified]
+		static bool IsEnabledWithVarArgs (int p1, __arglist)
+		{
+			return _isEnabledWithVarArgsField;
+		}
+
+		[Kept]
+		[LogDoesNotContain ("IsEnabledWithVarArgs")]
+		static void TestMethodWithVarArgs ()
+		{
+			int p = 0;
+			if (IsEnabledWithVarArgs (1, __arglist(1)))
+				MethodWithVarArgs_Reached1 ();
+			else
+				MethodWithVarArgs_Reached2 ();
+		}
+
+		[Kept] static void MethodWithVarArgs_Reached1 () { }
+		[Kept] static void MethodWithVarArgs_Reached2 () { }
 
 
 		[Kept] [KeptMember (".ctor()")] class TestClass { }

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/MethodWithParametersSubstitutions.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/MethodWithParametersSubstitutions.cs
@@ -24,6 +24,7 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 			TestMethodWithMultipleRefParams ();
 			TestMethodWithValueParamAndConstReturn_NoSubstitutions ();
 			TestMethodWithVarArgs ();
+			TestMethodWithParamAndVarArgs ();
 		}
 
 		static bool _isEnabledField;
@@ -186,7 +187,7 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 
 		[Kept]
 		[ExpectBodyModified]
-		static bool IsEnabledWithVarArgs (int p1, __arglist)
+		static bool IsEnabledWithVarArgs (__arglist)
 		{
 			return _isEnabledWithVarArgsField;
 		}
@@ -195,8 +196,7 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 		[LogDoesNotContain ("IsEnabledWithVarArgs")]
 		static void TestMethodWithVarArgs ()
 		{
-			int p = 0;
-			if (IsEnabledWithVarArgs (1, __arglist(1)))
+			if (IsEnabledWithVarArgs (__arglist(1)))
 				MethodWithVarArgs_Reached1 ();
 			else
 				MethodWithVarArgs_Reached2 ();
@@ -204,6 +204,29 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 
 		[Kept] static void MethodWithVarArgs_Reached1 () { }
 		[Kept] static void MethodWithVarArgs_Reached2 () { }
+
+
+		static bool _isEnabledWithParamAndVarArgsField;
+
+		[Kept]
+		[ExpectBodyModified]
+		static bool IsEnabledWithParamAndVarArgs (int p1, __arglist)
+		{
+			return _isEnabledWithParamAndVarArgsField;
+		}
+
+		[Kept]
+		[LogDoesNotContain ("IsEnabledWithParamAndVarArgs")]
+		static void TestMethodWithParamAndVarArgs ()
+		{
+			if (IsEnabledWithParamAndVarArgs (1, __arglist (1)))
+				MethodWithParamAndVarArgs_Reached1 ();
+			else
+				MethodWithParamAndVarArgs_Reached2 ();
+		}
+
+		[Kept] static void MethodWithParamAndVarArgs_Reached1 () { }
+		[Kept] static void MethodWithParamAndVarArgs_Reached2 () { }
 
 
 		[Kept] [KeptMember (".ctor()")] class TestClass { }

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/MethodWithParametersSubstitutions.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/MethodWithParametersSubstitutions.cs
@@ -33,7 +33,7 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 		{
 			return _isEnabledField;
 		}
- 
+
 		[Kept]
 		[ExpectBodyModified]
 		static void TestMethodWithValueParam ()

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/MethodWithParametersSubstitutions.xml
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/MethodWithParametersSubstitutions.xml
@@ -8,6 +8,7 @@
       <!--<method signature="System.Boolean IsEnabledWithOutParam(System.Int32&amp;)" body="stub" value="true" />-->
       <method signature="System.Boolean IsEnabledWithRefParam(System.Int32&amp;)" body="stub" value="true" />
       <method signature="System.Boolean IsEnabledWithMultipleRefParams(System.Int32,System.Int32&amp;,Mono.Linker.Tests.Cases.UnreachableBlock.MethodWithParametersSubstitutions/TestStruct&amp;,System.String)" body="stub" value="true" />
+      <method signature="System.Boolean IsEnabledWithVarArgs(System.Int32)" body="stub" value="true" />
     </type>
   </assembly>
 </linker>

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/MethodWithParametersSubstitutions.xml
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/MethodWithParametersSubstitutions.xml
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<linker>
+  <assembly fullname="test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+    <type fullname="Mono.Linker.Tests.Cases.UnreachableBlock.MethodWithParametersSubstitutions">
+      <method signature="System.Boolean IsEnabledWithValueParam(System.Int32)" body="stub" value="true" />
+      <method signature="System.Boolean IsEnabledWithReferenceParam(System.String)" body="stub" value="true" />
+      <method signature="System.Boolean IsEnabledWithMultipleInParamsInstance(System.Int32,System.String,Mono.Linker.Tests.Cases.UnreachableBlock.MethodWithParametersSubstitutions/TestClass,Mono.Linker.Tests.Cases.UnreachableBlock.MethodWithParametersSubstitutions/TestStruct,Mono.Linker.Tests.Cases.UnreachableBlock.MethodWithParametersSubstitutions/TestEnum)" body="stub" value="true" />
+      <!--<method signature="System.Boolean IsEnabledWithOutParam(System.Int32&amp;)" body="stub" value="true" />-->
+      <method signature="System.Boolean IsEnabledWithRefParam(System.Int32&amp;)" body="stub" value="true" />
+      <method signature="System.Boolean IsEnabledWithMultipleRefParams(System.Int32,System.Int32&amp;,Mono.Linker.Tests.Cases.UnreachableBlock.MethodWithParametersSubstitutions/TestStruct&amp;,System.String)" body="stub" value="true" />
+    </type>
+  </assembly>
+</linker>

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/MethodWithParametersSubstitutions.xml
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/MethodWithParametersSubstitutions.xml
@@ -8,7 +8,8 @@
       <!--<method signature="System.Boolean IsEnabledWithOutParam(System.Int32&amp;)" body="stub" value="true" />-->
       <method signature="System.Boolean IsEnabledWithRefParam(System.Int32&amp;)" body="stub" value="true" />
       <method signature="System.Boolean IsEnabledWithMultipleRefParams(System.Int32,System.Int32&amp;,Mono.Linker.Tests.Cases.UnreachableBlock.MethodWithParametersSubstitutions/TestStruct&amp;,System.String)" body="stub" value="true" />
-      <method signature="System.Boolean IsEnabledWithVarArgs(System.Int32)" body="stub" value="true" />
+      <method signature="System.Boolean IsEnabledWithVarArgs()" body="stub" value="true" />
+      <method signature="System.Boolean IsEnabledWithParamAndVarArgs(System.Int32)" body="stub" value="true" />
     </type>
   </assembly>
 </linker>


### PR DESCRIPTION
This is currently limitted only to method explicitly substituted via substitution.xml and only to methods with in parameters. Out and Ref parameters are not allowed.

Fixes https://github.com/mono/linker/issues/1288.

/cc @eerhardt 