### PR TITLE
Correctly handle assembly qualified names in generic parameters

### DIFF
--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -1336,7 +1336,7 @@ namespace Mono.Linker.Dataflow
 								continue;
 							}
 
-							var resolvedType = (TypeNameResolver.ResolveTypeName (resolvedAssembly, typeNameStringValue.Contents))?.Resolve ();
+							var resolvedType = (_context.TypeNameResolver.ResolveTypeName (resolvedAssembly, typeNameStringValue.Contents))?.Resolve ();
 							if (resolvedType == null) {
 								// It's not wrong to have a reference to non-existing type - the code may well expect to get an exception in this case
 								// Note that we did find the assembly, so it's not a linker config problem, it's either intentional, or wrong versions of assemblies

--- a/src/linker/Linker.Steps/LinkAttributesStep.cs
+++ b/src/linker/Linker.Steps/LinkAttributesStep.cs
@@ -172,7 +172,7 @@ namespace Mono.Linker.Steps
 					return false;
 				}
 
-				attributeType = TypeNameResolver.ResolveTypeName (assembly, attributeFullName)?.Resolve ();
+				attributeType = Context.TypeNameResolver.ResolveTypeName (assembly, attributeFullName)?.Resolve ();
 			}
 
 			if (attributeType == null) {

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -748,7 +748,7 @@ namespace Mono.Linker.Steps
 
 			TypeDefinition td;
 			if (args.Count >= 2 && args[1].Value is string typeName) {
-				td = TypeNameResolver.ResolveTypeName (assembly ?? context.Module.Assembly, typeName)?.Resolve ();
+				td = _context.TypeNameResolver.ResolveTypeName (assembly ?? context.Module.Assembly, typeName)?.Resolve ();
 				if (td == null) {
 					_context.LogWarning (
 						$"Could not resolve dependency type '{typeName}' specified in a `PreserveDependency` attribute", 2004, context.Resolve ());
@@ -1562,10 +1562,10 @@ namespace Mono.Linker.Steps
 					TypeName typeName = TypeParser.ParseTypeName (targetTypeName);
 					if (typeName is AssemblyQualifiedTypeName assemblyQualifiedTypeName) {
 						AssemblyDefinition assembly = _context.GetLoadedAssembly (assemblyQualifiedTypeName.AssemblyName.Name);
-						return TypeNameResolver.ResolveTypeName (assembly, targetTypeName)?.Resolve ();
+						return _context.TypeNameResolver.ResolveTypeName (assembly, targetTypeName)?.Resolve ();
 					}
 
-					return TypeNameResolver.ResolveTypeName (asm, targetTypeName)?.Resolve ();
+					return _context.TypeNameResolver.ResolveTypeName (asm, targetTypeName)?.Resolve ();
 				}
 			}
 

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ApplyTypeAnnotations.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ApplyTypeAnnotations.cs
@@ -150,11 +150,11 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[Kept]
-		[KeptMember(".ctor()")]
+		[KeptMember (".ctor()")]
 		class FromStringConstantWithGenericAndAssemblyQualified<T>
 		{
 			[Kept]
-			public T GetValue() { return default (T);  }
+			public T GetValue () { return default (T); }
 		}
 
 		[Kept]
@@ -162,8 +162,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		// and since the KeptAttribute is otherwise not referenced by the test anywhere (the test-validation attributes are removed before processing normally)
 		// it would not resolve from name - since its assembly is not loaded.
 		// Adding DynamicDependency solves this problem as it is basically the only attribute which has the ability to load new assemblies.
-		[DynamicDependency(DynamicallyAccessedMemberTypes.None, typeof(KeptAttribute))]
-		static void TestFromStringConstantWithGenericAndAssemblyQualified()
+		[DynamicDependency (DynamicallyAccessedMemberTypes.None, typeof (KeptAttribute))]
+		static void TestFromStringConstantWithGenericAndAssemblyQualified ()
 		{
 			RequireCombinationOnString ("Mono.Linker.Tests.Cases.DataFlow.ApplyTypeAnnotations+FromStringConstantWithGenericAndAssemblyQualified`1[[Mono.Linker.Tests.Cases.Expectations.Assertions.KeptAttribute,Mono.Linker.Tests.Cases.Expectations]]");
 		}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ApplyTypeAnnotations.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ApplyTypeAnnotations.cs
@@ -17,6 +17,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			TestFromTypeOf ();
 			TestFromTypeGetTypeOverConstant ();
 			TestFromStringContantWithAnnotation ();
+			TestFromStringConstantWithGeneric ();
+			TestFromStringConstantWithGenericAndAssemblyQualified ();
 		}
 
 		[Kept]
