### PR TITLE
Don't record unspecified dependencies

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -55,6 +55,7 @@ namespace Mono.Linker.Steps
 
 #if DEBUG
 		static readonly DependencyKind[] _entireTypeReasons = new DependencyKind[] {
+			DependencyKind.Unspecified,
 			DependencyKind.NestedType,
 #if !FEATURE_ILLINK
 			DependencyKind.PreservedDependency,
@@ -66,6 +67,7 @@ namespace Mono.Linker.Steps
 		};
 
 		static readonly DependencyKind[] _fieldReasons = new DependencyKind[] {
+			DependencyKind.Unspecified,
 			DependencyKind.AccessedViaReflection,
 			DependencyKind.AlreadyMarked,
 			DependencyKind.Custom,
@@ -85,6 +87,7 @@ namespace Mono.Linker.Steps
 		};
 
 		static readonly DependencyKind[] _typeReasons = new DependencyKind[] {
+			DependencyKind.Unspecified,
 			DependencyKind.AccessedViaReflection,
 			DependencyKind.AlreadyMarked,
 			DependencyKind.AttributeType,
@@ -115,6 +118,7 @@ namespace Mono.Linker.Steps
 		};
 
 		static readonly DependencyKind[] _methodReasons = new DependencyKind[] {
+			DependencyKind.Unspecified,
 			DependencyKind.AccessedViaReflection,
 			DependencyKind.AlreadyMarked,
 			DependencyKind.AttributeConstructor,

--- a/src/linker/Linker/XmlDependencyRecorder.cs
+++ b/src/linker/Linker/XmlDependencyRecorder.cs
@@ -91,6 +91,9 @@ namespace Mono.Linker
 
 		public void RecordDependency (object target, in DependencyInfo reason, bool marked)
 		{
+			if (reason.Kind == DependencyKind.Unspecified)
+				return;
+
 			// For now, just report a dependency from source to target without noting the DependencyKind.
 			RecordDependency (reason.Source, target, marked);
 		}


### PR DESCRIPTION
This gives us a way to punt on giving reasons to all of our marking behaviors.