### PR TITLE
Warn when DynamicallyAccessedMembersAttribute is used on a member of unsupported type

### DIFF
--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -1427,3 +1427,41 @@ This is technically possible if a custom assembly defines `DynamicDependencyAttr
     public override void TestMethod<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>() {}
   }
   ```
+
+#### 'IL2096': Trim analysis: Field 'field' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'
+
+- `DynamicallyAccessedMembersAttribute` is only applicable to items of type `System.Type` or `System.String` (or derived), on all other types the attribute will be ignored. Using the attribute on any other type is likely incorrect and unintentional.
+
+  ```C#
+  // IL2096: Field '_valueField' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'
+  [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+  object _valueField;
+
+  // IL2096: 
+  void TestMethod([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] object param)
+  {
+    // param.GetType()....
+  }
+  ```
+
+#### 'IL2097': Trim analysis: Parameter 'parameter' of method 'method' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'
+
+- `DynamicallyAccessedMembersAttribute` is only applicable to items of type `System.Type` or `System.String` (or derived), on all other types the attribute will be ignored. Using the attribute on any other type is likely incorrect and unintentional.
+
+  ```C#
+  // IL2097: Parameter 'param' of method 'TestMethod' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'
+  void TestMethod([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] object param)
+  {
+    // param.GetType()....
+  }
+  ```
+
+#### 'IL2098': Trim analysis: Property 'property' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'
+
+- `DynamicallyAccessedMembersAttribute` is only applicable to items of type `System.Type` or `System.String` (or derived), on all other types the attribute will be ignored. Using the attribute on any other type is likely incorrect and unintentional.
+
+  ```C#
+  // IL2098: Parameter 'param' of method 'TestMethod' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'
+  [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+  object TestProperty { get; set; }
+  ```

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -1450,24 +1450,24 @@ This is technically possible if a custom assembly defines `DynamicDependencyAttr
   object _valueField;
   ```
 
-#### 'IL2098': Trim analysis: Parameter 'parameter' of method 'method' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'
+#### 'IL2098': Trim analysis: Parameter 'parameter' of method 'method' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'
 
 - `DynamicallyAccessedMembersAttribute` is only applicable to items of type `System.Type` or `System.String` (or derived), on all other types the attribute will be ignored. Using the attribute on any other type is likely incorrect and unintentional.
 
   ```C#
-  // IL2098: Parameter 'param' of method 'TestMethod' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'
+  // IL2098: Parameter 'param' of method 'TestMethod' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'
   void TestMethod([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] object param)
   {
     // param.GetType()....
   }
   ```
 
-#### 'IL2099': Trim analysis: Property 'property' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'
+#### 'IL2099': Trim analysis: Property 'property' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'
 
 - `DynamicallyAccessedMembersAttribute` is only applicable to items of type `System.Type` or `System.String` (or derived), on all other types the attribute will be ignored. Using the attribute on any other type is likely incorrect and unintentional.
 
   ```C#
-  // IL2099: Parameter 'param' of method 'TestMethod' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'
+  // IL2099: Parameter 'param' of method 'TestMethod' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'
   [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
   object TestProperty { get; set; }
   ```

--- a/src/linker/Linker.Dataflow/FlowAnnotations.cs
+++ b/src/linker/Linker.Dataflow/FlowAnnotations.cs
@@ -127,14 +127,19 @@ namespace Mono.Linker.Dataflow
 			// First go over all fields with an explicit annotation
 			if (type.HasFields) {
 				foreach (FieldDefinition field in type.Fields) {
-					if (!IsTypeInterestingForDataflow (field.FieldType))
-						continue;
-
 					DynamicallyAccessedMemberTypes annotation = GetMemberTypesForDynamicallyAccessedMembersAttribute (field);
 					if (annotation == DynamicallyAccessedMemberTypes.None) {
 						continue;
 					}
 
+					if (!IsTypeInterestingForDataflow (field.FieldType)) {
+						// Already know that there's a non-empty annotation on a field which is not System.Type/String and we're about to ignore it
+						_context.LogWarning (
+							$"Field '{field.GetDisplayName ()}' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'",
+							2096, field, subcategory: MessageSubCategory.TrimAnalysis);
+						continue;
+					}
+					
 					annotatedFields.Add (new FieldAnnotation (field, annotation));
 				}
 			}
