### PR TITLE
Allow stripping Delegate.BeginInvoke/EndInvoke

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2379,7 +2379,7 @@ namespace Mono.Linker.Steps
 					methodPair = "EndInvoke";
 				else if (method.Name == "EndInvoke")
 					methodPair = "BeginInvoke";
-				
+
 				if (methodPair != null) {
 					TypeDefinition declaringType = method.DeclaringType;
 					MarkMethodIf (declaringType.Methods, m => m.Name == methodPair, new DependencyInfo (DependencyKind.MethodForSpecialType, declaringType), declaringType);

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2005,12 +2005,9 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		protected virtual void MarkMulticastDelegate (TypeDefinition type, bool markAllMethods = false)
+		protected virtual void MarkMulticastDelegate (TypeDefinition type)
 		{
-			if (markAllMethods)
-				MarkMethodCollection (type.Methods, new DependencyInfo (DependencyKind.MethodForSpecialType, type), type);
-			else
-				MarkMethodsIf (type.Methods, m => m.Name == ".ctor" || m.Name == "Invoke", new DependencyInfo (DependencyKind.MethodForSpecialType, type), type);
+			MarkMethodsIf (type.Methods, m => m.Name == ".ctor" || m.Name == "Invoke", new DependencyInfo (DependencyKind.MethodForSpecialType, type), type);
 		}
 
 		protected (TypeReference, DependencyInfo) GetOriginalType (TypeReference type, DependencyInfo reason, IMemberDefinition sourceLocationMember)
@@ -2376,8 +2373,17 @@ namespace Mono.Linker.Steps
 			if (ShouldParseMethodBody (method))
 				MarkMethodBody (method.Body);
 
-			if (method.DeclaringType.IsMulticastDelegate () && (method.Name == "BeginInvoke" || method.Name == "EndInvoke")) {
-				MarkMulticastDelegate (method.DeclaringType, markAllMethods: true);
+			if (method.DeclaringType.IsMulticastDelegate ()) {
+				string methodPair = null;
+				if (method.Name == "BeginInvoke")
+					methodPair = "EndInvoke";
+				else if (method.Name == "EndInvoke")
+					methodPair = "BeginInvoke";
+				
+				if (methodPair != null) {
+					TypeDefinition declaringType = method.DeclaringType;
+					MarkMethodIf (declaringType.Methods, m => m.Name == methodPair, new DependencyInfo (DependencyKind.MethodForSpecialType, declaringType), declaringType);
+				}
 			}
 
 			DoAdditionalMethodProcessing (method);

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2376,7 +2376,7 @@ namespace Mono.Linker.Steps
 			if (ShouldParseMethodBody (method))
 				MarkMethodBody (method.Body);
 
-			if (method.DeclaringType.IsMulticastDelegate() && (method.Name == "BeginInvoke" || method.Name == "EndInvoke")) {
+			if (method.DeclaringType.IsMulticastDelegate () && (method.Name == "BeginInvoke" || method.Name == "EndInvoke")) {
 				MarkMulticastDelegate (method.DeclaringType, markAllMethods: true);
 			}
 

--- a/test/Mono.Linker.Tests.Cases/Basic/DelegateBeginInvokeEndInvokePair.cs
+++ b/test/Mono.Linker.Tests.Cases/Basic/DelegateBeginInvokeEndInvokePair.cs
@@ -7,7 +7,7 @@ namespace Mono.Linker.Tests.Cases.Basic
 {
 	class DelegateBeginInvokeEndInvokePair
 	{
-		public static void Main()
+		public static void Main ()
 		{
 			SomeDelegate d1 = Method;
 			d1.BeginInvoke (null, null);
@@ -20,7 +20,7 @@ namespace Mono.Linker.Tests.Cases.Basic
 		}
 
 		[Kept]
-		static void Method()
+		static void Method ()
 		{
 		}
 

--- a/test/Mono.Linker.Tests.Cases/Basic/DelegateBeginInvokeEndInvokePair.cs
+++ b/test/Mono.Linker.Tests.Cases/Basic/DelegateBeginInvokeEndInvokePair.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Basic
+{
+	class DelegateBeginInvokeEndInvokePair
+	{
+		public static void Main()
+		{
+			SomeDelegate d1 = Method;
+			d1.BeginInvoke (null, null);
+
+			OtherDelegate d2 = Method;
+			d2.EndInvoke (null);
+
+			StrippedDelegate d3 = Method;
+			d3.DynamicInvoke (null);
+		}
+
+		[Kept]
+		static void Method()
+		{
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (MulticastDelegate))]
+		[KeptMember (".ctor(System.Object,System.IntPtr)")]
+		[KeptMember ("Invoke()")]
+		[KeptMember ("BeginInvoke(System.AsyncCallback,System.Object)")]
+		[KeptMember ("EndInvoke(System.IAsyncResult)")]
+		public delegate void SomeDelegate ();
+
+		[Kept]
+		[KeptBaseType (typeof (MulticastDelegate))]
+		[KeptMember (".ctor(System.Object,System.IntPtr)")]
+		[KeptMember ("Invoke()")]
+		[KeptMember ("BeginInvoke(System.AsyncCallback,System.Object)")]
+		[KeptMember ("EndInvoke(System.IAsyncResult)")]
+		public delegate void OtherDelegate ();
+
+		[Kept]
+		[KeptBaseType (typeof (MulticastDelegate))]
+		[KeptMember (".ctor(System.Object,System.IntPtr)")]
+		[KeptMember ("Invoke()")]
+		public delegate void StrippedDelegate ();
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Basic/NestedDelegateInvokeMethodsPreserved.cs
+++ b/test/Mono.Linker.Tests.Cases/Basic/NestedDelegateInvokeMethodsPreserved.cs
@@ -17,8 +17,6 @@ namespace Mono.Linker.Tests.Cases.Basic
 		{
 			[Kept]
 			[KeptMember ("Invoke()")]
-			[KeptMember ("BeginInvoke(System.AsyncCallback,System.Object)")]
-			[KeptMember ("EndInvoke(System.IAsyncResult)")]
 			[KeptMember (".ctor(System.Object,System.IntPtr)")]
 			[KeptBaseType (typeof (System.MulticastDelegate))]
 			public delegate void Delegate ();

--- a/test/Mono.Linker.Tests.Cases/Basic/UsedEventIsKept.cs
+++ b/test/Mono.Linker.Tests.Cases/Basic/UsedEventIsKept.cs
@@ -28,8 +28,6 @@ namespace Mono.Linker.Tests.Cases.Basic
 			[KeptBaseType (typeof (MulticastDelegate))]
 			[KeptMember (".ctor(System.Object,System.IntPtr)")]
 			[KeptMember ("Invoke()")]
-			[KeptMember ("BeginInvoke(System.AsyncCallback,System.Object)")]
-			[KeptMember ("EndInvoke(System.IAsyncResult)")]
 			public delegate void CustomDelegate ();
 
 			[Kept]

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/BaseProvidesInterfaceMember/GenericInterfaceWithEvent.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/BaseProvidesInterfaceMember/GenericInterfaceWithEvent.cs
@@ -18,8 +18,6 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.BasePro
 
 		[Kept]
 		[KeptMember ("Invoke()")]
-		[KeptMember ("BeginInvoke(System.AsyncCallback,System.Object)")]
-		[KeptMember ("EndInvoke(System.IAsyncResult)")]
 		[KeptMember (".ctor(System.Object,System.IntPtr)")]
 		[KeptBaseType (typeof (System.MulticastDelegate))]
 		delegate void CustomDelegate<T> ();

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/BaseProvidesInterfaceMember/SimpleEvent.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/BaseProvidesInterfaceMember/SimpleEvent.cs
@@ -18,8 +18,6 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.BasePro
 
 		[Kept]
 		[KeptMember ("Invoke()")]
-		[KeptMember ("BeginInvoke(System.AsyncCallback,System.Object)")]
-		[KeptMember ("EndInvoke(System.IAsyncResult)")]
 		[KeptMember (".ctor(System.Object,System.IntPtr)")]
 		[KeptBaseType (typeof (System.MulticastDelegate))]
 		delegate void CustomDelegate ();


### PR DESCRIPTION
Per ECMA-335 I.8.9.3, the `BeginInvoke` and `EndInvoke` methods are not mandatory. On .NET Core, these methods only throw, so it's unlikely that apps would actually have a reference to them. This lets us strip the methods and the associated interfaces.