### PR TITLE
Rename DefaultConstructor to PublicParameterlessConstructor

### DIFF
--- a/src/linker/Linker.Dataflow/DiagnosticUtilities.cs
+++ b/src/linker/Linker.Dataflow/DiagnosticUtilities.cs
@@ -22,8 +22,8 @@ namespace Mono.Linker.Dataflow
 
 			if (memberTypes.HasFlag (DynamicallyAccessedMemberTypes.PublicConstructors))
 				results.Add (DynamicallyAccessedMemberTypes.PublicConstructors);
-			else if (memberTypes.HasFlag (DynamicallyAccessedMemberTypes.DefaultConstructor))
-				results.Add (DynamicallyAccessedMemberTypes.DefaultConstructor);
+			else if (memberTypes.HasFlag (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor))
+				results.Add (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor);
 
 			if (memberTypes.HasFlag (DynamicallyAccessedMemberTypes.NonPublicMethods))
 				results.Add (DynamicallyAccessedMemberTypes.NonPublicMethods);

--- a/src/linker/Linker.Dataflow/DynamicallyAccessedMembersBinder.cs
+++ b/src/linker/Linker.Dataflow/DynamicallyAccessedMembersBinder.cs
@@ -32,7 +32,7 @@ namespace Mono.Linker
 					yield return c;
 			}
 
-			if (memberTypes.HasFlag (DynamicallyAccessedMemberTypes.DefaultConstructor)) {
+			if (memberTypes.HasFlag (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)) {
 				foreach (var c in typeDefinition.GetConstructorsOnType (filter: m => m.IsPublic && m.Parameters.Count == 0))
 					yield return c;
 			}

--- a/src/linker/System.Diagnostics.CodeAnalysis/DynamicallyAccessedMemberTypes.cs
+++ b/src/linker/System.Diagnostics.CodeAnalysis/DynamicallyAccessedMemberTypes.cs
@@ -24,12 +24,12 @@ namespace System.Diagnostics.CodeAnalysis
 		/// <summary>
 		/// Specifies the default, parameterless public constructor.
 		/// </summary>
-		DefaultConstructor = 0x0001,
+		PublicParameterlessConstructor = 0x0001,
 
 		/// <summary>
 		/// Specifies all public constructors.
 		/// </summary>
-		PublicConstructors = 0x0002 | DefaultConstructor,
+		PublicConstructors = 0x0002 | PublicParameterlessConstructor,
 
 		/// <summary>
 		/// Specifies all non-public constructors.

--- a/test/Mono.Linker.Tests.Cases.Expectations/System.Diagnostics.CodeAnalysis/DynamicallyAccessedMemberTypes.cs
+++ b/test/Mono.Linker.Tests.Cases.Expectations/System.Diagnostics.CodeAnalysis/DynamicallyAccessedMemberTypes.cs
@@ -24,12 +24,12 @@ namespace System.Diagnostics.CodeAnalysis
 		/// <summary>
 		/// Specifies the default, parameterless public constructor.
 		/// </summary>
-		DefaultConstructor = 0x0001,
+		PublicParameterlessConstructor = 0x0001,
 
 		/// <summary>
 		/// Specifies all public constructors.
 		/// </summary>
-		PublicConstructors = 0x0002 | DefaultConstructor,
+		PublicConstructors = 0x0002 | PublicParameterlessConstructor,
 
 		/// <summary>
 		/// Specifies all non-public constructors.

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ApplyTypeAnnotations.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ApplyTypeAnnotations.cs
@@ -104,7 +104,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		private static void RequireCombination (
 			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			[DynamicallyAccessedMembers(
-				DynamicallyAccessedMemberTypes.DefaultConstructor |
+				DynamicallyAccessedMemberTypes.PublicParameterlessConstructor |
 				DynamicallyAccessedMemberTypes.PublicFields |
 				DynamicallyAccessedMemberTypes.PublicMethods |
 				DynamicallyAccessedMemberTypes.PublicProperties)]
@@ -116,7 +116,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		private static void RequireCombinationOnString (
 			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			[DynamicallyAccessedMembers(
-				DynamicallyAccessedMemberTypes.DefaultConstructor |
+				DynamicallyAccessedMemberTypes.PublicParameterlessConstructor |
 				DynamicallyAccessedMemberTypes.PublicFields |
 				DynamicallyAccessedMemberTypes.PublicMethods |
 				DynamicallyAccessedMemberTypes.PublicProperties)]

--- a/test/Mono.Linker.Tests.Cases/DataFlow/AssemblyQualifiedNameDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/AssemblyQualifiedNameDataflow.cs
@@ -13,17 +13,17 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 	{
 		static void Main ()
 		{
-			TestDefaultConstructor ();
+			TestPublicParameterlessConstructor ();
 			TestPublicConstructors ();
 			TestConstructors ();
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (AssemblyQualifiedNameDataflow), nameof (RequirePublicConstructors), new Type[] { typeof (string) })]
 		[UnrecognizedReflectionAccessPattern (typeof (AssemblyQualifiedNameDataflow), nameof (RequireNonPublicConstructors), new Type[] { typeof (string) })]
-		static void TestDefaultConstructor ()
+		static void TestPublicParameterlessConstructor ()
 		{
-			string type = GetTypeWithDefaultConstructor ().AssemblyQualifiedName;
-			RequireDefaultConstructor (type);
+			string type = GetTypeWithPublicParameterlessConstructor ().AssemblyQualifiedName;
+			RequirePublicParameterlessConstructor (type);
 			RequirePublicConstructors (type);
 			RequireNonPublicConstructors (type);
 			RequireNothing (type);
@@ -33,25 +33,25 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		static void TestPublicConstructors ()
 		{
 			string type = GetTypeWithPublicConstructors ().AssemblyQualifiedName;
-			RequireDefaultConstructor (type);
+			RequirePublicParameterlessConstructor (type);
 			RequirePublicConstructors (type);
 			RequireNonPublicConstructors (type);
 			RequireNothing (type);
 		}
 
-		[UnrecognizedReflectionAccessPattern (typeof (AssemblyQualifiedNameDataflow), nameof (RequireDefaultConstructor), new Type[] { typeof (string) })]
+		[UnrecognizedReflectionAccessPattern (typeof (AssemblyQualifiedNameDataflow), nameof (RequirePublicParameterlessConstructor), new Type[] { typeof (string) })]
 		[UnrecognizedReflectionAccessPattern (typeof (AssemblyQualifiedNameDataflow), nameof (RequirePublicConstructors), new Type[] { typeof (string) })]
 		static void TestConstructors ()
 		{
 			string type = GetTypeWithNonPublicConstructors ().AssemblyQualifiedName;
-			RequireDefaultConstructor (type);
+			RequirePublicParameterlessConstructor (type);
 			RequirePublicConstructors (type);
 			RequireNonPublicConstructors (type);
 			RequireNothing (type);
 		}
 
-		private static void RequireDefaultConstructor (
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.DefaultConstructor)]
+		private static void RequirePublicParameterlessConstructor (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			string type)
 		{
 		}
@@ -73,8 +73,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 
-		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
-		private static Type GetTypeWithDefaultConstructor ()
+		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+		private static Type GetTypeWithPublicParameterlessConstructor ()
 		{
 			return null;
 		}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ByRefDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ByRefDataflow.cs
@@ -37,14 +37,14 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		[Kept]
 		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
-		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
-		static Type s_typeWithDefaultConstructor;
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+		static Type s_typeWithPublicParameterlessConstructor;
 
 		[Kept]
 		[UnrecognizedReflectionAccessPattern (typeof (ByRefDataflow), nameof (MethodWithRefParameter), new string[] { "System.Type&" })]
 		public static void PassRefToField ()
 		{
-			MethodWithRefParameter (ref s_typeWithDefaultConstructor);
+			MethodWithRefParameter (ref s_typeWithPublicParameterlessConstructor);
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/DataFlow/EmbeddedLinkAttributes.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/EmbeddedLinkAttributes.cs
@@ -20,19 +20,19 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			instance.ReadFromInstanceField ();
 		}
 
-		Type _typeWithDefaultConstructor;
+		Type _typeWithPublicParameterlessConstructor;
 
 		[UnrecognizedReflectionAccessPattern (typeof (EmbeddedLinkAttributes), nameof (RequirePublicConstructors), new Type[] { typeof (Type) })]
 		[UnrecognizedReflectionAccessPattern (typeof (EmbeddedLinkAttributes), nameof (RequireNonPublicConstructors), new Type[] { typeof (Type) })]
 		[RecognizedReflectionAccessPattern]
 		private void ReadFromInstanceField ()
 		{
-			RequireDefaultConstructor (_typeWithDefaultConstructor);
-			RequirePublicConstructors (_typeWithDefaultConstructor);
-			RequireNonPublicConstructors (_typeWithDefaultConstructor);
+			RequirePublicParameterlessConstructor (_typeWithPublicParameterlessConstructor);
+			RequirePublicConstructors (_typeWithPublicParameterlessConstructor);
+			RequireNonPublicConstructors (_typeWithPublicParameterlessConstructor);
 		}
-		private static void RequireDefaultConstructor (
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.DefaultConstructor)]
+		private static void RequirePublicParameterlessConstructor (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			Type type)
 		{
 		}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/EmbeddedLinkAttributes.xml
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/EmbeddedLinkAttributes.xml
@@ -1,9 +1,9 @@
 ﻿<linker>
   <assembly fullname="test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
     <type fullname="Mono.Linker.Tests.Cases.DataFlow.EmbeddedLinkAttributes">
-      <field name="_typeWithDefaultConstructor">
+      <field name="_typeWithPublicParameterlessConstructor">
         <attribute fullname="System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute">
-          <argument>DefaultConstructor</argument>
+          <argument>PublicParameterlessConstructor</argument>
         </attribute>
       </field>
     </type>

--- a/test/Mono.Linker.Tests.Cases/DataFlow/EmptyArrayIntrinsicsDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/EmptyArrayIntrinsicsDataFlow.cs
@@ -22,26 +22,26 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[UnrecognizedReflectionAccessPattern (typeof (Type), nameof (Type.GetMethod), new Type[] { typeof (string) })]
 		static void TestGetPublicParameterlessConstructorWithEmptyTypes ()
 		{
-			s_typeWithKeptDefaultConstructor.GetConstructor (Type.EmptyTypes);
-			s_typeWithKeptDefaultConstructor.GetMethod ("Foo");
+			s_typeWithKeptPublicParameterlessConstructor.GetConstructor (Type.EmptyTypes);
+			s_typeWithKeptPublicParameterlessConstructor.GetMethod ("Foo");
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (Type), nameof (Type.GetMethod), new Type[] { typeof (string) })]
 		static void TestGetPublicParameterlessConstructorWithArrayEmpty ()
 		{
-			s_typeWithKeptDefaultConstructor.GetConstructor (Array.Empty<Type> ());
-			s_typeWithKeptDefaultConstructor.GetMethod ("Foo");
+			s_typeWithKeptPublicParameterlessConstructor.GetConstructor (Array.Empty<Type> ());
+			s_typeWithKeptPublicParameterlessConstructor.GetMethod ("Foo");
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (Type), nameof (Type.GetConstructor), new Type[] { typeof (Type[]) })]
 		static void TestGetPublicParameterlessConstructorWithUnknownArray ()
 		{
-			s_typeWithKeptDefaultConstructor.GetConstructor (s_localEmptyArrayInvisibleToAnalysis);
+			s_typeWithKeptPublicParameterlessConstructor.GetConstructor (s_localEmptyArrayInvisibleToAnalysis);
 		}
 
 		static Type[] s_localEmptyArrayInvisibleToAnalysis = Type.EmptyTypes;
 
