### PR TITLE
Fix processing of DynamicDependency when specified via attribute XML

### DIFF
--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/Dependencies/DynamicDependencyFromAttributeXmlOnNonReferencedAssemblyLibrary.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/Dependencies/DynamicDependencyFromAttributeXmlOnNonReferencedAssemblyLibrary.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies
+{
+#if METHOD
+	public class DynamicDependencyFromAttributeXmlOnNonReferencedAssemblyLibrary_Method
+#else
+	public class DynamicDependencyFromAttributeXmlOnNonReferencedAssemblyLibrary_Field
+#endif
+	{
+		public static void Method ()
+		{
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyFromAttributeXmlOnNonReferencedAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyFromAttributeXmlOnNonReferencedAssembly.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.DynamicDependencies
+{
+	[SetupCompileBefore ("method_library.dll", new[] { "Dependencies/DynamicDependencyFromAttributeXmlOnNonReferencedAssemblyLibrary.cs" }, defines: new[] { "METHOD" })]
+	[SetupCompileBefore ("field_library.dll", new[] { "Dependencies/DynamicDependencyFromAttributeXmlOnNonReferencedAssemblyLibrary.cs" }, defines: new[] { "FIELD" })]
+	[KeptAssembly ("method_library.dll")]
+	[KeptAssembly ("field_library.dll")]
+	[KeptMemberInAssembly ("method_library.dll", "Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies.DynamicDependencyFromAttributeXmlOnNonReferencedAssemblyLibrary_Method", "Method()")]
+	[KeptMemberInAssembly ("field_library.dll", "Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies.DynamicDependencyFromAttributeXmlOnNonReferencedAssemblyLibrary_Field", "Method()")]
+#if NETCOREAPP
+	[SetupLinkAttributesFile ("DynamicDependencyFromAttributeXmlOnNonReferencedAssembly.netcore.Attributes.xml")]
+#else
+	[SetupLinkAttributesFile ("DynamicDependencyFromAttributeXmlOnNonReferencedAssembly.mono.Attributes.xml")]
+#endif
+	public class DynamicDependencyFromAttributeXmlOnNonReferencedAssembly
+	{
+		public static void Main ()
+		{
+			MethodWithDependencyInXml ();
+			_fieldWithDependencyInXml = 0;
+		}
+
+		[Kept]
+		static void MethodWithDependencyInXml ()
+		{
+		}
+
+		[Kept]
+		static int _fieldWithDependencyInXml;
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyFromAttributeXmlOnNonReferencedAssembly.mono.Attributes.xml
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyFromAttributeXmlOnNonReferencedAssembly.mono.Attributes.xml
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<linker>
+  <assembly fullname="test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+    <type fullname="Mono.Linker.Tests.Cases.DynamicDependencies.DynamicDependencyFromAttributeXmlOnNonReferencedAssembly">
+      <method name="MethodWithDependencyInXml">
+        <attribute fullname="System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute" assembly="Mono.Linker.Tests.Cases.Expectations">
+          <argument>Method</argument>
+          <argument>Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies.DynamicDependencyFromAttributeXmlOnNonReferencedAssemblyLibrary_Method</argument>
+          <argument>method_library</argument>
+        </attribute>
+      </method>
+      <field name="_fieldWithDependencyInXml">
+        <attribute fullname="System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute" assembly="Mono.Linker.Tests.Cases.Expectations">
+          <argument>Method</argument>
+          <argument>Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies.DynamicDependencyFromAttributeXmlOnNonReferencedAssemblyLibrary_Field</argument>
+          <argument>field_library</argument>
+        </attribute>
+      </field>
+    </type>
+  </assembly>
+</linker>

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyFromAttributeXmlOnNonReferencedAssembly.netcore.Attributes.xml
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyFromAttributeXmlOnNonReferencedAssembly.netcore.Attributes.xml
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<linker>
+  <assembly fullname="test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+    <type fullname="Mono.Linker.Tests.Cases.DynamicDependencies.DynamicDependencyFromAttributeXmlOnNonReferencedAssembly">
+      <method name="MethodWithDependencyInXml">
+        <attribute fullname="System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute">
+          <argument>Method</argument>
+          <argument>Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies.DynamicDependencyFromAttributeXmlOnNonReferencedAssemblyLibrary_Method</argument>
+          <argument>method_library</argument>
+        </attribute>
+      </method>
+      <field name="_fieldWithDependencyInXml">
+        <attribute fullname="System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute">
+          <argument>Method</argument>
+          <argument>Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies.DynamicDependencyFromAttributeXmlOnNonReferencedAssemblyLibrary_Field</argument>
+          <argument>field_library</argument>
+        </attribute>
+      </field>
+    </type>
+  </assembly>
+</linker>


### PR DESCRIPTION
The `DynamicDependencyLookupStep` would not process `DynamicDependencyAttribute` specified via XML on a member without real attributes (from IL).
Fix is to not rely on `member.HasCustomAttributes` as that doesn't see attributes specified via XML.

Fixes #1547 