### PR TITLE
Don't error on non-IL warning codes

### DIFF
--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -113,10 +113,6 @@ the error code. For example:
 
 #### `IL1030`: Invalid argument for '{token}' option
 
-#### `IL1031`: "Invalid value 'value' was used as warning code
-
-- All warning codes must start with `IL` prefix followed by numeric code.
-
 ----
 ## Warning Codes
 

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -788,10 +788,8 @@ namespace Mono.Linker
 			value = Unquote (value);
 			string[] values = value.Split (new char[] { ',', ';', ' ' }, StringSplitOptions.RemoveEmptyEntries);
 			foreach (string id in values) {
-				if (!id.StartsWith ("IL", StringComparison.Ordinal) || !ushort.TryParse (id.Substring (2), out ushort code)) {
-					context.LogError ($"Invalid value '{id}' was used as warning code", 1031);
+				if (!id.StartsWith ("IL", StringComparison.Ordinal) || !ushort.TryParse (id.Substring (2), out ushort code))
 					continue;
-				}
 
 				yield return code;
 			}

--- a/test/Mono.Linker.Tests.Cases.Expectations/Assertions/SkipRemainingErrorsValidationAttribute.cs
+++ b/test/Mono.Linker.Tests.Cases.Expectations/Assertions/SkipRemainingErrorsValidationAttribute.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Assertions
+{
+	[AttributeUsage (AttributeTargets.Class, AllowMultiple = false)]
+	public class SkipRemainingErrorsValidationAttribute : BaseExpectedLinkedBehaviorAttribute
+	{
+		public SkipRemainingErrorsValidationAttribute () { }
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Warnings/CanDisableWarnAsError.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/CanDisableWarnAsError.cs
@@ -5,6 +5,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.Warnings
 {
 	[SkipKeptItemsValidation]
+	[SkipRemainingErrorsValidation]
 	[SetupLinkerSubstitutionFile ("CanDisableWarnAsErrorSubstitutions.xml")]
 	[SetupLinkerArgument ("--verbose")]
 	[SetupLinkerArgument ("--warnaserror")]

--- a/test/Mono.Linker.Tests.Cases/Warnings/NoWarnRegardlessOfWarnAsError.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/NoWarnRegardlessOfWarnAsError.cs
@@ -8,6 +8,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.Warnings
 {
 	[SkipKeptItemsValidation]
+	[SkipRemainingErrorsValidation]
 	[SetupLinkerArgument ("--warnaserror")]
 	[SetupLinkerArgument ("--nowarn", "IL2006")]
 	[LogDoesNotContain ("IL2006")]

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/CanGenerateWarningSuppressionFileXml.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/CanGenerateWarningSuppressionFileXml.cs
@@ -8,6 +8,7 @@ using System.Text;
 
 namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 {
+	[SkipRemainingErrorsValidation]
 	[SetupLinkerCoreAction ("skip")]
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/TriggerWarnings_Lib.cs" })]
 	[KeptAssembly ("library.dll")]

--- a/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -609,7 +609,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 									matchedMessages = logger.Messages.Where (mc => mc.Message.Contains (expectedMessage)).ToList (); ;
 								Assert.IsTrue (
 									matchedMessages.Count > 0,
-									$"Expected to find logged message matching `{expectedMessage}`, but no such message was found.{Environment.NewLine}Logged messages:{Environment.NewLine}{FormatAllMessages ()}");
+									$"Expected to find logged message matching `{expectedMessage}`, but no such message was found.{Environment.NewLine}Logged messages:{Environment.NewLine}{FormatMessages (logger.Messages)}");
 
 								foreach (var matchedMessage in matchedMessages)
 									logger.Messages.Remove (matchedMessage);
@@ -624,7 +624,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 											return !Regex.IsMatch (loggedMessage.Message, unexpectedMessage);
 										return !loggedMessage.Message.Contains (unexpectedMessage);
 									},
-									$"Expected to not find logged message matching `{unexpectedMessage}`, but found:{Environment.NewLine}{loggedMessage.Message}{Environment.NewLine}Logged messages:{Environment.NewLine}{FormatAllMessages ()}");
+									$"Expected to not find logged message matching `{unexpectedMessage}`, but found:{Environment.NewLine}{loggedMessage.Message}{Environment.NewLine}Logged messages:{Environment.NewLine}{FormatMessages (logger.Messages)}");
 								}
 							}
 							break;
@@ -669,7 +669,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 									$"Expected to find warning: {(fileName != null ? (fileName + (sourceLine != null ? $"({sourceLine},{sourceColumn})" : "")) + ": " : "")}" +
 									$"warning {expectedWarningCode}: {(fileName == null ? (actualMethod?.GetDisplayName () ?? attrProvider.FullName) + ": " : "")}" +
 									$"and message containing {string.Join (" ", expectedMessageContains.Select (m => "'" + m + "'"))}, " +
-									$"but no such message was found.{Environment.NewLine}Logged messages:{Environment.NewLine}{FormatAllMessages ()}");
+									$"but no such message was found.{Environment.NewLine}Logged messages:{Environment.NewLine}{FormatMessages (logger.Messages)}");
 							}
 							break;
 						}
@@ -677,9 +677,12 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				}
 			}
 
-			string FormatAllMessages ()
+			var remainingErrors = logger.Messages.Where (mc => mc.Category == MessageCategory.Error || mc.Category == MessageCategory.WarningAsError);
+			Assert.IsEmpty (remainingErrors, $"Found unexpected errors:{Environment.NewLine}{FormatMessages (remainingErrors)}");
+
+			string FormatMessages (IEnumerable<LinkerTestLogger.MessageRecord> messages)
 			{
-				return string.Join (Environment.NewLine, logger.Messages.Select (mc => mc.Message));
+				return string.Join (Environment.NewLine, messages.Select (mc => mc.Message));
 			}
 		}
 


### PR DESCRIPTION
We pass NoWarn which may contain warning codes for other tools. This is causing failures in https://github.com/dotnet/sdk/pull/12948.

Adds a check that testcases don't produce unexpected errors, which validates this behavior together with this existing testcase: https://github.com/mono/linker/blob/2b04c065c84aa8f30600e3b1989c537fc77de95b/test/Mono.Linker.Tests.Cases/Warnings/CanDisableWarnings.cs#L12