### PR TITLE
Add nowarn option

### DIFF
--- a/src/ILLink.Tasks/LinkTask.cs
+++ b/src/ILLink.Tasks/LinkTask.cs
@@ -51,10 +51,17 @@ namespace ILLink.Tasks
 
 		/// <summary>
 		///   The directory in which to place linked assemblies.
-		//    Maps to '-out'.
+		///    Maps to '-out'.
 		/// </summary>
 		[Required]
 		public ITaskItem OutputDirectory { get; set; }
+
+		/// <summary>
+		///	The subset of warnings that have to be turned off.
+		///	This has no effect if '--verbose' is used. Defaults to 'Analysis'.
+		///	Maps to '--nowarn'.
+		/// </summary>
+		public ITaskItem NoWarn { get; set; }
 
 		/// <summary>
 		///   A list of XML root descriptor files specifying linker
@@ -302,6 +309,9 @@ namespace ILLink.Tasks
 
 			if (OutputDirectory != null)
 				args.Append ("-out ").AppendLine (Quote (OutputDirectory.ItemSpec));
+
+			if (NoWarn != null)
+				args.Append ("--nowarn ").Append (NoWarn);
 
 			// Add global optimization arguments
 			if (_beforeFieldInit is bool beforeFieldInit)

--- a/src/linker/Linker.Dataflow/FlowAnnotations.cs
+++ b/src/linker/Linker.Dataflow/FlowAnnotations.cs
@@ -162,12 +162,14 @@ namespace Mono.Linker.Dataflow
 								paramAnnotations[0] = methodMemberTypes;
 							}
 						} else if (methodMemberTypes != DynamicallyAccessedMemberTypes.None) {
-							_context.LogWarning ($"The DynamicallyAccessedMembersAttribute is only allowed on method parameters, return value or generic parameters.", 2041, method);
+							_context.LogWarning ($"The DynamicallyAccessedMembersAttribute is only allowed on method parameters, return value or generic parameters.",
+								2041, method, subcategory: MessageSubCategory.DynamicDependency);
 						}
 					} else {
 						offset = 0;
 						if (methodMemberTypes != DynamicallyAccessedMemberTypes.None) {
-							_context.LogWarning ($"The DynamicallyAccessedMembersAttribute is only allowed on method parameters, return value or generic parameters.", 2041, method);
+							_context.LogWarning ($"The DynamicallyAccessedMembersAttribute is only allowed on method parameters, return value or generic parameters.",
+								2041, method, subcategory: MessageSubCategory.DynamicDependency);
 						}
 					}
 
