### PR TITLE
Attribute removal should not kick in for assemblies which are not linked

### DIFF
--- a/src/linker/Linker.Steps/LinkAttributesStep.cs
+++ b/src/linker/Linker.Steps/LinkAttributesStep.cs
@@ -272,7 +272,7 @@ namespace Mono.Linker.Steps
 		protected override AssemblyDefinition GetAssembly (LinkContext context, AssemblyNameReference assemblyName)
 		{
 			var assembly = context.Resolve (assemblyName);
-			context.ResolveReferences (assembly);
+			ProcessReferences (assembly);
 			return assembly;
 		}
 	}

--- a/src/linker/Linker.Steps/ProcessLinkerXmlStepBase.cs
+++ b/src/linker/Linker.Steps/ProcessLinkerXmlStepBase.cs
@@ -5,7 +5,7 @@ using Mono.Cecil;
 
 namespace Mono.Linker.Steps
 {
-	public abstract class ProcessLinkerXmlStepBase : BaseStep
+	public abstract class ProcessLinkerXmlStepBase : LoadReferencesStep
 	{
 		const string FullNameAttributeName = "fullname";
 		const string LinkerElementName = "linker";

--- a/src/linker/Linker.Steps/ResolveFromXmlStep.cs
+++ b/src/linker/Linker.Steps/ResolveFromXmlStep.cs
@@ -319,13 +319,8 @@ namespace Mono.Linker.Steps
 		protected override AssemblyDefinition GetAssembly (LinkContext context, AssemblyNameReference assemblyName)
 		{
 			var assembly = context.Resolve (assemblyName);
-			ProcessReferences (assembly, context);
+			ProcessReferences (assembly);
 			return assembly;
-		}
-
-		static void ProcessReferences (AssemblyDefinition assembly, LinkContext context)
-		{
-			context.ResolveReferences (assembly);
 		}
 
 		static bool IsRequired (XPathNavigator nav)

--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -454,7 +454,7 @@ namespace Mono.Linker
 		public bool HasLinkerAttribute<T> (IMemberDefinition member) where T : Attribute
 		{
 			// Avoid setting up and inserting LinkerAttributesInformation for members without attributes.
-			if (!member.HasCustomAttributes)
+			if (!context.CustomAttributes.HasAttributes (member))
 				return false;
 
 			if (!linker_attributes.TryGetValue (member, out var linkerAttributeInformation)) {
@@ -468,7 +468,7 @@ namespace Mono.Linker
 		public IEnumerable<T> GetLinkerAttributes<T> (IMemberDefinition member) where T : Attribute
 		{
 			// Avoid setting up and inserting LinkerAttributesInformation for members without attributes.
-			if (!member.HasCustomAttributes)
+			if (!context.CustomAttributes.HasAttributes (member))
 				return Enumerable.Empty<T> ();
 
 			if (!linker_attributes.TryGetValue (member, out var linkerAttributeInformation)) {

--- a/src/linker/Linker/CustomAttributeSource.cs
+++ b/src/linker/Linker/CustomAttributeSource.cs
@@ -72,5 +72,8 @@ namespace Mono.Linker
 		{
 			return _internalAttributes.ContainsKey (provider) ? true : false;
 		}
+
+		public bool HasAttributes (ICustomAttributeProvider provider) =>
+			HasCustomAttributes (provider) || HasInternalAttributes (provider);
 	}
 }

--- a/src/linker/Linker/LinkerAttributesInformation.cs
+++ b/src/linker/Linker/LinkerAttributesInformation.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Mono.Cecil;

--- a/test/Mono.Linker.Tests.Cases/DataFlow/Dependencies/LinkerAttributeRemovalAttributeToRemove.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/Dependencies/LinkerAttributeRemovalAttributeToRemove.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Mono.Linker.Tests.Cases.DataFlow.Dependencies
+{
+	public enum TestAttributeUsedFromCopyAssemblyEnum
+	{
+		None
+	}
+
+	public class TestAttributeUsedFromCopyAssemblyAttribute : Attribute
+	{
+		public TestAttributeUsedFromCopyAssemblyAttribute (TestAttributeUsedFromCopyAssemblyEnum n)
+		{
+		}
+	}
+
+	public class TestAnotherAttributeUsedFromCopyAssemblyAttribute : Attribute
+	{
+		public TestAnotherAttributeUsedFromCopyAssemblyAttribute ()
+		{
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/Dependencies/LinkerAttributeRemovalCopyAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/Dependencies/LinkerAttributeRemovalCopyAssembly.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+using Mono.Linker.Tests.Cases.DataFlow.Dependencies;
+
+[assembly: TestAnotherAttributeUsedFromCopyAssembly]
+
+namespace Mono.Linker.Tests.Cases.DataFlow.Dependencies
+{
+	[TestAttributeUsedFromCopyAssemblyAttribute (TestAttributeUsedFromCopyAssemblyEnum.None)]
+	[EditorBrowsable (EditorBrowsableState.Never)]
+	public class TypeOnCopyAssemblyWithAttributeUsage
+	{
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/LinkerAttributeRemoval.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/LinkerAttributeRemoval.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Mono.Linker.Tests.Cases.DataFlow.Dependencies;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using System;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
@@ -12,6 +14,25 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 {
 	[SetupLinkAttributesFile ("LinkerAttributeRemoval.xml")]
 	[IgnoreLinkAttributes (false)]
+
+	[SetupCompileBefore ("attribute.dll", new[] { "Dependencies/LinkerAttributeRemovalAttributeToRemove.cs" })]
+	[SetupCompileBefore ("copyassembly.dll", new[] { "Dependencies/LinkerAttributeRemovalCopyAssembly.cs" }, references: new[] { "attribute.dll" })]
+	[SetupLinkerAction ("copy", "copyassembly")]
+
+	// The test here is that the TypeOnCopyAssemblyWithAttributeUsage has an attribute TestAttributeUsedFromCopyAssemblyAttribute
+	// which is marked for removal by the LinkerAttributeRemoval.xml. Normally that would mean that the attribute usage
+	// as well as the type (and assembly since it's the only type in it) would be removed as there are no other usages of the attribute type.
+	// But because the copyassembly ios linkerd with "copy" action, the attribute usage should not be removed and thus the attribute
+	// should be kept.
+	[KeptAssembly ("copyassembly.dll")]
+	[KeptAssembly ("attribute.dll")]
+	[KeptTypeInAssembly ("attribute.dll", typeof (TestAttributeUsedFromCopyAssemblyAttribute))]
+	[KeptTypeInAssembly ("attribute.dll", typeof (TestAnotherAttributeUsedFromCopyAssemblyAttribute))]
+	[KeptTypeInAssembly ("copyassembly.dll", typeof (TypeOnCopyAssemblyWithAttributeUsage))]
+	[KeptAttributeInAssembly ("copyassembly.dll", typeof (TestAttributeUsedFromCopyAssemblyAttribute), typeof (TypeOnCopyAssemblyWithAttributeUsage))]
+	[KeptAttributeInAssembly ("copyassembly.dll", typeof (EditorBrowsableAttribute), typeof (TypeOnCopyAssemblyWithAttributeUsage))]
+	[KeptAttributeInAssembly ("copyassembly.dll", typeof (TestAnotherAttributeUsedFromCopyAssemblyAttribute))]
+
 	[KeptMember (".ctor()")]
 	[LogContains ("IL2045: Mono.Linker.Tests.Cases.DataFlow.LinkerAttributeRemoval.TestType(): Custom Attribute System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute is " +
 		"being referenced in code but the linker was instructed to remove all instances of this attribute. If the attribute instances are necessary make sure to either remove " +
@@ -24,6 +45,9 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			instance._fieldWithCustomAttribute = null;
 			string value = instance.methodWithCustomAttribute ("parameter");
 			TestType ();
+
+			_ = new TypeOnCopyAssemblyWithAttributeUsage ();
+			TestAttributeUsageRemovedEvenIfAttributeIsKeptForOtherReasons ();
 		}
 		[Kept]
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
@@ -32,6 +56,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[Kept]
 		[KeptAttributeAttribute (typeof (TestDontRemoveAttribute))]
 		[TestDontRemoveAttribute]
+		[TestRemoveAttribute]
 		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)]
 		private string methodWithCustomAttribute ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)] string parameterWithCustomAttribute)
 		{
@@ -44,6 +69,12 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			const string reflectionTypeKeptString = "System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute";
 			var typeKept = Type.GetType (reflectionTypeKeptString, false);
 		}
+
+		[Kept]
+		[TestAttributeUsedFromCopyAssembly (TestAttributeUsedFromCopyAssemblyEnum.None)]
+		static void TestAttributeUsageRemovedEvenIfAttributeIsKeptForOtherReasons ()
+		{
+		}
 	}
 
 	[KeptBaseType (typeof (System.Attribute))]
@@ -51,6 +82,13 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 	{
 		[Kept]
 		public TestDontRemoveAttribute ()
+		{
+		}
+	}
+
+	class TestRemoveAttribute : Attribute
+	{
+		public TestRemoveAttribute ()
 		{
 		}
 	}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/LinkerAttributeRemoval.xml
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/LinkerAttributeRemoval.xml
@@ -1,7 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <linker>
-  <assembly fullname="*">
+  <assembly fullname="*"> 
     <type fullname="System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute">
+      <attribute internal="RemoveAttributeInstances"/>
+    </type>
+    <type fullname="System.ComponentModel.EditorBrowsableAttribute">
+      <!-- Must use wildcard assembly for this type since it can come either from System.Private.CoreLib or mscorlib -->
       <attribute internal="RemoveAttributeInstances"/>
     </type>
   </assembly>
@@ -12,11 +16,6 @@
   </assembly>
   <assembly fullname="attribute, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
     <type fullname="Mono.Linker.Tests.Cases.DataFlow.Dependencies.TestAttributeUsedFromCopyAssemblyAttribute">
-      <attribute internal="RemoveAttributeInstances"/>
-    </type>
-  </assembly>
-  <assembly fullname="System.Private.CoreLib">
-    <type fullname="System.ComponentModel.EditorBrowsableAttribute">
       <attribute internal="RemoveAttributeInstances"/>
     </type>
   </assembly>

--- a/test/Mono.Linker.Tests.Cases/DataFlow/LinkerAttributeRemoval.xml
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/LinkerAttributeRemoval.xml
@@ -5,4 +5,19 @@
       <attribute internal="RemoveAttributeInstances"/>
     </type>
   </assembly>
+  <assembly fullname="test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+    <type fullname="Mono.Linker.Tests.Cases.DataFlow.TestRemoveAttribute">
+      <attribute internal="RemoveAttributeInstances"/>
+    </type>
+  </assembly>
+  <assembly fullname="attribute, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+    <type fullname="Mono.Linker.Tests.Cases.DataFlow.Dependencies.TestAttributeUsedFromCopyAssemblyAttribute">
+      <attribute internal="RemoveAttributeInstances"/>
+    </type>
+  </assembly>
+  <assembly fullname="System.Private.CoreLib">
+    <type fullname="System.ComponentModel.EditorBrowsableAttribute">
+      <attribute internal="RemoveAttributeInstances"/>
+    </type>
+  </assembly>
 </linker>

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyFromAttributeXml.Attributes.xml
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyFromAttributeXml.Attributes.xml
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<linker>
+  <assembly fullname="test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+    <type fullname="Mono.Linker.Tests.Cases.DynamicDependencies.DynamicDependencyFromAttributeXml">
+      <method name="DependencyToUnusedMethod">
+        <attribute fullname="System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute" assembly="Mono.Linker.Tests.Cases.Expectations">
+          <argument>UnusedMethod</argument>
+        </attribute>
+      </method>
+    </type>
+  </assembly>
+</linker>

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyFromAttributeXml.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyFromAttributeXml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.DynamicDependencies
+{
+	[SetupLinkAttributesFile ("DynamicDependencyFromAttributeXml.Attributes.xml")]
+	[IgnoreLinkAttributes (false)]
+	class DynamicDependencyFromAttributeXml
+	{
+		public static void Main ()
+		{
+			DependencyToUnusedMethod ();
+		}
+
+		[Kept]
+		static void DependencyToUnusedMethod ()
+		{
+		}
+
+		[Kept]
+		static void UnusedMethod ()
+		{
+		}
+	}
+}


### PR DESCRIPTION
MarkStep go over all assemblies (Regardless if they're being linked or just copied) and marks everything as usual. But in the end it will not "trim" anything from the copy assembly. So we must make sure that everything the assembly needs is marked.

Attribute removal needs to comply with this behavior as well.

This change fixes several other issues around link attribute XML files:
- If the XML refers to an attribute which will in turn bring in new assemblies to the closure it would not correctly register all of them - the step needs to behave just like any other step which can bring in new assembly to the closure
- Several places in MarkStep didn't use the CustomAttributeSource to detect presense of attributes - meaning that injecting attributes via the XML on a member which had no other (IL based) attributes didn't actually do anything.
- Also fixed the annotation's handling of the same issue - presence of custom attributes needs to be determined via the CustomAttributeSource in any place where attributes which are recognized by the linker as special are handled.

Added tests for all of the changes above

Fixes https://github.com/mono/linker/issues/1341.