### PR TITLE
Cleanup debugger attributes removed for ILLink

### DIFF
--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -533,6 +533,11 @@ namespace Mono.Linker
 							return -1;
 
 						continue;
+					case "v":
+						if (!GetBoolParam (token, l => context.KeepMembersForDebugger = l))
+							return -1;
+
+						continue;
 #endif
 					case "b":
 						if (!GetBoolParam (token, l => context.LinkSymbols = l))
@@ -546,11 +551,6 @@ namespace Mono.Linker
 						continue;
 					case "z":
 						if (!GetBoolParam (token, l => context.IgnoreDescriptors = !l))
-							return -1;
-
-						continue;
-					case "v":
-						if (!GetBoolParam (token, l => context.KeepMembersForDebugger = l))
 							return -1;
 
 						continue;
@@ -1024,8 +1024,8 @@ namespace Mono.Linker
 			Console.WriteLine ("  -d PATH             Specify additional directories to search in for references");
 			Console.WriteLine ("  -reference FILE     Specify additional assemblies to use as references");
 			Console.WriteLine ("  -b                  Update debug symbols for each linked module. Defaults to false");
-			Console.WriteLine ("  -v                  Keep members and types used by debugger. Defaults to false");
 #if !FEATURE_ILLINK
+			Console.WriteLine ("  -v                  Keep members and types used by debugger. Defaults to false");
 			Console.WriteLine ("  -l <name>,<name>    List of i18n assemblies to copy to the output directory. Defaults to 'all'");
 			Console.WriteLine ("                        Valid names are 'none', 'all', 'cjk', 'mideast', 'other', 'rare', 'west'");
 #endif

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -54,7 +54,6 @@ namespace Mono.Linker
 		readonly Dictionary<string, string> _parameters;
 		bool _linkSymbols;
 		bool _keepTypeForwarderOnlyAssemblies;
-		bool _keepMembersForDebugger;
 		bool _ignoreUnresolved;
 
 		readonly AssemblyResolver _resolver;
@@ -105,10 +104,11 @@ namespace Mono.Linker
 			set { _keepTypeForwarderOnlyAssemblies = value; }
 		}
 
