### PR TITLE
Simplify interface handling in TypeMapStep

### DIFF
--- a/src/linker/Linker.Steps/TypeMapStep.cs
+++ b/src/linker/Linker.Steps/TypeMapStep.cs
@@ -26,7 +26,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-using System.Collections.Generic;
 using Mono.Cecil;
 
 namespace Mono.Linker.Steps
@@ -58,49 +57,23 @@ namespace Mono.Linker.Steps
 			if (!type.HasInterfaces)
 				return;
 
-			foreach (var @interface in type.Interfaces) {
-				var interfaceType = @interface.InterfaceType;
-				var iface = interfaceType.Resolve ();
-				if (iface == null || !iface.HasMethods)
-					continue;
-
-				foreach (MethodDefinition interfaceMethod in iface.Methods) {
-					if (TryMatchMethod (type, interfaceMethod) != null)
+			foreach (var interfaceImpl in type.GetInflatedInterfaces()) {
+				foreach (MethodReference interfaceMethod in interfaceImpl.InflatedInterface.GetMethods()) {
+					MethodDefinition resolvedInterfaceMethod = interfaceMethod.Resolve ();
+					if (resolvedInterfaceMethod == null)
 						continue;
+
+					MethodDefinition exactMatchOnType = TryMatchMethod (type, interfaceMethod);
+					if (exactMatchOnType != null) {
+						AnnotateMethods (resolvedInterfaceMethod, exactMatchOnType);
+						continue;
+					}
 
 					var @base = GetBaseMethodInTypeHierarchy (type, interfaceMethod);
 					if (@base != null)
-						AnnotateMethods (interfaceMethod, @base, @interface);
-
-					if (interfaceType is GenericInstanceType genericInterfaceInstance) {
-						var genericContext = new Inflater.GenericContext (genericInterfaceInstance, null);
-						var baseInflated = GetBaseInflatedInterfaceMethodInTypeHierarchy (genericContext, type, interfaceMethod);
-						if (baseInflated != null)
-							Annotations.AddOverride (interfaceMethod, baseInflated, @interface);
-					}
+						AnnotateMethods (resolvedInterfaceMethod, @base, interfaceImpl.OriginalImpl);
 				}
 			}
-		}
-
-		static MethodReference CreateGenericInstanceCandidate (Inflater.GenericContext context, TypeDefinition candidateType, MethodDefinition interfaceMethod)
-		{
-			var methodReference = new MethodReference (interfaceMethod.Name, interfaceMethod.ReturnType, candidateType) { HasThis = interfaceMethod.HasThis };
-
-			foreach (var genericMethodParameter in interfaceMethod.GenericParameters)
-				methodReference.GenericParameters.Add (new GenericParameter (genericMethodParameter.Name, methodReference));
-
-			if (interfaceMethod.ReturnType.IsGenericParameter || interfaceMethod.ReturnType.IsGenericInstance)
-				methodReference.ReturnType = Inflater.InflateType (context, interfaceMethod.ReturnType);
-
-			foreach (var p in interfaceMethod.Parameters) {
-				var parameterType = p.ParameterType;
-				if (parameterType.IsGenericParameter || parameterType.IsGenericInstance)
-					parameterType = Inflater.InflateType (context, parameterType);
-
-				methodReference.Parameters.Add (new ParameterDefinition (p.Name, p.Attributes, parameterType));
-			}
-
-			return methodReference;
 		}
 
 		void MapVirtualMethods (TypeDefinition type)
@@ -121,23 +94,11 @@ namespace Mono.Linker.Steps
 
 		void MapVirtualMethod (MethodDefinition method)
 		{
-			MapVirtualBaseMethod (method);
-			MapVirtualInterfaceMethod (method);
-		}
-
-		void MapVirtualBaseMethod (MethodDefinition method)
-		{
 			MethodDefinition @base = GetBaseMethodInTypeHierarchy (method);
 			if (@base == null)
 				return;
 
 			AnnotateMethods (@base, method);
-		}
-
-		void MapVirtualInterfaceMethod (MethodDefinition method)
-		{
-			foreach (MethodDefinition @base in GetBaseMethodsInInterfaceHierarchy (method))
-				AnnotateMethods (@base, method);
 		}
 
 		void MapOverrides (MethodDefinition method)
@@ -162,7 +123,7 @@ namespace Mono.Linker.Steps
 			return GetBaseMethodInTypeHierarchy (method.DeclaringType, method);
 		}
 
