### PR TITLE
Don't crash if pinvoke has a function pointer

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2555,7 +2555,7 @@ namespace Mono.Linker.Steps
 				if (paramTypeReference is TypeSpecification) {
 					paramTypeReference = (paramTypeReference as TypeSpecification).ElementType;
 				}
-				TypeDefinition paramTypeDefinition = paramTypeReference.Resolve ();
+				TypeDefinition paramTypeDefinition = paramTypeReference?.Resolve ();
 				if (paramTypeDefinition != null && !paramTypeDefinition.IsImport) {
 					MarkFields (paramTypeDefinition, includeStaticFields, new DependencyInfo (DependencyKind.InteropMethodDependency, method));
 					if (pd.ParameterType.IsByReference) {


### PR DESCRIPTION
Linker tries to mark all instance fields on types referenced from p/invoke signatures but fails for function pointers because of a Cecil footgun (`TypeSpecification` has an `ElementType` property that is the actual element type for pointers/byrefs/arrays, is the generic definition for generic types, and `null` for pointer types).

(We shouldn't actually need to mark the instance fields in the first place because these need to have a non-Auto layout but I digress. If something actually needs that behavior, this is still buggy because it needs to happen recursively to actually work in interop, but CoreCLR would block Auto classes/structs right away.)

Fixes #1345.