### PR TITLE
Show error for unresolved root assemblies

### DIFF
--- a/src/linker/Linker.Steps/ResolveFromAssemblyStep.cs
+++ b/src/linker/Linker.Steps/ResolveFromAssemblyStep.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // ResolveFromAssemblyStep.cs
 //
 // Author:
@@ -64,15 +64,12 @@ namespace Mono.Linker.Steps
 				Context.Resolver.CacheAssembly (_assembly);
 
 			var ignoreUnresolved = Context.Resolver.IgnoreUnresolved;
-			if (_rootVisibility == RootVisibility.PublicAndFamily) {
-				Context.Resolver.IgnoreUnresolved = false;
-			}
-
+			Context.Resolver.IgnoreUnresolved = false;
 			AssemblyDefinition assembly = _assembly ?? Context.Resolve (_file);
 			Context.Resolver.IgnoreUnresolved = ignoreUnresolved;
-			if (_rootVisibility != RootVisibility.Any && HasInternalsVisibleTo (assembly)) {
+
+			if (_rootVisibility != RootVisibility.Any && HasInternalsVisibleTo (assembly))
 				_rootVisibility = RootVisibility.PublicAndFamilyAndAssembly;
-			}
 
 			switch (assembly.MainModule.Kind) {
 			case ModuleKind.Dll:

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -52,6 +52,7 @@ namespace Mono.Linker
 		public static int Main (string[] args)
 		{
 			if (args.Length == 0) {
+				Usage ();
 				Console.Error.WriteLine ("No parameters specified");
 				return 1;
 			}

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -52,7 +52,6 @@ namespace Mono.Linker
 		public static int Main (string[] args)
 		{
 			if (args.Length == 0) {
-				Usage ();
 				Console.Error.WriteLine ("No parameters specified");
 				return 1;
 			}
@@ -199,6 +198,10 @@ namespace Mono.Linker
 				//
 				if (token[0] == '-' && token[1] == '-') {
 					switch (token) {
+					case "--help":
+						Usage ();
+						return 1;
+
 					case "--skip-unresolved":
 						if (!GetBoolParam (token, l => context.IgnoreUnresolved = context.Resolver.IgnoreUnresolved = l))
 							return -1;
@@ -539,6 +542,7 @@ namespace Mono.Linker
 
 						continue;
 					case "?":
+					case "h":
 					case "help":
 						Usage ();
 						return 1;
@@ -1000,7 +1004,7 @@ namespace Mono.Linker
 			Console.WriteLine ("  --about             About the {0}", _linker);
 			Console.WriteLine ("  --verbose           Log messages indicating progress and warnings");
 			Console.WriteLine ("  --version           Print the version number of the {0}", _linker);
-			Console.WriteLine ("  -help               Lists all linker options");
+			Console.WriteLine ("  --help              Lists all linker options");
 			Console.WriteLine ("  @FILE               Read response file for more options");
 
 			Console.WriteLine ();

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -699,6 +699,7 @@ namespace Mono.Linker
 				Console.Error.WriteLine (lex.ToString ());
 				Debug.Assert (lex.MessageContainer.Category == MessageCategory.Error);
 				Debug.Assert (lex.MessageContainer.Code != null);
+				Debug.Assert (lex.MessageContainer.Code.Value != 0);
 				return lex.MessageContainer.Code ?? 1;
 			} catch (Exception) {
 				// Unhandled exceptions are usually linker bugs. Ask the user to report it.

--- a/src/linker/Linker/LinkerAttributesInformation.cs
+++ b/src/linker/Linker/LinkerAttributesInformation.cs
@@ -58,9 +58,8 @@ namespace Mono.Linker
 			if (_linkerAttributes == null || !_linkerAttributes.TryGetValue (typeof (T), out var attributeList))
 				return Enumerable.Empty<T> ();
 
-			if (attributeList == null || attributeList.Count == 0) {
-				throw new LinkerFatalErrorException ("Unexpected list of attributes.");
-			}
+			if (attributeList == null || attributeList.Count == 0)
+				throw new InvalidOperationException ("Unexpected list of attributes.");
 
 			return attributeList.Cast<T> ();
 		}

--- a/src/linker/Linker/LinkerFatalErrorException.cs
+++ b/src/linker/Linker/LinkerFatalErrorException.cs
@@ -2,25 +2,14 @@
 
 namespace Mono.Linker
 {
+	/// <summary>
+	/// Represents a known error that occurred during link time which is not solvable by the user.
+	/// This is used when we want to present the non-recoverable error with a specific error code.
+	/// </summary>
 	public class LinkerFatalErrorException : Exception
 	{
 		public MessageContainer MessageContainer { get; }
 
-		/// <summary>
-		/// Represents an internal error that occured during link time which is not solvable by the user.
-		/// </summary>
-		/// <param name="internalErrorMessage">The additional message to attach to the error.
-		/// The main error message will be about internal error and make it clear this is not a user error.</param>
-		public LinkerFatalErrorException (string internalErrorMessage)
-			: this (MessageContainer.CreateErrorMessage (
-				"IL Linker has encountered an unexpected error. Please report the issue at https://github.com/mono/linker/issues \n" + internalErrorMessage,
-				1012))
-		{
-		}
-
-		/// <summary>
-		/// Represents a known error that occurred during link time which is solvable by the user.
-		/// </summary>
 		/// <param name="message">Error message with a description of what went wrong</param>
 		public LinkerFatalErrorException (MessageContainer message)
 			: base (message.ToString ())
@@ -31,9 +20,6 @@ namespace Mono.Linker
 			MessageContainer = message;
 		}
 
-		/// <summary>
-		/// Represents a known error that occurred during link time which is solvable by the user.
-		/// </summary>
 		/// <param name="message">Error message with a description of what went wrong</param>
 		/// <param name="innerException"></param>
 		public LinkerFatalErrorException (MessageContainer message, Exception innerException)

--- a/src/linker/Linker/LinkerFatalErrorException.cs
+++ b/src/linker/Linker/LinkerFatalErrorException.cs
@@ -17,6 +17,9 @@ namespace Mono.Linker
 			if (message.Category != MessageCategory.Error)
 				throw new ArgumentException ($"'{nameof (LinkerFatalErrorException)}' ought to be used for errors only");
 
+			if (message.Code == null || message.Code.Value == 0)
+				throw new ArgumentException ($"'{nameof (LinkerFatalErrorException)}' must have a code that indicates a failure");
+
 			MessageContainer = message;
 		}
 
@@ -27,6 +30,9 @@ namespace Mono.Linker
 		{
 			if (message.Category != MessageCategory.Error)
 				throw new ArgumentException ($"'{nameof (LinkerFatalErrorException)}' ought to be used for errors only");
+
+			if (message.Code == null || message.Code.Value == 0)
+				throw new ArgumentException ($"'{nameof (LinkerFatalErrorException)}' must have a code that indicates failure");
 
 			MessageContainer = message;
 		}

--- a/test/ILLink.Tasks.Tests/ILLink.Tasks.Tests.cs
+++ b/test/ILLink.Tasks.Tests/ILLink.Tasks.Tests.cs
@@ -542,5 +542,18 @@ namespace ILLink.Tasks.Tests
 			};
 			Assert.Throws<ArgumentException> (() => task.CreateDriver ());
 		}
+
+		[Fact]
+		public void TestUnhandledException ()
+		{
+			var task = new MockTask () {
+				RootAssemblyNames = new ITaskItem[] { new TaskItem ("MissingAssembly.dll") }
+			};
+			task.BuildEngine = new MockBuildEngine ();
+			task.Execute ();
+			Assert.Contains (task.Messages, message =>
+				message.Importance == MessageImportance.High &&
+				message.Line.Contains ("Unable to find 'MissingAssembly.dll.dll'"));
+		}
 	}
 }