@@ -247,7 +249,8 @@ namespace Mono.Linker.Dataflow
 						}
 
 						if (annotatedMethods.Any (a => a.Method == setMethod)) {
-							_context.LogWarning ($"Trying to propagate DynamicallyAccessedMemberAttribute from property '{property.FullName}' to its setter '{setMethod}', but it already has such attribute on the 'value' parameter.", 2043, setMethod);
+							_context.LogWarning ($"Trying to propagate DynamicallyAccessedMemberAttribute from property '{property.FullName}' to its setter '{setMethod}', but it already has such attribute on the 'value' parameter.",
+								2043, setMethod, subcategory: MessageSubCategory.DynamicDependency);
 						} else {
 							int offset = setMethod.HasImplicitThis () ? 1 : 0;
 							if (setMethod.Parameters.Count > 0) {
@@ -274,7 +277,8 @@ namespace Mono.Linker.Dataflow
 						}
 
 						if (annotatedMethods.Any (a => a.Method == getMethod)) {
-							_context.LogWarning ($"Trying to propagate DynamicallyAccessedMemberAttribute from property '{property.FullName}' to its getter '{getMethod}', but it already has such attribute on the return value.", 2043, getMethod);
+							_context.LogWarning ($"Trying to propagate DynamicallyAccessedMemberAttribute from property '{property.FullName}' to its getter '{getMethod}', but it already has such attribute on the return value.",
+								2043, getMethod, subcategory: MessageSubCategory.DynamicDependency);
 						} else {
 							annotatedMethods.Add (new MethodAnnotations (getMethod, null, annotation, null));
 						}
@@ -283,7 +287,8 @@ namespace Mono.Linker.Dataflow
 					FieldDefinition backingField;
 					if (backingFieldFromGetter != null && backingFieldFromSetter != null &&
 						backingFieldFromGetter != backingFieldFromSetter) {
-						_context.LogWarning ($"Could not find a unique backing field for property '{property.FullName}' to propagate DynamicallyAccessedMembersAttribute. The backing fields from getter '{backingFieldFromGetter.FullName}' and setter '{backingFieldFromSetter.FullName}' are not the same.", 2042, property);
+						_context.LogWarning ($"Could not find a unique backing field for property '{property.FullName}' to propagate DynamicallyAccessedMembersAttribute. The backing fields from getter '{backingFieldFromGetter.FullName}' and setter '{backingFieldFromSetter.FullName}' are not the same.",
+							2042, property, subcategory: MessageSubCategory.DynamicDependency);
 						backingField = null;
 					} else {
 						backingField = backingFieldFromGetter ?? backingFieldFromSetter;
@@ -291,7 +296,8 @@ namespace Mono.Linker.Dataflow
 
 					if (backingField != null) {
 						if (annotatedFields.Any (a => a.Field == backingField)) {
-							_context.LogWarning ($"Trying to propagate DynamicallyAccessedMemberAttribute from property '{property.FullName}' to its field '{backingField}', but it already has such attribute.", 2043, backingField);
+							_context.LogWarning ($"Trying to propagate DynamicallyAccessedMemberAttribute from property '{property.FullName}' to its field '{backingField}', but it already has such attribute.",
+								2043, backingField, subcategory: MessageSubCategory.DynamicDependency);
 						} else {
 							annotatedFields.Add (new FieldAnnotation (backingField, annotation));
 						}

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -1248,7 +1248,7 @@ namespace Mono.Linker.Dataflow
 							message += " " + requiresUnreferencedCode.Url;
 						}
 
-						_context.LogWarning (message, 2026, callingMethodDefinition, operation.Offset);
+						_context.LogWarning (message, 2026, callingMethodDefinition, operation.Offset, MessageSubCategory.UnreferencedCode);
 					}
 
 					// To get good reporting of errors we need to track the origin of the value for all method calls

--- a/src/linker/Linker.Steps/DynamicDependencyLookupStep.cs
+++ b/src/linker/Linker.Steps/DynamicDependencyLookupStep.cs
@@ -59,7 +59,8 @@ namespace Mono.Linker.Steps
 				if (!IsPreserveDependencyAttribute (ca.AttributeType))
 					continue;
 #if FEATURE_ILLINK
-				Context.LogWarning ($"PreserveDependencyAttribute is deprecated. Use DynamicDependencyAttribute instead.", 2033, member);
+				Context.LogWarning ($"PreserveDependencyAttribute is deprecated. Use DynamicDependencyAttribute instead.",
+					2033, member, subcategory: MessageSubCategory.PreserveDependency);
 #endif
 				if (ca.ConstructorArguments.Count != 3)
 					continue;
@@ -82,7 +83,8 @@ namespace Mono.Linker.Steps
 
 				var assembly = Context.Resolve (new AssemblyNameReference (dynamicDependency.AssemblyName, new Version ()));
 				if (assembly == null) {
-					Context.LogWarning ($"Unresolved assembly '{dynamicDependency.AssemblyName}' in DynamicDependencyAttribute on '{member}'", 2035, member);
+					Context.LogWarning ($"Unresolved assembly '{dynamicDependency.AssemblyName}' in DynamicDependencyAttribute on '{member}'",
+						2035, member, subcategory: MessageSubCategory.DynamicDependency);
 					continue;
 				}
 

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -579,7 +579,8 @@ namespace Mono.Linker.Steps
 			if (dynamicDependency.AssemblyName != null) {
 				assembly = _context.GetLoadedAssembly (dynamicDependency.AssemblyName);
 				if (assembly == null) {
-					_context.LogWarning ($"Unresolved assembly '{dynamicDependency.AssemblyName}' in DynamicDependencyAttribute on '{context}'", 2035, context);
+					_context.LogWarning ($"Unresolved assembly '{dynamicDependency.AssemblyName}' in DynamicDependencyAttribute on '{context}'",
+						2035, context, subcategory: MessageSubCategory.DynamicDependency);
 					return;
 				}
 			} else {
@@ -591,19 +592,22 @@ namespace Mono.Linker.Steps
 			if (dynamicDependency.TypeName is string typeName) {
 				type = DocumentationSignatureParser.GetTypeByDocumentationSignature (assembly, typeName);
 				if (type == null) {
-					_context.LogWarning ($"Unresolved type '{typeName}' in DynamicDependencyAttribute on '{context}'", 2036, context);
+					_context.LogWarning ($"Unresolved type '{typeName}' in DynamicDependencyAttribute on '{context}'",
+						2036, context, subcategory: MessageSubCategory.DynamicDependency);
 					return;
 				}
 			} else if (dynamicDependency.Type is TypeReference typeReference) {
 				type = typeReference.Resolve ();
 				if (type == null) {
-					_context.LogWarning ($"Unresolved type '{typeReference}' in DynamicDependencyAtribute on '{context}'", 2036, context);
+					_context.LogWarning ($"Unresolved type '{typeReference}' in DynamicDependencyAtribute on '{context}'",
+						2036, context, subcategory: MessageSubCategory.DynamicDependency);
 					return;
 				}
 			} else {
 				type = context.DeclaringType.Resolve ();
 				if (type == null) {
-					_context.LogWarning ($"Unresolved type '{context.DeclaringType}' in DynamicDependencyAttribute on '{context}'", 2036, context);
+					_context.LogWarning ($"Unresolved type '{context.DeclaringType}' in DynamicDependencyAttribute on '{context}'",
+						2036, context, subcategory: MessageSubCategory.DynamicDependency);
 					return;
 				}
 			}
@@ -612,14 +616,16 @@ namespace Mono.Linker.Steps
 			if (dynamicDependency.MemberSignature is string memberSignature) {
 				members = DocumentationSignatureParser.GetMembersByDocumentationSignature (type, memberSignature, acceptName: true);
 				if (!members.Any ()) {
-					_context.LogWarning ($"No members were resolved for '{memberSignature}'.", 2037, context);
+					_context.LogWarning ($"No members were resolved for '{memberSignature}'.",
+						2037, context, subcategory: MessageSubCategory.DynamicDependency);
 					return;
 				}
 			} else {
 				var memberTypes = dynamicDependency.MemberTypes;
 				members = DynamicallyAccessedMembersBinder.GetDynamicallyAccessedMembers (type, memberTypes);
 				if (!members.Any ()) {
-					_context.LogWarning ($"No members were resolved for '{memberTypes}'.", 2037, context);
+					_context.LogWarning ($"No members were resolved for '{memberTypes}'.",
+						2037, context, subcategory: MessageSubCategory.DynamicDependency);
 					return;
 				}
 			}
@@ -688,7 +694,8 @@ namespace Mono.Linker.Steps
 				assembly = _context.GetLoadedAssembly (assemblyName);
 				if (assembly == null) {
 					_context.LogWarning (
-						$"Could not resolve '{assemblyName}' assembly dependency specified in a `PreserveDependency` attribute that targets method '{context.FullName}'", 2003, context.Resolve ());
+						$"Could not resolve '{assemblyName}' assembly dependency specified in a `PreserveDependency` attribute that targets method '{context.FullName}'",
+						2003, context.Resolve (), subcategory: MessageSubCategory.PreserveDependency);
 					return;
 				}
 			} else {
@@ -701,7 +708,8 @@ namespace Mono.Linker.Steps
 
 				if (td == null) {
 					_context.LogWarning (
-						$"Could not resolve '{typeName}' type dependency specified in a `PreserveDependency` attribute that targets method '{context.FullName}'", 2004, context.Resolve ());
+						$"Could not resolve '{typeName}' type dependency specified in a `PreserveDependency` attribute that targets method '{context.FullName}'",
+						2004, context.Resolve (), subcategory: MessageSubCategory.PreserveDependency);
 					return;
 				}
 			} else {
@@ -735,7 +743,8 @@ namespace Mono.Linker.Steps
 				return;
 
 			_context.LogWarning (
-				$"Could not resolve dependency member '{member}' declared in type '{td.FullName}' specified in a `PreserveDependency` attribute that targets method '{context.FullName}'", 2005, td);
+				$"Could not resolve dependency member '{member}' declared in type '{td.FullName}' specified in a `PreserveDependency` attribute that targets method '{context.FullName}'",
+				2005, td, subcategory: MessageSubCategory.PreserveDependency);
 		}
 
 		bool MarkDependencyMethod (TypeDefinition type, string name, string[] signature, in DependencyInfo reason, IMemberDefinition sourceLocationMember)

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -438,6 +438,17 @@ namespace Mono.Linker
 						context.OutputWarningSuppressions = true;
 						continue;
 
