### PR TITLE
Keep base fields of non-auto layout classes

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1257,8 +1257,15 @@ namespace Mono.Linker.Steps
 			// is violated with Unsafe.As).
 			//
 			// This won't do too much work because classes are rarely tagged for explicit/sequential layout.
-			if (!field.DeclaringType.IsValueType)
-				MarkImplicitlyUsedFields (field.DeclaringType);
+			if (!field.DeclaringType.IsValueType && !field.DeclaringType.IsAutoLayout) {
+				// We also need to walk the base hierarchy because the offset of the field depends on the
+				// layout of the base.
+				TypeDefinition typeWithFields = field.DeclaringType;
+				while (typeWithFields != null) {
+					MarkImplicitlyUsedFields (typeWithFields);
+					typeWithFields = typeWithFields.BaseType.Resolve ();
+				}
+			}
 
 			var parent = field.DeclaringType;
 			if (!Annotations.HasPreservedStaticCtor (parent)) {

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1263,7 +1263,7 @@ namespace Mono.Linker.Steps
 				TypeDefinition typeWithFields = field.DeclaringType;
 				while (typeWithFields != null) {
 					MarkImplicitlyUsedFields (typeWithFields);
-					typeWithFields = typeWithFields.BaseType.Resolve ();
+					typeWithFields = typeWithFields.BaseType?.Resolve ();
 				}
 			}
 

--- a/test/Mono.Linker.Tests.Cases/Attributes.StructLayout/SequentialClass.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.StructLayout/SequentialClass.cs
@@ -44,7 +44,7 @@ namespace Mono.Linker.Tests.Cases.Attributes.StructLayout
 
 	[Kept]
 	[StructLayout (LayoutKind.Sequential)]
-	[KeptBaseType(typeof(UnallocatedButWithSingleFieldUsedSequentialClassDataBase))]
+	[KeptBaseType (typeof (UnallocatedButWithSingleFieldUsedSequentialClassDataBase))]
 	class UnallocatedButWithSingleFieldUsedSequentialClassData : UnallocatedButWithSingleFieldUsedSequentialClassDataBase
 	{
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/Attributes.StructLayout/SequentialClass.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.StructLayout/SequentialClass.cs
@@ -31,7 +31,21 @@ namespace Mono.Linker.Tests.Cases.Attributes.StructLayout
 
 	[Kept]
 	[StructLayout (LayoutKind.Sequential)]
-	class UnallocatedButWithSingleFieldUsedSequentialClassData
+	class UnallocatedButWithSingleFieldUsedSequentialClassDataBase
+	{
+		// We expect this to be kept because of the sequential layout.
+		// Code could do Unsafe.As tricks to alias a never allocated type
+		// with another type and access fields on it.
+		// Removing the base or fields on the base would shift the offsets
+		// and break the aliasing.
+		[Kept]
+		public int never_used_base;
+	}
+
+	[Kept]
+	[StructLayout (LayoutKind.Sequential)]
+	[KeptBaseType(typeof(UnallocatedButWithSingleFieldUsedSequentialClassDataBase))]
+	class UnallocatedButWithSingleFieldUsedSequentialClassData : UnallocatedButWithSingleFieldUsedSequentialClassDataBase
 	{
 		[Kept]
 		public int never_used;


### PR DESCRIPTION
If a field is accessed on a sequential/explicit class, we need to keep the instance fields on base types intact so that the offsets match. This happens naturally, except for the case where the type is not seen as allocated and we still have a field access somewhere (which could be in dead code or code that throws a nullreference, or code that did shenanigans with Unsafe.As and actually operates on an instance of a different type).