### PR TITLE
Fix possible endless recursion in MarkEntireType

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -270,11 +270,11 @@ namespace Mono.Linker.Steps
 
 		internal void MarkEntireType (TypeDefinition type, bool includeBaseTypes, in DependencyInfo reason, IMemberDefinition sourceLocationMember)
 		{
-			MarkEntireTypeInternal (type, includeBaseTypes, reason, sourceLocationMember, new HashSet<TypeDefinition>());
+			MarkEntireTypeInternal (type, includeBaseTypes, reason, sourceLocationMember, new HashSet<TypeDefinition> ());
 		}
 
 		private void MarkEntireTypeInternal (TypeDefinition type, bool includeBaseTypes, in DependencyInfo reason, IMemberDefinition sourceLocationMember, HashSet<TypeDefinition> typesAlreadyVisited)
-		{ 
+		{
 #if DEBUG
 			if (!_entireTypeReasons.Contains (reason.Kind))
 				throw new ArgumentOutOfRangeException ($"Internal error: unsupported type dependency {reason.Kind}");

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -270,20 +270,28 @@ namespace Mono.Linker.Steps
 
 		internal void MarkEntireType (TypeDefinition type, bool includeBaseTypes, in DependencyInfo reason, IMemberDefinition sourceLocationMember)
 		{
+			MarkEntireTypeInternal (type, includeBaseTypes, reason, sourceLocationMember, new HashSet<TypeDefinition>());
+		}
+
+		private void MarkEntireTypeInternal (TypeDefinition type, bool includeBaseTypes, in DependencyInfo reason, IMemberDefinition sourceLocationMember, HashSet<TypeDefinition> typesAlreadyVisited)
+		{ 
 #if DEBUG
 			if (!_entireTypeReasons.Contains (reason.Kind))
 				throw new ArgumentOutOfRangeException ($"Internal error: unsupported type dependency {reason.Kind}");
 #endif
 
+			if (!typesAlreadyVisited.Add (type))
+				return;
+
 			if (type.HasNestedTypes) {
 				foreach (TypeDefinition nested in type.NestedTypes)
-					MarkEntireType (nested, includeBaseTypes, new DependencyInfo (DependencyKind.NestedType, type), type);
+					MarkEntireTypeInternal (nested, includeBaseTypes, new DependencyInfo (DependencyKind.NestedType, type), type, typesAlreadyVisited);
 			}
 
 			Annotations.Mark (type, reason);
 			var baseTypeDefinition = type.BaseType?.Resolve ();
 			if (includeBaseTypes && baseTypeDefinition != null) {
-				MarkEntireType (baseTypeDefinition, includeBaseTypes: true, new DependencyInfo (DependencyKind.BaseType, type), type);
+				MarkEntireTypeInternal (baseTypeDefinition, includeBaseTypes: true, new DependencyInfo (DependencyKind.BaseType, type), type, typesAlreadyVisited);
 			}
 			MarkCustomAttributes (type, new DependencyInfo (DependencyKind.CustomAttribute, type), type);
 			MarkTypeSpecialCustomAttributes (type);

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MemberTypes.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MemberTypes.cs
@@ -41,6 +41,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			RequireNonPublicEvents (typeof (NonPublicEventsType));
 			RequireAllEvents (typeof (AllEventsType));
 			RequireAll (typeof (AllType));
+			RequireAll (typeof (RequireAllWithRecursiveTypeReferences));
 		}
 
 
@@ -1845,6 +1846,53 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[Kept]
 			[KeptMember (".ctor()")]
 			public class HideNestedType { }
+		}
+
+		[Kept]
+		class RequireAllWithRecursiveTypeReferences
+		{
+			[Kept]
+			RequireAllWithRecursiveTypeReferences()
+			{
+			}
+
+			[Kept]
+			class NestedType
+			{
+				[Kept]
+				NestedType()
+				{
+				}
+
+				[Kept]
+				RequireAllWithRecursiveTypeReferences parent;
+			}
+
+			[Kept]
+			[KeptMember(".ctor()")]
+			[KeptBaseType(typeof(RequireAllWithRecursiveTypeReferences))]
+			class NestedTypeWithRecursiveBase : RequireAllWithRecursiveTypeReferences
+			{
+			}
+
+			[Kept]
+			[KeptInterface(typeof(IEquatable<RequireAllWithRecursiveTypeReferences>))]
+			[KeptMember(".ctor()")]
+			class NestedTypeWithRecursiveGenericInterface : IEquatable<RequireAllWithRecursiveTypeReferences>
+			{
+				[Kept]
+				public bool Equals (RequireAllWithRecursiveTypeReferences other)
+				{
+					throw new NotImplementedException ();
+				}
+			}
+
+			[Kept]
+			[KeptMember (".ctor()")]
+			[KeptBaseType (typeof(List<RequireAllWithRecursiveTypeReferences>))]
+			class NestedTypeWithRecursiveGenericBaseClass : List<RequireAllWithRecursiveTypeReferences>
+			{
+			}
 		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MemberTypes.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MemberTypes.cs
@@ -1852,7 +1852,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		class RequireAllWithRecursiveTypeReferences
 		{
 			[Kept]
-			RequireAllWithRecursiveTypeReferences()
+			RequireAllWithRecursiveTypeReferences ()
 			{
 			}
 
@@ -1860,7 +1860,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			class NestedType
 			{
 				[Kept]
-				NestedType()
+				NestedType ()
 				{
 				}
 
@@ -1869,15 +1869,15 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			}
 
 			[Kept]
-			[KeptMember(".ctor()")]
-			[KeptBaseType(typeof(RequireAllWithRecursiveTypeReferences))]
+			[KeptMember (".ctor()")]
+			[KeptBaseType (typeof (RequireAllWithRecursiveTypeReferences))]
 			class NestedTypeWithRecursiveBase : RequireAllWithRecursiveTypeReferences
 			{
 			}
 
 			[Kept]
-			[KeptInterface(typeof(IEquatable<RequireAllWithRecursiveTypeReferences>))]
-			[KeptMember(".ctor()")]
+			[KeptInterface (typeof (IEquatable<RequireAllWithRecursiveTypeReferences>))]
+			[KeptMember (".ctor()")]
 			class NestedTypeWithRecursiveGenericInterface : IEquatable<RequireAllWithRecursiveTypeReferences>
 			{
 				[Kept]
@@ -1889,7 +1889,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 			[Kept]
 			[KeptMember (".ctor()")]
-			[KeptBaseType (typeof(List<RequireAllWithRecursiveTypeReferences>))]
+			[KeptBaseType (typeof (List<RequireAllWithRecursiveTypeReferences>))]
 			class NestedTypeWithRecursiveGenericBaseClass : List<RequireAllWithRecursiveTypeReferences>
 			{
 			}


### PR DESCRIPTION
The method recursively calls itself to mark nested types and base types. This means that if nested type has the parent type as its base type, the method will cause stack overflow.

Fixing this by adding a hash of already visited types to break the recursion.

Added tests for the repro and similar cases.

Should fix #1470 (although we don't have a repro, so it's hard to validate)