### PR TITLE
Use TryGetValue when retrieving local variables from stack

### DIFF
--- a/src/linker/Linker.Steps/RemoveUnreachableBlocksStep.cs
+++ b/src/linker/Linker.Steps/RemoveUnreachableBlocksStep.cs
@@ -1217,9 +1217,8 @@ namespace Mono.Linker.Steps
 
 			Instruction GetLocalsValue (int index, MethodBody body)
 			{
-				var instr = locals?[index];
-				if (instr != null)
-					return instr;
+				if (locals != null && locals.TryGetValue (index, out Instruction instruction))
+					return instruction;
 
 				if (!body.InitLocals)
 					return null;

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/Dependencies/LocalsWithoutStore.il
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/Dependencies/LocalsWithoutStore.il
@@ -18,22 +18,31 @@
     .method public hidebysig specialname rtspecialname
            instance default void '.ctor' ()  cil managed
     {
-    IL_0000:  ldarg.0
-    IL_0001:  call instance void class [mscorlib]System.Object::'.ctor'()
-    IL_0006:  ret
+      IL_0000:  ldarg.0
+      IL_0001:  call instance void class [mscorlib]System.Object::'.ctor'()
+      IL_0006:  ret
     }
 
     .method public static hidebysig object Method_1() cil managed
     {
-	.locals init (
-		object	V_0,
-		object	V_1)
-	    
-        ldloc.1 
-	    stloc.0
-        ldnull
-        ret
-    }    
+      .locals init (object V_0,
+          object V_1)
+      ldloc.1 
+      stloc.0
+      ldnull
+      ret
+    }
 
+    .method public static hidebysig object Method_2() cil managed
+    {
+      .maxstack 2
+      .locals init (int32 A, int32 B)
+      ldc.i4.1
+      stloc.0
+      ldloc.0
+      ldloc.1
+      ldnull
+      ret
+    }
   }
 }

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/UninitializedLocals.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/UninitializedLocals.cs
@@ -13,6 +13,7 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 		{
 #if IL_ASSEMBLY_AVAILABLE
 			Mono.Linker.Tests.Cases.UnreachableBlock.Dependencies.ClassA.Method_1 ();
+			Mono.Linker.Tests.Cases.UnreachableBlock.Dependencies.ClassA.Method_2 ();
 #endif
 		}
 	}


### PR DESCRIPTION
Should avoid #1508 from happening. I suspect that the only way in which the key wouldn't exist here is by linking unverifiable CIL. From the ECMA: 

> For verifiable code, this instruction [ldloc] shall guarantee that it is not loading an uninitialized value –
> whether that initialization is done explicitly by having set the localsinit bit for the method, or by
> previous instructions (where the CLI performs definite-assignment analysis).

/cc @agocke