### PR TITLE
Fix some tests

### DIFF
--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerDisplayAttributeOnTypeCopy.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/DebuggerDisplayAttributeOnTypeCopy.cs
@@ -1,6 +1,4 @@
-﻿#if NETCOREAPP
-
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
@@ -42,4 +40,3 @@ namespace Mono.Linker.Tests.Cases.Attributes.Debugger
 		}
 	}
 }
-#endif

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/DefaultInterfaceMethodCallIntoClass.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/DefaultInterfaceMethodCallIntoClass.cs
@@ -6,14 +6,19 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 {
-#if NETCOREAPP
+#if !NETCOREAPP
+	[IgnoreTestCase ("Requires support for default interface methods")]
+#endif
 	class DefaultInterfaceMethodCallIntoClass
 	{
 		public static void Main ()
 		{
+#if NETCOREAPP
 			((IBase) new Derived ()).Frob ();
+#endif
 		}
 
+#if NETCOREAPP
 		[Kept]
 		interface IBase
 		{
@@ -46,6 +51,6 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 			[Kept]
 			public void Actual () { }
 		}
-	}
 #endif
+	}
 }

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/GenericDefaultInterfaceMethods.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/GenericDefaultInterfaceMethods.cs
@@ -5,15 +5,20 @@ using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 {
-#if NETCOREAPP
+#if !NETCOREAPP
+	[IgnoreTestCase ("Requires support for default interface methods")]
+#endif
 	class GenericDefaultInterfaceMethods
 	{
 		public static void Main ()
 		{
+#if NETCOREAPP
 			((IFoo<int>) new Bar ()).Method (12);
 			((IFoo<int>) new Baz ()).Method (12);
+#endif
 		}
 
+#if NETCOREAPP
 		[Kept]
 		interface IFoo<T>
 		{
@@ -61,6 +66,6 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 			{
 			}
 		}
-	}
 #endif
+	}
 }

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/SimpleDefaultInterfaceMethod.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/SimpleDefaultInterfaceMethod.cs
@@ -6,14 +6,19 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 {
-#if NETCOREAPP
+#if !NETCOREAPP
+	[IgnoreTestCase ("Requires support for default interface methods")]
+#endif
 	class SimpleDefaultInterfaceMethod
 	{
 		public static void Main ()
 		{
+#if NETCOREAPP
 			((IBasic) new Basic ()).DoSomething ();
+#endif
 		}
 
+#if NETCOREAPP
 		[Kept]
 		interface IBasic
 		{
@@ -51,6 +56,6 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 			[Kept]
 			public Basic () { }
 		}
-	}
 #endif
+	}
 }

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/UnusedDefaultInterfaceImplementation.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/UnusedDefaultInterfaceImplementation.cs
@@ -5,14 +5,19 @@ using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 {
-#if NETCOREAPP
+#if !NETCOREAPP
+	[IgnoreTestCase ("Requires support for default interface methods")]
+#endif
 	class UnusedDefaultInterfaceImplementation
 	{
 		public static void Main ()
 		{
+#if NETCOREAPP
 			((IFoo) new Foo ()).InterfaceMethod ();
+#endif
 		}
 
+#if NETCOREAPP
 		[Kept]
 		interface IFoo
 		{
@@ -39,6 +44,6 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 			{
 			}
 		}
-	}
 #endif
+	}
 }

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/AttributesScopeUpdated.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/AttributesScopeUpdated.cs
@@ -21,23 +21,24 @@ namespace Mono.Linker.Tests.Cases.TypeForwarding
 
 	[RemovedAssembly ("Forwarder.dll")]
 	[KeptMemberInAssembly ("Implementation.dll", typeof (ImplementationLibrary))]
-	static class AttributeScopeUpdated
+	static class AttributesScopeUpdated
 	{
 		static void Main ()
 		{
 		}
 
 		[Kept]
-		public static void Test_1 ([TestType3 (typeof (ImplementationLibrary))] int arg)
+		public static void Test_1 ([KeptAttributeAttribute (typeof (TestType3Attribute))] [TestType3 (typeof (ImplementationLibrary))] int arg)
 		{
 		}
 
 		[Kept]
-		public static void Test_2<[TestType3 (typeof (ImplementationLibrary))] T> ()
+		public static void Test_2<[KeptAttributeAttribute (typeof (TestType3Attribute))] [TestType3 (typeof (ImplementationLibrary))] T> ()
 		{
 		}
 
 		[Kept]
+		[return: KeptAttributeAttribute (typeof (TestType3Attribute))]
 		[return: TestType3 (typeof (ImplementationLibrary))]
 		public static void Test_3 ()
 		{


### PR DESCRIPTION
Every test .cs file must be able to resolve a type of the same name during test execution.  Otherwise it triggers a warning and if warnings ever accumulate it becomes impossible to notice when you have a test type name that doesn't match the file name

The rule of thumb to follow is, never #if out the test case type definition.  Include an ignore and and exclude any code that can't compile.

* Fix `DebuggerDisplayAttributeOnTypeCopy` only existing when `NETCOREAPP` is defined.  I just removed the define.  I don't see why it wouldn't work on .NET Framework

* Fix `DefaultInterfaceMethodCallIntoClass` only existing when `NETCOREAPP` is defined.  I most of the test is #if away when not `NETCOREAPP` app and an `[IgnoreTestCase]` is included

* Fix `GenericDefaultInterfaceMethods` only existing when `NETCOREAPP` is defined.  I most of the test is #if away when not `NETCOREAPP` app and an `[IgnoreTestCase]` is included

* Fix `SimpleDefaultInterfaceMethod` only existing when `NETCOREAPP` is defined.  I most of the test is #if away when not `NETCOREAPP` app and an `[IgnoreTestCase]` is included

* Fix `UnusedDefaultInterfaceImplementation` only existing when `NETCOREAPP` is defined.  I most of the test is #if away when not `NETCOREAPP` app and an `[IgnoreTestCase]` is included

* Fix `AttributeScopeUpdated`.  The type name did not match the file name.