+					case "--nowarn":
+						string noWarnArgument = null;
+						if (!GetStringParam (token, l => noWarnArgument = l))
+							return -1;
+
+						if (!Enum.TryParse (typeof (NoWarn), noWarnArgument, true, out var noWarnEnum))
+							return -1;
+
+						context.DontWarn = (NoWarn) noWarnEnum;
+						continue;
+
 					case "--version":
 						Version ();
 						return 1;
@@ -998,6 +1009,9 @@ namespace Mono.Linker
 			Console.WriteLine ("  -out PATH           Specify the output directory. Defaults to 'output'");
 			Console.WriteLine ("  --about             About the {0}", _linker);
 			Console.WriteLine ("  --verbose           Log messages indicating progress and warnings");
+			Console.WriteLine ("  --nowarn OPTION     Turn off all warnings or a predefined subset. Ignored if 'verbose' is used. Defaults to 'analysis'.");
+			Console.WriteLine ("                        all: Disable all warnings");
+			Console.WriteLine ("                        analysis: Disable dataflow analysis warnings");
 			Console.WriteLine ("  --version           Print the version number of the {0}", _linker);
 			Console.WriteLine ("  -help               Lists all linker options");
 			Console.WriteLine ("  @FILE               Read response file for more options");

--- a/src/linker/Linker/LoggingReflectionPatternRecorder.cs
+++ b/src/linker/Linker/LoggingReflectionPatternRecorder.cs
@@ -45,7 +45,7 @@ namespace Mono.Linker
 		public void UnrecognizedReflectionAccessPattern (IMemberDefinition source, Instruction sourceInstruction, IMetadataTokenProvider accessedItem, string message)
 		{
 			var origin = new MessageOrigin (source, sourceInstruction?.Offset);
-			_context.LogWarning (message, 2006, origin, "Unrecognized reflection pattern");
+			_context.LogWarning (message, 2006, origin, MessageSubCategory.UnrecognizedReflectionPattern);
 		}
 	}
 }

