### PR TITLE
Warn about some COM usage

### DIFF
--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -257,3 +257,7 @@ error and warning codes.
 #### `IL2049`: Unrecognized internal attribute 'attribute'
 
 - The internal attribute name 'attribute' being used in the xml is not supported by the linker, check the spelling and the supported internal attributes.
+
+#### `IL2050`: Correctness of COM interop cannot be guaranteed
+
+- P/invoke method 'method' declares a parameter with COM marshalling. Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2574,13 +2574,30 @@ namespace Mono.Linker.Steps
 
 			TypeDefinition returnTypeDefinition = method.ReturnType.Resolve ();
 
+			bool didWarnAboutCom = false;
+
 			const bool includeStaticFields = false;
-			if (returnTypeDefinition != null && !returnTypeDefinition.IsImport) {
-				MarkDefaultConstructor (returnTypeDefinition, new DependencyInfo (DependencyKind.InteropMethodDependency, method), method);
-				MarkFields (returnTypeDefinition, includeStaticFields, new DependencyInfo (DependencyKind.InteropMethodDependency, method));
+			if (returnTypeDefinition != null) {
+				if (!returnTypeDefinition.IsImport) {
+					// What we keep here is correct most of the time, but not every time. Fine for now.
+					MarkDefaultConstructor (returnTypeDefinition, new DependencyInfo (DependencyKind.InteropMethodDependency, method), method);
+					MarkFields (returnTypeDefinition, includeStaticFields, new DependencyInfo (DependencyKind.InteropMethodDependency, method));
+				}
+
+				// Best-effort attempt to find COM marshalling.
+				// It might seem reasonable to allow out parameters, but once we get a foreign object back (an RCW), it's going to look
+				// like a regular managed class/interface, but every method invocation that takes a class/interface implies COM
+				// marshalling. We can't detect that once we have an RCW.
+				if (method.IsPInvokeImpl) {
+					if (IsComInterop(method.MethodReturnType, method.ReturnType) && !didWarnAboutCom) {
+						_context.LogWarning ($"P/invoke method '{method.GetDisplayName ()}' declares a parameter with COM marshalling. Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.", 2050, method);
+						didWarnAboutCom = true;
+					}
+				}
 			}
 
 			if (method.HasThis && !method.DeclaringType.IsImport) {
+				// This is probably Mono-specific. One can't have InternalCall or P/invoke instance methods in CoreCLR or .NET.
 				MarkFields (method.DeclaringType, includeStaticFields, new DependencyInfo (DependencyKind.InteropMethodDependency, method));
 			}
 
@@ -2590,13 +2607,68 @@ namespace Mono.Linker.Steps
 					paramTypeReference = (paramTypeReference as TypeSpecification).ElementType;
 				}
 				TypeDefinition paramTypeDefinition = paramTypeReference?.Resolve ();
-				if (paramTypeDefinition != null && !paramTypeDefinition.IsImport) {
-					MarkFields (paramTypeDefinition, includeStaticFields, new DependencyInfo (DependencyKind.InteropMethodDependency, method));
-					if (pd.ParameterType.IsByReference) {
-						MarkDefaultConstructor (paramTypeDefinition, new DependencyInfo (DependencyKind.InteropMethodDependency, method), method);
+				if (paramTypeDefinition != null) {
+					if (!paramTypeDefinition.IsImport) {
+						// What we keep here is correct most of the time, but not every time. Fine for now.
+						MarkFields (paramTypeDefinition, includeStaticFields, new DependencyInfo (DependencyKind.InteropMethodDependency, method));
+						if (pd.ParameterType.IsByReference) {
+							MarkDefaultConstructor (paramTypeDefinition, new DependencyInfo (DependencyKind.InteropMethodDependency, method), method);
+						}
+					}
+
+					// Best-effort attempt to find COM marshalling.
+					// It might seem reasonable to allow out parameters, but once we get a foreign object back (an RCW), it's going to look
+					// like a regular managed class/interface, but every method invocation that takes a class/interface implies COM
+					// marshalling. We can't detect that once we have an RCW.
+					if (method.IsPInvokeImpl) {
+						if (IsComInterop (pd, paramTypeReference) && !didWarnAboutCom) {
+							_context.LogWarning ($"P/invoke method '{method.GetDisplayName ()}' declares a parameter with COM marshalling. Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.", 2050, method);
+							didWarnAboutCom = true;
+						}
 					}
 				}
 			}
+		}
+
+		private bool IsComInterop(IMarshalInfoProvider marshalInfoProvider, TypeReference parameterType)
+		{
+			// This is best effort. One can likely find ways how to get COM without triggering these alarms.
+			// AsAny marshalling of a struct with an object-typed field would be one, for example.
+
+			NativeType nativeType = NativeType.None;
+			if (marshalInfoProvider.HasMarshalInfo) {
+				nativeType = marshalInfoProvider.MarshalInfo.NativeType;
+			}
+
+			if (nativeType == NativeType.IUnknown || nativeType == NativeType.IDispatch || nativeType == NativeType.IntF) {
+				return true;
+			}
+
+			if (nativeType == NativeType.None) {
+				if (parameterType.IsTypeOf ("System", "Array")) {
+					return true;
+				} else if (parameterType.IsTypeOf ("System", "String") ||
+					parameterType.IsTypeOf ("System", "StringBuilder")) {
+					return false;
+				}
+
+				var parameterTypeDef = parameterType.Resolve ();
+				if (parameterTypeDef != null) {
+					if (parameterTypeDef.IsInterface) {
+						return true;
+					} else if (parameterTypeDef.IsMulticastDelegate ()) {
+						return false;
+					} else if (parameterTypeDef.IsSubclassOf ("System.Runtime.InteropServices", "CriticalHandle")) {
+						return false;
+					} else if (parameterTypeDef.IsSubclassOf ("System.Runtime.InteropServices", "SafeHandle")) {
+						return false;
+					} else if (!parameterTypeDef.IsValueType && !parameterTypeDef.IsSequentialLayout && !parameterTypeDef.IsExplicitLayout) {
+						return true;
+					}
+				}
+			}
+
+			return false;
 		}
 
 		protected virtual bool ShouldParseMethodBody (MethodDefinition method)

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2589,7 +2589,7 @@ namespace Mono.Linker.Steps
 				// like a regular managed class/interface, but every method invocation that takes a class/interface implies COM
 				// marshalling. We can't detect that once we have an RCW.
 				if (method.IsPInvokeImpl) {
-					if (IsComInterop(method.MethodReturnType, method.ReturnType) && !didWarnAboutCom) {
+					if (IsComInterop (method.MethodReturnType, method.ReturnType) && !didWarnAboutCom) {
 						_context.LogWarning ($"P/invoke method '{method.GetDisplayName ()}' declares a parameter with COM marshalling. Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.", 2050, method);
 						didWarnAboutCom = true;
 					}
@@ -2630,7 +2630,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		private bool IsComInterop(IMarshalInfoProvider marshalInfoProvider, TypeReference parameterType)
+		private bool IsComInterop (IMarshalInfoProvider marshalInfoProvider, TypeReference parameterType)
 		{
 			// This is best effort. One can likely find ways how to get COM without triggering these alarms.
 			// AsAny marshalling of a struct with an object-typed field would be one, for example.

--- a/src/linker/Linker/TypeReferenceExtensions.cs
+++ b/src/linker/Linker/TypeReferenceExtensions.cs
@@ -362,5 +362,17 @@ namespace Mono.Linker
 			var type = typeof (T);
 			return tr.Name == type.Name && tr.Namespace == tr.Namespace;
 		}
+
+		public static bool IsSubclassOf (this TypeReference type, string ns, string name)
+		{
+			TypeDefinition baseType = type.Resolve ()?.BaseType?.Resolve ();
+			while (baseType != null) {
+				if (baseType.IsTypeOf (ns, name))
+					return true;
+				baseType = baseType.BaseType?.Resolve ();
+			}
+
+			return false;
+		}
 	}
 }