--- a/test/ILLink.Tasks.Tests/Mock.cs
+++ b/test/ILLink.Tasks.Tests/Mock.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Linq;
@@ -11,6 +12,9 @@ namespace ILLink.Tasks.Tests
 {
 	public class MockTask : ILLink
 	{
+
+		public List<(MessageImportance Importance, string Line)> Messages { get; } = new List<(MessageImportance Importance, string Line)> ();
+
 		public MockTask ()
 		{
 			// Ensure that [Required] members are non-null
@@ -54,6 +58,21 @@ namespace ILLink.Tasks.Tests
 				yield return property.Name;
 			}
 		}
+
+		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance) => Messages.Add ((messageImportance, singleLine));
+	}
+
+	public class MockBuildEngine : IBuildEngine
+	{
+		public void LogErrorEvent(BuildErrorEventArgs e) {}
+		public void LogWarningEvent(BuildWarningEventArgs e) {}
+		public void LogMessageEvent(BuildMessageEventArgs e) {}
+		public void LogCustomEvent(CustomBuildEventArgs e) {}
+		public bool BuildProjectFile(string projectFileName, string[] targetNames, IDictionary globalProperties, IDictionary targetOutputs) => false;
+		public bool ContinueOnError => false;
+		public int LineNumberOfTaskNode => 0;
+		public int ColumnNumberOfTaskNode => 0;
+		public string ProjectFileOfTaskNode => null;
 	}
 
 	public class MockDriver : Driver

