### PR TITLE
Check the correct interface list in IsInterfaceImplementationMarkedRecursively

### DIFF
--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/InterfaceNeededOnUnrelatedInterfaceList.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/InterfaceNeededOnUnrelatedInterfaceList.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType
+{
+	class InterfaceNeededOnUnrelatedInterfaceList
+	{
+		[Kept]
+		static Foo s_foo;
+
+		static void Main ()
+		{
+			object ob = new Bar ();
+			((IBar) ob).Frob ();
+			s_foo = null;
+		}
+
+		[Kept]
+		interface IFoo
+		{
+			[Kept]
+			void Frob ();
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IFoo))]
+		interface IBar : IFoo
+		{
+		}
+
+		[Kept]
+		class Foo : IBar
+		{
+			void IFoo.Frob ()
+			{
+			}
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IBar))]
+		[KeptInterface (typeof (IFoo))]
+		class Bar : IBar
+		{
+			[Kept]
+			public Bar () { }
+
+			[Kept]
+			void IFoo.Frob ()
+			{
+			}
+		}
+	}
+}


### PR DESCRIPTION
`IsInterfaceImplementationMarkedRecursively` was incorrectly rewritten from a global prepass to a local interface walk in #1186.

The new code was looking at the wrong interface list (looking at `IBar`'s interface list instead of `Bar`). We need to keep looking at the same interface list that we started with.

Fixes #1421.