--- a/src/linker/Linker/TypeReferenceExtensions.cs
+++ b/src/linker/Linker/TypeReferenceExtensions.cs
@@ -365,7 +365,7 @@ namespace Mono.Linker
 
 		public static bool IsSubclassOf (this TypeReference type, string ns, string name)
 		{
-			TypeDefinition baseType = type.Resolve ()?.BaseType?.Resolve ();
+			TypeDefinition baseType = type.Resolve ();
 			while (baseType != null) {
 				if (baseType.IsTypeOf (ns, name))
 					return true;

--- a/test/Mono.Linker.Tests.Cases/Interop/PInvoke/Warnings/ComPInvokeWarning.cs
+++ b/test/Mono.Linker.Tests.Cases/Interop/PInvoke/Warnings/ComPInvokeWarning.cs
@@ -6,19 +6,19 @@ using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Interop.PInvoke.Warnings
 {
-	[LogContains("SomeMethodTakingInterface")]
+	[LogContains ("SomeMethodTakingInterface")]
 	[LogContains ("SomeMethodTakingObject")]
-	[KeptModuleReference("Foo")]
+	[KeptModuleReference ("Foo")]
 	class ComPInvokeWarning
 	{
-		static void Main()
+		static void Main ()
 		{
 			SomeMethodTakingInterface (null);
 			SomeMethodTakingObject (null);
 		}
 
 		[Kept]
-		[DllImport("Foo")]
+		[DllImport ("Foo")]
 		static extern void SomeMethodTakingInterface (IFoo foo);
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/Interop/PInvoke/Warnings/ComPInvokeWarning.cs
+++ b/test/Mono.Linker.Tests.Cases/Interop/PInvoke/Warnings/ComPInvokeWarning.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Interop.PInvoke.Warnings
+{
+	[LogContains("SomeMethodTakingInterface")]
+	[LogContains ("SomeMethodTakingObject")]
+	[KeptModuleReference("Foo")]
+	class ComPInvokeWarning
+	{
+		static void Main()
+		{
+			SomeMethodTakingInterface (null);
+			SomeMethodTakingObject (null);
+		}
+
+		[Kept]
+		[DllImport("Foo")]
+		static extern void SomeMethodTakingInterface (IFoo foo);
+
+		[Kept]
+		[DllImport ("Foo")]
+		static extern void SomeMethodTakingObject ([MarshalAs (UnmanagedType.IUnknown)] object obj);
+
+		[Kept]
+		interface IFoo { }
+	}
+}


### PR DESCRIPTION
COM represents a problem for trimming because the usage of the interfaces are not visible to the linker.

The problem is twofold:
* The IDispatch interface that COM objects can be cast to is basically reflection.
* IUnknown.QueryInterface lets the native side get to any COM visible interface on the managed side. COM visible is pretty much everything because it's the default. We can't root those because it would make trimming ineffective.