@@ -177,12 +182,15 @@ namespace Mono.Linker.Dataflow
 					}
 
 					for (int i = 0; i < method.Parameters.Count; i++) {
-						if (!IsTypeInterestingForDataflow (method.Parameters[i].ParameterType)) {
+						var methodParameter = method.Parameters[i];
+						DynamicallyAccessedMemberTypes pa = GetMemberTypesForDynamicallyAccessedMembersAttribute (methodParameter, method);
+						if (pa == DynamicallyAccessedMemberTypes.None)
 							continue;
-						}
 
-						DynamicallyAccessedMemberTypes pa = GetMemberTypesForDynamicallyAccessedMembersAttribute (method.Parameters[i], method);
-						if (pa == DynamicallyAccessedMemberTypes.None) {
+						if (!IsTypeInterestingForDataflow (methodParameter.ParameterType)) {
+							_context.LogWarning (
+								$"Parameter '{DiagnosticUtilities.GetParameterNameForErrorMessage (methodParameter)}' of method '{DiagnosticUtilities.GetMethodSignatureDisplayName (methodParameter.Method)}' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'",
+								2097, method, subcategory: MessageSubCategory.TrimAnalysis);
 							continue;
 						}
 
@@ -230,13 +238,14 @@ namespace Mono.Linker.Dataflow
 
 			if (type.HasProperties) {
 				foreach (PropertyDefinition property in type.Properties) {
+					DynamicallyAccessedMemberTypes annotation = GetMemberTypesForDynamicallyAccessedMembersAttribute (property);
+					if (annotation == DynamicallyAccessedMemberTypes.None)
+						continue;
 
 					if (!IsTypeInterestingForDataflow (property.PropertyType)) {
-						continue;
-					}
-
-					DynamicallyAccessedMemberTypes annotation = GetMemberTypesForDynamicallyAccessedMembersAttribute (property);
-					if (annotation == DynamicallyAccessedMemberTypes.None) {
+						_context.LogWarning (
+							$"Property '{property.GetDisplayName ()}' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'",
+							2098, property, subcategory: MessageSubCategory.TrimAnalysis);
 						continue;
 					}
 

--- a/src/linker/Linker.Dataflow/FlowAnnotations.cs
+++ b/src/linker/Linker.Dataflow/FlowAnnotations.cs
@@ -189,7 +189,7 @@ namespace Mono.Linker.Dataflow
 
 						if (!IsTypeInterestingForDataflow (methodParameter.ParameterType)) {
 							_context.LogWarning (
-								$"Parameter '{DiagnosticUtilities.GetParameterNameForErrorMessage (methodParameter)}' of method '{DiagnosticUtilities.GetMethodSignatureDisplayName (methodParameter.Method)}' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'",
+								$"Parameter '{DiagnosticUtilities.GetParameterNameForErrorMessage (methodParameter)}' of method '{DiagnosticUtilities.GetMethodSignatureDisplayName (methodParameter.Method)}' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'",
 								2098, method, subcategory: MessageSubCategory.TrimAnalysis);
 							continue;
 						}
@@ -244,7 +244,7 @@ namespace Mono.Linker.Dataflow
 
 					if (!IsTypeInterestingForDataflow (property.PropertyType)) {
 						_context.LogWarning (
-							$"Property '{property.GetDisplayName ()}' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'",
+							$"Property '{property.GetDisplayName ()}' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'",
 							2099, property, subcategory: MessageSubCategory.TrimAnalysis);
 						continue;
 					}

--- a/src/linker/Linker.Dataflow/FlowAnnotations.cs
+++ b/src/linker/Linker.Dataflow/FlowAnnotations.cs
@@ -139,7 +139,7 @@ namespace Mono.Linker.Dataflow
 							2096, field, subcategory: MessageSubCategory.TrimAnalysis);
 						continue;
 					}
-					
+
 					annotatedFields.Add (new FieldAnnotation (field, annotation));
 				}
 			}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/FieldDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/FieldDataFlow.cs
@@ -32,6 +32,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			instance.WriteToStaticFieldOnADifferentClass ();
 
 			instance.WriteUnknownValue ();
+
+			_ = _annotationOnWrongType;
 		}
 
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
@@ -41,6 +43,10 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		static Type _staticTypeWithPublicParameterlessConstructor;
 
 		static Type _staticTypeWithoutRequirements;
+
+		[ExpectedWarning ("IL2096", nameof(_annotationOnWrongType))]
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)]
+		static object _annotationOnWrongType;
 
 		[UnrecognizedReflectionAccessPattern (typeof (FieldDataFlow), nameof (RequirePublicConstructors), new Type[] { typeof (Type) },
 			messageCode: "IL2077", message: new string[] { "_typeWithPublicParameterlessConstructor", "type", "RequirePublicConstructors(Type)" })]

--- a/test/Mono.Linker.Tests.Cases/DataFlow/FieldDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/FieldDataFlow.cs
@@ -44,7 +44,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		static Type _staticTypeWithoutRequirements;
 
