### PR TITLE
Prevent null-ref in GetMethodWithNoParameters

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1038,7 +1038,7 @@ namespace Mono.Linker.Steps
 				if (method != null)
 					return method;
 
-				type = type.BaseType.Resolve ();
+				type = type.BaseType?.Resolve ();
 			}
 
 			return null;


### PR DESCRIPTION
Fixes https://github.com/mono/linker/issues/1390