### PR TITLE
Fix reflection pattern error

### DIFF
--- a/src/linker/Linker/TypeNameResolver.cs
+++ b/src/linker/Linker/TypeNameResolver.cs
@@ -48,7 +48,7 @@ namespace Mono.Linker
 
 		static TypeReference ResolveTypeName (AssemblyDefinition assembly, TypeName typeName)
 		{
-			if (assembly == null)
+			if (assembly == null || typeName == null)
 				return null;
 
 			if (typeName is AssemblyQualifiedTypeName assemblyQualifiedTypeName) {

--- a/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflection.cs
@@ -37,6 +37,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestTypeOverloadWith4Parameters ();
 			TestTypeOverloadWith5ParametersWithIgnoreCase ();
 			TestTypeOverloadWith5ParametersWithoutIgnoreCase ();
+			TestInvalidTypeName ();
 		}
 
 		[Kept]
@@ -336,6 +337,15 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		{
 			const string reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+OverloadWith5ParametersWithoutIgnoreCase";
 			var typeKept = Type.GetType (reflectionTypeKeptString, AssemblyResolver, GetTypeFromAssembly, false, false);
+		}
+
+		/// <summary>
+		/// This test verifies that if `TypeParser.ParseTypeName` hits an exception and returns null that the linker doesn't fail
+		/// </summary>
+		[Kept]
+		static void TestInvalidTypeName ()
+		{
+			var type = Type.GetType ("System.Collections.Generic.List`1[GenericClass`1[System.String]+Nested]");
 		}
 
 		[Kept]


### PR DESCRIPTION
When TypeParser.ParseTypeName hits an exception it returns null.  That null leads to NullReferenceException here https://github.com/mono/linker/blob/b89cb90abdfdc4e1ccd0822b62d367fa35d30f00/src/linker/Linker/TypeNameResolver.cs#L80 which then leads to the exception below.

```
Mono.Linker.LinkerFatalErrorException: ILLink: error IL1005: Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflectionInvalidName.Main(): Error processing method 'Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflectionInvalidName.Main()' in assembly 'test.exe' ---> System.InvalidOperationException: Internal error: A reflection pattern was analyzed, but no result was reported. System.Void Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflectionInvalidName::Main() -> System.Type System.Type::GetType(System.String)
   at Mono.Linker.Dataflow.ReflectionPatternContext.Dispose() in D:\Unity\dev\unity-monolinker-1\src\linker\Linker.Dataflow\ReflectionPatternContext.cs:line 104
   at Mono.Linker.Dataflow.ReflectionMethodBodyScanner.HandleCall(MethodBody callingMethodBody, MethodReference calledMethod, Instruction operation, ValueNodeList methodParams, ValueNode& methodReturnValue) in D:\Unity\dev\unity-monolinker-1\src\linker\Linker.Dataflow\ReflectionMethodBodyScanner.cs:line 1287
   at Mono.Linker.Dataflow.MethodBodyScanner.HandleCall(MethodBody callingMethodBody, Instruction operation, Stack`1 currentStack) in D:\Unity\dev\unity-monolinker-1\src\linker\Linker.Dataflow\MethodBodyScanner.cs:line 859
   at Mono.Linker.Dataflow.MethodBodyScanner.Scan(MethodBody methodBody) in D:\Unity\dev\unity-monolinker-1\src\linker\Linker.Dataflow\MethodBodyScanner.cs:line 530
   at Mono.Linker.Dataflow.ReflectionMethodBodyScanner.ScanAndProcessReturnValue(MethodBody methodBody) in D:\Unity\dev\unity-monolinker-1\src\linker\Linker.Dataflow\ReflectionMethodBodyScanner.cs:line 69
   at Mono.Linker.Steps.MarkStep.MarkReflectionLikeDependencies(MethodBody body, Boolean requiresReflectionMethodBodyScanner) in D:\Unity\dev\unity-monolinker-1\src\linker\Linker.Steps\MarkStep.cs:line 2955
   at Mono.Linker.Steps.MarkStep.MarkMethodBody(MethodBody body) in D:\Unity\dev\unity-monolinker-1\src\linker\Linker.Steps\MarkStep.cs:line 2799
   at Mono.Linker.Steps.MarkStep.ProcessMethod(MethodDefinition method, DependencyInfo& reason) in D:\Unity\dev\unity-monolinker-1\src\linker\Linker.Steps\MarkStep.cs:line 2422
   at Mono.Linker.Steps.MarkStep.ProcessQueue() in D:\Unity\dev\unity-monolinker-1\src\linker\Linker.Steps\MarkStep.cs:line 386
   --- End of inner exception stack trace ---
   at Mono.Linker.Steps.MarkStep.ProcessQueue() in D:\Unity\dev\unity-monolinker-1\src\linker\Linker.Steps\MarkStep.cs:line 388
   at Mono.Linker.Steps.MarkStep.ProcessPrimaryQueue() in D:\Unity\dev\unity-monolinker-1\src\linker\Linker.Steps\MarkStep.cs:line 371
   at Mono.Linker.Steps.MarkStep.Process() in D:\Unity\dev\unity-monolinker-1\src\linker\Linker.Steps\MarkStep.cs:line 338
   at Mono.Linker.Steps.MarkStep.Process(LinkContext context) in D:\Unity\dev\unity-monolinker-1\src\linker\Linker.Steps\MarkStep.cs:line 182
   at Mono.Linker.Pipeline.ProcessStep(LinkContext context, IStep step) in D:\Unity\dev\unity-monolinker-1\src\linker\Linker\Pipeline.cs:line 135
   at Mono.Linker.Pipeline.Process(LinkContext context) in D:\Unity\dev\unity-monolinker-1\src\linker\Linker\Pipeline.cs:line 128
   at Mono.Linker.Driver.Run(ILogger customLogger) in D:\Unity\dev\unity-monolinker-1\src\linker\Linker\Driver.cs:line 755
```