### PR TITLE
Linker fails when BaseType is null

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1038,7 +1038,7 @@ namespace Mono.Linker.Steps
 				if (method != null)
 					return method;
 
-				type = type.BaseType.Resolve ();
+				type = type.BaseType?.Resolve ();
 			}
 
 			return null;

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerDisplayAttributeOnTypeWithNonExistentMethod.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerDisplayAttributeOnTypeWithNonExistentMethod.cs
@@ -1,0 +1,41 @@
+﻿#define FLAG
+
+using System.Diagnostics;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Attributes.Debugger
+{
+#if NETCOREAPP
+	[SetupLinkerCoreAction ("copy")]
+#else
+	[SetupLinkerCoreAction ("link")]
+	[SetupLinkerKeepDebugMembers ("false")]
+
+	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168
+	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
+
+	[KeptMemberInAssembly (PlatformAssemblies.CoreLib, typeof (DebuggerDisplayAttribute), ".ctor(System.String)")]
+#endif
+	public class DebuggerDisplayAttributeOnTypeWithNonExistentMethod
+	{
+		public static void Main ()
+		{
+			var bar = new Bar ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptAttributeAttribute (typeof (DebuggerDisplayAttribute))]
+		[DebuggerDisplay ("{Method()}")]
+		class Bar
+		{
+#if !FLAG
+			public int Method ()
+			{
+				return 1;
+			}
+#endif
+		}
+	}
+}


### PR DESCRIPTION
This fixes #1375 the code is inside a loop to get a certain method inside the Type or any of its BaseType. In this case, the method does not exist so the linker should return null but instead while evaluating the BaseType of Object type (which is null) the linker fails to resolve it and ends the execution