-		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
-		static Type s_typeWithKeptDefaultConstructor = typeof (EmptyArrayIntrinsicsDataFlow);
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+		static Type s_typeWithKeptPublicParameterlessConstructor = typeof (EmptyArrayIntrinsicsDataFlow);
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/DataFlow/FieldDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/FieldDataFlow.cs
@@ -32,35 +32,35 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			instance.WriteToStaticFieldOnADifferentClass ();
 		}
 
-		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
-		Type _typeWithDefaultConstructor;
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+		Type _typeWithPublicParameterlessConstructor;
 
-		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
-		static Type _staticTypeWithDefaultConstructor;
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+		static Type _staticTypeWithPublicParameterlessConstructor;
 
 		[UnrecognizedReflectionAccessPattern (typeof (FieldDataFlow), nameof (RequirePublicConstructors), new Type[] { typeof (Type) },
-			"The field 'System.Type Mono.Linker.Tests.Cases.DataFlow.FieldDataFlow::_typeWithDefaultConstructor' " +
-			"with dynamically accessed member kinds 'DefaultConstructor' is passed into " +
+			"The field 'System.Type Mono.Linker.Tests.Cases.DataFlow.FieldDataFlow::_typeWithPublicParameterlessConstructor' " +
+			"with dynamically accessed member kinds 'PublicParameterlessConstructor' is passed into " +
 			"the parameter 'type' of method 'Mono.Linker.Tests.Cases.DataFlow.FieldDataFlow.RequirePublicConstructors(Type)' " +
 			"which requires dynamically accessed member kinds 'PublicConstructors'. " +
 			"To fix this add DynamicallyAccessedMembersAttribute to it and specify at least these member kinds 'PublicConstructors'.")]
 		[UnrecognizedReflectionAccessPattern (typeof (FieldDataFlow), nameof (RequireNonPublicConstructors), new Type[] { typeof (Type) })]
 		private void ReadFromInstanceField ()
 		{
-			RequireDefaultConstructor (_typeWithDefaultConstructor);
-			RequirePublicConstructors (_typeWithDefaultConstructor);
-			RequireNonPublicConstructors (_typeWithDefaultConstructor);
-			RequireNothing (_typeWithDefaultConstructor);
+			RequirePublicParameterlessConstructor (_typeWithPublicParameterlessConstructor);
+			RequirePublicConstructors (_typeWithPublicParameterlessConstructor);
+			RequireNonPublicConstructors (_typeWithPublicParameterlessConstructor);
+			RequireNothing (_typeWithPublicParameterlessConstructor);
 		}
 
-		[UnrecognizedReflectionAccessPattern (typeof (FieldDataFlow), nameof (_typeWithDefaultConstructor))]
-		[UnrecognizedReflectionAccessPattern (typeof (FieldDataFlow), nameof (_typeWithDefaultConstructor))]
+		[UnrecognizedReflectionAccessPattern (typeof (FieldDataFlow), nameof (_typeWithPublicParameterlessConstructor))]
+		[UnrecognizedReflectionAccessPattern (typeof (FieldDataFlow), nameof (_typeWithPublicParameterlessConstructor))]
 		private void WriteToInstanceField ()
 		{
-			_typeWithDefaultConstructor = GetTypeWithDefaultConstructor ();
-			_typeWithDefaultConstructor = GetTypeWithPublicConstructors ();
-			_typeWithDefaultConstructor = GetTypeWithNonPublicConstructors ();
-			_typeWithDefaultConstructor = GetUnkownType ();
+			_typeWithPublicParameterlessConstructor = GetTypeWithPublicParameterlessConstructor ();
+			_typeWithPublicParameterlessConstructor = GetTypeWithPublicConstructors ();
+			_typeWithPublicParameterlessConstructor = GetTypeWithNonPublicConstructors ();
+			_typeWithPublicParameterlessConstructor = GetUnkownType ();
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (FieldDataFlow), nameof (RequirePublicConstructors), new Type[] { typeof (Type) })]
@@ -69,66 +69,66 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		{
 			var store = new TypeStore ();
 
-			RequireDefaultConstructor (store._typeWithDefaultConstructor);
-			RequirePublicConstructors (store._typeWithDefaultConstructor);
-			RequireNonPublicConstructors (store._typeWithDefaultConstructor);
-			RequireNothing (store._typeWithDefaultConstructor);
+			RequirePublicParameterlessConstructor (store._typeWithPublicParameterlessConstructor);
+			RequirePublicConstructors (store._typeWithPublicParameterlessConstructor);
+			RequireNonPublicConstructors (store._typeWithPublicParameterlessConstructor);
+			RequireNothing (store._typeWithPublicParameterlessConstructor);
 		}
 
-		[UnrecognizedReflectionAccessPattern (typeof (TypeStore), nameof (TypeStore._typeWithDefaultConstructor))]
-		[UnrecognizedReflectionAccessPattern (typeof (TypeStore), nameof (TypeStore._typeWithDefaultConstructor))]
+		[UnrecognizedReflectionAccessPattern (typeof (TypeStore), nameof (TypeStore._typeWithPublicParameterlessConstructor))]
+		[UnrecognizedReflectionAccessPattern (typeof (TypeStore), nameof (TypeStore._typeWithPublicParameterlessConstructor))]
 		private void WriteToInstanceFieldOnADifferentClass ()
 		{
 			var store = new TypeStore ();
 
-			store._typeWithDefaultConstructor = GetTypeWithDefaultConstructor ();
-			store._typeWithDefaultConstructor = GetTypeWithPublicConstructors ();
-			store._typeWithDefaultConstructor = GetTypeWithNonPublicConstructors ();
-			store._typeWithDefaultConstructor = GetUnkownType ();
+			store._typeWithPublicParameterlessConstructor = GetTypeWithPublicParameterlessConstructor ();
+			store._typeWithPublicParameterlessConstructor = GetTypeWithPublicConstructors ();
+			store._typeWithPublicParameterlessConstructor = GetTypeWithNonPublicConstructors ();
+			store._typeWithPublicParameterlessConstructor = GetUnkownType ();
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (FieldDataFlow), nameof (RequirePublicConstructors), new Type[] { typeof (Type) })]
 		[UnrecognizedReflectionAccessPattern (typeof (FieldDataFlow), nameof (RequireNonPublicConstructors), new Type[] { typeof (Type) })]
 		private void ReadFromStaticField ()
 		{
-			RequireDefaultConstructor (_staticTypeWithDefaultConstructor);
-			RequirePublicConstructors (_staticTypeWithDefaultConstructor);
-			RequireNonPublicConstructors (_staticTypeWithDefaultConstructor);
-			RequireNothing (_staticTypeWithDefaultConstructor);
+			RequirePublicParameterlessConstructor (_staticTypeWithPublicParameterlessConstructor);
+			RequirePublicConstructors (_staticTypeWithPublicParameterlessConstructor);
+			RequireNonPublicConstructors (_staticTypeWithPublicParameterlessConstructor);
+			RequireNothing (_staticTypeWithPublicParameterlessConstructor);
 		}
 
