### PR TITLE
Add support for default interface methods

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -442,7 +442,7 @@ namespace Mono.Linker.Steps
 			var defaultImplementations = Annotations.GetDefaultInterfaceImplementations (method);
 			if (defaultImplementations != null) {
 				foreach (var defaultImplementationInfo in defaultImplementations) {
-					ProcessDefaultImplementation (defaultImplementationInfo.Item1, defaultImplementationInfo.Item2);
+					ProcessDefaultImplementation (defaultImplementationInfo.InstanceType, defaultImplementationInfo.ProvidingInterface);
 				}
 			}
 		}

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -434,11 +434,17 @@ namespace Mono.Linker.Steps
 			_context.Annotations.EnqueueVirtualMethod (method);
 
 			var overrides = Annotations.GetOverrides (method);
-			if (overrides == null)
-				return;
+			if (overrides != null) {
+				foreach (OverrideInformation @override in overrides)
+					ProcessOverride (@override);
+			}
 
-			foreach (OverrideInformation @override in overrides)
-				ProcessOverride (@override);
+			var defaultImplementations = Annotations.GetDefaultInterfaceImplementations (method);
+			if (defaultImplementations != null) {
+				foreach (var defaultImplementationInfo in defaultImplementations) {
+					ProcessDefaultImplementation (defaultImplementationInfo.Item1, defaultImplementationInfo.Item2);
+				}
+			}
 		}
 
 		void ProcessOverride (OverrideInformation overrideInformation)
@@ -516,6 +522,14 @@ namespace Mono.Linker.Steps
 			}
 
 			return false;
+		}
+
+		void ProcessDefaultImplementation (TypeDefinition typeWithDefaultImplementedInterfaceMethod, InterfaceImplementation implementation)
+		{
+			if (!Annotations.IsInstantiated (typeWithDefaultImplementedInterfaceMethod))
+				return;
+
+			MarkInterfaceImplementation (implementation, typeWithDefaultImplementedInterfaceMethod);
 		}
 
 		void MarkMarshalSpec (IMarshalInfoProvider spec, in DependencyInfo reason, IMemberDefinition sourceLocationMember)

--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -58,7 +58,7 @@ namespace Mono.Linker
 		protected readonly Dictionary<MethodDefinition, List<MethodDefinition>> base_methods = new Dictionary<MethodDefinition, List<MethodDefinition>> ();
 		protected readonly Dictionary<AssemblyDefinition, ISymbolReader> symbol_readers = new Dictionary<AssemblyDefinition, ISymbolReader> ();
 		readonly Dictionary<IMemberDefinition, LinkerAttributesInformation> linker_attributes = new Dictionary<IMemberDefinition, LinkerAttributesInformation> ();
-		protected readonly Dictionary<MethodDefinition, List<(TypeDefinition, InterfaceImplementation)>> default_interface_implementations = new Dictionary<MethodDefinition, List<(TypeDefinition, InterfaceImplementation)>> ();
+		protected readonly Dictionary<MethodDefinition, List<(TypeDefinition InstanceType, InterfaceImplementation ImplementationProvider)>> default_interface_implementations = new Dictionary<MethodDefinition, List<(TypeDefinition, InterfaceImplementation)>> ();
 
 		readonly Dictionary<object, Dictionary<IMetadataTokenProvider, object>> custom_annotations = new Dictionary<object, Dictionary<IMetadataTokenProvider, object>> ();
 		protected readonly Dictionary<AssemblyDefinition, HashSet<EmbeddedResource>> resources_to_remove = new Dictionary<AssemblyDefinition, HashSet<EmbeddedResource>> ();
@@ -359,7 +359,7 @@ namespace Mono.Linker
 			implementations.Add ((implementingType, matchingInterfaceImplementation));
 		}
 
