### PR TITLE
TypeDelegator_Ctor should not push values to stack when used with call

### DIFF
--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -516,7 +516,8 @@ namespace Mono.Linker.Dataflow
 
 				case IntrinsicId.TypeDelegator_Ctor: {
 						// This is an identity function for analysis purposes
-						methodReturnValue = methodParams[1];
+						if (operation.OpCode == OpCodes.Newobj)
+							methodReturnValue = methodParams[1];
 					}
 					break;
 


### PR DESCRIPTION
Currently, when processing `TypeDelegator_Ctor` we'll always push the called method's return value to the stack. This behavior is wrong, since ctors return void.