-		[UnrecognizedReflectionAccessPattern (typeof (FieldDataFlow), nameof (_staticTypeWithDefaultConstructor))]
-		[UnrecognizedReflectionAccessPattern (typeof (FieldDataFlow), nameof (_staticTypeWithDefaultConstructor))]
+		[UnrecognizedReflectionAccessPattern (typeof (FieldDataFlow), nameof (_staticTypeWithPublicParameterlessConstructor))]
+		[UnrecognizedReflectionAccessPattern (typeof (FieldDataFlow), nameof (_staticTypeWithPublicParameterlessConstructor))]
 		private void WriteToStaticField ()
 		{
-			_staticTypeWithDefaultConstructor = GetTypeWithDefaultConstructor ();
-			_staticTypeWithDefaultConstructor = GetTypeWithPublicConstructors ();
-			_staticTypeWithDefaultConstructor = GetTypeWithNonPublicConstructors ();
-			_staticTypeWithDefaultConstructor = GetUnkownType ();
+			_staticTypeWithPublicParameterlessConstructor = GetTypeWithPublicParameterlessConstructor ();
+			_staticTypeWithPublicParameterlessConstructor = GetTypeWithPublicConstructors ();
+			_staticTypeWithPublicParameterlessConstructor = GetTypeWithNonPublicConstructors ();
+			_staticTypeWithPublicParameterlessConstructor = GetUnkownType ();
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (FieldDataFlow), nameof (RequirePublicConstructors), new Type[] { typeof (Type) })]
 		[UnrecognizedReflectionAccessPattern (typeof (FieldDataFlow), nameof (RequireNonPublicConstructors), new Type[] { typeof (Type) })]
 		private void ReadFromStaticFieldOnADifferentClass ()
 		{
-			RequireDefaultConstructor (TypeStore._staticTypeWithDefaultConstructor);
-			RequirePublicConstructors (TypeStore._staticTypeWithDefaultConstructor);
-			RequireNonPublicConstructors (TypeStore._staticTypeWithDefaultConstructor);
-			RequireNothing (TypeStore._staticTypeWithDefaultConstructor);
+			RequirePublicParameterlessConstructor (TypeStore._staticTypeWithPublicParameterlessConstructor);
+			RequirePublicConstructors (TypeStore._staticTypeWithPublicParameterlessConstructor);
+			RequireNonPublicConstructors (TypeStore._staticTypeWithPublicParameterlessConstructor);
+			RequireNothing (TypeStore._staticTypeWithPublicParameterlessConstructor);
 		}
 
-		[UnrecognizedReflectionAccessPattern (typeof (TypeStore), nameof (TypeStore._staticTypeWithDefaultConstructor))]
-		[UnrecognizedReflectionAccessPattern (typeof (TypeStore), nameof (TypeStore._staticTypeWithDefaultConstructor))]
+		[UnrecognizedReflectionAccessPattern (typeof (TypeStore), nameof (TypeStore._staticTypeWithPublicParameterlessConstructor))]
+		[UnrecognizedReflectionAccessPattern (typeof (TypeStore), nameof (TypeStore._staticTypeWithPublicParameterlessConstructor))]
 		private void WriteToStaticFieldOnADifferentClass ()
 		{
-			TypeStore._staticTypeWithDefaultConstructor = GetTypeWithDefaultConstructor ();
-			TypeStore._staticTypeWithDefaultConstructor = GetTypeWithPublicConstructors ();
-			TypeStore._staticTypeWithDefaultConstructor = GetTypeWithNonPublicConstructors ();
-			TypeStore._staticTypeWithDefaultConstructor = GetUnkownType ();
+			TypeStore._staticTypeWithPublicParameterlessConstructor = GetTypeWithPublicParameterlessConstructor ();
+			TypeStore._staticTypeWithPublicParameterlessConstructor = GetTypeWithPublicConstructors ();
+			TypeStore._staticTypeWithPublicParameterlessConstructor = GetTypeWithNonPublicConstructors ();
+			TypeStore._staticTypeWithPublicParameterlessConstructor = GetUnkownType ();
 		}
 
-		private static void RequireDefaultConstructor (
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.DefaultConstructor)]
+		private static void RequirePublicParameterlessConstructor (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			Type type)
 		{
 		}
@@ -145,8 +145,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		{
 		}
 
-		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
-		private static Type GetTypeWithDefaultConstructor ()
+		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+		private static Type GetTypeWithPublicParameterlessConstructor ()
 		{
 			return null;
 		}
@@ -174,11 +174,11 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		class TypeStore
 		{
-			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
-			public Type _typeWithDefaultConstructor;
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+			public Type _typeWithPublicParameterlessConstructor;
 
-			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
-			public static Type _staticTypeWithDefaultConstructor;
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+			public static Type _staticTypeWithPublicParameterlessConstructor;
 		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/DataFlow/GetTypeDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/GetTypeDataFlow.cs
@@ -17,7 +17,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 	{
 		public static void Main ()
 		{
-			TestDefaultConstructor ();
+			TestPublicParameterlessConstructor ();
 			TestPublicConstructors ();
 			TestConstructors ();
 			TestUnknownType ();
@@ -36,10 +36,10 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		[UnrecognizedReflectionAccessPattern (typeof (GetTypeDataFlow), nameof (RequirePublicConstructors), new Type[] { typeof (Type) })]
 		[UnrecognizedReflectionAccessPattern (typeof (GetTypeDataFlow), nameof (RequireNonPublicConstructors), new Type[] { typeof (Type) })]
-		static void TestDefaultConstructor ()
+		static void TestPublicParameterlessConstructor ()
 		{
-			Type type = Type.GetType (GetStringTypeWithDefaultConstructor ());
-			RequireDefaultConstructor (type);
+			Type type = Type.GetType (GetStringTypeWithPublicParameterlessConstructor ());
+			RequirePublicParameterlessConstructor (type);
 			RequirePublicConstructors (type);
 			RequireNonPublicConstructors (type);
 			RequireNothing (type);
@@ -49,18 +49,18 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		static void TestPublicConstructors ()
 		{
 			Type type = Type.GetType (GetStringTypeWithPublicConstructors ());
-			RequireDefaultConstructor (type);
+			RequirePublicParameterlessConstructor (type);
 			RequirePublicConstructors (type);
 			RequireNonPublicConstructors (type);
 			RequireNothing (type);
 		}
 
-		[UnrecognizedReflectionAccessPattern (typeof (GetTypeDataFlow), nameof (RequireDefaultConstructor), new Type[] { typeof (Type) })]
+		[UnrecognizedReflectionAccessPattern (typeof (GetTypeDataFlow), nameof (RequirePublicParameterlessConstructor), new Type[] { typeof (Type) })]
 		[UnrecognizedReflectionAccessPattern (typeof (GetTypeDataFlow), nameof (RequirePublicConstructors), new Type[] { typeof (Type) })]
 		static void TestConstructors ()
 		{
 			Type type = Type.GetType (GetStringTypeWithNonPublicConstructors ());
-			RequireDefaultConstructor (type);
+			RequirePublicParameterlessConstructor (type);
 			RequirePublicConstructors (type);
 			RequireNonPublicConstructors (type);
 			RequireNothing (type);
@@ -74,19 +74,19 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		[UnrecognizedReflectionAccessPattern (typeof (GetTypeDataFlow), nameof (RequirePublicConstructors), new Type[] { typeof (Type) })]
 		static void TestTypeNameFromParameter (
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.DefaultConstructor)]
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			string typeName)
 		{
 			RequirePublicConstructors (Type.GetType (typeName));
 		}
 
-		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
-		static string _typeNameWithDefaultConstructor;
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+		static string _typeNameWithPublicParameterlessConstructor;
 
 		[UnrecognizedReflectionAccessPattern (typeof (GetTypeDataFlow), nameof (RequirePublicConstructors), new Type[] { typeof (Type) })]
 		static void TestTypeNameFromField ()
 		{
-			RequirePublicConstructors (Type.GetType (_typeNameWithDefaultConstructor));
+			RequirePublicConstructors (Type.GetType (_typeNameWithPublicParameterlessConstructor));
 		}
 
 		static int _switchOnField;
@@ -113,7 +113,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (GetTypeDataFlow), nameof (RequireNonPublicConstructors), new Type[] { typeof (Type) },
-			"The method return value with dynamically accessed member kinds 'DefaultConstructor' is passed into " +
+			"The method return value with dynamically accessed member kinds 'PublicParameterlessConstructor' is passed into " +
 			"the parameter 'type' of method 'Mono.Linker.Tests.Cases.DataFlow.GetTypeDataFlow.RequireNonPublicConstructors(Type)' " +
 			"which requires dynamically accessed member kinds 'NonPublicConstructors'. " +
 			"To fix this add DynamicallyAccessedMembersAttribute to it and specify at least these member kinds 'NonPublicConstructors'.")]
@@ -125,7 +125,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			string typeName = null;
 			switch (_switchOnField) {
 			case 0:
-				typeName = GetStringTypeWithDefaultConstructor ();
+				typeName = GetStringTypeWithPublicParameterlessConstructor ();
 				break;
 			case 1:
 				typeName = GetStringTypeWithNonPublicConstructors ();
@@ -141,8 +141,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			RequireNonPublicConstructors (Type.GetType (typeName));
 		}
 
-		private static void RequireDefaultConstructor (
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.DefaultConstructor)]
+		private static void RequirePublicParameterlessConstructor (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			Type type)
 		{
 		}
