### PR TITLE
Test Clean up

### DIFF
--- a/test/Mono.Linker.Tests.Cases/Warnings/Dependencies/TriggerWarnings_Lib.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/Dependencies/TriggerWarnings_Lib.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
-using System.Text;
 
 namespace Mono.Linker.Tests.Cases.Warnings.Dependencies
 {

--- a/test/Mono.Linker.Tests.Cases/Warnings/Individual/CanGenerateWarningSuppressionFileCSharp.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/Individual/CanGenerateWarningSuppressionFileCSharp.cs
@@ -12,7 +12,11 @@ namespace Mono.Linker.Tests.Cases.Warnings.Individual
 	[Reference ("System.Core.dll")]
 #endif
 	[SetupLinkerCoreAction ("skip")]
-	[SetupCompileBefore ("library.dll", new[] { "../Dependencies/TriggerWarnings_Lib.cs" })]
+#if !ILLINK
+	[SetupCompileBefore ("library.dll", new[] { typeof (TriggerWarnings_Lib) }, new[] { "System.Core.dll" })]
+#else
+	[SetupCompileBefore ("library.dll", new[] { typeof (TriggerWarnings_Lib) })]
+#endif
 	[KeptAssembly ("library.dll")]
 	[SetupLinkerAction ("link", "library.dll")]
 	[SetupLinkerArgument ("--verbose")]

--- a/test/Mono.Linker.Tests.Cases/Warnings/Individual/CanGenerateWarningSuppressionFileXml.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/Individual/CanGenerateWarningSuppressionFileXml.cs
@@ -6,7 +6,11 @@ namespace Mono.Linker.Tests.Cases.Warnings.Individual
 {
 	[SkipRemainingErrorsValidation]
 	[SetupLinkerCoreAction ("skip")]
-	[SetupCompileBefore ("library.dll", new[] { "../Dependencies/TriggerWarnings_Lib.cs" })]
+#if !ILLINK
+	[SetupCompileBefore ("library.dll", new[] { typeof (TriggerWarnings_Lib) }, new[] { "System.Core.dll" })]
+#else
+	[SetupCompileBefore ("library.dll", new[] { typeof (TriggerWarnings_Lib) })]
+#endif
 	[KeptAssembly ("library.dll")]
 	[SetupLinkerAction ("link", "library.dll")]
 	[SetupLinkerArgument ("--verbose")]

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsUsingTargetViaXml.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsUsingTargetViaXml.cs
@@ -17,7 +17,12 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 #else
 	[SetupLinkAttributesFile ("SuppressWarningsUsingTargetViaXml.mono.xml")]
 #endif
-	[SetupCompileBefore ("library.dll", new[] { "../Dependencies/TriggerWarnings_Lib.cs" })]
+#if !ILLINK
+	[SetupCompileBefore ("library.dll", new[] { typeof (TriggerWarnings_Lib) }, new[] { "System.Core.dll" })]
+#else
+	[SetupCompileBefore ("library.dll", new[] { typeof (TriggerWarnings_Lib) })]
+#endif
+
 	[KeptAssembly ("library.dll")]
 	[SetupLinkerAction ("link", "library.dll")]
 	[LogDoesNotContain ("TriggerUnrecognizedPattern()")]


### PR DESCRIPTION
* Explicitly declare a reference to System.Core.dll

* Remove unused using statement

* Use typeof overload instead of string to make it easier trace usages