-		public IEnumerable<(TypeDefinition, InterfaceImplementation)> GetDefaultInterfaceImplementations (MethodDefinition method)
+		public IEnumerable<(TypeDefinition InstanceType, InterfaceImplementation ProvidingInterface)> GetDefaultInterfaceImplementations (MethodDefinition method)
 		{
 			default_interface_implementations.TryGetValue (method, out var ret);
 			return ret;

--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -58,6 +58,7 @@ namespace Mono.Linker
 		protected readonly Dictionary<MethodDefinition, List<MethodDefinition>> base_methods = new Dictionary<MethodDefinition, List<MethodDefinition>> ();
 		protected readonly Dictionary<AssemblyDefinition, ISymbolReader> symbol_readers = new Dictionary<AssemblyDefinition, ISymbolReader> ();
 		readonly Dictionary<IMemberDefinition, LinkerAttributesInformation> linker_attributes = new Dictionary<IMemberDefinition, LinkerAttributesInformation> ();
+		protected readonly Dictionary<MethodDefinition, List<(TypeDefinition, InterfaceImplementation)>> default_interface_implementations = new Dictionary<MethodDefinition, List<(TypeDefinition, InterfaceImplementation)>> ();
 
 		readonly Dictionary<object, Dictionary<IMetadataTokenProvider, object>> custom_annotations = new Dictionary<object, Dictionary<IMetadataTokenProvider, object>> ();
 		protected readonly Dictionary<AssemblyDefinition, HashSet<EmbeddedResource>> resources_to_remove = new Dictionary<AssemblyDefinition, HashSet<EmbeddedResource>> ();
@@ -346,6 +347,22 @@ namespace Mono.Linker
 		{
 			override_methods.TryGetValue (method, out List<OverrideInformation> overrides);
 			return overrides;
+		}
+
+		public void AddDefaultInterfaceImplementation (MethodDefinition @base, TypeDefinition implementingType, InterfaceImplementation matchingInterfaceImplementation)
+		{
+			if (!default_interface_implementations.TryGetValue (@base, out var implementations)) {
+				implementations = new List<(TypeDefinition, InterfaceImplementation)> ();
+				default_interface_implementations.Add (@base, implementations);
+			}
+
+			implementations.Add ((implementingType, matchingInterfaceImplementation));
+		}
+
+		public IEnumerable<(TypeDefinition, InterfaceImplementation)> GetDefaultInterfaceImplementations (MethodDefinition method)
+		{
+			default_interface_implementations.TryGetValue (method, out var ret);
+			return ret;
 		}
 
 		public void AddBaseMethod (MethodDefinition method, MethodDefinition @base)

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/DefaultInterfaceMethodCallIntoClass.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/DefaultInterfaceMethodCallIntoClass.cs
@@ -1,5 +1,4 @@
-﻿#if ILLINK
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
@@ -7,6 +6,9 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 {
+#if !NETCOREAPP
+	[IgnoreTestCase ("Default interface methods not supported outside Core")]
+#endif
 	class DefaultInterfaceMethodCallIntoClass
 	{
 		public static void Main ()
@@ -48,4 +50,3 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 		}
 	}
 }
-#endif

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/DefaultInterfaceMethodCallIntoClass.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/DefaultInterfaceMethodCallIntoClass.cs
@@ -6,9 +6,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 {
-#if !NETCOREAPP
-	[IgnoreTestCase ("Default interface methods not supported outside Core")]
-#endif
+#if NETCOREAPP
 	class DefaultInterfaceMethodCallIntoClass
 	{
 		public static void Main ()
@@ -49,4 +47,5 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 			public void Actual () { }
 		}
 	}