@@ -163,8 +163,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		{
 		}
 
-		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
-		private static string GetStringTypeWithDefaultConstructor ()
+		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+		private static string GetStringTypeWithPublicParameterlessConstructor ()
 		{
 			return null;
 		}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/LinkerAttributeRemoval.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/LinkerAttributeRemoval.cs
@@ -26,7 +26,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			TestType ();
 		}
 		[Kept]
-		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 		Type _fieldWithCustomAttribute;
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MemberTypes.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MemberTypes.cs
@@ -15,9 +15,9 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 	{
 		public static void Main ()
 		{
-			RequireDefaultConstructor (typeof (DefaultConstructorType));
-			RequireDefaultConstructor (typeof (PrivateParameterlessConstructorType));
-			RequireDefaultConstructor (typeof (DefaultConstructorBeforeFieldInitType));
+			RequirePublicParameterlessConstructor (typeof (PublicParameterlessConstructorType));
+			RequirePublicParameterlessConstructor (typeof (PrivateParameterlessConstructorType));
+			RequirePublicParameterlessConstructor (typeof (PublicParameterlessConstructorBeforeFieldInitType));
 			RequirePublicConstructors (typeof (PublicConstructorsType));
 			RequirePublicConstructors (typeof (PublicConstructorsBeforeFieldInitType));
 			RequirePublicConstructors (typeof (PublicConstructorsPrivateParameterlessConstructorType));
@@ -45,37 +45,37 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 
 		[Kept]
-		private static void RequireDefaultConstructor (
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.DefaultConstructor)]
+		private static void RequirePublicParameterlessConstructor (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type type)
 		{
 		}
 
 		[Kept]
-		class DefaultConstructorBaseType
+		class PublicParameterlessConstructorBaseType
 		{
 			[Kept]
-			public DefaultConstructorBaseType () { }
+			public PublicParameterlessConstructorBaseType () { }
 
-			public DefaultConstructorBaseType (int i) { }
+			public PublicParameterlessConstructorBaseType (int i) { }
 		}
 
 		[Kept]
-		[KeptBaseType (typeof (DefaultConstructorBaseType))]
-		class DefaultConstructorType : DefaultConstructorBaseType
+		[KeptBaseType (typeof (PublicParameterlessConstructorBaseType))]
+		class PublicParameterlessConstructorType : PublicParameterlessConstructorBaseType
 		{
 			[Kept]
-			public DefaultConstructorType () { }
+			public PublicParameterlessConstructorType () { }
 
-			public DefaultConstructorType (int i) { }
+			public PublicParameterlessConstructorType (int i) { }
 
-			private DefaultConstructorType (int i, int j) { }
+			private PublicParameterlessConstructorType (int i, int j) { }
 
 			// Not implied by the DynamicallyAccessedMemberTypes logic, but
 			// explicit cctors would be kept by the linker.
 			// [Kept]
-			// static DefaultConstructorType () { }
+			// static PublicParameterlessConstructorType () { }
 
 			public void Method1 () { }
 			public bool Property1 { get; set; }
@@ -83,12 +83,12 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[Kept]
-		class DefaultConstructorBeforeFieldInitType
+		class PublicParameterlessConstructorBeforeFieldInitType
 		{
 			static int i = 10;
 
 			[Kept]
-			public DefaultConstructorBeforeFieldInitType () { }
+			public PublicParameterlessConstructorBeforeFieldInitType () { }
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MethodParametersDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MethodParametersDataFlow.cs
@@ -20,7 +20,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		{
 			var instance = new MethodParametersDataFlow ();
 
-			DefaultConstructorParameter (typeof (TestType));
+			PublicParameterlessConstructorParameter (typeof (TestType));
 			PublicConstructorsParameter (typeof (TestType));
 			NonPublicConstructorsParameter (typeof (TestType));
 			WriteToParameterOnStaticMethod (null);
@@ -39,17 +39,17 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		// Validate the error message when annotated parameter is passed to another annotated parameter
 		[UnrecognizedReflectionAccessPattern (typeof (MethodParametersDataFlow), nameof (RequirePublicConstructors), new Type[] { typeof (Type) },
-			"The parameter 'type' of method 'Mono.Linker.Tests.Cases.DataFlow.MethodParametersDataFlow.DefaultConstructorParameter(Type)' " +
-			"with dynamically accessed member kinds 'DefaultConstructor' is passed into the parameter 'type' " +
+			"The parameter 'type' of method 'Mono.Linker.Tests.Cases.DataFlow.MethodParametersDataFlow.PublicParameterlessConstructorParameter(Type)' " +
+			"with dynamically accessed member kinds 'PublicParameterlessConstructor' is passed into the parameter 'type' " +
 			"of method 'Mono.Linker.Tests.Cases.DataFlow.MethodParametersDataFlow.RequirePublicConstructors(Type)' " +
 			"which requires dynamically accessed member kinds 'PublicConstructors'. " +
 			"To fix this add DynamicallyAccessedMembersAttribute to it and specify at least these member kinds 'PublicConstructors'.")]
 		[UnrecognizedReflectionAccessPattern (typeof (MethodParametersDataFlow), nameof (RequireNonPublicConstructors), new Type[] { typeof (Type) })]
-		private static void DefaultConstructorParameter (
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.DefaultConstructor)]
+		private static void PublicParameterlessConstructorParameter (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			Type type)
 		{
-			RequireDefaultConstructor (type);
+			RequirePublicParameterlessConstructor (type);
 			RequirePublicConstructors (type);
 			RequireNonPublicConstructors (type);
 		}
@@ -59,28 +59,28 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
 			Type type)
 		{
-			RequireDefaultConstructor (type);
+			RequirePublicParameterlessConstructor (type);
 			RequirePublicConstructors (type);
 			RequireNonPublicConstructors (type);
 		}
 
-		[UnrecognizedReflectionAccessPattern (typeof (MethodParametersDataFlow), nameof (RequireDefaultConstructor), new Type[] { typeof (Type) })]
+		[UnrecognizedReflectionAccessPattern (typeof (MethodParametersDataFlow), nameof (RequirePublicParameterlessConstructor), new Type[] { typeof (Type) })]
 		[UnrecognizedReflectionAccessPattern (typeof (MethodParametersDataFlow), nameof (RequirePublicConstructors), new Type[] { typeof (Type) })]
 		private static void NonPublicConstructorsParameter (
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors)]
 			Type type)
 		{
-			RequireDefaultConstructor (type);
+			RequirePublicParameterlessConstructor (type);
 			RequirePublicConstructors (type);
 			RequireNonPublicConstructors (type);
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (MethodParametersDataFlow), nameof (RequirePublicConstructors), new Type[] { typeof (Type) })]
 		private void InstanceMethod (
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.DefaultConstructor)]
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			Type type)
 		{
-			RequireDefaultConstructor (type);
+			RequirePublicParameterlessConstructor (type);
 			RequirePublicConstructors (type);
 		}
 
@@ -89,7 +89,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors)]
 			Type type)
 		{
-			type = ReturnThingsWithDefaultConstructor ();
+			type = ReturnThingsWithPublicParameterlessConstructor ();
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (Type), "type")]
@@ -97,7 +97,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors)]
 			Type type)
 		{
-			type = ReturnThingsWithDefaultConstructor ();
+			type = ReturnThingsWithPublicParameterlessConstructor ();
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (Type), "type")]
@@ -106,7 +106,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors)]
 			Type type)
 		{
-			type = ReturnThingsWithDefaultConstructor ();
+			type = ReturnThingsWithPublicParameterlessConstructor ();
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (Type), "type")]
@@ -115,68 +115,68 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors)]
 			Type type)
 		{
-			type = ReturnThingsWithDefaultConstructor ();
+			type = ReturnThingsWithPublicParameterlessConstructor ();
 		}
 
-		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
-		static private Type ReturnThingsWithDefaultConstructor ()
+		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+		static private Type ReturnThingsWithPublicParameterlessConstructor ()
 		{
 			return null;
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (MethodParametersDataFlow), nameof (RequirePublicConstructors), new Type[] { typeof (Type) })]
 		private void TwoAnnotatedParameters (
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.DefaultConstructor)]
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			Type type,
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
 			Type type2)
 		{
-			RequireDefaultConstructor (type);
-			RequireDefaultConstructor (type2);
+			RequirePublicParameterlessConstructor (type);
+			RequirePublicParameterlessConstructor (type2);
 			RequirePublicConstructors (type);
 			RequirePublicConstructors (type2);
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (MethodParametersDataFlow), nameof (RequirePublicConstructors), new Type[] { typeof (Type) })]
 		private void TwoAnnotatedParametersIntoOneValue (
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.DefaultConstructor)]
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			Type type,
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
 			Type type2)
 		{
 			Type t = type == null ? type : type2;
-			RequireDefaultConstructor (t);
+			RequirePublicParameterlessConstructor (t);
 			RequirePublicConstructors (t);
 		}
 
 		// Validate the error message for the case of unannotated method return value passed to an annotated parameter.
