### PR TITLE
Waring IL2050 should be considered TrimAnalysis warning

### DIFF
--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -748,7 +748,7 @@ This is technically possible if a custom assembly defines `DynamicDependencyAttr
   </linker>
   ```
 
-#### `IL2050`: Correctness of COM interop cannot be guaranteed
+#### `IL2050`: Trim analysis: Correctness of COM interop cannot be guaranteed
 
 - P/invoke method 'method' declares a parameter with COM marshalling. Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.
 

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2618,7 +2618,7 @@ namespace Mono.Linker.Steps
 				// marshalling. We can't detect that once we have an RCW.
 				if (method.IsPInvokeImpl) {
 					if (IsComInterop (method.MethodReturnType, method.ReturnType) && !didWarnAboutCom) {
-						_context.LogWarning ($"P/invoke method '{method.GetDisplayName ()}' declares a parameter with COM marshalling. Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.", 2050, method);
+						_context.LogWarning ($"P/invoke method '{method.GetDisplayName ()}' declares a parameter with COM marshalling. Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.", 2050, method, MessageSubCategory.TrimAnalysis);
 						didWarnAboutCom = true;
 					}
 				}

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2618,7 +2618,9 @@ namespace Mono.Linker.Steps
 				// marshalling. We can't detect that once we have an RCW.
 				if (method.IsPInvokeImpl) {
 					if (IsComInterop (method.MethodReturnType, method.ReturnType) && !didWarnAboutCom) {
-						_context.LogWarning ($"P/invoke method '{method.GetDisplayName ()}' declares a parameter with COM marshalling. Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.", 2050, method, MessageSubCategory.TrimAnalysis);
+						_context.LogWarning (
+							$"P/invoke method '{method.GetDisplayName ()}' declares a parameter with COM marshalling. Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.",
+							2050, method, subcategory: MessageSubCategory.TrimAnalysis);
 						didWarnAboutCom = true;
 					}
 				}


### PR DESCRIPTION
It warns about places in COM related interop where we know ILLink could break the app by removing more than it should.
In a way it's similar to refleciton - a mechanism outside of .NET whihc let's you affect the ILLink behavior.