--- a/src/linker/Linker/MessageSubcategory.cs
+++ b/src/linker/Linker/MessageSubcategory.cs
@@ -6,7 +6,18 @@ namespace Mono.Linker
 {
 	public static class MessageSubCategory
 	{
+		public const string DynamicDependency = "Dynamic dependency";
 		public const string None = "";
+		public const string PreserveDependency = "Preserve dependency";
+		public const string UnrecognizedReflectionPattern = "Unrecognized reflection pattern";
+		public const string UnreferencedCode = "Unreferenced code";
 		public const string UnresolvedAssembly = "Unresolved assembly";
+
+		public static readonly string[] Analysis = {
+			DynamicDependency,
+			PreserveDependency,
+			UnrecognizedReflectionPattern,
+			UnreferencedCode
+		};
 	}
 }

--- a/src/linker/Linker/NoWarn.cs
+++ b/src/linker/Linker/NoWarn.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Mono.Linker
+{
+	public enum NoWarn
+	{
+		// Turn off all warnings.
+		All,
+
+		// Turn off warnings having the DynamicDependency, PreserveDependency, 
+		// UnrecognizedReflectionPattern, or UnreferencedCode subcategory.
+		Analysis
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MethodThisDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MethodThisDataFlow.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -13,6 +14,7 @@ using System.Text;
 namespace Mono.Linker.Tests.Cases.DataFlow
 {
 	[SkipKeptItemsValidation]
+	[SetupLinkerArgument ("--verbose")]
 	public class MethodThisDataFlow
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
@@ -9,12 +9,14 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.DataFlow
 {
 	// Note: this test's goal is to validate that the product correctly reports unrecognized patterns
 	//   - so the main validation is done by the UnrecognizedReflectionAccessPattern attributes.
 	[SkipKeptItemsValidation]
+	[SetupLinkerArgument ("--verbose")]
 	public class PropertyDataFlow
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMemberSignatureWildcard.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMemberSignatureWildcard.cs
@@ -5,8 +5,9 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.DynamicDependencies
 {
-	[LogContains ("IL2037: Mono.Linker.Tests.Cases.DynamicDependencies.DynamicDependencyMemberSignatureWildcard.Dependency(): No members were resolved for '*'.")]
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/DynamicDependencyMethodInAssemblyLibrary.cs" })]
+	[SetupLinkerArgument ("--verbose")]
+	[LogContains ("IL2037: Mono.Linker.Tests.Cases.DynamicDependencies.DynamicDependencyMemberSignatureWildcard.Dependency(): No members were resolved for '*'.")]
 	public class DynamicDependencyMemberSignatureWildcard
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMethod.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMethod.cs
@@ -5,6 +5,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.DynamicDependencies
 {
+	[SetupLinkerArgument ("--verbose")]
 	[LogContains ("IL2037: Mono.Linker.Tests.Cases.DynamicDependencies.DynamicDependencyMethod.B.Broken(): No members were resolved for 'MissingMethod'.")]
 	[LogContains ("IL2037: Mono.Linker.Tests.Cases.DynamicDependencies.DynamicDependencyMethod.B.Broken(): No members were resolved for 'Dependency2``1(``0,System.Int32,System.Object)'.")]
 	[LogContains ("IL2037: Mono.Linker.Tests.Cases.DynamicDependencies.DynamicDependencyMethod.B.Broken(): No members were resolved for '#ctor()'.")]

--- a/test/Mono.Linker.Tests.Cases/Logging/SourceLines.cs
+++ b/test/Mono.Linker.Tests.Cases/Logging/SourceLines.cs
@@ -9,11 +9,12 @@ namespace Mono.Linker.Tests.Cases.Logging
 	[SkipKeptItemsValidation]
 	[SetupCompileBefore ("FakeSystemAssembly.dll", new[] { "../PreserveDependencies/Dependencies/PreserveDependencyAttribute.cs" })]
 	[SetupCompileArgument ("/debug:full")]
-	[LogContains ("(37,4): Unrecognized reflection pattern warning IL2006: Mono.Linker.Tests.Cases.Logging.SourceLines.UnrecognizedReflectionPattern(): " +
+	[SetupLinkerArgument ("--verbose")]
+	[LogContains ("(38,4): Unrecognized reflection pattern warning IL2006: Mono.Linker.Tests.Cases.Logging.SourceLines.UnrecognizedReflectionPattern(): " +
 		"The return value of method 'System.Type Mono.Linker.Tests.Cases.Logging.SourceLines::GetUnknownType()' " +
 		"with dynamically accessed member kinds 'None' is passed into the field 'System.Type Mono.Linker.Tests.Cases.Logging.SourceLines::type' which requires dynamically " +
 		"accessed member kinds 'PublicConstructors'. To fix this add DynamicallyAccessedMembersAttribute to it and specify at least these member kinds 'PublicConstructors'.")]
-	[LogContains ("(38,4): Unrecognized reflection pattern warning IL2006: Mono.Linker.Tests.Cases.Logging.SourceLines.UnrecognizedReflectionPattern(): " +
+	[LogContains ("(39,4): Unrecognized reflection pattern warning IL2006: Mono.Linker.Tests.Cases.Logging.SourceLines.UnrecognizedReflectionPattern(): " +
 		"The return value of method 'System.Type Mono.Linker.Tests.Cases.Logging.SourceLines::GetUnknownType()' " +
 		"with dynamically accessed member kinds 'None' is passed into the field 'System.Type Mono.Linker.Tests.Cases.Logging.SourceLines::type' which requires dynamically " +
 		"accessed member kinds 'PublicConstructors'. To fix this add DynamicallyAccessedMembersAttribute to it and specify at least these member kinds 'PublicConstructors'.")]

--- a/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyDeprecated.cs
+++ b/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyDeprecated.cs
@@ -8,6 +8,7 @@ namespace Mono.Linker.Tests.Cases.PreserveDependencies
 	[IgnoreTestCase ("This test checks that PreserveDependency correctly issues a warning on .NET Core where it is deprecated.")]
 #endif
 	[SetupCompileBefore ("FakeSystemAssembly.dll", new[] { "Dependencies/PreserveDependencyAttribute.cs" })]
+	[SetupLinkerArgument ("--verbose")]
 	[LogContains ("IL2033: Mono.Linker.Tests.Cases.PreserveDependencies.PreserveDependencyDeprecated.B.Method(): PreserveDependencyAttribute is deprecated. Use DynamicDependencyAttribute instead.")]
 	[LogContains ("IL2033: Mono.Linker.Tests.Cases.PreserveDependencies.PreserveDependencyDeprecated.B.SameContext(): PreserveDependencyAttribute is deprecated. Use DynamicDependencyAttribute instead.")]
 	[LogContains ("IL2033: Mono.Linker.Tests.Cases.PreserveDependencies.PreserveDependencyDeprecated.B.Broken(): PreserveDependencyAttribute is deprecated. Use DynamicDependencyAttribute instead.")]

--- a/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethod.cs
+++ b/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethod.cs
@@ -5,6 +5,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.PreserveDependencies
 {
 	[SetupCompileBefore ("FakeSystemAssembly.dll", new[] { "Dependencies/PreserveDependencyAttribute.cs" })]
+	[SetupLinkerArgument ("--verbose")]
 	[LogContains ("Could not resolve 'Mono.Linker.Tests.Cases.PreserveDependencies.MissingType' type dependency")]
 	[LogContains ("Could not resolve dependency member 'MissingMethod' declared in type 'Mono.Linker.Tests.Cases.PreserveDependencies.C'")]
 	[LogContains ("Could not resolve dependency member 'Dependency2`1' declared in type 'Mono.Linker.Tests.Cases.PreserveDependencies.C'")]

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
@@ -7,10 +7,12 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.RequiresCapability
 {
 	[SkipKeptItemsValidation]
+	[SetupLinkerArgument ("--verbose")]
 	public class RequiresUnreferencedCodeCapability
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapabilityReflectionAnalysisEnabled.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapabilityReflectionAnalysisEnabled.cs
@@ -7,6 +7,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.RequiresCapability
 {
+	[SetupLinkerArgument ("--verbose")]
 	public class RequiresUnreferencedCodeCapabilityReflectionAnalysisEnabled
 	{
 		[LogContains ("-- DynamicallyAccessedMembersEnabled --")]

--- a/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadaProvider.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadaProvider.cs
@@ -84,13 +84,6 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				tclo.AdditionalArguments.Add (new KeyValuePair<string, string[]> ((string) ca[0].Value, values));
 			}
 
-			if (_testCaseTypeDefinition.CustomAttributes.Any (attr =>
-				attr.AttributeType.Name == nameof (LogContainsAttribute) || attr.AttributeType.Name == nameof (LogDoesNotContainAttribute)) ||
-				_testCaseTypeDefinition.AllMembers ().Any (method => method.CustomAttributes.Any (attr =>
-				attr.AttributeType.Name == nameof (LogContainsAttribute) || attr.AttributeType.Name == nameof (LogDoesNotContainAttribute)))) {
-				tclo.AdditionalArguments.Add (new KeyValuePair<string, string[]> ("--verbose", new string[] { }));
-			}
-
 			return tclo;
 		}
 
@@ -109,7 +102,6 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				customizations.CustomizeContext += context => {
 					customizations.ReflectionPatternRecorder.PreviousRecorder = context.ReflectionPatternRecorder;
 					context.ReflectionPatternRecorder = customizations.ReflectionPatternRecorder;
-					context.LogMessages = true;
 				};
 			}
 		}


### PR DESCRIPTION
This turns off the analysis warnings by default and adds the ability to turn off all warnings or a subset of them by specifying a warning "subcategory superset", this can be done either using the command line or the ILLink task. 

A warning subcategory superset is a set of subcategories. The only such superset added in this PR is `analysis`, which contains the following subcategories: `UnrecognizedReflectionPattern`, `DynamicDependency`, `PreserveDependency` `UnreferencedCode`. As an example, by specifying `--nowarn analysis`, the user would turn off all warnings that have their subcategory set to any of the subcategories aforementioned.

Usage examples:

Turning off all warnings
```
--nowarn all
```

Turning off warnings using a subcategory superset
```
--nowarn analysis
```

Here's a table that summarizes all warnings that specify a subcategory:

| Code | Message                                                                                                                                         | Subcategory                   |
|------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------|
| 2003 | Could not resolve 'assembly' assembly dependency specified in a 'PreserveDependency' attribute that targets method 'method'                     | PreserveDependency            |
| 2004 | Could not resolve 'type' type dependency specified in a 'PreserveDependency' attribute that targets method 'method'                             | PreserveDependency            |
| 2005 | Could not resolve dependency member 'member' declared in type 'type' specified in a 'PreserveDependency' attribute that targets method 'method' | PreserveDependency            |
| 2006 | -                                                                                                                                               | UnrecognizedReflectionPattern |
| 2026 | Calling method annotated with RequiresUnreferencedCodeAttribute                                                                                 | UnreferencedCode              |
| 2033 | PreserveDependencyAttribute is deprecated. Use DynamicDependencyAttribute instead.                                                              | PreserveDependency            |
| 2034 | Invalid DynamicDependencyAttribute on 'member'                                                                                                  | DynamicDependency             |
| 2035 | Unresolved assembly 'assemblyName' in DynamicDependencyAttribute on 'member'                                                                    | DynamicDependency             |
| 2036 | Unresolved type 'typeName' in DynamicDependencyAttribute on 'member'                                                                            | DynamicDependency             |
| 2037 | No members were resolved for 'memberSignature/memberTypes'.                                                                                     | DynamicDependency             |
| 2041 | DynamicallyAccessedMembersAttribute is only allowed on method parameters, return value or generic parameters.                                   | DynamicDependency             |
| 2042 | Could not find a unique backing field for property 'property' to propagate DynamicallyAccessedMembersAttribute                                  | DynamicDependency             |
| 2043 | Trying to propagate DynamicallyAccessedMemberAttribute from property 'property' to its getter 'method', but it already has such attribute.      | DynamicDependency             |

---

I'd like some comments on whether or not these new subcategories make sense (DynamicDependency, PreserveDependency, UnreferencedCode) and if all warnings that use these should indeed be categorized as analysis warnings.

---

This PR also changes the logging behavior so that warnings and errors are _always_ logged, no matter if the `--verbose` option isn't used.

/cc @eerhardt 