### PR TITLE
Keep GetInstance method on custom marshalers

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -108,6 +108,9 @@ namespace Mono.Linker.Steps
 			DependencyKind.ReturnType,
 			DependencyKind.UnreachableBodyRequirement,
 			DependencyKind.VariableType,
+			DependencyKind.ParameterMarshalSpec,
+			DependencyKind.FieldMarshalSpec,
+			DependencyKind.ReturnTypeMarshalSpec,
 		};
 
 		static readonly DependencyKind[] _methodReasons = new DependencyKind[] {
@@ -151,6 +154,9 @@ namespace Mono.Linker.Steps
 			DependencyKind.UnreachableBodyRequirement,
 			DependencyKind.VirtualCall,
 			DependencyKind.VirtualNeededDueToPreservedScope,
+			DependencyKind.ParameterMarshalSpec,
+			DependencyKind.FieldMarshalSpec,
+			DependencyKind.ReturnTypeMarshalSpec,
 		};
 #endif
 
@@ -518,8 +524,10 @@ namespace Mono.Linker.Steps
 			if (!spec.HasMarshalInfo)
 				return;
 
-			if (spec.MarshalInfo is CustomMarshalInfo marshaler)
+			if (spec.MarshalInfo is CustomMarshalInfo marshaler) {
 				MarkType (marshaler.ManagedType, reason, sourceLocationMember);
+				MarkGetInstanceMethod (marshaler.ManagedType.Resolve (), in reason, sourceLocationMember);
+			}
 		}
 
 		void MarkCustomAttributes (ICustomAttributeProvider provider, in DependencyInfo reason, IMemberDefinition sourceLocationMember)
@@ -1875,6 +1883,16 @@ namespace Mono.Linker.Steps
 				return false;
 
 			return MarkMethodIf (type.Methods, MethodDefinitionExtensions.IsDefaultConstructor, reason, sourceLocationMember) != null;
+		}
+
+		protected bool MarkGetInstanceMethod (TypeDefinition type, in DependencyInfo reason, IMemberDefinition sourceLocationMember)
+		{
+			if (type?.HasMethods != true)
+				return false;
+
+			return MarkMethodIf (type.Methods, m =>
+				m.Name == "GetInstance" && m.Parameters.Count == 1 && m.Parameters[0].ParameterType.MetadataType == MetadataType.String,
+				reason, sourceLocationMember) != null;
 		}
 
 		static bool IsNonEmptyStaticConstructor (MethodDefinition method)

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1892,7 +1892,7 @@ namespace Mono.Linker.Steps
 
 			MarkMethodIf (type.Methods, m =>
 				m.Name == "GetInstance" && m.Parameters.Count == 1 && m.Parameters[0].ParameterType.MetadataType == MetadataType.String,
-				reason, sourceLocationMember) != null;
+				reason, sourceLocationMember);
 		}
 
 		static bool IsNonEmptyStaticConstructor (MethodDefinition method)

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1885,12 +1885,12 @@ namespace Mono.Linker.Steps
 			return MarkMethodIf (type.Methods, MethodDefinitionExtensions.IsDefaultConstructor, reason, sourceLocationMember) != null;
 		}
 
-		protected bool MarkGetInstanceMethod (TypeDefinition type, in DependencyInfo reason, IMemberDefinition sourceLocationMember)
+		void MarkGetInstanceMethod (TypeDefinition type, in DependencyInfo reason, IMemberDefinition sourceLocationMember)
 		{
 			if (type?.HasMethods != true)
 				return false;
 
-			return MarkMethodIf (type.Methods, m =>
+			MarkMethodIf (type.Methods, m =>
 				m.Name == "GetInstance" && m.Parameters.Count == 1 && m.Parameters[0].ParameterType.MetadataType == MetadataType.String,
 				reason, sourceLocationMember) != null;
 		}

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1888,7 +1888,7 @@ namespace Mono.Linker.Steps
 		void MarkGetInstanceMethod (TypeDefinition type, in DependencyInfo reason, IMemberDefinition sourceLocationMember)
 		{
 			if (type?.HasMethods != true)
-				return false;
+				return;
 
 			MarkMethodIf (type.Methods, m =>
 				m.Name == "GetInstance" && m.Parameters.Count == 1 && m.Parameters[0].ParameterType.MetadataType == MetadataType.String,

--- a/test/Mono.Linker.Tests.Cases/Attributes/MarshalAsCustomMarshaler.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes/MarshalAsCustomMarshaler.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Attributes
+{
+	[KeptModuleReference ("lib")]
+	class MarshalAsCustomMarshaler
+	{
+		static void Main ()
+		{
+			KeepParamMarshal (null);
+			KeepReturnParamMarshal ();
+			var k = new KeepFieldMarshaler ();
+		}
+
+		[Kept]
+		class ParamMarshal
+		{
+			[Kept]
+			public static ICustomMarshaler GetInstance (string s) => null;
+		}
+
+		[Kept]
+		[DllImport ("lib")]
+		static extern void KeepParamMarshal ([MarshalAs (UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof (ParamMarshal))] string s);
+
+		[Kept]
+		class RetParamMarshal
+		{
+			[Kept]
+			public static ICustomMarshaler GetInstance (string s) => null;
+		}
+
+		[Kept]
+		[DllImport ("lib")]
+		[return: MarshalAs (UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof (RetParamMarshal))]
+		static extern int KeepReturnParamMarshal ();
+
+		[Kept]
+		class FieldMarshal
+		{
+			[Kept]
+			public static ICustomMarshaler GetInstance (string s) => null;
+		}
+
+		[Kept]
+		struct KeepFieldMarshaler
+		{
+			[Kept]
+			[MarshalAs (UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof (FieldMarshal))]
+			int _f;
+		}
+	}
+}


### PR DESCRIPTION
Fixes #1281.

We also need a trimming directive in CoreLib that says we want to keep all methods on ICustomMarshaler to make this work E2E, but that's not a linker concern anymore (and it's not testable here...).