-		[ExpectedWarning ("IL2096", nameof(_annotationOnWrongType))]
+		[ExpectedWarning ("IL2096", nameof (_annotationOnWrongType))]
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)]
 		static object _annotationOnWrongType;
 

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MethodParametersDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MethodParametersDataFlow.cs
@@ -35,6 +35,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			instance.UnknownValueToUnAnnotatedParameterOnInterestingMethod ();
 			instance.WriteToParameterOnInstanceMethod (null);
 			instance.LongWriteToParameterOnInstanceMethod (0, 0, 0, 0, null);
+			instance.UnsupportedParameterType (null);
 		}
 
 		// Validate the error message when annotated parameter is passed to another annotated parameter
@@ -181,6 +182,11 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		private void UnknownValueToUnAnnotatedParameterOnInterestingMethod ()
 		{
 			RequirePublicParameterlessConstructorAndNothing (typeof (TestType), this.GetType ());
+		}
+
+		[ExpectedWarning ("IL2097", "p1", nameof(UnsupportedParameterType))]
+		private void UnsupportedParameterType ([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] object p1)
+		{
 		}
 
 		private static void RequirePublicParameterlessConstructor (

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MethodParametersDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MethodParametersDataFlow.cs
@@ -184,8 +184,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			RequirePublicParameterlessConstructorAndNothing (typeof (TestType), this.GetType ());
 		}
 
-		[ExpectedWarning ("IL2097", "p1", nameof(UnsupportedParameterType))]
-		private void UnsupportedParameterType ([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] object p1)
+		[ExpectedWarning ("IL2097", "p1", nameof (UnsupportedParameterType))]
+		private void UnsupportedParameterType ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] object p1)
 		{
 		}
 

--- a/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
@@ -43,7 +43,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)]
 		static Type StaticPropertyWithPublicConstructor { get; set; }
 
-		[ExpectedWarning ("IL2098", nameof(PropertyWithUnsupportedType))]
+		[ExpectedWarning ("IL2098", nameof (PropertyWithUnsupportedType))]
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)]
 		static object PropertyWithUnsupportedType { get; set; }
 

--- a/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
@@ -43,6 +43,10 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)]
 		static Type StaticPropertyWithPublicConstructor { get; set; }
 
+		[ExpectedWarning ("IL2098", nameof(PropertyWithUnsupportedType))]
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)]
+		static object PropertyWithUnsupportedType { get; set; }
+
 		[UnrecognizedReflectionAccessPattern (typeof (PropertyDataFlow), nameof (RequireNonPublicConstructors), new Type[] { typeof (Type) }, messageCode: "IL2072")]
 		private void ReadFromInstanceProperty ()
 		{

--- a/test/Mono.Linker.Tests/TestCasesRunner/LinkerTestLogger.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/LinkerTestLogger.cs
@@ -11,6 +11,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			public MessageOrigin? Origin;
 			public int? Code;
 			public string Text;
+			public string OriginMemberDefinitionFullName;
 		}
 
 		public List<MessageRecord> Messages { get; private set; } = new List<MessageRecord> ();
@@ -22,7 +23,8 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				Category = msBuildMessage.Category,
 				Origin = msBuildMessage.Origin,
 				Code = msBuildMessage.Code,
-				Text = msBuildMessage.Text
+				Text = msBuildMessage.Text,
+				OriginMemberDefinitionFullName = msBuildMessage.Origin?.MemberDefinition?.FullName
 			});
 		}
 	}

--- a/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -644,7 +644,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 								Assert.IsTrue (
 									logger.Messages.Any (mc => {
-										if (mc.Category == MessageCategory.Warning && mc.Code != expectedWarningCodeNumber)
+										if (mc.Category != MessageCategory.Warning || mc.Code != expectedWarningCodeNumber)
 											return false;
 
 										foreach (var expectedMessage in expectedMessageContains)
@@ -661,7 +661,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 											if (sourceColumn != null && mc.Origin?.SourceColumn != sourceColumn.Value)
 												return false;
-										} else if (mc.Origin?.MemberDefinition?.FullName != attrProvider.FullName)
+										} else if (mc.OriginMemberDefinitionFullName != attrProvider.FullName)
 											return false;
 
 										return true;


### PR DESCRIPTION
`DynamicallyAccessedMembersAttribute` is only supported on items of type `System.Type` or `System.String` (and derived classes) otherwise linker will ignore it. When it happens it's very likely not intentional and so linker should warn about it. Since it only affects analysis results, these are marked as TrimAnalysis.