@@ -122,6 +124,46 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				DynamicallyAccessedMemberTypes.PublicProperties)]
 			string typeName)
 		{
+		}
+
+		// Issue: https://github.com/mono/linker/issues/1537
+		//[Kept]
+		//[KeptMember (".ctor()")]
+		class FromStringConstantWithGenericInner
+		{
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		class FromStringConstantWithGeneric<T>
+		{
+			[Kept]
+			public T GetValue () { return default (T); }
+		}
+
+		[Kept]
+		static void TestFromStringConstantWithGeneric ()
+		{
+			RequireCombinationOnString ("Mono.Linker.Tests.Cases.DataFlow.ApplyTypeAnnotations+FromStringConstantWithGeneric`1[[Mono.Linker.Tests.Cases.DataFlow.ApplyTypeAnnotations+FromStringConstantWithGenericInner]]");
+		}
+
+		[Kept]
+		[KeptMember(".ctor()")]
+		class FromStringConstantWithGenericAndAssemblyQualified<T>
+		{
+			[Kept]
+			public T GetValue() { return default (T);  }
+		}
+
+		[Kept]
+		// This is a workaround for the inability to lazy load assemblies. The type name resolver will not load new assemblies
+		// and since the KeptAttribute is otherwise not referenced by the test anywhere (the test-validation attributes are removed before processing normally)
+		// it would not resolve from name - since its assembly is not loaded.
+		// Adding DynamicDependency solves this problem as it is basically the only attribute which has the ability to load new assemblies.
+		[DynamicDependency(DynamicallyAccessedMemberTypes.None, typeof(KeptAttribute))]
+		static void TestFromStringConstantWithGenericAndAssemblyQualified()
+		{
+			RequireCombinationOnString ("Mono.Linker.Tests.Cases.DataFlow.ApplyTypeAnnotations+FromStringConstantWithGenericAndAssemblyQualified`1[[Mono.Linker.Tests.Cases.Expectations.Assertions.KeptAttribute,Mono.Linker.Tests.Cases.Expectations]]");
 		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ApplyTypeAnnotations.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ApplyTypeAnnotations.cs
@@ -19,6 +19,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			TestFromStringContantWithAnnotation ();
 			TestFromStringConstantWithGeneric ();
 			TestFromStringConstantWithGenericAndAssemblyQualified ();
+			TestFromStringConstantWithGenericAndAssemblyQualifiedInvalidAssembly ();
+			TestFromStringConstantWithGenericAndAssemblyQualifiedNonExistingAssembly ();
 		}
 
 		[Kept]
@@ -164,6 +166,26 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		static void TestFromStringConstantWithGenericAndAssemblyQualified()
 		{
 			RequireCombinationOnString ("Mono.Linker.Tests.Cases.DataFlow.ApplyTypeAnnotations+FromStringConstantWithGenericAndAssemblyQualified`1[[Mono.Linker.Tests.Cases.Expectations.Assertions.KeptAttribute,Mono.Linker.Tests.Cases.Expectations]]");
+		}
+
+		class InvalidAssemblyNameType
+		{
+		}
+
+		[Kept]
+		static void TestFromStringConstantWithGenericAndAssemblyQualifiedInvalidAssembly ()
+		{
+			RequireCombinationOnString ("Mono.Linker.Tests.Cases.DataFlow.ApplyTypeAnnotations+InvalidAssemblyNameType,Invalid/Assembly/Name");
+		}
+
+		class NonExistingAssemblyType
+		{
+		}
+
+		[Kept]
+		static void TestFromStringConstantWithGenericAndAssemblyQualifiedNonExistingAssembly ()
+		{
+			RequireCombinationOnString ("Mono.Linker.Tests.Cases.DataFlow.ApplyTypeAnnotations+InvalidAssemblyNameType,NonExistingAssembly");
 		}
 	}
 }


### PR DESCRIPTION
We always assumed that the generic parameters would come from the same assembly as the generic type itself.
Adds a new test to validate the scenario.

Fixes the primary issue in #1536 
The other parts to make that scenario work fully are tracked by different issues.