### PR TITLE
Allow new() constraint to satisfy DynamicallyAccessedMemberTypes.PublicParameterlessConstructor

### DIFF
--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -1357,7 +1357,12 @@ namespace Mono.Linker.Dataflow
 		void RequireDynamicallyAccessedMembers (ref ReflectionPatternContext reflectionContext, DynamicallyAccessedMemberTypes requiredMemberTypes, ValueNode value, IMetadataTokenProvider targetContext)
 		{
 			foreach (var uniqueValue in value.UniqueValues ()) {
-				if (uniqueValue is LeafValueWithDynamicallyAccessedMemberNode valueWithDynamicallyAccessedMember) {
+				if (requiredMemberTypes == DynamicallyAccessedMemberTypes.PublicParameterlessConstructor
+					&& uniqueValue is SystemTypeForGenericParameterValue genericParam
+					&& genericParam.GenericParameter.HasDefaultConstructorConstraint) {
+					// We allow a new() constraint on a generic parameter to satisfy DynamicallyAccessedMemberTypes.PublicParameterlessConstructor
+					reflectionContext.RecordHandledPattern ();
+				} else if (uniqueValue is LeafValueWithDynamicallyAccessedMemberNode valueWithDynamicallyAccessedMember) {
 					if (!valueWithDynamicallyAccessedMember.DynamicallyAccessedMemberTypes.HasFlag (requiredMemberTypes)) {
 						reflectionContext.RecordUnrecognizedPattern ($"The {GetValueDescriptionForErrorMessage (valueWithDynamicallyAccessedMember)} " +
 							$"with dynamically accessed member kinds '{DiagnosticUtilities.GetDynamicallyAccessedMemberTypesDescription (valueWithDynamicallyAccessedMember.DynamicallyAccessedMemberTypes)}' " +

--- a/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
@@ -28,6 +28,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 			TestMakeGenericType ();
 			TestMakeGenericMethod ();
+
+			TestNewConstraintSatisfiesParameterlessConstructor<object> ();
 		}
 
 		static void TestSingleGenericParameterOnType ()
@@ -786,6 +788,16 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		public class TestType
+		{
+		}
+
+		[RecognizedReflectionAccessPattern]
+		static void TestNewConstraintSatisfiesParameterlessConstructor<T> () where T : new()
+		{
+			RequiresParameterlessConstructor<T> ();
+		}
+
+		static void RequiresParameterlessConstructor<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T> ()
 		{
 		}
 	}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
@@ -797,7 +797,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			RequiresParameterlessConstructor<T> ();
 		}
 
-		static void RequiresParameterlessConstructor<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T> ()
+		static void RequiresParameterlessConstructor<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T> ()
 		{
 		}
 	}


### PR DESCRIPTION
These two are equivalent.

Fixes #1412.