### PR TITLE
Use ServerGarbageCollection=true

### DIFF
--- a/src/linker/Mono.Linker.csproj
+++ b/src/linker/Mono.Linker.csproj
@@ -1,7 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(MonoBuild)' == ''">


### PR DESCRIPTION
Following @MichalStrehovsky advice I set the `ServerGarbageCollection`... and it looks good.

The server GC mode allows for multiple GC threads to exists simultaneously - one for each CPU available. It improves the throughput of the linker quite a bit by allowing the GC to process as much data as it can in a time unit. Trade off here is memory cost: memory use will be higher, since GCs will happen less often.

Linking a hello world app with `ServerGarbageCollection` set improves the linker total CPU time by ~20% (20,600ms vs 16,380ms) and brings down the total GC pause from 4,816.2ms to 317.4ms, the peak GC process working set augmented from 304MB to 371MB (of course perf gains are dependent upon # of CPUs - I ran this on a machine with 6 processors.) 