### PR TITLE
Allow skipping the processing of a reflection call if its MarkStep's ProcessReflectionDependency() returns true

### DIFF
--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -487,13 +487,17 @@ namespace Mono.Linker.Dataflow
 
 		public override bool HandleCall (MethodBody callingMethodBody, MethodReference calledMethod, Instruction operation, ValueNodeList methodParams, out ValueNode methodReturnValue)
 		{
+			methodReturnValue = null;
+
+			var reflectionProcessed = _markStep.ProcessReflectionDependency (callingMethodBody, operation);
+			if (reflectionProcessed)
+				return false;
+
 			var callingMethodDefinition = callingMethodBody.Method;
 			bool shouldEnableReflectionWarnings = ShouldEnableReflectionPatternReporting (callingMethodDefinition);
 			var reflectionContext = new ReflectionPatternContext (_context, shouldEnableReflectionWarnings, callingMethodDefinition, calledMethod.Resolve (), operation);
 
 			DynamicallyAccessedMemberTypes returnValueDynamicallyAccessedMemberTypes = 0;
-
-			methodReturnValue = null;
 
 			var calledMethodDefinition = calledMethod.Resolve ();
 			if (calledMethodDefinition == null)

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2940,7 +2940,7 @@ namespace Mono.Linker.Steps
 		//
 		// Extension point for reflection logic handling customization
 		//
-		protected virtual bool ProcessReflectionDependency (MethodBody body, Instruction instruction)
+		internal protected virtual bool ProcessReflectionDependency (MethodBody body, Instruction instruction)
 		{
 			return false;
 		}
@@ -2953,21 +2953,6 @@ namespace Mono.Linker.Steps
 			if (requiresReflectionMethodBodyScanner) {
 				var scanner = new ReflectionMethodBodyScanner (_context, this);
 				scanner.ScanAndProcessReturnValue (body);
-			}
-
-			var instructions = body.Instructions;
-
-			//
-			// Starting at 1 because all patterns require at least 1 instruction backward lookup
-			//
-			for (var i = 1; i < instructions.Count; i++) {
-				var instruction = instructions[i];
-
-				if (instruction.OpCode != OpCodes.Call && instruction.OpCode != OpCodes.Callvirt)
-					continue;
-
-				if (ProcessReflectionDependency (body, instruction))
-					continue;
 			}
 		}
 


### PR DESCRIPTION
Allow ReflectionMethodBodyScanner's HandleCall() to skip processing an instruction if its MarkStep's ProcessReflectionDependency() returns true.