-		[UnrecognizedReflectionAccessPattern (typeof (MethodParametersDataFlow), nameof (RequireDefaultConstructor), new Type[] { typeof (Type) },
+		[UnrecognizedReflectionAccessPattern (typeof (MethodParametersDataFlow), nameof (RequirePublicParameterlessConstructor), new Type[] { typeof (Type) },
 			"The parameter 'type' of method 'Mono.Linker.Tests.Cases.DataFlow.MethodParametersDataFlow.NoAnnotation(Type)' " +
 			"with dynamically accessed member kinds 'None' is passed into " +
-			"the parameter 'type' of method 'Mono.Linker.Tests.Cases.DataFlow.MethodParametersDataFlow.RequireDefaultConstructor(Type)' " +
-			"which requires dynamically accessed member kinds 'DefaultConstructor'. " +
-			"To fix this add DynamicallyAccessedMembersAttribute to it and specify at least these member kinds 'DefaultConstructor'.")]
+			"the parameter 'type' of method 'Mono.Linker.Tests.Cases.DataFlow.MethodParametersDataFlow.RequirePublicParameterlessConstructor(Type)' " +
+			"which requires dynamically accessed member kinds 'PublicParameterlessConstructor'. " +
+			"To fix this add DynamicallyAccessedMembersAttribute to it and specify at least these member kinds 'PublicParameterlessConstructor'.")]
 		private void NoAnnotation (Type type)
 		{
-			RequireDefaultConstructor (type);
+			RequirePublicParameterlessConstructor (type);
 		}
 
 		// Validate error message when untracable value is passed to an annotated parameter.
-		[UnrecognizedReflectionAccessPattern (typeof (MethodParametersDataFlow), nameof (RequireDefaultConstructor), new Type[] { typeof (Type) },
+		[UnrecognizedReflectionAccessPattern (typeof (MethodParametersDataFlow), nameof (RequirePublicParameterlessConstructor), new Type[] { typeof (Type) },
 			"A value from unknown source is passed " +
-			"into the parameter 'type' of method 'Mono.Linker.Tests.Cases.DataFlow.MethodParametersDataFlow.RequireDefaultConstructor(Type)' " +
-			"which requires dynamically accessed member kinds 'DefaultConstructor'. " +
+			"into the parameter 'type' of method 'Mono.Linker.Tests.Cases.DataFlow.MethodParametersDataFlow.RequirePublicParameterlessConstructor(Type)' " +
+			"which requires dynamically accessed member kinds 'PublicParameterlessConstructor'. " +
 			"It's not possible to guarantee that these requirements are met by the application.")]
 		private void UnknownValue ()
 		{
 			var array = new object[1];
 			array[0] = this.GetType ();
-			RequireDefaultConstructor ((Type) array[0]);
+			RequirePublicParameterlessConstructor ((Type) array[0]);
 		}
 
 		[RecognizedReflectionAccessPattern]
 		private void AnnotatedValueToUnAnnotatedParameter (
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.DefaultConstructor)]
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			Type type)
 		{
 			RequireNothing (type);
@@ -191,11 +191,11 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[RecognizedReflectionAccessPattern]
 		private void UnknownValueToUnAnnotatedParameterOnInterestingMethod ()
 		{
-			RequireDefaultConstructorAndNothing (typeof (TestType), this.GetType ());
+			RequirePublicParameterlessConstructorAndNothing (typeof (TestType), this.GetType ());
 		}
 
-		private static void RequireDefaultConstructor (
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.DefaultConstructor)]
+		private static void RequirePublicParameterlessConstructor (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			Type type)
 		{
 		}
@@ -216,8 +216,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		{
 		}
 
-		private static void RequireDefaultConstructorAndNothing (
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.DefaultConstructor)]
+		private static void RequirePublicParameterlessConstructorAndNothing (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			Type type,
 			Type type2)
 		{

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MethodReturnParameterDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MethodReturnParameterDataFlow.cs
@@ -22,16 +22,16 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 			// Validation that assigning value to the return value is verified
 			NoRequirements ();
-			instance.ReturnDefaultConstructor (typeof (TestType), typeof (TestType), typeof (TestType));
-			instance.ReturnDefaultConstructorFromUnknownType (null);
-			instance.ReturnDefaultConstructorFromConstant ();
-			instance.ReturnDefaultConstructorFromNull ();
+			instance.ReturnPublicParameterlessConstructor (typeof (TestType), typeof (TestType), typeof (TestType));
+			instance.ReturnPublicParameterlessConstructorFromUnknownType (null);
+			instance.ReturnPublicParameterlessConstructorFromConstant ();
+			instance.ReturnPublicParameterlessConstructorFromNull ();
 			instance.ReturnPublicConstructorsFailure (null);
 			instance.ReturnNonPublicConstructorsFailure (null);
 
 			// Validation that value comming from return value of a method is correctly propagated
-			instance.PropagateReturnDefaultConstructor ();
-			instance.PropagateReturnDefaultConstructorFromConstant ();
+			instance.PropagateReturnPublicParameterlessConstructor ();
+			instance.PropagateReturnPublicParameterlessConstructorFromConstant ();
 		}
 
 		private static Type NoRequirements ()
@@ -39,12 +39,12 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			return typeof (TestType);
 		}
 
-		[UnrecognizedReflectionAccessPattern (typeof (MethodReturnParameterDataFlow), nameof (ReturnDefaultConstructor),
+		[UnrecognizedReflectionAccessPattern (typeof (MethodReturnParameterDataFlow), nameof (ReturnPublicParameterlessConstructor),
 			new Type[] { typeof (Type), typeof (Type), typeof (Type) }, returnType: typeof (Type))]
-		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
-		private Type ReturnDefaultConstructor (
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.DefaultConstructor)]
-			Type defaultConstructorType,
+		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+		private Type ReturnPublicParameterlessConstructor (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+			Type publicParameterlessConstructorType,
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
 			Type publicConstructorsType,
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicConstructors)]
@@ -52,7 +52,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		{
 			switch (GetHashCode ()) {
 			case 1:
-				return defaultConstructorType;
+				return publicParameterlessConstructorType;
 			case 2:
 				return publicConstructorsType;
 			case 3:
@@ -64,24 +64,24 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			}
 		}
 
