### PR TITLE
Prevent multiple allocations of ReaderParameters

### DIFF
--- a/src/linker/Linker/DirectoryAssemblyResolver.cs
+++ b/src/linker/Linker/DirectoryAssemblyResolver.cs
@@ -20,23 +20,16 @@ namespace Mono.Linker {
 
 		readonly List<MemoryMappedViewStream> viewStreams = new List<MemoryMappedViewStream> ();
 
+		readonly ReaderParameters defaultReaderParameters;
+
 		public void AddSearchDirectory (string directory)
 		{
 			directories.Add (directory);
 		}
 
-		public void RemoveSearchDirectory (string directory)
-		{
-			directories.Remove (directory);
-		}
-
-		public string [] GetSearchDirectories ()
-		{
-			return this.directories.ToArray ();
-		}
-
 		protected DirectoryAssemblyResolver ()
 		{
+			defaultReaderParameters = new ReaderParameters ();
 			directories = new Collection<string> (2) { "." };
 		}
 
@@ -71,7 +64,8 @@ namespace Mono.Linker {
 
 		public virtual AssemblyDefinition Resolve (AssemblyNameReference name)
 		{
-			return Resolve (name, new ReaderParameters ());
+			defaultReaderParameters.AssemblyResolver = this;
+			return Resolve (name, defaultReaderParameters);
 		}
 
 		public virtual AssemblyDefinition Resolve (AssemblyNameReference name, ReaderParameters parameters)
@@ -98,7 +92,7 @@ namespace Mono.Linker {
 						continue;
 					try {
 						return GetAssembly (file, parameters);
-					} catch (System.BadImageFormatException) {
+					} catch (BadImageFormatException) {
 						continue;
 					}
 				}

--- a/src/linker/Linker/DirectoryAssemblyResolver.cs
+++ b/src/linker/Linker/DirectoryAssemblyResolver.cs
@@ -30,6 +30,7 @@ namespace Mono.Linker {
 		protected DirectoryAssemblyResolver ()
 		{
 			defaultReaderParameters = new ReaderParameters ();
+			defaultReaderParameters.AssemblyResolver = this;
 			directories = new Collection<string> (2) { "." };
 		}
 
@@ -64,7 +65,6 @@ namespace Mono.Linker {
 
 		public virtual AssemblyDefinition Resolve (AssemblyNameReference name)
 		{
-			defaultReaderParameters.AssemblyResolver = this;
 			return Resolve (name, defaultReaderParameters);
 		}
 


### PR DESCRIPTION
`ReaderParams` gets allocated multiple times inside `DirectoryAssemblyResolver`, accounting for about 4.6% of the memory allocated in the process when linking a hello world app. Preventing this many allocations can help us improve the performance of the linker just a little bit by easing up the GC work.

![image](https://user-images.githubusercontent.com/3836488/92987590-b9e0ed00-f478-11ea-8283-0f48581b224f.png)

Comparison table (linking a hello world app)

|                      | Before   | After    |
|----------------------|----------|----------|
| Total Allocs            | 324MB | 305MB |
| Total CPU Time       | 20,642ms | 19,672ms |
| Total GC CPU Time    | 4,546ms  | 4,235ms  |
| Total GC Pause       | 4,795ms  | 4,468ms  |
| % Time paused for GC | 24%      | 23.2%    |

/cc @agocke