### PR TITLE
Add WarningsAsErrors and WarningsNotAsErrors

### DIFF
--- a/src/ILLink.Tasks/LinkTask.cs
+++ b/src/ILLink.Tasks/LinkTask.cs
@@ -334,7 +334,7 @@ namespace ILLink.Tasks
 				args.Append ("--warn ").AppendLine (Quote (Warn));
 
 			if (TreatWarningsAsErrors)
-				args.AppendLine ("--warnaserror");
+				args.Append ("--warnaserror");
 			else
 				args.AppendLine ("--warnaserror-");
 

--- a/src/ILLink.Tasks/LinkTask.cs
+++ b/src/ILLink.Tasks/LinkTask.cs
@@ -71,7 +71,8 @@ namespace ILLink.Tasks
 		/// Treat all warnings as errors.
 		/// Maps to '--warnaserror' if true, '--warnaserror-' if false.
 		/// </summary>
-		public bool TreatWarningsAsErrors { get; set; }
+		public bool TreatWarningsAsErrors { set => _treatWarningsAsErrors = value; }
+		bool? _treatWarningsAsErrors;
 
 		/// <summary>
 		/// The list of warnings to report as errors.
@@ -333,10 +334,10 @@ namespace ILLink.Tasks
 			if (Warn != null)
 				args.Append ("--warn ").AppendLine (Quote (Warn));
 
-			if (TreatWarningsAsErrors)
-				args.Append ("--warnaserror");
+			if (_treatWarningsAsErrors is bool treatWarningsAsErrors && treatWarningsAsErrors)
+				args.Append ("--warnaserror ");
 			else
-				args.AppendLine ("--warnaserror-");
+				args.Append ("--warnaserror- ");
 
 			if (WarningsAsErrors != null)
 				args.Append ("--warnaserror ").AppendLine (Quote (WarningsAsErrors));

--- a/src/ILLink.Tasks/LinkTask.cs
+++ b/src/ILLink.Tasks/LinkTask.cs
@@ -62,6 +62,18 @@ namespace ILLink.Tasks
 		public string NoWarn { get; set; }
 
 		/// <summary>
+		/// The list of warnings to report as errors.
+		/// Maps to '--warnaserror'.
+		/// </summary>
+		public string WarningsAsErrors { get; set; }
+
+		/// <summary>
+		/// The list of warnings to report as usual.
+		/// Maps to '--warnaserror-'.
+		/// </summary>
+		public string WarningsNotAsErrors { get; set; }
+
+		/// <summary>
 		///   A list of XML root descriptor files specifying linker
 		///   roots at a granular level. See the mono/linker
 		///   documentation for details about the format.
@@ -305,6 +317,12 @@ namespace ILLink.Tasks
 
 			if (NoWarn != null)
 				args.Append ("--nowarn ").AppendLine (Quote (NoWarn));
+
+			if (WarningsAsErrors != null)
+				args.Append ("--warnaserror ").AppendLine (Quote (WarningsAsErrors));
+
+			if (WarningsNotAsErrors != null)
+				args.Append ("--warnaserror- ").AppendLine (Quote (WarningsNotAsErrors));
 
 			// Add global optimization arguments
 			if (_beforeFieldInit is bool beforeFieldInit)

--- a/src/ILLink.Tasks/LinkTask.cs
+++ b/src/ILLink.Tasks/LinkTask.cs
@@ -68,14 +68,20 @@ namespace ILLink.Tasks
 		public string Warn { get; set; }
 
 		/// <summary>
+		/// Treat all warnings as errors.
+		/// Maps to '--warnaserror' if true, '--warnaserror-' if false.
+		/// </summary>
+		public bool TreatWarningsAsErrors { get; set; }
+
+		/// <summary>
 		/// The list of warnings to report as errors.
-		/// Maps to '--warnaserror'.
+		/// Maps to '--warnaserror LIST-OF-WARNINGS'.
 		/// </summary>
 		public string WarningsAsErrors { get; set; }
 
 		/// <summary>
 		/// The list of warnings to report as usual.
-		/// Maps to '--warnaserror-'.
+		/// Maps to '--warnaserror- LIST-OF-WARNINGS'.
 		/// </summary>
 		public string WarningsNotAsErrors { get; set; }
 
@@ -326,6 +332,11 @@ namespace ILLink.Tasks
 
 			if (Warn != null)
 				args.Append ("--warn ").AppendLine (Quote (Warn));
