### PR TITLE
Use class hierarchy in IsTypeInterestingForDataflow

### DIFF
--- a/src/linker/Linker.Dataflow/FlowAnnotations.cs
+++ b/src/linker/Linker.Dataflow/FlowAnnotations.cs
@@ -377,7 +377,7 @@ namespace Mono.Linker.Dataflow
 		bool IsTypeInterestingForDataflow (TypeReference typeReference)
 		{
 			return typeReference.MetadataType == MetadataType.String ||
-				_hierarchyInfo.IsSystemType(typeReference) ||
+				_hierarchyInfo.IsSystemType (typeReference) ||
 				(typeReference.Name == "IReflect" && typeReference.Namespace == "System.Reflection");
 		}
 

--- a/src/linker/Linker.Dataflow/FlowAnnotations.cs
+++ b/src/linker/Linker.Dataflow/FlowAnnotations.cs
@@ -378,7 +378,7 @@ namespace Mono.Linker.Dataflow
 		{
 			return typeReference.MetadataType == MetadataType.String ||
 				_hierarchyInfo.IsSystemType (typeReference) ||
-				(typeReference.Name == "IReflect" && typeReference.Namespace == "System.Reflection");
+				_hierarchyInfo.IsSystemReflectionIReflect (typeReference);
 		}
 
 		internal void ValidateMethodAnnotationsAreSame (MethodDefinition method, MethodDefinition baseMethod)

