### PR TITLE
AddDirectDependency adjustments

### DIFF
--- a/src/linker/Linker/Tracer.cs
+++ b/src/linker/Linker/Tracer.cs
@@ -68,7 +68,7 @@ namespace Mono.Linker
 			return recorders != null;
 		}
 
-		public void AddDirectDependency (object target, in DependencyInfo reason, bool marked)
+		public virtual void AddDirectDependency (object target, in DependencyInfo reason, bool marked)
 		{
 			if (IsRecordingEnabled ()) {
 				foreach (IDependencyRecorder recorder in recorders)


### PR DESCRIPTION
I don't know what we are going to do with `DependencyInfo` yet.  For now I'm just having us pass `new DependencyInfo(DependencyKind.Custom, null)` in a bunch of places.

This causes a lot of pointless tracing being recorded, which leads to CanEnableReducedTracing failing for us.

By making AddDirectDependency virtual we can override it and then ignore our dependency info's that we don't want recorded.