+
+			if (TreatWarningsAsErrors)
+				args.AppendLine ("--warnaserror");
+			else
+				args.AppendLine ("--warnaserror-");
 
 			if (WarningsAsErrors != null)
 				args.Append ("--warnaserror ").AppendLine (Quote (WarningsAsErrors));

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -765,7 +765,7 @@ namespace Mono.Linker
 
 			value = Unquote (value);
 			string[] values = value.Split (new char[] { ',', ';', ' ' }, StringSplitOptions.RemoveEmptyEntries);
-			HashSet<uint> noWarnCodes = new HashSet<uint> ();
+			HashSet<uint> warningCodes = new HashSet<uint> ();
 			foreach (string id in values) {
 				if (!id.StartsWith ("IL", StringComparison.Ordinal))
 					continue;
@@ -773,10 +773,10 @@ namespace Mono.Linker
 				var warningCode = id.Substring (2);
 				if (ushort.TryParse (warningCode, out ushort code)
 					&& code > 2000 && code <= 6000)
-					noWarnCodes.Add (code);
+					warningCodes.Add (code);
 			}
 
-			return noWarnCodes;
+			return warningCodes;
 		}
 
 		private static Assembly GetCustomAssembly (string arg)

--- a/test/ILLink.Tasks.Tests/ILLink.Tasks.Tests.cs
+++ b/test/ILLink.Tasks.Tests/ILLink.Tasks.Tests.cs
@@ -4,13 +4,9 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using Xunit;
-using Xunit.Abstractions;
-using Xunit.Sdk;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
-using ILLink.Tasks;
 using Mono.Linker;
-using Mono.Linker.Steps;
 
 namespace ILLink.Tasks.Tests
 {
@@ -289,6 +285,40 @@ namespace ILLink.Tasks.Tests
 			using (var driver = task.CreateDriver ()) {
 				var actualUsedNoWarns = driver.Context.NoWarn;
 				Assert.Equal (actualUsedNoWarns.Count, validNoWarns);
+			}
+		}
+
+		[Theory]
+		[InlineData ("", "blah", true, new uint[] { }, new uint[] { })]
+		[InlineData ("IL1001,IL####,IL2000,IL2021,IL2022", "x", false,
+			new uint[] { 2021, 2022 }, new uint[] { })]
+		[InlineData ("IL2023,IL6000;IL5042 IL2040", "IL4000,IL4001;IL4002 IL4003", false,
+			new uint[] { 2023, 2040, 5042, 6000 }, new uint[] { 4000, 4001, 4002, 4003 })]
+		[InlineData ("IL3000;IL3000;ABCD", "IL2005 il3000 IL2005", false,
+			new uint[] { 3000 }, new uint[] { 2005 })]
+		[InlineData ("", "IL2006", true, new uint[] { }, new uint[] { 2006 })]
+		[InlineData ("IL2001", "IL2001", false, new uint[] { }, new uint[] { 2001 })]
+		public void TestWarningsAsErrors (string warningsAsErrors, string warningsNotAsErrors, bool generalWarnAsErrorsIsSet, uint[] warnAsError, uint[] warnNotAsError)
+		{
+			var task = new MockTask () {
+				WarningsAsErrors = warningsAsErrors,
+				WarningsNotAsErrors = warningsNotAsErrors
+			};
+
+			using (var driver = task.CreateDriver ()) {
+				var actualWarnAsError = driver.Context.WarnAsError;
+				var actualGeneralWarnAsError = driver.Context.GeneralWarnAsError;
+				Assert.Equal (actualWarnAsError.Count, warnAsError.Distinct().Count() + warnNotAsError.Distinct().Count());
+				Assert.Equal (actualGeneralWarnAsError, generalWarnAsErrorsIsSet);
+				if (warnAsError.Length > 0) {
+					foreach (var warningCode in warnAsError)
+						Assert.True (actualWarnAsError.ContainsKey (warningCode) && actualWarnAsError[warningCode] == true);
+				}
+
+				if (warnNotAsError.Length > 0) {
+					foreach (var warningCode in warnNotAsError)
+						Assert.True (actualWarnAsError.ContainsKey (warningCode) && actualWarnAsError[warningCode] == false);
+				}
 			}
 		}
 

--- a/test/ILLink.Tasks.Tests/ILLink.Tasks.Tests.cs
+++ b/test/ILLink.Tasks.Tests/ILLink.Tasks.Tests.cs
@@ -302,19 +302,21 @@ namespace ILLink.Tasks.Tests
 			}
 		}
 
+#nullable enable
 		[Theory]