-		[UnrecognizedReflectionAccessPattern (typeof (MethodReturnParameterDataFlow), nameof (ReturnDefaultConstructorFromUnknownType),
+		[UnrecognizedReflectionAccessPattern (typeof (MethodReturnParameterDataFlow), nameof (ReturnPublicParameterlessConstructorFromUnknownType),
 			new Type[] { typeof (Type) }, returnType: typeof (Type))]
-		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
-		private Type ReturnDefaultConstructorFromUnknownType (Type unknownType)
+		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+		private Type ReturnPublicParameterlessConstructorFromUnknownType (Type unknownType)
 		{
 			return unknownType;
 		}
 
 		[RecognizedReflectionAccessPattern]
-		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
-		private Type ReturnDefaultConstructorFromConstant ()
+		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+		private Type ReturnPublicParameterlessConstructorFromConstant ()
 		{
 			return typeof (TestType);
 		}
 
 		[RecognizedReflectionAccessPattern]
-		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
-		private Type ReturnDefaultConstructorFromNull ()
+		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+		private Type ReturnPublicParameterlessConstructorFromNull ()
 		{
 			return null;
 		}
@@ -89,17 +89,17 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		// Validate error message when insufficiently annotated value is returned from a method
 		[UnrecognizedReflectionAccessPattern (typeof (MethodReturnParameterDataFlow), nameof (ReturnPublicConstructorsFailure),
 			new Type[] { typeof (Type) },
-			"The parameter 'defaultConstructorType' of method 'Mono.Linker.Tests.Cases.DataFlow.MethodReturnParameterDataFlow.ReturnPublicConstructorsFailure(Type)' " +
-			"with dynamically accessed member kinds 'DefaultConstructor' is " +
+			"The parameter 'publicParameterlessConstructorType' of method 'Mono.Linker.Tests.Cases.DataFlow.MethodReturnParameterDataFlow.ReturnPublicConstructorsFailure(Type)' " +
+			"with dynamically accessed member kinds 'PublicParameterlessConstructor' is " +
 			"passed into the return value of method 'Mono.Linker.Tests.Cases.DataFlow.MethodReturnParameterDataFlow.ReturnPublicConstructorsFailure(Type)' " +
 			"which requires dynamically accessed member kinds 'PublicConstructors'. " +
 			"To fix this add DynamicallyAccessedMembersAttribute to it and specify at least these member kinds 'PublicConstructors'.", typeof (Type))]
 		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)]
 		private Type ReturnPublicConstructorsFailure (
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.DefaultConstructor)]
-			Type defaultConstructorType)
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+			Type publicParameterlessConstructorType)
 		{
-			return defaultConstructorType;
+			return publicParameterlessConstructorType;
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (MethodReturnParameterDataFlow), nameof (ReturnNonPublicConstructorsFailure),
@@ -114,10 +114,10 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		[UnrecognizedReflectionAccessPattern (typeof (MethodReturnParameterDataFlow), nameof (RequirePublicConstructors), new Type[] { typeof (Type) })]
 		[UnrecognizedReflectionAccessPattern (typeof (MethodReturnParameterDataFlow), nameof (RequireNonPublicConstructors), new Type[] { typeof (Type) })]
-		private void PropagateReturnDefaultConstructor ()
+		private void PropagateReturnPublicParameterlessConstructor ()
 		{
-			Type t = ReturnDefaultConstructor (typeof (TestType), typeof (TestType), typeof (TestType));
-			RequireDefaultConstructor (t);
+			Type t = ReturnPublicParameterlessConstructor (typeof (TestType), typeof (TestType), typeof (TestType));
+			PublicParameterlessConstructorConstructor (t);
 			RequirePublicConstructors (t);
 			RequireNonPublicConstructors (t);
 			RequireNothing (t);
@@ -125,17 +125,17 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		[UnrecognizedReflectionAccessPattern (typeof (MethodReturnParameterDataFlow), nameof (RequirePublicConstructors), new Type[] { typeof (Type) })]
 		[UnrecognizedReflectionAccessPattern (typeof (MethodReturnParameterDataFlow), nameof (RequireNonPublicConstructors), new Type[] { typeof (Type) })]
-		private void PropagateReturnDefaultConstructorFromConstant ()
+		private void PropagateReturnPublicParameterlessConstructorFromConstant ()
 		{
-			Type t = ReturnDefaultConstructorFromConstant ();
-			RequireDefaultConstructor (t);
+			Type t = ReturnPublicParameterlessConstructorFromConstant ();
+			PublicParameterlessConstructorConstructor (t);
 			RequirePublicConstructors (t);
 			RequireNonPublicConstructors (t);
 			RequireNothing (t);
 		}
 
-		private static void RequireDefaultConstructor (
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.DefaultConstructor)]
+		private static void PublicParameterlessConstructorConstructor (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			Type type)
 		{
 		}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
@@ -27,10 +27,10 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			instance.ReadFromStaticProperty ();
 			instance.WriteToStaticProperty ();
 
-			_ = instance.PropertyDefaultConstructorWithExplicitAccessors;
+			_ = instance.PropertyPublicParameterlessConstructorWithExplicitAccessors;
 			_ = instance.PropertyPublicConstructorsWithExplicitAccessors;
 			_ = instance.PropertyNonPublicConstructorsWithExplicitAccessors;
-			instance.PropertyDefaultConstructorWithExplicitAccessors = null;
+			instance.PropertyPublicParameterlessConstructorWithExplicitAccessors = null;
 			instance.PropertyPublicConstructorsWithExplicitAccessors = null;
 			instance.PropertyNonPublicConstructorsWithExplicitAccessors = null;
 
@@ -46,7 +46,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[UnrecognizedReflectionAccessPattern (typeof (PropertyDataFlow), nameof (RequireNonPublicConstructors), new Type[] { typeof (Type) })]
 		private void ReadFromInstanceProperty ()
 		{
-			RequireDefaultConstructor (PropertyWithPublicConstructor);
+			RequirePublicParameterlessConstructor (PropertyWithPublicConstructor);
 			RequirePublicConstructors (PropertyWithPublicConstructor);
 			RequireNonPublicConstructors (PropertyWithPublicConstructor);
 			RequireNothing (PropertyWithPublicConstructor);
@@ -55,7 +55,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[UnrecognizedReflectionAccessPattern (typeof (PropertyDataFlow), nameof (RequireNonPublicConstructors), new Type[] { typeof (Type) })]
 		private void ReadFromStaticProperty ()
 		{
-			RequireDefaultConstructor (StaticPropertyWithPublicConstructor);
+			RequirePublicParameterlessConstructor (StaticPropertyWithPublicConstructor);
 			RequirePublicConstructors (StaticPropertyWithPublicConstructor);
 			RequireNonPublicConstructors (StaticPropertyWithPublicConstructor);
 			RequireNothing (StaticPropertyWithPublicConstructor);
@@ -66,7 +66,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[UnrecognizedReflectionAccessPattern (typeof (PropertyDataFlow), "set_" + nameof (PropertyWithPublicConstructor), new Type[] { typeof (Type) })]
 		private void WriteToInstanceProperty ()
 		{
-			PropertyWithPublicConstructor = GetTypeWithDefaultConstructor ();
+			PropertyWithPublicConstructor = GetTypeWithPublicParameterlessConstructor ();
 			PropertyWithPublicConstructor = GetTypeWithPublicConstructors ();
 			PropertyWithPublicConstructor = GetTypeWithNonPublicConstructors ();
 			PropertyWithPublicConstructor = GetUnkownType ();
@@ -77,7 +77,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[UnrecognizedReflectionAccessPattern (typeof (PropertyDataFlow), "set_" + nameof (StaticPropertyWithPublicConstructor), new Type[] { typeof (Type) })]
 		private void WriteToStaticProperty ()
 		{
-			StaticPropertyWithPublicConstructor = GetTypeWithDefaultConstructor ();
+			StaticPropertyWithPublicConstructor = GetTypeWithPublicParameterlessConstructor ();
 			StaticPropertyWithPublicConstructor = GetTypeWithPublicConstructors ();
 			StaticPropertyWithPublicConstructor = GetTypeWithNonPublicConstructors ();
 			StaticPropertyWithPublicConstructor = GetUnkownType ();
@@ -100,15 +100,15 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			}
 		}
 
-		Type PropertyDefaultConstructorWithExplicitAccessors {
+		Type PropertyPublicParameterlessConstructorWithExplicitAccessors {
 			[RecognizedReflectionAccessPattern]
-			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
+			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			get {
 				return _fieldWithPublicConstructors;
 			}
 
 			[UnrecognizedReflectionAccessPattern (typeof (PropertyDataFlow), nameof (_fieldWithPublicConstructors))]
-			[param: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
+			[param: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			set {
 				_fieldWithPublicConstructors = value;
 			}
@@ -147,7 +147,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			public void TestImplicitProperty ()
 			{
 				RequirePublicConstructors (ImplicitProperty);
-				ImplicitProperty = GetTypeWithDefaultConstructor (); // This will warn since the setter requires public .ctors
+				ImplicitProperty = GetTypeWithPublicParameterlessConstructor (); // This will warn since the setter requires public .ctors
 			}
 
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)]
@@ -263,8 +263,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			}
 		}
 
-		private static void RequireDefaultConstructor (
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.DefaultConstructor)]
+		private static void RequirePublicParameterlessConstructor (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			Type type)
 		{
 		}
@@ -281,8 +281,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		{
 		}
 
-		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
-		private static Type GetTypeWithDefaultConstructor ()
+		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+		private static Type GetTypeWithPublicParameterlessConstructor ()
 		{
 			return null;
 		}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/SuppressWarningWithLinkAttributes.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/SuppressWarningWithLinkAttributes.cs
@@ -23,22 +23,22 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			instance.ReadFromInstanceField ();
 		}
 
-		Type _typeWithDefaultConstructor;
+		Type _typeWithPublicParameterlessConstructor;
 
-		Type PropertyWithDefaultConstructor { get; set; }
+		Type PropertyWithPublicParameterlessConstructor { get; set; }
 
 		[UnrecognizedReflectionAccessPattern (typeof (SuppressWarningWithLinkAttributes), nameof (RequirePublicConstructors), new Type[] { typeof (Type) })]
 		[UnrecognizedReflectionAccessPattern (typeof (SuppressWarningWithLinkAttributes), nameof (RequireNonPublicConstructors), new Type[] { typeof (Type) })]
 		[RecognizedReflectionAccessPattern]
 		private void ReadFromInstanceField ()
 		{
-			RequireDefaultConstructor (_typeWithDefaultConstructor);
-			RequirePublicConstructors (_typeWithDefaultConstructor);
-			RequireNonPublicConstructors (_typeWithDefaultConstructor);
+			RequirePublicParameterlessConstructor (_typeWithPublicParameterlessConstructor);
+			RequirePublicConstructors (_typeWithPublicParameterlessConstructor);
+			RequireNonPublicConstructors (_typeWithPublicParameterlessConstructor);
 		}
 
-		private static void RequireDefaultConstructor (
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.DefaultConstructor)]
+		private static void RequirePublicParameterlessConstructor (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			Type type)
 		{
 		}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/SuppressWarningWithLinkAttributes.xml
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/SuppressWarningWithLinkAttributes.xml
@@ -6,12 +6,12 @@
       <argument>IL2006</argument>
     </attribute>
     <type fullname="Mono.Linker.Tests.Cases.DataFlow.SuppressWarningWithLinkAttributes">
-      <field name="_typeWithDefaultConstructor">
+      <field name="_typeWithPublicParameterlessConstructor">
         <attribute fullname="System.DoesNotExistattribute" assembly="Mono.Linker.Tests.Cases.Expectations">
           <argument>0</argument>
         </attribute>
         <attribute fullname="System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute">
-          <argument>DefaultConstructor</argument>
+          <argument>PublicParameterlessConstructor</argument>
         </attribute>
       </field>
     </type>

--- a/test/Mono.Linker.Tests.Cases/DataFlow/VirtualMethodHierarchyDataflowAnnotationValidation.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/VirtualMethodHierarchyDataflowAnnotationValidation.cs
@@ -46,23 +46,23 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			// Other than the basics, the return value also checks all of the inheritance cases - we omit those for the other tests
 			public virtual Type ReturnValueBaseWithoutDerivedWithout () => null;
 			public virtual Type ReturnValueBaseWithoutDerivedWith () => null;
-			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
+			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			public virtual Type ReturnValueBaseWithDerivedWithout () => null;
-			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
+			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			public virtual Type ReturnValueBaseWithDerivedWith () => null;
 
-			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
+			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			public virtual Type ReturnValueBaseWithSuperDerivedWithout () => null;
 
 			// === Method parameters ===
 			// This does not check complicated inheritance cases as that is already validated by the return values
 			public virtual void SingleParameterBaseWithDerivedWithout (
-				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 				Type p)
 			{ }
 
 			public virtual void SingleParameterBaseWithDerivedWith_ (
-				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 				Type p)
 			{ }
 
