### PR TITLE
Postpone marking fields on types with layout

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1292,6 +1292,8 @@ namespace Mono.Linker.Steps
 			// could be incorrect) or IsAssignableFrom (where assignability of unconstructed types might change).
 			Annotations.MarkRelevantToVariantCasting (reference.Resolve ());
 
+			MarkImplicitlyUsedFields (reference.Resolve ());
+
 			return MarkType (reference, reason, sourceLocationMember);
 		}
 
@@ -1379,10 +1381,6 @@ namespace Mono.Linker.Steps
 			MarkTypeSpecialCustomAttributes (type);
 
 			MarkGenericParameterProvider (type, sourceLocationMember);
-
-			// keep fields for value-types and for classes with LayoutKind.Sequential or Explicit
-			if (type.IsValueType || !type.IsAutoLayout)
-				MarkFields (type, includeStatic: type.IsEnum, reason: new DependencyInfo (DependencyKind.MemberOfType, type));
 
 			// There are a number of markings we can defer until later when we know it's possible a reference type could be instantiated
 			// For example, if no instance of a type exist, then we don't need to mark the interfaces on that type
@@ -2341,6 +2339,16 @@ namespace Mono.Linker.Steps
 		{
 		}
 
+		void MarkImplicitlyUsedFields (TypeDefinition type)
+		{
+			if (type?.HasFields != true)
+				return;
+
+			// keep fields for types with explicit layout and for enums
+			if (!type.IsAutoLayout || type.IsEnum)
+				MarkFields (type, includeStatic: type.IsEnum, reason: new DependencyInfo (DependencyKind.MemberOfType, type));
+		}
+
 		protected virtual void MarkRequirementsForInstantiatedTypes (TypeDefinition type)
 		{
 			if (Annotations.IsInstantiated (type))
@@ -2352,6 +2360,8 @@ namespace Mono.Linker.Steps
 
 			foreach (var method in GetRequiredMethodsForInstantiatedType (type))
 				MarkMethod (method, new DependencyInfo (DependencyKind.MethodForInstantiatedType, type), type);
+
+			MarkImplicitlyUsedFields (type);
 
 			DoAdditionalInstantiatedTypeProcessing (type);
 		}

--- a/test/Mono.Linker.Tests.Cases/Attributes.StructLayout/ExplicitClass.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.StructLayout/ExplicitClass.cs
@@ -19,12 +19,36 @@ namespace Mono.Linker.Tests.Cases.Attributes.StructLayout
 		public int never_ever_used;
 	}
 
+	[StructLayout (LayoutKind.Explicit)]
+	[Kept]
+	class UnallocatedExplicitClassData
+	{
+		[FieldOffset (0)]
+		public int never_used;
+	}
+
+	[StructLayout (LayoutKind.Explicit)]
+	[Kept]
+	class UnallocatedButReferencedWithReflectionExplicitClassData
+	{
+		[Kept]
+		[FieldOffset (0)]
+		public int never_used;
+	}
+
 	public class ExplicitClass
 	{
+		[Kept]
+		static UnallocatedExplicitClassData _myField;
+
 		public static void Main ()
 		{
 			var c = new ExplicitClassData ();
 			c.used = 1;
+
+			_myField = null;
+
+			typeof (UnallocatedButReferencedWithReflectionExplicitClassData).ToString ();
 		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/Attributes.StructLayout/SequentialClass.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.StructLayout/SequentialClass.cs
@@ -14,14 +14,36 @@ namespace Mono.Linker.Tests.Cases.Attributes.StructLayout
 		public int used;
 	}
 
+	[Kept]
+	[StructLayout (LayoutKind.Sequential)]
+	class UnallocatedSequentialClassData
+	{
+		public int never_used;
+	}
+
+	[Kept]
+	[StructLayout (LayoutKind.Sequential)]
+	class UnallocatedButReferencedWithReflectionSequentialClassData
+	{
+		[Kept]
+		public int never_used;
+	}
+
 	public class SequentialClass
 	{
+		[Kept]
+		static UnallocatedSequentialClassData _field;
+
 		public static void Main ()
 		{
 			var c = new SequentialClassData ();
 			c.used = 1;
 			if (Marshal.SizeOf (c) != 8)
 				throw new ApplicationException ();
+
+			_field = null;
+
+			typeof (UnallocatedButReferencedWithReflectionSequentialClassData).ToString ();
 		}
 	}
 }


### PR DESCRIPTION
We can postpone marking fields on types with layout until we're really sure they're needed. They're needed if they're visible to reflection, or considered instantiated (valuetypes are implicitly considered instantiated).

I'm also allowing stripping fields on Auto layout structs. This is a rare sight, but there's no reason that I know of to force them to have all their fields kept.