### PR TITLE
Check if generic types encode its arity when using GetDisplayName

### DIFF
--- a/src/linker/Linker/TypeReferenceExtensions.cs
+++ b/src/linker/Linker/TypeReferenceExtensions.cs
@@ -45,7 +45,8 @@ namespace Mono.Linker
 							else
 								PrependGenericParameters (type.GenericParameters.Skip (declaringTypeGenericParametersCount).ToList (), sb);
 
-							simpleName = type.Name.Substring (0, type.Name.IndexOf ('`'));
+							int explicitArityIndex = type.Name.IndexOf ('`');
+							simpleName = explicitArityIndex != -1 ? type.Name.Substring (0, explicitArityIndex) : type.Name;
 						} else
 							simpleName = type.Name;
 


### PR DESCRIPTION
We currently assume that generic type names always encode its arity in the IL, whereas the ECMA explicitly states that both the grave accent and arity are optional.

Fixes #1435 and #1448