--- a/test/ILLink.Tasks.Tests/Mock.cs
+++ b/test/ILLink.Tasks.Tests/Mock.cs
@@ -64,11 +64,11 @@ namespace ILLink.Tasks.Tests
 
 	public class MockBuildEngine : IBuildEngine
 	{
-		public void LogErrorEvent(BuildErrorEventArgs e) {}
-		public void LogWarningEvent(BuildWarningEventArgs e) {}
-		public void LogMessageEvent(BuildMessageEventArgs e) {}
-		public void LogCustomEvent(CustomBuildEventArgs e) {}
-		public bool BuildProjectFile(string projectFileName, string[] targetNames, IDictionary globalProperties, IDictionary targetOutputs) => false;
+		public void LogErrorEvent (BuildErrorEventArgs e) { }
+		public void LogWarningEvent (BuildWarningEventArgs e) { }
+		public void LogMessageEvent (BuildMessageEventArgs e) { }
+		public void LogCustomEvent (CustomBuildEventArgs e) { }
+		public bool BuildProjectFile (string projectFileName, string[] targetNames, IDictionary globalProperties, IDictionary targetOutputs) => false;
 		public bool ContinueOnError => false;
 		public int LineNumberOfTaskNode => 0;
 		public int ColumnNumberOfTaskNode => 0;


### PR DESCRIPTION
Fixes https://github.com/mono/linker/issues/1319. This will also help with https://github.com/mono/linker/issues/811.

This has two parts:
1. Changes the nullref exception into the following:
```
Unhandled exception. Mono.Cecil.AssemblyResolutionException: Failed to resolve assembly: 'System.Threading.Tasks.dll, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'
   ---> System.IO.FileNotFoundException: Unable to find 'System.Threading.Tasks.dll.dll' or 'System.Threading.Tasks.dll.exe' file
     at Mono.Linker.DirectoryAssemblyResolver.Resolve(AssemblyNameReference name, ReaderParameters parameters)
     at Mono.Linker.AssemblyResolver.Resolve(AssemblyNameReference name, ReaderParameters parameters)
     at Mono.Linker.LinkContext.Resolve(IMetadataScope scope)
     at Mono.Linker.LinkContext.Resolve(String name)
     at Mono.Linker.Steps.ResolveFromAssemblyStep.Process()
     at Mono.Linker.Steps.BaseStep.Process(LinkContext context)
     at Mono.Linker.Pipeline.ProcessStep(LinkContext context, IStep step)
     at Mono.Linker.Pipeline.Process(LinkContext context)
     at Mono.Linker.Driver.Run(ILogger customLogger)
     at Mono.Linker.Driver.Execute(String[] args, ILogger customLogger)
     at Mono.Linker.Driver.Main(String[] args)
```
which makes it more obvious that it is treating the extension as part of the assembly name.

2. Surfaces unhandled exceptions like the above by rethrowing them. Previously they were [passed](https://github.com/mono/linker/blob/master/src/linker/Linker/Driver.cs#L705) to `LogError`, which currently doesn't log them without `--verbose`, and even with `--verbose` will only show up with `diagnostic` MSBuild verbosity settings. With this change, it will be rethrown, logged to stderr, and shown with `High` importance by the [task](https://github.com/mono/linker/blob/master/src/ILLink.Tasks/LinkTask.cs#L198), causing it to show up with the default `minimal` MSBuild verbosity settings.