@@ -141,14 +141,14 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				"DynamicallyAccessedMemberTypes in DynamicallyAccessedMembersAttribute on return value of method 'Mono.Linker.Tests.Cases.DataFlow.VirtualMethodHierarchyDataflowAnnotationValidation.DerivedClass.ReturnValueBaseWithoutDerivedWith()' " +
 				"don't match overridden return value of method 'Mono.Linker.Tests.Cases.DataFlow.VirtualMethodHierarchyDataflowAnnotationValidation.BaseClass.ReturnValueBaseWithoutDerivedWith()'. " +
 				"All overridden members must have the same DynamicallyAccessedMembersAttribute usage.")]
-			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
+			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			public override Type ReturnValueBaseWithoutDerivedWith () => null;
 
 			[LogContains ("DerivedClass.ReturnValueBaseWithDerivedWithout")]
 			public override Type ReturnValueBaseWithDerivedWithout () => null;
 
 			[LogDoesNotContain ("DerivedClass.ReturnValueBaseWithDerivedWitht")]
-			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
+			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			public override Type ReturnValueBaseWithDerivedWith () => null;
 
 
@@ -161,7 +161,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 			[LogDoesNotContain ("DerivedClass.SingleParameterBaseWithDerivedWith_")]
 			public override void SingleParameterBaseWithDerivedWith_ (
-				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 				Type p)
 			{ }
 
@@ -170,7 +170,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				"don't match overridden parameter 'p' of method 'Mono.Linker.Tests.Cases.DataFlow.VirtualMethodHierarchyDataflowAnnotationValidation.BaseClass.SingleParameterBaseWithoutDerivedWith_(Type)'. " +
 				"All overridden members must have the same DynamicallyAccessedMembersAttribute usage.")]
 			public override void SingleParameterBaseWithoutDerivedWith_ (
-				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 				Type p)
 			{ }
 
@@ -338,7 +338,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		{
 			// === Return values ===
 			[LogContains ("DerivedOverNoAnnotations.ReturnValueBaseWithoutDerivedWith")]
-			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
+			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			public override Type ReturnValueBaseWithoutDerivedWith () => null;
 
 			[LogDoesNotContain ("DerivedOverNoAnnotations.ReturnValueBaseWithoutDerivedWithout")]
@@ -347,7 +347,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			// === Method parameters ===
 			[LogContains ("DerivedOverNoAnnotations.SingleParameterBaseWithoutDerivedWith_")]
 			public override void SingleParameterBaseWithoutDerivedWith_ (
-				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 				Type p)
 			{ }
 
@@ -374,19 +374,19 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		abstract class BaseWithAnnotations
 		{
 			// === Return values ===
-			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
+			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			public abstract Type ReturnValueBaseWithDerivedWithout ();
 
 			public abstract Type ReturnValueBaseWithoutDerivedWithout ();
 
 			// === Method parameters ===
 			public virtual void SingleParameterBaseWithDerivedWithout (
-				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 				Type p)
 			{ }
 
 			public virtual void SingleParameterBaseWithDerivedWith_ (
-				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 				Type p)
 			{ }
 
@@ -421,7 +421,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 			[LogDoesNotContain ("DerivedWithNoAnnotations.SingleParameterBaseWithDerivedWith_")]
 			public override void SingleParameterBaseWithDerivedWith_ (
-				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 				Type p)
 			{ }
 
@@ -445,24 +445,24 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		interface IBase
 		{
 			// === Return values ===
-			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
+			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			Type ReturnValueInterfaceBaseWithImplementationWithout ();
 
 			Type ReturnValueInterfaceBaseWithoutImplementationWith_ ();
 
-			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
+			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			Type ReturnValueInterfaceBaseWithImplementationWith_ ();
 
 
 			// === Method parameters ===
 			void SingleParameterBaseWithImplementationWith_ (
-				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 				Type p);
 
 			void SingleParameterBaseWithoutImplementationWith_ (Type p);
 
 			void SingleParameterBaseWithImplementationWithout (
-				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 				Type p);
 
 			void SingleParameterBaseWithoutImplementationWithout (Type p);
@@ -486,7 +486,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		interface IDerived : IBase
 		{
 			// === Return values ===
-			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
+			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			Type ReturnTypeInterfaceDerivedWithImplementationWithout ();
 
 
@@ -500,11 +500,11 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			public Type ReturnValueInterfaceBaseWithImplementationWithout () => null;
 
 			[LogContains ("ImplementationClass.ReturnValueInterfaceBaseWithoutImplementationWith_")]
-			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
+			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			public Type ReturnValueInterfaceBaseWithoutImplementationWith_ () => null;
 
 			[LogDoesNotContain ("ImplementationClass.ReturnValueInterfaceBaseWithImplementationWith_")]
-			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
+			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			public Type ReturnValueInterfaceBaseWithImplementationWith_ () => null;
 
 			[LogContains ("ImplementationClass.ReturnTypeInterfaceDerivedWithImplementationWithout")]
@@ -514,7 +514,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			// === Method parameters ===
 			[LogDoesNotContain ("ImplementationClass.SingleParameterBaseWithImplementationWith_")]
 			public void SingleParameterBaseWithImplementationWith_ (
-				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 				Type p)
 			{ }
 
@@ -523,7 +523,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 			[LogContains ("ImplementationClass.SingleParameterBaseWithoutImplementationWith_")]
 			public void SingleParameterBaseWithoutImplementationWith_ (
-				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 				Type p)
 			{ }
 
@@ -541,7 +541,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			// === Properties ===
 			[LogContains ("ImplementationClass.get_PropertyInterfaceBaseWithoutImplementationWith")]
 			[LogContains ("ImplementationClass.set_PropertyInterfaceBaseWithoutImplementationWith")]
-			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			public Type PropertyInterfaceBaseWithoutImplementationWith { get; set; }
 
 
@@ -569,7 +569,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				"DynamicallyAccessedMemberTypes in DynamicallyAccessedMembersAttribute on return value of method 'Mono.Linker.Tests.Cases.DataFlow.VirtualMethodHierarchyDataflowAnnotationValidation.BaseImplementsInterfaceViaDerived.ReturnValueBaseWithInterfaceWithout()' " +
 				"don't match overridden return value of method 'Mono.Linker.Tests.Cases.DataFlow.VirtualMethodHierarchyDataflowAnnotationValidation.IBaseImplementedInterface.ReturnValueBaseWithInterfaceWithout()'. " +
 				"All overridden members must have the same DynamicallyAccessedMembersAttribute usage.")]
-			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor)]
+			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			public virtual Type ReturnValueBaseWithInterfaceWithout () => null;
 
 			[LogContains ("BaseImplementsInterfaceViaDerived.RequiresUnreferencedCodeBaseWithoutInterfaceWith")]

--- a/test/Mono.Linker.Tests.Cases/DataFlow/XmlAnnotations.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/XmlAnnotations.cs
@@ -33,18 +33,18 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			nestedinstance.ReadFromInstanceField ();
 		}
 
-		Type _typeWithDefaultConstructor;
+		Type _typeWithPublicParameterlessConstructor;
 
-		Type PropertyWithDefaultConstructor { get; set; }
+		Type PropertyWithPublicParameterlessConstructor { get; set; }
 
 		[UnrecognizedReflectionAccessPattern (typeof (XmlAnnotations), nameof (RequirePublicConstructors), new Type[] { typeof (Type) })]
 		[UnrecognizedReflectionAccessPattern (typeof (XmlAnnotations), nameof (RequireNonPublicConstructors), new Type[] { typeof (Type) })]
 		[RecognizedReflectionAccessPattern]
 		private void ReadFromInstanceField ()
 		{
-			RequireDefaultConstructor (_typeWithDefaultConstructor);
-			RequirePublicConstructors (_typeWithDefaultConstructor);
-			RequireNonPublicConstructors (_typeWithDefaultConstructor);
+			RequirePublicParameterlessConstructor (_typeWithPublicParameterlessConstructor);
+			RequirePublicConstructors (_typeWithPublicParameterlessConstructor);
+			RequireNonPublicConstructors (_typeWithPublicParameterlessConstructor);
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (XmlAnnotations), nameof (RequirePublicConstructors), new Type[] { typeof (Type) })]
@@ -53,18 +53,18 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			Type type,
 			Type type2)
 		{
-			RequireDefaultConstructor (type);
-			RequireDefaultConstructor (type2);
+			RequirePublicParameterlessConstructor (type);
+			RequirePublicParameterlessConstructor (type2);
 			RequirePublicConstructors (type);
 			RequirePublicConstructors (type2);
 		}
 
-		[UnrecognizedReflectionAccessPattern (typeof (XmlAnnotations), nameof (RequireDefaultConstructor), new Type[] { typeof (Type) })]
+		[UnrecognizedReflectionAccessPattern (typeof (XmlAnnotations), nameof (RequirePublicParameterlessConstructor), new Type[] { typeof (Type) })]
 		private void SpacesBetweenParametersWrongArgument (
 			Type type,
 			bool nonused)
 		{
-			RequireDefaultConstructor (type);
+			RequirePublicParameterlessConstructor (type);
 		}
 
 		[RecognizedReflectionAccessPattern]
