### PR TITLE
Add suppressions before checking for ca removal instances

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -558,6 +558,9 @@ namespace Mono.Linker.Steps
 						continue;
 					}
 
+					if (UnconditionalSuppressMessageAttributeState.TypeRefHasUnconditionalSuppressions (ca.Constructor.DeclaringType))
+						_context.Suppressions.AddSuppression (ca, provider);
+
 					if (_context.Annotations.HasLinkerAttribute<RemoveAttributeInstancesAttribute> (ca.AttributeType.Resolve ()) && providerInLinkedAssembly)
 						continue;
 
@@ -1590,8 +1593,6 @@ namespace Mono.Linker.Steps
 					provider,
 					sourceLocationMember);
 				return true;
-			} else if (UnconditionalSuppressMessageAttributeState.TypeRefHasUnconditionalSuppressions (dt)) {
-				_context.Suppressions.AddSuppression (ca, provider);
 			}
 
 			return false;

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/AddSuppressionsBeforeAttributeRemoval.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/AddSuppressionsBeforeAttributeRemoval.cs
@@ -1,0 +1,27 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using System.Text;
+
+namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
+{
+	[SkipKeptItemsValidation]
+	[SetupLinkAttributesFile ("AddSuppressionsBeforeAttributeRemoval.xml")]
+	[LogDoesNotContain ("IL2006: Mono.Linker.Tests.Cases.Warnings.WarningSuppression.AddSuppressionsBeforeAttributeRemoval.Main()")]
+	public class AddSuppressionsBeforeAttributeRemoval
+	{
+		public static Type TriggerUnrecognizedPattern ()
+		{
+			return typeof (AddedPseudoAttributeAttribute);
+		}
+
+		[UnconditionalSuppressMessage ("ILLinker", "IL2006")]
+		public static void Main ()
+		{
+			Expression.Call (TriggerUnrecognizedPattern (), "", Type.EmptyTypes);
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/AddSuppressionsBeforeAttributeRemoval.xml
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/AddSuppressionsBeforeAttributeRemoval.xml
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<linker>
+	<assembly fullname="test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+		<type fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+			<attribute internal="RemoveAttributeInstances" />
+		</type>
+	</assembly>
+</linker>


### PR DESCRIPTION
Fixes #1392. This will add suppressions before checking if the attribute (`UnconditionalSuppressMessage`) was marked for removal by a custom attribute annotation.

/cc @eerhardt 