### PR TITLE
Restore the ability to not mark System.Object.Finalize

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1448,7 +1448,7 @@ namespace Mono.Linker.Steps
 				MarkMulticastDelegate (type);
 			}
 
-			if (type.IsClass && type.BaseType == null && type.Name == "Object")
+			if (type.IsClass && type.BaseType == null && type.Name == "Object" && ShouldMarkSystemObjectFinalize)
 				MarkMethodIf (type.Methods, m => m.Name == "Finalize", new DependencyInfo (DependencyKind.MethodForSpecialType, type), type);
 
 			if (type.IsSerializable ())
@@ -1520,6 +1520,11 @@ namespace Mono.Linker.Steps
 
 			return type;
 		}
+
+		/// <summary>
+		/// Allow subclasses to disable marking of System.Object.Finalize()
+		/// </summary>
+		protected virtual bool ShouldMarkSystemObjectFinalize => true;
 
 		// Allow subclassers to mark additional things in the main processing loop
 		protected virtual void DoAdditionalProcessing ()


### PR DESCRIPTION
Previously we overrode `GetRequiredMethodsForInstantiatedType` and used that to disable marking of Finalize during a special use case we have.

That broke with https://github.com/mono/linker/commit/9c84659e8ff12a7af366a5f4d64ffc6c3623618c

This PR adds a simple bool property to allow us to switch the new behavior that change added off.