@@ -72,28 +72,28 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			T input,
 			Type type)
 		{
-			RequireDefaultConstructor (type);
+			RequirePublicParameterlessConstructor (type);
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (XmlAnnotations), nameof (ReturnConstructorsFailure), new Type[] { typeof (Type) },
 			returnType: typeof (Type))]
 		private Type ReturnConstructorsFailure (
-			Type defaultConstructorType)
+			Type publicParameterlessConstructorType)
 		{
-			return defaultConstructorType;
+			return publicParameterlessConstructorType;
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (XmlAnnotations), nameof (RequirePublicConstructors), new Type[] { typeof (Type) })]
 		[UnrecognizedReflectionAccessPattern (typeof (XmlAnnotations), nameof (RequireNonPublicConstructors), new Type[] { typeof (Type) })]
 		private void ReadFromInstanceProperty ()
 		{
-			RequireDefaultConstructor (PropertyWithDefaultConstructor);
-			RequirePublicConstructors (PropertyWithDefaultConstructor);
-			RequireNonPublicConstructors (PropertyWithDefaultConstructor);
+			RequirePublicParameterlessConstructor (PropertyWithPublicParameterlessConstructor);
+			RequirePublicConstructors (PropertyWithPublicParameterlessConstructor);
+			RequireNonPublicConstructors (PropertyWithPublicParameterlessConstructor);
 		}
 
-		private static void RequireDefaultConstructor (
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.DefaultConstructor)]
+		private static void RequirePublicParameterlessConstructor (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			Type type)
 		{
 		}
@@ -114,20 +114,20 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		class NestedType
 		{
-			Type _typeWithDefaultConstructor;
+			Type _typeWithPublicParameterlessConstructor;
 
 			[UnrecognizedReflectionAccessPattern (typeof (NestedType), nameof (RequirePublicConstructors), new Type[] { typeof (Type) })]
 			[UnrecognizedReflectionAccessPattern (typeof (NestedType), nameof (RequireConstructors), new Type[] { typeof (Type) })]
 			[RecognizedReflectionAccessPattern]
 			public void ReadFromInstanceField ()
 			{
-				RequireDefaultConstructor (_typeWithDefaultConstructor);
-				RequirePublicConstructors (_typeWithDefaultConstructor);
-				RequireConstructors (_typeWithDefaultConstructor);
+				RequirePublicParameterlessConstructor (_typeWithPublicParameterlessConstructor);
+				RequirePublicConstructors (_typeWithPublicParameterlessConstructor);
+				RequireConstructors (_typeWithPublicParameterlessConstructor);
 			}
 
-			private static void RequireDefaultConstructor (
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.DefaultConstructor)]
+			private static void RequirePublicParameterlessConstructor (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			Type type)
 			{
 			}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/XmlAnnotations.xml
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/XmlAnnotations.xml
@@ -2,18 +2,18 @@
 <linker>
   <assembly fullname="Test">
     <type fullname="Mono.Linker.Tests.Cases.DataFlow.XmlAnnotations">
-      <field name="_typeWithDefaultConstructor">
+      <field name="_typeWithPublicParameterlessConstructor">
         <attribute fullname="System.DoesNotExistattribute" assembly="Mono.Linker.Tests.Cases.Expectations">
           <argument>0</argument>
         </attribute>
         <attribute fullname="System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute">
-          <argument>DefaultConstructor</argument>
+          <argument>PublicParameterlessConstructor</argument>
         </attribute>
       </field>
       <method signature="System.Void TwoAnnotatedParameters(System.Type,System.Type)">
         <parameter name="type">
           <attribute fullname="System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute" assembly="Mono.Linker.Tests.Cases.Expectations">
-            <argument>DefaultConstructor</argument>
+            <argument>PublicParameterlessConstructor</argument>
           </attribute>
         </parameter>
         <parameter name="type2">
@@ -32,26 +32,26 @@
       <method signature="GenericMethod&lt;T&gt;(T,System.Type)">
         <parameter name="type">
           <attribute fullname="System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute" assembly="Mono.Linker.Tests.Cases.Expectations">
-            <argument>DefaultConstructor</argument>
+            <argument>PublicParameterlessConstructor</argument>
           </attribute>
         </parameter>
       </method>
       <method name="ReturnConstructorsFailure">
         <return>
           <attribute fullname="System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute" assembly="Mono.Linker.Tests.Cases.Expectations">
-            <argument>DefaultConstructor</argument>
+            <argument>PublicParameterlessConstructor</argument>
           </attribute>
         </return>
       </method>
-      <property name="PropertyWithDefaultConstructor">
+      <property name="PropertyWithPublicParameterlessConstructor">
         <attribute fullname="System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute" assembly="Mono.Linker.Tests.Cases.Expectations">
-          <argument>DefaultConstructor</argument>
+          <argument>PublicParameterlessConstructor</argument>
         </attribute>
       </property>
       <type name="NestedType">
-        <field name="_typeWithDefaultConstructor">
+        <field name="_typeWithPublicParameterlessConstructor">
           <attribute fullname="System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute" assembly="Mono.Linker.Tests.Cases.Expectations">
-            <argument>DefaultConstructor</argument>
+            <argument>PublicParameterlessConstructor</argument>
           </attribute>
         </field>
       </type>

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMemberTypes.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMemberTypes.cs
@@ -16,8 +16,8 @@ namespace Mono.Linker.Tests.Cases.DynamicDependencies
 		static class B
 		{
 			[Kept]
-			[DynamicDependency (DynamicallyAccessedMemberTypes.DefaultConstructor, typeof (TypeWithAutoImplementedDefaultConstructor))]
-			[DynamicDependency (DynamicallyAccessedMemberTypes.DefaultConstructor, typeof (TypeWithDefaultConstructor))]
+			[DynamicDependency (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, typeof (TypeWithAutoImplementedPublicParameterlessConstructor))]
+			[DynamicDependency (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, typeof (TypeWithPublicParameterlessConstructor))]
 			[DynamicDependency (DynamicallyAccessedMemberTypes.PublicConstructors, typeof (TypeWithPublicConstructor))]
 			[DynamicDependency (DynamicallyAccessedMemberTypes.NonPublicConstructors, typeof (TypeWithNonPublicConstructor))]
 			[DynamicDependency (DynamicallyAccessedMemberTypes.PublicMethods, typeof (TypeWithPublicMethod))]
@@ -39,19 +39,19 @@ namespace Mono.Linker.Tests.Cases.DynamicDependencies
 
 
 		[KeptMember (".ctor()")]
-		class TypeWithAutoImplementedDefaultConstructor
+		class TypeWithAutoImplementedPublicParameterlessConstructor
 		{
 			public void Method () { }
 
 			public int field;
 		}
 
-		class TypeWithDefaultConstructor
+		class TypeWithPublicParameterlessConstructor
 		{
 			[Kept]
-			public TypeWithDefaultConstructor () { }
+			public TypeWithPublicParameterlessConstructor () { }
 
-			public TypeWithDefaultConstructor (int i) { }
+			public TypeWithPublicParameterlessConstructor (int i) { }
 		}
 
 		class TypeWithPublicConstructor

--- a/test/Mono.Linker.Tests.Cases/Reflection/ActivatorCreateInstance.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ActivatorCreateInstance.cs
@@ -101,7 +101,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
 		[Kept]
 		private static void FromParameterOnStaticMethod (
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.DefaultConstructor)]
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type type)
 		{
@@ -136,7 +136,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		[UnrecognizedReflectionAccessPattern (typeof (Activator), nameof (Activator.CreateInstance), new Type[] { typeof (Type), typeof (BindingFlags), typeof (Binder), typeof (object[]), typeof (CultureInfo) })]
 		[Kept]
 		private void FromParameterOnInstanceMethod (
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.DefaultConstructor)]
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 			Type type)
 		{
@@ -425,7 +425,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		[Kept]
 		[RecognizedReflectionAccessPattern]
 		private static void TestCreateInstanceOfTWithDataflow<
-			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.DefaultConstructor),
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor),
 			KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))] T> ()
 		{
 			Activator.CreateInstance<T> ();

--- a/test/Mono.Linker.Tests.Cases/Reflection/ConstructorUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ConstructorUsedViaReflection.cs
@@ -64,8 +64,8 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		[UnrecognizedReflectionAccessPattern (
 			typeof (Type), nameof (Type.GetConstructor), new Type[] { typeof (Type[]) },
 			"The return value of method 'Mono.Linker.Tests.Cases.Reflection.ConstructorUsedViaReflection.FindType()' with dynamically accessed member kinds 'None' " +
-			"is passed into the implicit 'this' parameter of method 'System.Type.GetConstructor(Type[])' which requires dynamically accessed member kinds 'DefaultConstructor'. " +
-			"To fix this add DynamicallyAccessedMembersAttribute to it and specify at least these member kinds 'DefaultConstructor'.")]
+			"is passed into the implicit 'this' parameter of method 'System.Type.GetConstructor(Type[])' which requires dynamically accessed member kinds 'PublicParameterlessConstructor'. " +
+			"To fix this add DynamicallyAccessedMembersAttribute to it and specify at least these member kinds 'PublicParameterlessConstructor'.")]
 		[Kept]
 		static void TestDataFlowType ()
 		{


### PR DESCRIPTION
This turned out to be important as we used the enum name in linker attribute XML as well (so we would not recognize the correct name).

I tried to rename everything, including test type/method names and so on.

This also includes remaining renames of DynamicallyAccessedMemberKinds to DynamicallyAccessedMemberTypes (mostly local variable names and such).

No functional changes.