-		[InlineData ("", "blah", true, new uint[] { }, new uint[] { })]
-		[InlineData ("IL1001,IL####,IL2000,IL2021,IL2022", "x", false,
+		[InlineData (true, null, null, new uint[] { }, new uint[] { })]
+		[InlineData (false, "IL1001,IL####,IL2000,IL2021,IL2022", null,
 			new uint[] { 2021, 2022 }, new uint[] { })]
-		[InlineData ("IL2023,IL6000;IL5042 IL2040", "IL4000,IL4001;IL4002 IL4003", false,
+		[InlineData (false, "IL2023,IL6000;IL5042 IL2040", "IL4000,IL4001;IL4002 IL4003",
 			new uint[] { 2023, 2040, 5042, 6000 }, new uint[] { 4000, 4001, 4002, 4003 })]
-		[InlineData ("IL3000;IL3000;ABCD", "IL2005 il3000 IL2005", false,
+		[InlineData (false, "IL3000;IL3000;ABCD", "IL2005 il3000 IL2005",
 			new uint[] { 3000 }, new uint[] { 2005 })]
-		[InlineData ("", "IL2006", true, new uint[] { }, new uint[] { 2006 })]
-		[InlineData ("IL2001", "IL2001", false, new uint[] { }, new uint[] { 2001 })]
-		public void TestWarningsAsErrors (string warningsAsErrors, string warningsNotAsErrors, bool generalWarnAsErrorsIsSet, uint[] warnAsError, uint[] warnNotAsError)
+		[InlineData (true, null, "IL2006", new uint[] { }, new uint[] { 2006 })]
+		[InlineData (true, "IL2001", "IL2001", new uint[] { }, new uint[] { 2001 })]
+		public void TestWarningsAsErrors (bool treatWarningsAsErrors, string? warningsAsErrors, string? warningsNotAsErrors, uint[] warnAsError, uint[] warnNotAsError)
 		{
 			var task = new MockTask () {
+				TreatWarningsAsErrors = treatWarningsAsErrors,
 				WarningsAsErrors = warningsAsErrors,
 				WarningsNotAsErrors = warningsNotAsErrors
 			};
@@ -323,7 +325,7 @@ namespace ILLink.Tasks.Tests
 				var actualWarnAsError = driver.Context.WarnAsError;
 				var actualGeneralWarnAsError = driver.Context.GeneralWarnAsError;
 				Assert.Equal (actualWarnAsError.Count, warnAsError.Distinct ().Count () + warnNotAsError.Distinct ().Count ());
-				Assert.Equal (actualGeneralWarnAsError, generalWarnAsErrorsIsSet);
+				Assert.Equal (actualGeneralWarnAsError, treatWarningsAsErrors);
 				if (warnAsError.Length > 0) {
 					foreach (var warningCode in warnAsError)
 						Assert.True (actualWarnAsError.ContainsKey (warningCode) && actualWarnAsError[warningCode] == true);
@@ -335,6 +337,7 @@ namespace ILLink.Tasks.Tests
 				}
 			}
 		}
+#nullable disable
 
 		public static IEnumerable<object[]> CustomDataCases => new List<object[]> {
 			new object [] {

--- a/test/ILLink.Tasks.Tests/ILLink.Tasks.Tests.cs
+++ b/test/ILLink.Tasks.Tests/ILLink.Tasks.Tests.cs
@@ -322,7 +322,7 @@ namespace ILLink.Tasks.Tests
 			using (var driver = task.CreateDriver ()) {
 				var actualWarnAsError = driver.Context.WarnAsError;
 				var actualGeneralWarnAsError = driver.Context.GeneralWarnAsError;
-				Assert.Equal (actualWarnAsError.Count, warnAsError.Distinct().Count() + warnNotAsError.Distinct().Count());
+				Assert.Equal (actualWarnAsError.Count, warnAsError.Distinct ().Count () + warnNotAsError.Distinct ().Count ());
 				Assert.Equal (actualGeneralWarnAsError, generalWarnAsErrorsIsSet);
 				if (warnAsError.Length > 0) {
 					foreach (var warningCode in warnAsError)

--- a/test/ILLink.Tasks.Tests/Mock.cs
+++ b/test/ILLink.Tasks.Tests/Mock.cs
@@ -45,7 +45,8 @@ namespace ILLink.Tasks.Tests
 
 		static readonly string[] nonOptimizationBooleanProperties = new string[] {
 			"DumpDependencies",
-			"RemoveSymbols"
+			"RemoveSymbols",
+			"TreatWarningsAsErrors"
 		};
 
 		public static IEnumerable<string> GetOptimizationPropertyNames ()


### PR DESCRIPTION
Adds the ILLink Task options `WarningsAsErrors` and `WarningsNotAsErrors` which map to the command-line options `--warnaserror` and `--warnaserror-` respectively.