+#endif
 }

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/DefaultInterfaceMethodCallIntoClass.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/DefaultInterfaceMethodCallIntoClass.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
+{
+	class DefaultInterfaceMethodCallIntoClass
+	{
+		public static void Main ()
+		{
+			((IBase) new Derived ()).Frob ();
+		}
+
+		[Kept]
+		interface IBase
+		{
+			[Kept]
+			void Frob ();
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IBase))]
+		interface IDerived : IBase
+		{
+			[Kept]
+			void IBase.Frob ()
+			{
+				Actual ();
+			}
+
+			[Kept]
+			void Actual ();
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IDerived))]
+		[KeptInterface (typeof (IBase))]
+		class Derived : IDerived
+		{
+			[Kept]
+			public Derived () { }
+
+			[Kept]
+			public void Actual () { }
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/DefaultInterfaceMethodCallIntoClass.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/DefaultInterfaceMethodCallIntoClass.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if ILLINK
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
@@ -47,3 +48,4 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 		}
 	}
 }
+#endif

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/GenericDefaultInterfaceMethods.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/GenericDefaultInterfaceMethods.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if ILLINK
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
@@ -62,3 +63,4 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 		}
 	}
 }
+#endif

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/GenericDefaultInterfaceMethods.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/GenericDefaultInterfaceMethods.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
+{
+	class GenericDefaultInterfaceMethods
+	{
+		public static void Main ()
+		{
+			((IFoo<int>) new Bar ()).Method (12);
+			((IFoo<int>) new Baz ()).Method (12);
+		}
+
+		[Kept]
+		interface IFoo<T>
+		{
+			[Kept]
+			void Method (T x);
+
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IFoo<>), "T")]
+		interface IBar<T> : IFoo<T>
+		{
+			[Kept]
+			void IFoo<T>.Method (T x)
+			{
+			}
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IBar<int>))]
+		[KeptInterface (typeof (IFoo<int>))]
+		class Bar : IBar<int>
+		{
+			[Kept]
+			public Bar () { }
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IFoo<object>))]
+		interface IBaz : IFoo<object>
+		{
+			[Kept]
+			void IFoo<object>.Method (object o)
+			{
+			}
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IBaz))]
+		[KeptInterface (typeof (IFoo<object>))]
+		class Baz : IBaz
+		{
+			[Kept]
+			public Baz ()
+			{
+			}
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/GenericDefaultInterfaceMethods.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/GenericDefaultInterfaceMethods.cs
@@ -5,9 +5,7 @@ using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 {
-#if !NETCOREAPP
-	[IgnoreTestCase ("Default interface methods not supported outside Core")]
-#endif
+#if NETCOREAPP
 	class GenericDefaultInterfaceMethods
 	{
 		public static void Main ()
@@ -64,4 +62,5 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 			}
 		}
 	}
+#endif
 }

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/GenericDefaultInterfaceMethods.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/GenericDefaultInterfaceMethods.cs
@@ -1,11 +1,13 @@
-﻿#if ILLINK
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 {
+#if !NETCOREAPP
+	[IgnoreTestCase ("Default interface methods not supported outside Core")]
+#endif
 	class GenericDefaultInterfaceMethods
 	{
 		public static void Main ()
@@ -63,4 +65,3 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 		}
 	}
 }
-#endif

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/SimpleDefaultInterfaceMethod.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/SimpleDefaultInterfaceMethod.cs
@@ -6,9 +6,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 {
-#if !NETCOREAPP
-	[IgnoreTestCase ("Default interface methods not supported outside Core")]
-#endif
+#if NETCOREAPP
 	class SimpleDefaultInterfaceMethod
 	{
 		public static void Main ()
@@ -54,4 +52,5 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 			public Basic () { }
 		}
 	}
+#endif
 }

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/SimpleDefaultInterfaceMethod.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/SimpleDefaultInterfaceMethod.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if ILLINK
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
@@ -52,3 +53,4 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 		}
 	}
 }
+#endif

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/SimpleDefaultInterfaceMethod.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/SimpleDefaultInterfaceMethod.cs
@@ -1,5 +1,4 @@
-﻿#if ILLINK
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
@@ -7,6 +6,9 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 {
+#if !NETCOREAPP
+	[IgnoreTestCase ("Default interface methods not supported outside Core")]
+#endif
 	class SimpleDefaultInterfaceMethod
 	{
 		public static void Main ()
@@ -53,4 +55,3 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 		}
 	}
 }