--- a/src/linker/Linker.Dataflow/FlowAnnotations.cs
+++ b/src/linker/Linker.Dataflow/FlowAnnotations.cs
@@ -13,6 +13,7 @@ namespace Mono.Linker.Dataflow
 	{
 		readonly LinkContext _context;
 		readonly Dictionary<TypeDefinition, TypeAnnotations> _annotations = new Dictionary<TypeDefinition, TypeAnnotations> ();
+		readonly TypeHierarchyCache _hierarchyInfo = new TypeHierarchyCache ();
 
 		public FlowAnnotations (LinkContext context)
 		{
@@ -373,15 +374,11 @@ namespace Mono.Linker.Dataflow
 			return true;
 		}
 
-		static bool IsTypeInterestingForDataflow (TypeReference typeReference)
+		bool IsTypeInterestingForDataflow (TypeReference typeReference)
 		{
-			// We will accept any System.Type* as interesting to enable testing
-			// It's necessary to be able to implement a custom "Type" type in tests to validate
-			// the correct propagation of the annotations on "this" parameter. And tests can't really
-			// override System.Type - as it creates too many issues.
-			// It also covers TypeBuilder and RuntimeType.
 			return typeReference.MetadataType == MetadataType.String ||
-				(typeReference.Name.Contains ("Type") && typeReference.Namespace.StartsWith ("System"));
+				_hierarchyInfo.IsSystemType(typeReference) ||
+				(typeReference.Name == "IReflect" && typeReference.Namespace == "System.Reflection");
 		}
 
 		internal void ValidateMethodAnnotationsAreSame (MethodDefinition method, MethodDefinition baseMethod)

--- a/src/linker/Linker/TypeHierarchyCache.cs
+++ b/src/linker/Linker/TypeHierarchyCache.cs
@@ -14,7 +14,7 @@ namespace Mono.Linker
 
 		Dictionary<TypeDefinition, BaseTypeFlags> _cache = new Dictionary<TypeDefinition, BaseTypeFlags> ();
 
-		private BaseTypeFlags GetFlags(TypeReference type)
+		private BaseTypeFlags GetFlags (TypeReference type)
 		{
 			TypeDefinition resolvedType = type.Resolve ();
 			if (resolvedType == null)
@@ -38,7 +38,7 @@ namespace Mono.Linker
 			return flags;
 		}
 
-		public bool IsSystemType(TypeReference type)
+		public bool IsSystemType (TypeReference type)
 		{
 			return (GetFlags (type) & BaseTypeFlags.IsSystemType) != 0;
 		}

--- a/src/linker/Linker/TypeHierarchyCache.cs
+++ b/src/linker/Linker/TypeHierarchyCache.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using Mono.Cecil;
+
+namespace Mono.Linker
+{
+	class TypeHierarchyCache
+	{
+		[Flags]
+		private enum BaseTypeFlags
+		{
+			IsSystemType = 0x01,
+		}
+
+		Dictionary<TypeDefinition, BaseTypeFlags> _cache = new Dictionary<TypeDefinition, BaseTypeFlags> ();
+
+		private BaseTypeFlags GetFlags(TypeReference type)
+		{
+			TypeDefinition resolvedType = type.Resolve ();
+			if (resolvedType == null)
+				return 0;
+
+			if (_cache.TryGetValue (resolvedType, out var flags)) {
+				return flags;
+			}
+
+			TypeDefinition baseType = resolvedType;
+			while (baseType != null) {
+				if (baseType.Name == "Type" && baseType.Namespace == "System") {
+					flags |= BaseTypeFlags.IsSystemType;
+				}
+
+				baseType = baseType.BaseType?.Resolve ();
+			}
+
+			_cache.Add (resolvedType, flags);
+
+			return flags;
+		}
+
+		public bool IsSystemType(TypeReference type)
+		{
+			return (GetFlags (type) & BaseTypeFlags.IsSystemType) != 0;
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/IReflectDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/IReflectDataflow.cs
@@ -9,9 +9,9 @@ using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.DataFlow
 {
-    // Hits what appears to be a bug in the tool
+	// Hits what appears to be a bug in the tool
 	// Could not initialize vtable of class(0x02000007) .MyReflect due to VTable setup of type Mono.Linker.Tests.Cases.DataFlow.IReflectDataflow+MyReflect failed assembly:/tmp/linker_tests/output/test.exe type:MyReflect member:(null)
-    [SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
+	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
 	class IReflectDataflow
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/DataFlow/IReflectDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/IReflectDataflow.cs
@@ -9,6 +9,9 @@ using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.DataFlow
 {
+    // Hits what appears to be a bug in the tool
+	// Could not initialize vtable of class(0x02000007) .MyReflect due to VTable setup of type Mono.Linker.Tests.Cases.DataFlow.IReflectDataflow+MyReflect failed assembly:/tmp/linker_tests/output/test.exe type:MyReflect member:(null)
+    [SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
 	class IReflectDataflow
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/DataFlow/IReflectDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/IReflectDataflow.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Reflection;
+using System.Text;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.DataFlow
+{
+	class IReflectDataflow
+	{
+		public static void Main ()
+		{
+			// The cast here fails at runtime, but that's okay, we just want something to flow here.
+			// Casts are transparent to the dataflow analysis and preserve the tracked value.
+			RequirePublicParameterlessConstructor ((object) typeof (C1) as MyReflect);
+			s_requirePublicNestedTypes = ((object) typeof (C2)) as MyReflectDerived;
+			RequirePrivateMethods (typeof (C3));
+		}
+
+		[Kept]
+		class C1
+		{
+			[Kept]
+			public C1 () { }
+			public C1 (string s) { }
+		}
+
+		[Kept]
+		class C2
+		{
+			public C2 () { }
+
+			[Kept]
+			public class Nested { }
+		}
+
+		[Kept]
+		class C3
+		{
+			[Kept]
+			static void Foo () { }
+			public static void Bar () { }
+		}
+
+		[Kept]
+		static void RequirePublicParameterlessConstructor ([KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute)), DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] MyReflect mine)
+		{
+		}
+
+		[Kept]
+		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicNestedTypes)]
+		static MyReflectDerived s_requirePublicNestedTypes;
+
+		[Kept]
+		static void RequirePrivateMethods ([KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute)), DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicMethods)] IReflect m)
+		{
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IReflect))]
+		class MyReflect : IReflect
+		{
+			public Type UnderlyingSystemType => throw new NotImplementedException ();
+			public FieldInfo GetField (string name, BindingFlags bindingAttr) => throw new NotImplementedException ();
+			public FieldInfo[] GetFields (BindingFlags bindingAttr) => throw new NotImplementedException ();
+			public MemberInfo[] GetMember (string name, BindingFlags bindingAttr) => throw new NotImplementedException ();
+			public MemberInfo[] GetMembers (BindingFlags bindingAttr) => throw new NotImplementedException ();
+			public MethodInfo GetMethod (string name, BindingFlags bindingAttr) => throw new NotImplementedException ();
+			public MethodInfo GetMethod (string name, BindingFlags bindingAttr, Binder binder, Type[] types, ParameterModifier[] modifiers) => throw new NotImplementedException ();
+			public MethodInfo[] GetMethods (BindingFlags bindingAttr) => throw new NotImplementedException ();
+			public PropertyInfo[] GetProperties (BindingFlags bindingAttr) => throw new NotImplementedException ();
+			public PropertyInfo GetProperty (string name, BindingFlags bindingAttr) => throw new NotImplementedException ();
+			public PropertyInfo GetProperty (string name, BindingFlags bindingAttr, Binder binder, Type returnType, Type[] types, ParameterModifier[] modifiers) => throw new NotImplementedException ();
+			public object InvokeMember (string name, BindingFlags invokeAttr, Binder binder, object target, object[] args, ParameterModifier[] modifiers, CultureInfo culture, string[] namedParameters) => throw new NotImplementedException ();
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (MyReflect))]
+		class MyReflectDerived : MyReflect
+		{
+		}
+	}
+}


### PR DESCRIPTION
Fixes #1365.

Extracted the base type caching into a separate class. We might want to make this more global and use this where we're doing similar checks within linker (we have existing code that is checking whether a type is EventSource or deriving from some security attribute). It feels like a general purpose question, but those things are out of scope of this pull request.