### PR TITLE
Do not call MarkInterfaceImplementation if already marked

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -529,8 +529,7 @@ namespace Mono.Linker.Steps
 			if (!Annotations.IsInstantiated (typeWithDefaultImplementedInterfaceMethod))
 				return;
 
-			if (!Annotations.IsMarked (implementation))
-				MarkInterfaceImplementation (implementation, typeWithDefaultImplementedInterfaceMethod);
+			MarkInterfaceImplementation (implementation, typeWithDefaultImplementedInterfaceMethod);
 		}
 
 		void MarkMarshalSpec (IMarshalInfoProvider spec, in DependencyInfo reason, IMemberDefinition sourceLocationMember)
@@ -2898,6 +2897,9 @@ namespace Mono.Linker.Steps
 
 		protected virtual void MarkInterfaceImplementation (InterfaceImplementation iface, TypeDefinition type)
 		{
+			if (Annotations.IsMarked (iface))
+				return;
+
 			// Blame the type that has the interfaceimpl, expecting the type itself to get marked for other reasons.
 			MarkCustomAttributes (iface, new DependencyInfo (DependencyKind.CustomAttribute, iface), type);
 			// Blame the interface type on the interfaceimpl itself.

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -529,7 +529,8 @@ namespace Mono.Linker.Steps
 			if (!Annotations.IsInstantiated (typeWithDefaultImplementedInterfaceMethod))
 				return;
 
-			MarkInterfaceImplementation (implementation, typeWithDefaultImplementedInterfaceMethod);
+			if (!Annotations.IsMarked (implementation))
+				MarkInterfaceImplementation (implementation, typeWithDefaultImplementedInterfaceMethod);
 		}
 
 		void MarkMarshalSpec (IMarshalInfoProvider spec, in DependencyInfo reason, IMemberDefinition sourceLocationMember)

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/Dependencies/InterfaceWithAttributeOnImpl.il
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/Dependencies/InterfaceWithAttributeOnImpl.il
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib { }
+
+.assembly 'library' { }
+
+.class interface public auto ansi abstract IMyInterface
+{
+	.method public hidebysig newslot virtual 
+		instance void Frob () cil managed 
+	{
+	    ret
+	}
+}
+
+.class public auto ansi MyClass
+	extends [mscorlib]System.Object
+	implements IMyInterface
+{
+	.interfaceimpl type IMyInterface
+	.custom instance void MyAttribute::.ctor() = ( 01 00 00 00 )
+
+	.method public hidebysig specialname rtspecialname
+	instance void .ctor () cil managed
+	{
+		ret
+	}
+}
+
+.class private auto ansi sealed beforefieldinit MyAttribute
+	extends [mscorlib]System.Attribute
+{
+	.method public hidebysig specialname rtspecialname
+		instance void .ctor () cil managed
+	{
+		ret
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/InterfaceWithAttributeOnImplementation.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/InterfaceWithAttributeOnImplementation.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
+{
+#if NETCOREAPP
+	[Define ("IL_ASSEMBLY_AVAILABLE")]
+	[SetupCompileBefore ("library.dll", new[] { "Dependencies/InterfaceWithAttributeOnImpl.il" })]
+	class InterfaceWithAttributeOnImplementation
+	{
+		static void Main ()
+		{
+#if IL_ASSEMBLY_AVAILABLE
+			((IMyInterface)new MyClass ()).Frob ();
+#endif
+		}
+	}
+#endif
+	}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/InterfaceWithAttributeOnImplementation.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/InterfaceWithAttributeOnImplementation.cs
@@ -19,4 +19,4 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 		}
 	}
 #endif
-	}
+}


### PR DESCRIPTION
Fixes #1394.

The problem was that marking the interface implementation marks the custom attributes on the InterfaceImpl record which enqueues the attribute constructor. The constructor is already processed, but enqueuing a new method causes the main processing loop to run again. This will rerun the virtual method logic and cause the attribute constructor to be re-added, forever.

Normally, linker protects itself from things like this by having a "processed" state along with "marked" state for various entities. InterfaceImpls don't have a "processed" state and calling Mark will cause the same logic to run. Alternative fix would be to add a "processed" state.

There's no regression test because I couldn't get Roslyn to generate the custom attribute on the MethodImpl record. I'm unclear why there's an attribute in the EF case to begin with. The problematic MethodImpl is this one: https://github.com/dotnet/efcore/blob/59734ea22f29d22f8d0c1673c59a99c54ec4e78d/src/EFCore.Relational/Scaffolding/ProviderCodeGenerator.cs#L15. There's a NullableAttribute on the impl, but I'm quite puzzled why.