-		public bool KeepMembersForDebugger {
-			get { return _keepMembersForDebugger; }
-			set { _keepMembersForDebugger = value; }
-		}
+#if FEATURE_ILLINK
+		public readonly bool KeepMembersForDebugger = true;
+#else
+		public bool KeepMembersForDebugger { get; set; }
+#endif
 
 		public bool IgnoreUnresolved {
 			get { return _ignoreUnresolved; }

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerAttributesRemoved.xml
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerAttributesRemoved.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<linker>
+  <assembly fullname="*">
+    <type fullname="System.Diagnostics.DebuggerTypeProxyAttribute">
+      <attribute internal="RemoveAttributeInstances"/>
+    </type>
+    <type fullname="System.Diagnostics.DebuggerDisplayAttribute">
+      <attribute internal="RemoveAttributeInstances"/>
+    </type>
+  </assembly>
+</linker>

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerDisplayAttributeOnAssemblyUsingTarget.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerDisplayAttributeOnAssemblyUsingTarget.cs
@@ -3,11 +3,18 @@ using Mono.Linker.Tests.Cases.Attributes.Debugger;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
+#if !NETCOREAPP
 [assembly: KeptAttributeAttribute (typeof (DebuggerDisplayAttribute))]
+#endif
+
 [assembly: DebuggerDisplay ("{Property}", Target = typeof (DebuggerDisplayAttributeOnAssemblyUsingTarget.Foo))]
 
 namespace Mono.Linker.Tests.Cases.Attributes.Debugger
 {
+#if NETCOREAPP
+	[SetupLinkAttributesFile ("DebuggerAttributesRemoved.xml")]
+	[SetupLinkerCoreAction ("copy")]
+#else
 	[SetupLinkerCoreAction ("link")]
 	[SetupLinkerKeepDebugMembers ("false")]
 
@@ -16,6 +23,7 @@ namespace Mono.Linker.Tests.Cases.Attributes.Debugger
 
 	[KeptMemberInAssembly (PlatformAssemblies.CoreLib, typeof (DebuggerDisplayAttribute), ".ctor(System.String)")]
 	[KeptMemberInAssembly (PlatformAssemblies.CoreLib, typeof (DebuggerDisplayAttribute), "set_Target(System.Type)")]
+#endif
 	public class DebuggerDisplayAttributeOnAssemblyUsingTarget
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerDisplayAttributeOnAssemblyUsingTargetOnUnusedType.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerDisplayAttributeOnAssemblyUsingTargetOnUnusedType.cs
@@ -7,6 +7,10 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Attributes.Debugger
 {
+#if NETCOREAPP
+	[SetupLinkAttributesFile ("DebuggerAttributesRemoved.xml")]
+	[SetupLinkerCoreAction ("copy")]
+#else
 	[SetupLinkerCoreAction ("link")]
 	[SetupLinkerKeepDebugMembers ("false")]
 
@@ -14,6 +18,7 @@ namespace Mono.Linker.Tests.Cases.Attributes.Debugger
 	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
 
 	[KeptMemberInAssembly (PlatformAssemblies.CoreLib, typeof (DebuggerDisplayAttribute), ".ctor(System.String)")]
+#endif
 	public class DebuggerDisplayAttributeOnAssemblyUsingTargetOnUnusedType
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly.cs
@@ -3,20 +3,29 @@ using Mono.Linker.Tests.Cases.Attributes.Debugger.Dependencies;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
+#if !NETCOREAPP
 [assembly: KeptAttributeAttribute (typeof (DebuggerDisplayAttribute))]
+#endif
+
 [assembly: DebuggerDisplay ("{Property}", TargetTypeName = "Mono.Linker.Tests.Cases.Attributes.Debugger.Dependencies.DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly_Lib, library")]
 
 namespace Mono.Linker.Tests.Cases.Attributes.Debugger
 {
+	[SetupCompileBefore ("library.dll", new[] { typeof (DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly_Lib) })]
+
+#if NETCOREAPP
+	[SetupLinkAttributesFile ("DebuggerAttributesRemoved.xml")]
+	[SetupLinkerCoreAction ("copy")]
+#else
 	[SetupLinkerCoreAction ("link")]
 	[SetupLinkerKeepDebugMembers ("false")]
-	[SetupCompileBefore ("library.dll", new[] { typeof (DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly_Lib) })]
 
 	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168
 	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
 
 	[KeptMemberInAssembly (PlatformAssemblies.CoreLib, typeof (DebuggerDisplayAttribute), ".ctor(System.String)")]
 	[KeptMemberInAssembly (PlatformAssemblies.CoreLib, typeof (DebuggerDisplayAttribute), "set_TargetTypeName(System.String)")]
+#endif
 
 	[RemovedMemberInAssembly ("library.dll", typeof (DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly_Lib), "get_Property()")]
 	[KeptMemberInAssembly ("library.dll", typeof (DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly_Lib), "set_Property(System.Int32)")]

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerDisplayAttributeOnTypeCopy.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerDisplayAttributeOnTypeCopy.cs
@@ -1,22 +1,15 @@
-﻿using System.Diagnostics;
+﻿#if NETCOREAPP
+
+using System.Diagnostics;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Attributes.Debugger
 {
-#if NETCOREAPP
 	[SetupLinkAttributesFile ("DebuggerAttributesRemoved.xml")]
 	[SetupLinkerCoreAction ("copy")]
-#else
-	[SetupLinkerCoreAction ("link")]
-	[SetupLinkerKeepDebugMembers ("false")]
-
-	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168
-	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
-
-	[KeptMemberInAssembly (PlatformAssemblies.CoreLib, typeof (DebuggerDisplayAttribute), ".ctor(System.String)")]
-#endif
-	public class DebuggerDisplayAttributeOnType
+	[SetupLinkerAction ("copy", "test")]
+	public static class DebuggerDisplayAttributeOnTypeCopy
 	{
 		public static void Main ()
 		{
@@ -26,23 +19,22 @@ namespace Mono.Linker.Tests.Cases.Attributes.Debugger
 
 		[Kept]
 		[KeptMember (".ctor()")]
-#if !NETCOREAPP
 		[KeptAttributeAttribute (typeof (DebuggerDisplayAttribute))]
-#endif
 		[DebuggerDisplay ("{Property}")]
 		class Foo
 		{
-			public int Property { get; set; }
+			[Kept]
+			[KeptBackingField]
+			public int Property { [Kept] get; [Kept] set; }
 		}
 
 		[Kept]
 		[KeptMember (".ctor()")]
-#if !NETCOREAPP
 		[KeptAttributeAttribute (typeof (DebuggerDisplayAttribute))]
-#endif
 		[DebuggerDisplay ("{Method()}")]
 		class Bar
 		{
+			[Kept]
 			public int Method ()
 			{
 				return 1;
@@ -50,3 +42,4 @@ namespace Mono.Linker.Tests.Cases.Attributes.Debugger
 		}
 	}
 }
+#endif

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerDisplayAttributeOnTypeThatIsNotUsed.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerDisplayAttributeOnTypeThatIsNotUsed.cs
@@ -4,11 +4,16 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Attributes.Debugger
 {
+#if NETCOREAPP
+	[SetupLinkAttributesFile ("DebuggerAttributesRemoved.xml")]
+	[SetupLinkerCoreAction ("copy")]
+#else
 	[SetupLinkerCoreAction ("link")]
 	[SetupLinkerKeepDebugMembers ("false")]
 
 	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168
 	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
+#endif
 	public class DebuggerDisplayAttributeOnTypeThatIsNotUsed
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerTypeProxyAttributeOnAssemblyUsingTarget.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerTypeProxyAttributeOnAssemblyUsingTarget.cs
@@ -39,6 +39,9 @@ namespace Mono.Linker.Tests.Cases.Attributes.Debugger
 			[KeptBackingField]
 			public int Property { get; [Kept] set; }
 
+#if !NETCOREAPP
+			[Kept]
+#endif
 			internal class FooDebugView
 			{
 				private Foo _foo;

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerTypeProxyAttributeOnAssemblyUsingTarget.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerTypeProxyAttributeOnAssemblyUsingTarget.cs
@@ -3,11 +3,18 @@ using Mono.Linker.Tests.Cases.Attributes.Debugger;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
+#if !NETCOREAPP
 [assembly: KeptAttributeAttribute (typeof (DebuggerTypeProxyAttribute))]
+#endif
+
 [assembly: DebuggerTypeProxy (typeof (DebuggerTypeProxyAttributeOnAssemblyUsingTarget.Foo.FooDebugView), Target = typeof (DebuggerTypeProxyAttributeOnAssemblyUsingTarget.Foo))]
 
 namespace Mono.Linker.Tests.Cases.Attributes.Debugger
 {
+#if NETCOREAPP
+	[SetupLinkAttributesFile ("DebuggerAttributesRemoved.xml")]
+	[SetupLinkerCoreAction ("copy")]
+#else
 	[SetupLinkerCoreAction ("link")]
 	[SetupLinkerKeepDebugMembers ("false")]
 
@@ -15,6 +22,7 @@ namespace Mono.Linker.Tests.Cases.Attributes.Debugger
 	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
 
 	[KeptMemberInAssembly (PlatformAssemblies.CoreLib, typeof (DebuggerTypeProxyAttribute), ".ctor(System.Type)")]
+#endif
 	public class DebuggerTypeProxyAttributeOnAssemblyUsingTarget
 	{
 		public static void Main ()
@@ -31,7 +39,6 @@ namespace Mono.Linker.Tests.Cases.Attributes.Debugger
 			[KeptBackingField]
 			public int Property { get; [Kept] set; }
 
-			[Kept]
 			internal class FooDebugView
 			{
 				private Foo _foo;

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerTypeProxyAttributeOnType.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerTypeProxyAttributeOnType.cs
@@ -4,6 +4,10 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Attributes.Debugger
 {
+#if NETCOREAPP
+	[SetupLinkAttributesFile ("DebuggerAttributesRemoved.xml")]
+	[SetupLinkerCoreAction ("copy")]
+#else
 	[SetupLinkerCoreAction ("link")]
 	[SetupLinkerKeepDebugMembers ("false")]
 
@@ -11,6 +15,7 @@ namespace Mono.Linker.Tests.Cases.Attributes.Debugger
 	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
 
 	[KeptMemberInAssembly (PlatformAssemblies.CoreLib, typeof (DebuggerTypeProxyAttribute), ".ctor(System.Type)")]
+#endif
 	public class DebuggerTypeProxyAttributeOnType
 	{
 		public static void Main ()
@@ -20,13 +25,14 @@ namespace Mono.Linker.Tests.Cases.Attributes.Debugger
 
 		[Kept]
 		[KeptMember (".ctor()")]
+#if !NETCOREAPP
 		[KeptAttributeAttribute (typeof (DebuggerTypeProxyAttribute))]
+#endif
 		[DebuggerTypeProxy (typeof (FooDebugView))]
 		class Foo
 		{
 		}
 
-		[Kept]
 		class FooDebugView
 		{
 			public FooDebugView (Foo foo)

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerTypeProxyAttributeOnType.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerTypeProxyAttributeOnType.cs
@@ -33,6 +33,9 @@ namespace Mono.Linker.Tests.Cases.Attributes.Debugger
 		{
 		}
 
+#if !NETCOREAPP
+		[Kept]
+#endif
 		class FooDebugView
 		{
 			public FooDebugView (Foo foo)

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnAssemblyUsingTarget.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnAssemblyUsingTarget.cs
@@ -9,7 +9,9 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.Attributes.Debugger.KeepDebugMembers
 {
 	[SetupLinkerCoreAction ("link")]
+#if !NETCOREAPP
 	[SetupLinkerKeepDebugMembers ("true")]
+#endif
 
 	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168
 	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnAssemblyUsingTargetOnUnusedType.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnAssemblyUsingTargetOnUnusedType.cs
@@ -8,7 +8,9 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.Attributes.Debugger.KeepDebugMembers
 {
 	[SetupLinkerCoreAction ("link")]
+#if !NETCOREAPP
 	[SetupLinkerKeepDebugMembers ("true")]
+#endif
 
 	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168
 	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly.cs
@@ -10,7 +10,9 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.Attributes.Debugger.KeepDebugMembers
 {
 	[SetupLinkerCoreAction ("link")]
+#if !NETCOREAPP
 	[SetupLinkerKeepDebugMembers ("true")]
+#endif
 	[SetupCompileBefore ("library.dll", new[] { "../Dependencies/DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly_Lib.cs" })]
 
 	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInSameAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInSameAssembly.cs
@@ -8,7 +8,9 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.Attributes.Debugger.KeepDebugMembers
 {
 	[SetupLinkerCoreAction ("link")]
+#if !NETCOREAPP
 	[SetupLinkerKeepDebugMembers ("true")]
+#endif
 
 	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168
 	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameOfGenericTypeInOtherAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameOfGenericTypeInOtherAssembly.cs
@@ -9,7 +9,9 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.Attributes.Debugger.KeepDebugMembers
 {
 	[SetupLinkerCoreAction ("link")]
+#if !NETCOREAPP
 	[SetupLinkerKeepDebugMembers ("true")]
+#endif
 	[SetupCompileBefore ("library.dll", new[] { "../Dependencies/DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly_Lib.cs" })]
 
 	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameOfNestedTypeInOtherAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameOfNestedTypeInOtherAssembly.cs
@@ -9,7 +9,9 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.Attributes.Debugger.KeepDebugMembers
 {
 	[SetupLinkerCoreAction ("link")]
+#if !NETCOREAPP
 	[SetupLinkerKeepDebugMembers ("true")]
+#endif
 	[SetupCompileBefore ("library.dll", new[] { "../Dependencies/DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly_Lib.cs" })]
 
 	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnGenerics.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnGenerics.cs
@@ -6,10 +6,12 @@ using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
-namespace Mono.Linker.Tests.Cases.Attributes.Debugger
+namespace Mono.Linker.Tests.Cases.Attributes.Debugger.KeepDebugMembers
 {
 	[SetupLinkerCoreAction ("link")]
+#if !NETCOREAPP
 	[SetupLinkerKeepDebugMembers ("true")]
+#endif
 
 	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168
 	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnType.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnType.cs
@@ -5,7 +5,9 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.Attributes.Debugger.KeepDebugMembers
 {
 	[SetupLinkerCoreAction ("link")]
+#if !NETCOREAPP
 	[SetupLinkerKeepDebugMembers ("true")]
+#endif
 
 	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168
 	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnTypeThatIsNotUsed.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnTypeThatIsNotUsed.cs
@@ -5,7 +5,9 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.Attributes.Debugger.KeepDebugMembers
 {
 	[SetupLinkerCoreAction ("link")]
+#if !NETCOREAPP
 	[SetupLinkerKeepDebugMembers ("true")]
+#endif
 
 	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168
 	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayOnTypeWithCallToExtensionMethodOnFieldType.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayOnTypeWithCallToExtensionMethodOnFieldType.cs
@@ -7,7 +7,9 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Attributes.Debugger.KeepDebugMembers
 {
+#if !NETCOREAPP
 	[SetupLinkerKeepDebugMembers ("true")]
+#endif
 	public class DebuggerDisplayOnTypeWithCallToExtensionMethodOnFieldType
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayOnTypeWithCallToMethodOnFieldType.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayOnTypeWithCallToMethodOnFieldType.cs
@@ -4,7 +4,9 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Attributes.Debugger.KeepDebugMembers
 {
+#if !NETCOREAPP
 	[SetupLinkerKeepDebugMembers ("true")]
+#endif
 	public class DebuggerDisplayOnTypeWithCallToMethodOnFieldType
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerTypeProxyAttributeOnAssemblyUsingTarget.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerTypeProxyAttributeOnAssemblyUsingTarget.cs
@@ -9,7 +9,9 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.Attributes.Debugger.KeepDebugMembers
 {
 	[SetupLinkerCoreAction ("link")]
+#if !NETCOREAPP
 	[SetupLinkerKeepDebugMembers ("true")]
+#endif
 
 	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168
 	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerTypeProxyAttributeOnType.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerTypeProxyAttributeOnType.cs
@@ -5,7 +5,9 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.Attributes.Debugger.KeepDebugMembers
 {
 	[SetupLinkerCoreAction ("link")]
+#if !NETCOREAPP
 	[SetupLinkerKeepDebugMembers ("true")]
+#endif
 
 	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168
 	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]


### PR DESCRIPTION
- Remove conflicting -v option from ILLink
- Add more test coverage for attributes removal with debugger attributes