### PR TITLE
Stop processing attributes after RemoveAttributeInstances

### DIFF
--- a/src/linker/Linker.Steps/LinkAttributesStep.cs
+++ b/src/linker/Linker.Steps/LinkAttributesStep.cs
@@ -39,6 +39,7 @@ namespace Mono.Linker.Steps
 				if (internalAttribute == "RemoveAttributeInstances" && provider != null) {
 					IEnumerable<Attribute> removeAttributeInstance = new List<Attribute> { new RemoveAttributeInstancesAttribute () };
 					Context.CustomAttributes.AddInternalAttributes (provider, removeAttributeInstance);
+					continue;
 				}
 
 				string attributeFullName = GetFullName (iterator.Current);


### PR DESCRIPTION
Currently, the code tries to continue processing attributes when internal attribute RemoveAttributeInstances is detected causing a warning since the internal attribute doesn't contain fullname. Correct behavior should be: continue after a RemoveAttributeInstances attribute has been detected.
This fixes #1337  #1338 