### PR TITLE
Expose method on Driver

### DIFF
--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -994,7 +994,7 @@ namespace Mono.Linker
 			return false;
 		}
 
-		static bool GetWarningSuppressionWriterFileOutputKind (string text, out WarningSuppressionWriter.FileOutputKind fileOutputKind)
+		protected static bool GetWarningSuppressionWriterFileOutputKind (string text, out WarningSuppressionWriter.FileOutputKind fileOutputKind)
 		{
 			switch (text.ToLowerInvariant ()) {
 			case "cs":


### PR DESCRIPTION
We have our own driver class and would like to reuse this helper method to parse the value of the --generate-warning-suppressions