-		static MethodDefinition GetBaseMethodInTypeHierarchy (TypeDefinition type, MethodDefinition method)
+		static MethodDefinition GetBaseMethodInTypeHierarchy (TypeDefinition type, MethodReference method)
 		{
 			TypeReference @base = type.GetInflatedBaseType ();
 			while (@base != null) {
@@ -174,39 +135,6 @@ namespace Mono.Linker.Steps
 			}
 
 			return null;
-		}
-
-		static MethodDefinition GetBaseInflatedInterfaceMethodInTypeHierarchy (Inflater.GenericContext context, TypeDefinition type, MethodDefinition interfaceMethod)
-		{
-			TypeReference @base = type.GetInflatedBaseType ();
-			while (@base != null) {
-				var candidate = CreateGenericInstanceCandidate (context, @base.Resolve (), interfaceMethod);
-
-				MethodDefinition base_method = TryMatchMethod (@base, candidate);
-				if (base_method != null)
-					return base_method;
-
-				@base = @base.GetInflatedBaseType ();
-			}
-
-			return null;
-		}
-
-		static IEnumerable<MethodDefinition> GetBaseMethodsInInterfaceHierarchy (MethodDefinition method)
-		{
-			return GetBaseMethodsInInterfaceHierarchy (method.DeclaringType, method);
-		}
-
-		static IEnumerable<MethodDefinition> GetBaseMethodsInInterfaceHierarchy (TypeReference type, MethodDefinition method)
-		{
-			foreach (TypeReference @interface in type.GetInflatedInterfaces ()) {
-				MethodDefinition base_method = TryMatchMethod (@interface, method);
-				if (base_method != null)
-					yield return base_method;
-
-				foreach (MethodDefinition @base in GetBaseMethodsInInterfaceHierarchy (@interface, method))
-					yield return @base;
-			}
 		}
 
 		static MethodDefinition TryMatchMethod (TypeReference type, MethodReference method)

--- a/src/linker/Linker.Steps/TypeMapStep.cs
+++ b/src/linker/Linker.Steps/TypeMapStep.cs
@@ -57,8 +57,8 @@ namespace Mono.Linker.Steps
 			if (!type.HasInterfaces)
 				return;
 
-			foreach (var interfaceImpl in type.GetInflatedInterfaces()) {
-				foreach (MethodReference interfaceMethod in interfaceImpl.InflatedInterface.GetMethods()) {
+			foreach (var interfaceImpl in type.GetInflatedInterfaces ()) {
+				foreach (MethodReference interfaceMethod in interfaceImpl.InflatedInterface.GetMethods ()) {
 					MethodDefinition resolvedInterfaceMethod = interfaceMethod.Resolve ();
 					if (resolvedInterfaceMethod == null)
 						continue;

--- a/src/linker/Linker/TypeReferenceExtensions.cs
+++ b/src/linker/Linker/TypeReferenceExtensions.cs
@@ -168,7 +168,7 @@ namespace Mono.Linker
 			return resolved?.DeclaringType;
 		}
 
-		public static IEnumerable<TypeReference> GetInflatedInterfaces (this TypeReference typeRef)
+		public static IEnumerable<(TypeReference InflatedInterface, InterfaceImplementation OriginalImpl)> GetInflatedInterfaces (this TypeReference typeRef)
 		{
 			var typeDef = typeRef.Resolve ();
 
@@ -177,10 +177,10 @@ namespace Mono.Linker
 
 			if (typeRef is GenericInstanceType genericInstance) {
 				foreach (var interfaceImpl in typeDef.Interfaces)
-					yield return InflateGenericType (genericInstance, interfaceImpl.InterfaceType);
+					yield return (InflateGenericType (genericInstance, interfaceImpl.InterfaceType), interfaceImpl);
 			} else {
 				foreach (var interfaceImpl in typeDef.Interfaces)
-					yield return interfaceImpl.InterfaceType;
+					yield return (interfaceImpl.InterfaceType, interfaceImpl);
 			}
 		}
 


### PR DESCRIPTION
I can't tell if I'm deleting a bunch of cargo cults or if this is necessary for something. The tests seem to be passing.

I stumbled over this when trying to find a place where to slot in default interface method support (#427).

TypeMapStep was computing interface implementation by doing two passes:

1. For each interface & for each method on the interface, try to find a name/sig match on the current class and all the bases. If the match happens on the current class, do nothing, otherwise record the overrides/base relationship.
2. For each virtual method on the class & for each interface implemented by the class try to find a name/sig match of the virtual method on the interface. If one is found, record that info.

We were basically running two `O(N*M*L)` algorithms for something that should be possible to compute in the first pass. (We actually computed it in the first pass as described above, but we did the "do nothing" instead of recording the info we found.)

Feels like we should be able to delete the second pass.