-#endif

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/SimpleDefaultInterfaceMethod.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/SimpleDefaultInterfaceMethod.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
+{
+	class SimpleDefaultInterfaceMethod
+	{
+		public static void Main ()
+		{
+			((IBasic) new Basic ()).DoSomething ();
+		}
+
+		[Kept]
+		interface IBasic
+		{
+			[Kept]
+			void DoSomething ()
+			{
+				DoOtherThing ();
+			}
+
+			void UnusedMethodWithDefaultImplementation ()
+			{
+			}
+
+			[Kept]
+			sealed void DoOtherThing ()
+			{
+			}
+
+			sealed void UnusedNonvirtualMethod ()
+			{
+			}
+		}
+
+		interface IUnusedInterface
+		{
+			void UnusedDefaultImplementation ()
+			{
+			}
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IBasic))]
+		class Basic : IBasic, IUnusedInterface
+		{
+			[Kept]
+			public Basic () { }
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/UnusedDefaultInterfaceImplementation.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/UnusedDefaultInterfaceImplementation.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
+{
+	class UnusedDefaultInterfaceImplementation
+	{
+		public static void Main ()
+		{
+			((IFoo) new Foo ()).InterfaceMethod ();
+		}
+
+		[Kept]
+		interface IFoo
+		{
+			[Kept]
+			void InterfaceMethod ();
+		}
+
+		interface IDefaultImpl : IFoo
+		{
+			void IFoo.InterfaceMethod ()
+			{
+			}
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IFoo))]
+		class Foo : IDefaultImpl
+		{
+			[Kept]
+			public Foo () { }
+
+			[Kept]
+			public void InterfaceMethod ()
+			{
+			}
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/UnusedDefaultInterfaceImplementation.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/UnusedDefaultInterfaceImplementation.cs
@@ -1,11 +1,13 @@
-﻿#if ILLINK
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 {
+#if !NETCOREAPP
+	[IgnoreTestCase ("Default interface methods not supported outside Core")]
+#endif
 	class UnusedDefaultInterfaceImplementation
 	{
 		public static void Main ()
@@ -41,4 +43,3 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 		}
 	}
 }
-#endif

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/UnusedDefaultInterfaceImplementation.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/UnusedDefaultInterfaceImplementation.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if ILLINK
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
@@ -40,3 +41,4 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 		}
 	}
 }
+#endif

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/UnusedDefaultInterfaceImplementation.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/UnusedDefaultInterfaceImplementation.cs
@@ -5,9 +5,7 @@ using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 {
-#if !NETCOREAPP
-	[IgnoreTestCase ("Default interface methods not supported outside Core")]
-#endif
+#if NETCOREAPP
 	class UnusedDefaultInterfaceImplementation
 	{
 		public static void Main ()
@@ -42,4 +40,5 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 			}
 		}
 	}
+#endif
 }

--- a/test/Mono.Linker.Tests/Mono.Linker.Tests.csproj
+++ b/test/Mono.Linker.Tests/Mono.Linker.Tests.csproj
@@ -35,7 +35,7 @@
   <ItemGroup Condition="'$(MonoBuild)' == ''">
     <PackageReference Include="System.CodeDom" Version="4.5.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.5.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.6.0" />
     <PackageReference Include="nunit" Version="3.10.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <!-- This reference is purely so that the linker can resolve this


### PR DESCRIPTION
Spec for default interface methods is here: https://github.com/dotnet/runtime/blob/master/docs/design/features/default-interface-methods.md

But the short version is basically:

* Default interface methods only kick in if there's no implementation on the class
* The default implementation can either be provided by the method that declares the interface slot, or by any other interface that requires the interface in question. In that case, we look for an override record. These are not done by name and sig match.

Fixes #427.