### PR TITLE
Fix problem with GetDisplayName on nested generic types

### DIFF
--- a/src/linker/Linker/TypeReferenceExtensions.cs
+++ b/src/linker/Linker/TypeReferenceExtensions.cs
@@ -30,24 +30,26 @@ namespace Mono.Linker
 					AppendArrayType (arrayType, sb);
 					break;
 				case GenericInstanceType genericInstanceType:
-					int arguments = int.Parse (genericInstanceType.Name.Substring (genericInstanceType.Name.IndexOf ('`') + 1));
 					genericArguments = new Stack<TypeReference> (genericInstanceType.GenericArguments);
-					PrependGenericArguments (genericArguments, arguments, sb);
-					sb.Insert (0, genericInstanceType.Name.Substring (0, genericInstanceType.Name.IndexOf ('`')));
-					break;
+					type = genericInstanceType.ElementType;
+					continue;
 				default:
 					if (type.HasGenericParameters) {
-						if (!int.TryParse (type.Name.Substring (type.Name.IndexOf ('`') + 1), out int arity)) {
-							sb.Insert (0, type.Name);
-							break;
-						}
+						int genericParametersCount = type.GenericParameters.Count;
+						int declaringTypeGenericParametersCount = type.DeclaringType?.GenericParameters?.Count ?? 0;
 
-						if (genericArguments?.Count > 0)
-							PrependGenericArguments (genericArguments, arity, sb);
-						else
-							PrependGenericParameters (type.GenericParameters.Skip (type.GenericParameters.Count - arity).ToList (), sb);
+						string simpleName;
+						if (genericParametersCount > declaringTypeGenericParametersCount) {
+							if (genericArguments?.Count > 0)
+								PrependGenericArguments (genericArguments, genericParametersCount - declaringTypeGenericParametersCount, sb);
+							else
+								PrependGenericParameters (type.GenericParameters.Skip (declaringTypeGenericParametersCount).ToList (), sb);
 
-						sb.Insert (0, type.Name.Substring (0, type.Name.IndexOf ('`')));
+							simpleName = type.Name.Substring (0, type.Name.IndexOf ('`'));
+						} else
+							simpleName = type.Name;
+
+						sb.Insert (0, simpleName);
 						break;
 					}
 

--- a/test/Mono.Linker.Tests/Tests/GetDisplayNameTests.cs
+++ b/test/Mono.Linker.Tests/Tests/GetDisplayNameTests.cs
@@ -169,6 +169,9 @@ namespace Mono.Linker.Tests
 			}
 		}
 
+		[DisplayName ("Mono.Linker.Tests.GetDisplayNameTests.MethodWithNestedGenericTypeArgumentsNoArgumentsOnLeaf(GetDisplayNameTests.GenericClassOneParameter<Int32>.B)")]
+		public void MethodWithNestedGenericTypeArgumentsNoArgumentsOnLeaf (GenericClassOneParameter<int>.B p) { }
+
 		[DisplayName ("Mono.Linker.Tests.GetDisplayNameTests.GenericClassMultipleParameters<T,S>")]
 		public class GenericClassMultipleParameters<T, S>
 		{
@@ -191,6 +194,13 @@ namespace Mono.Linker.Tests
 		[DisplayName ("Mono.Linker.Tests.GetDisplayNameTests.MethodWithNestedGenericTypeArguments" +
 			"(GetDisplayNameTests.GenericClassMultipleParameters<Char*[],Int32[,][]>.NestedGenericClassMultipleParameters<Char*[],Int32[,][]>)")]
 		public void MethodWithNestedGenericTypeArguments (GenericClassMultipleParameters<char*[], int[,][]>.NestedGenericClassMultipleParameters<char*[], int[,][]> p)
+		{
+		}
+
+		[DisplayName ("Mono.Linker.Tests.GetDisplayNameTests.MethodWithPartiallyInstantiatedNestedGenericTypeArguments<MethodT,MethodV>" +
+			"(GetDisplayNameTests.GenericClassMultipleParameters<MethodT,String>.NestedGenericClassMultipleParameters<Int32,MethodV>)")]
+		public void MethodWithPartiallyInstantiatedNestedGenericTypeArguments<MethodT, MethodV> (
+			GenericClassMultipleParameters<MethodT, string>.NestedGenericClassMultipleParameters<int, MethodV> p)
 		{
 		}
 	}


### PR DESCRIPTION
I changed the algorithm to not rely on teh backtick notation (parsing numbers from names) and instead use Cecil's generic parameter counts.

This also changes how instantiated generics are handled (GenericInstanceType) - now we just store the generic arguments and loop again on the open generic type (ElementType) which will apply the generic arguments if available.

Added test for the failing case as well as another one for partially instantiated generics.

Related https://github.com/mono/linker/issues/1321