### PR TITLE
[release/5.0] Build against Cecil submodule

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,9 +22,8 @@
     <IsPackable>false</IsPackable>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <_ToolsProjectTargets>$(ArtifactsToolsetDir)Common\Tools.proj.nuget.g.targets</_ToolsProjectTargets>
-    <!-- Set this to false to build against the submodule. Convenient for experimenting locally. -->
-    <UseCecilPackage Condition="'$(MonoBuild)' != '' And '$(UseCecilPackage)' == ''">false</UseCecilPackage>
-    <UseCecilPackage Condition="'$(UseCecilPackage)' == ''">true</UseCecilPackage>
+    <!-- Set this to true to build against the package instead of the submodule. -->
+    <UseCecilPackage Condition="'$(UseCecilPackage)' == ''">false</UseCecilPackage>
     <!-- No symbols are produced for ref assemblies, but some parts of the SDK still expect pdbs, so we explicitly tell it there are none. -->
     <!-- Must be set after importing Arcade to override its defaults. -->
     <DebugType Condition=" '$(IsReferenceAssembly)' == 'true' ">none</DebugType>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -21,7 +21,9 @@
     <MicrosoftBuildFrameworkVersion>15.4.8</MicrosoftBuildFrameworkVersion>
     <MicrosoftBuildUtilitiesCoreVersion>15.4.8</MicrosoftBuildUtilitiesCoreVersion>
     <MicrosoftDotNetApiCompatVersion>5.0.0-beta.20431.1</MicrosoftDotNetApiCompatVersion>
-    <!-- We depend on (and redistribute) the official Mono.Cecil NuGet package built from https://github.com/jbevain/cecil -->
+    <!-- This controls the version of the cecil package, or the version of cecil in the project graph
+         when we build the cecil submodule. The reference assembly package will depend on this version of cecil.
+         Keep this in sync with ProjectInfo.cs in the submodule. -->
     <MonoCecilVersion>0.11.2</MonoCecilVersion>
   </PropertyGroup>
 </Project>

--- a/external/Mono.Cecil.overrides
+++ b/external/Mono.Cecil.overrides
@@ -8,6 +8,11 @@
     <!-- Cecil sets PublicSign on windows, but we always want to
          PublicSign. -->
     <PublicSign>true</PublicSign>
+    <!-- When we build the cecil submodule, use the same version number
+         as the package dependency. This way the linker ref assembly package
+         will depend on the publicly available package. Note that we can't set
+         just set Version here because Arcade will override it. -->
+    <PackageVersion>$(MonoCecilVersion)</PackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(MonoBuild)' == ''">


### PR DESCRIPTION
Doing this will change a few things:

- Our package will no longer include Mono.Cecil.Mdb or Mono.Cecil.Rocks. (These all included with the official package, but we don't depend on them when building against the individual projects. We might want to filter them out even when we go back to building against the package).
- The ref package produced from `release/5.0` will now have a dependency on the local cecil version (it gets a `5.0.0-rc*` version from our Versions.props). To consume it, the consuming project needs to include a version of Mono.Cecil compatible with this version, which in practice probably means also building against the submodule and giving it a custom version. @marek-safar I assume that this is OK since we will go back to shipping with the official package when use the ref assembly for plugins in 6. The alternative is to build the ref and lib against different versions of Cecil.