### PR TITLE
Keep all fields on sequential/explicit layout classes if a field was kept

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1247,6 +1247,17 @@ namespace Mono.Linker.Steps
 			MarkMarshalSpec (field, new DependencyInfo (DependencyKind.FieldMarshalSpec, field), field);
 			DoAdditionalFieldProcessing (field);
 
+			// If we accessed a field on a type and the type has explicit/sequential layout, make sure to keep
+			// all the other fields.
+			//
+			// We normally do this when the type is seen as instantiated, but one can get into a situation
+			// where the type is not seen as instantiated and the offsets still matter (usually when type safety
+			// is violated with Unsafe.As).
+			//
+			// This won't do too much work because classes are rarely tagged for explicit/sequential layout.
+			if (!field.DeclaringType.IsValueType)
+				MarkImplicitlyUsedFields (field.DeclaringType);
+
 			var parent = field.DeclaringType;
 			if (!Annotations.HasPreservedStaticCtor (parent)) {
 				var cctorReason = reason.Kind switch

--- a/test/Mono.Linker.Tests.Cases/Attributes.StructLayout/SequentialClass.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.StructLayout/SequentialClass.cs
@@ -29,10 +29,24 @@ namespace Mono.Linker.Tests.Cases.Attributes.StructLayout
 		public int never_used;
 	}
 
+	[Kept]
+	[StructLayout (LayoutKind.Sequential)]
+	class UnallocatedButWithSingleFieldUsedSequentialClassData
+	{
+		[Kept]
+		public int never_used;
+
+		[Kept]
+		public int used;
+	}
+
 	public class SequentialClass
 	{
 		[Kept]
 		static UnallocatedSequentialClassData _field;
+
+		[Kept]
+		static UnallocatedButWithSingleFieldUsedSequentialClassData _otherField;
 
 		public static void Main ()
 		{
@@ -44,6 +58,10 @@ namespace Mono.Linker.Tests.Cases.Attributes.StructLayout
 			_field = null;
 
 			typeof (UnallocatedButReferencedWithReflectionSequentialClassData).ToString ();
+
+			if (string.Empty.Length > 0) {
+				_otherField.used = 123;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Should fix the [issue](https://github.com/mono/linker/pull/1309) observed in CoreLib where `RawData` class is used with `Unsafe.As` to break type safety and linker stripped its fields because it's not seen as instantiated.