### PR TITLE
Mark generic arguments of dynamically accessed types passed as string

### DIFF
--- a/external/corert/src/System.Private.CoreLib/src/System/Reflection/Runtime/TypeParsing/TypeName.cs
+++ b/external/corert/src/System.Private.CoreLib/src/System/Reflection/Runtime/TypeParsing/TypeName.cs
@@ -140,15 +140,15 @@ namespace System.Reflection.Runtime.TypeParsing
 		public MultiDimArrayTypeName(TypeName elementTypeName, int rank)
 			: base(elementTypeName)
 		{
-			_rank = rank;
+			Rank = rank;
 		}
 
 		public sealed override string ToString()
 		{
-			return ElementTypeName + "[" + (_rank == 1 ? "*" : new string(',', _rank - 1)) + "]";
+			return ElementTypeName + "[" + (Rank == 1 ? "*" : new string(',', Rank - 1)) + "]";
 		}
 
-		private int _rank;
+		public int Rank { get; }
 	}
 
 	//

--- a/src/linker/Linker.Dataflow/MethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/MethodBodyScanner.cs
@@ -709,9 +709,7 @@ namespace Mono.Linker.Dataflow
 			}
 
 			if (operation.Operand is TypeReference typeReference) {
-				var resolvedReference = typeReference is ArrayType ?
-					typeReference.Module.ImportReference (typeof (Array))?.Resolve () : typeReference.Resolve ();
-
+				var resolvedReference = typeReference.ResolveToMainTypeDefinition ();
 				if (resolvedReference != null) {
 					StackSlot slot = new StackSlot (new RuntimeTypeHandleValue (resolvedReference));
 					currentStack.Push (slot);

--- a/src/linker/Linker.Dataflow/MethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/MethodBodyScanner.cs
@@ -708,6 +708,12 @@ namespace Mono.Linker.Dataflow
 				return;
 			}
 
+			if (operation.Operand is ArrayType arrayType) {
+				StackSlot slot = new StackSlot (new ArrayValue (new ConstIntValue (arrayType.Rank)));
+				currentStack.Push (slot);
+				return;
+			}
+
 			if (operation.Operand is TypeReference typeReference) {
 				var resolvedReference = typeReference.Resolve ();
 				if (resolvedReference != null) {

--- a/src/linker/Linker.Dataflow/MethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/MethodBodyScanner.cs
@@ -708,14 +708,10 @@ namespace Mono.Linker.Dataflow
 				return;
 			}
 
-			if (operation.Operand is ArrayType arrayType) {
-				StackSlot slot = new StackSlot (new ArrayValue (new ConstIntValue (arrayType.Rank)));
-				currentStack.Push (slot);
-				return;
-			}
-
 			if (operation.Operand is TypeReference typeReference) {
-				var resolvedReference = typeReference.Resolve ();
+				var resolvedReference = typeReference is ArrayType ?
+					typeReference.Module.ImportReference (typeof (Array))?.Resolve () : typeReference.Resolve ();
+
 				if (resolvedReference != null) {
 					StackSlot slot = new StackSlot (new RuntimeTypeHandleValue (resolvedReference));
 					currentStack.Push (slot);

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -1577,11 +1577,8 @@ namespace Mono.Linker.Dataflow
 						// Intentionally ignore - it's not wrong for code to call Type.GetType on non-existing name, the code might expect null/exception back.
 						reflectionContext.RecordHandledPattern ();
 					} else {
+						MarkType (ref reflectionContext, typeRef);
 						MarkTypeForDynamicallyAccessedMembers (ref reflectionContext, foundType, requiredMemberTypes);
-						if (typeRef is GenericInstanceType genericType) {
-							foreach (var arg in genericType.GenericArguments)
-								MarkType (ref reflectionContext, arg);
-						}
 					}
 				} else if (uniqueValue == NullValue.Instance) {
 					// Ignore - probably unreachable path as it would fail at runtime anyway.

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -146,7 +146,7 @@ namespace Mono.Linker.Dataflow
 				return new SystemTypeForGenericParameterValue (inputGenericParameter, _context.Annotations.FlowAnnotations.GetGenericParameterAnnotation (inputGenericParameter));
 			} else {
 				TypeDefinition genericArgumentTypeDef = genericArgument is ArrayType ?
-					genericArgument.Module.ImportReference (typeof(Array))?.Resolve () : genericArgument.Resolve ();
+					genericArgument.Module.ImportReference (typeof (Array))?.Resolve () : genericArgument.Resolve ();
 				if (genericArgumentTypeDef != null) {
 					return new SystemTypeValue (genericArgumentTypeDef);
 				} else {

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -113,7 +113,7 @@ namespace Mono.Linker.Dataflow
 		{
 			ValueNode valueNode;
 			if (argument.Type.Name == "Type") {
-				TypeDefinition referencedType = ((TypeReference) argument.Value).Resolve ();
+				TypeDefinition referencedType = ((TypeReference) argument.Value).ResolveToMainTypeDefinition ();
 				valueNode = referencedType == null ? null : new SystemTypeValue (referencedType);
 			} else if (argument.Type.MetadataType == MetadataType.String) {
 				valueNode = new KnownStringValue ((string) argument.Value);
@@ -145,8 +145,7 @@ namespace Mono.Linker.Dataflow
 				// That said we only use it to perform the dynamically accessed members checks and for that purpose treating it as System.Type is perfectly valid.
 				return new SystemTypeForGenericParameterValue (inputGenericParameter, _context.Annotations.FlowAnnotations.GetGenericParameterAnnotation (inputGenericParameter));
 			} else {
-				TypeDefinition genericArgumentTypeDef = genericArgument is ArrayType ?
-					genericArgument.Module.ImportReference (typeof (Array))?.Resolve () : genericArgument.Resolve ();
+				TypeDefinition genericArgumentTypeDef = genericArgument.ResolveToMainTypeDefinition ();
 				if (genericArgumentTypeDef != null) {
 					return new SystemTypeValue (genericArgumentTypeDef);
 				} else {
@@ -753,13 +752,13 @@ namespace Mono.Linker.Dataflow
 								if (methodParam.ParameterIndex == 0) {
 									staticType = callingMethodDefinition.DeclaringType;
 								} else {
-									staticType = callingMethodDefinition.Parameters[methodParam.ParameterIndex - 1].ParameterType.Resolve ();
+									staticType = callingMethodDefinition.Parameters[methodParam.ParameterIndex - 1].ParameterType.ResolveToMainTypeDefinition ();
 								}
 							} else {
-								staticType = callingMethodDefinition.Parameters[methodParam.ParameterIndex].ParameterType.Resolve ();
+								staticType = callingMethodDefinition.Parameters[methodParam.ParameterIndex].ParameterType.ResolveToMainTypeDefinition ();
 							}
 						} else if (methodParams[0] is LoadFieldValue loadedField) {
-							staticType = loadedField.Field.FieldType.Resolve ();
+							staticType = loadedField.Field.FieldType.ResolveToMainTypeDefinition ();
 						}
 
 						if (staticType != null) {
@@ -803,7 +802,7 @@ namespace Mono.Linker.Dataflow
 						foreach (var typeNameValue in methodParams[0].UniqueValues ()) {
 							if (typeNameValue is KnownStringValue knownStringValue) {
 								TypeReference foundTypeRef = _context.TypeNameResolver.ResolveTypeName (knownStringValue.Contents);
-								TypeDefinition foundType = foundTypeRef?.Resolve ();
+								TypeDefinition foundType = foundTypeRef?.ResolveToMainTypeDefinition ();
 								if (foundType == null) {
 									// Intentionally ignore - it's not wrong for code to call Type.GetType on non-existing name, the code might expect null/exception back.
 									reflectionContext.RecordHandledPattern ();
@@ -1341,11 +1340,13 @@ namespace Mono.Linker.Dataflow
 								continue;
 							}
 
-							var resolvedType = _context.TypeNameResolver.ResolveTypeName (resolvedAssembly, typeNameStringValue.Contents)?.Resolve ();
-							if (resolvedType == null) {
+							var typeRef = _context.TypeNameResolver.ResolveTypeName (resolvedAssembly, typeNameStringValue.Contents);
+							var resolvedType = typeRef?.Resolve ();
+							if (resolvedType == null || typeRef is ArrayType) {
 								// It's not wrong to have a reference to non-existing type - the code may well expect to get an exception in this case
 								// Note that we did find the assembly, so it's not a linker config problem, it's either intentional, or wrong versions of assemblies
-								// but linker can't know that.
+								// but linker can't know that. In case a user tries to create an array using System.Activator we should simply ignore it, the user
+								// might expect an exception to be thrown.
 								reflectionContext.RecordHandledPattern ();
 								continue;
 							}

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -1657,7 +1657,7 @@ namespace Mono.Linker.Dataflow
 		void MarkType (ref ReflectionPatternContext reflectionContext, TypeReference typeReference)
 		{
 			var source = reflectionContext.Source;
-			reflectionContext.RecordRecognizedPattern (typeReference?.Resolve (), () => _markStep.MarkType (typeReference, new DependencyInfo (DependencyKind.AccessedViaReflection, source), source));
+			reflectionContext.RecordRecognizedPattern (typeReference?.Resolve (), () => _markStep.MarkTypeVisibleToReflection (typeReference, new DependencyInfo (DependencyKind.AccessedViaReflection, source), source));
 		}
 
 		void MarkMethod (ref ReflectionPatternContext reflectionContext, MethodDefinition method)

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -1573,7 +1573,7 @@ namespace Mono.Linker.Dataflow
 					MarkTypeForDynamicallyAccessedMembers (ref reflectionContext, systemTypeValue.TypeRepresented, requiredMemberTypes);
 				} else if (uniqueValue is KnownStringValue knownStringValue) {
 					TypeReference typeRef = _context.TypeNameResolver.ResolveTypeName (knownStringValue.Contents);
-					TypeDefinition foundType = typeRef?.Resolve ();
+					TypeDefinition foundType = typeRef?.ResolveToMainTypeDefinition ();
 					if (foundType == null) {
 						// Intentionally ignore - it's not wrong for code to call Type.GetType on non-existing name, the code might expect null/exception back.
 						reflectionContext.RecordHandledPattern ();

--- a/src/linker/Linker/TypeNameResolver.cs
+++ b/src/linker/Linker/TypeNameResolver.cs
@@ -77,22 +77,14 @@ namespace Mono.Linker
 				if (elementType == null)
 					return null;
 
-				switch (typeName) {
-				case ArrayTypeName:
-					return new ArrayType (elementType);
-
-				case MultiDimArrayTypeName multiDimArrayTypeName:
-					return new ArrayType (elementType, multiDimArrayTypeName.Rank);
-
-				case ByRefTypeName:
-					return new ByReferenceType (elementType);
-
-				case PointerTypeName:
-					return new PointerType (elementType);
-
-				default:
-					return elementType;
-				}
+				return typeName switch
+				{
+					ArrayTypeName _ => new ArrayType (elementType),
+					MultiDimArrayTypeName multiDimArrayTypeName => new ArrayType (elementType, multiDimArrayTypeName.Rank),
+					ByRefTypeName _ => new ByReferenceType (elementType),
+					PointerTypeName _ => new PointerType (elementType),
+					_ => elementType
+				};
 			}
 
 			return assembly.MainModule.GetType (typeName.ToString ());

--- a/src/linker/Linker/TypeNameResolver.cs
+++ b/src/linker/Linker/TypeNameResolver.cs
@@ -77,6 +77,9 @@ namespace Mono.Linker
 				if (elementType == null)
 					return null;
 
+				if (typeName is ArrayTypeName)
+					return new ArrayType (elementType);
+
 				return elementType;
 			}
 

--- a/src/linker/Linker/TypeNameResolver.cs
+++ b/src/linker/Linker/TypeNameResolver.cs
@@ -77,10 +77,22 @@ namespace Mono.Linker
 				if (elementType == null)
 					return null;
 
-				if (typeName is ArrayTypeName)
+				switch (typeName) {
+				case ArrayTypeName:
 					return new ArrayType (elementType);
 
-				return elementType;
+				case MultiDimArrayTypeName multiDimArrayTypeName:
+					return new ArrayType (elementType, multiDimArrayTypeName.Rank);
+
+				case ByRefTypeName:
+					return new ByReferenceType (elementType);
+
+				case PointerTypeName:
+					return new PointerType (elementType);
+
+				default:
+					return elementType;
+				}
 			}
 
 			return assembly.MainModule.GetType (typeName.ToString ());

--- a/src/linker/Linker/TypeReferenceExtensions.cs
+++ b/src/linker/Linker/TypeReferenceExtensions.cs
@@ -375,5 +375,14 @@ namespace Mono.Linker
 
 			return false;
 		}
+
+		public static TypeDefinition ResolveToMainTypeDefinition (this TypeReference type)
+		{
+			return type switch
+			{
+				ArrayType _ => type.Module.ImportReference (typeof (Array))?.Resolve (),
+				_ => type?.Resolve ()
+			};
+		}
 	}
 }

--- a/src/linker/Linker/TypeReferenceExtensions.cs
+++ b/src/linker/Linker/TypeReferenceExtensions.cs
@@ -376,6 +376,9 @@ namespace Mono.Linker
 			return false;
 		}
 
+		// Array types that are dynamically accessed should resolve to System.Array instead of its element type - which is what Cecil resolves to.
+		// Any data flow annotations placed on a type parameter which receives an array type apply to the array itself. None of the members in its
+		// element type should be marked.
 		public static TypeDefinition ResolveToMainTypeDefinition (this TypeReference type)
 		{
 			return type switch

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ApplyTypeAnnotations.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ApplyTypeAnnotations.cs
@@ -169,6 +169,11 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[Kept]
+		class FromStringConstantWitGenericInnerMultiDimArray
+		{
+		}
+
+		[Kept]
 		[KeptMember (".ctor()")]
 		class FromStringConstantWithGenericTwoParameters<T, S>
 		{
@@ -179,6 +184,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		{
 			RequireCombinationOnString ("Mono.Linker.Tests.Cases.DataFlow.ApplyTypeAnnotations+FromStringConstantWithGeneric`1[[Mono.Linker.Tests.Cases.DataFlow.ApplyTypeAnnotations+FromStringConstantWithGenericInner]]");
 			RequireCombinationOnString ("Mono.Linker.Tests.Cases.DataFlow.ApplyTypeAnnotations+FromStringConstantWithGenericTwoParameters`2[Mono.Linker.Tests.Cases.DataFlow.ApplyTypeAnnotations+FromStringConstantWithGenericInnerOne`1[Mono.Linker.Tests.Cases.DataFlow.ApplyTypeAnnotations+FromStringConstantWithGenericInnerInner],Mono.Linker.Tests.Cases.DataFlow.ApplyTypeAnnotations+FromStringConstantWithGenericInnerTwo]");
+			RequireCombinationOnString ("Mono.Linker.Tests.Cases.DataFlow.ApplyTypeAnnotations+FromStringConstantWithGeneric`1[[Mono.Linker.Tests.Cases.DataFlow.ApplyTypeAnnotations+FromStringConstantWitGenericInnerMultiDimArray[,]]]");
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ApplyTypeAnnotations.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ApplyTypeAnnotations.cs
@@ -174,6 +174,12 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[Kept]
+		class FromStringConstantWithMultiDimArray
+		{
+			public void UnusedMethod () { }
+		}
+
+		[Kept]
 		[KeptMember (".ctor()")]
 		class FromStringConstantWithGenericTwoParameters<T, S>
 		{
@@ -185,6 +191,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			RequireCombinationOnString ("Mono.Linker.Tests.Cases.DataFlow.ApplyTypeAnnotations+FromStringConstantWithGeneric`1[[Mono.Linker.Tests.Cases.DataFlow.ApplyTypeAnnotations+FromStringConstantWithGenericInner]]");
 			RequireCombinationOnString ("Mono.Linker.Tests.Cases.DataFlow.ApplyTypeAnnotations+FromStringConstantWithGenericTwoParameters`2[Mono.Linker.Tests.Cases.DataFlow.ApplyTypeAnnotations+FromStringConstantWithGenericInnerOne`1[Mono.Linker.Tests.Cases.DataFlow.ApplyTypeAnnotations+FromStringConstantWithGenericInnerInner],Mono.Linker.Tests.Cases.DataFlow.ApplyTypeAnnotations+FromStringConstantWithGenericInnerTwo]");
 			RequireCombinationOnString ("Mono.Linker.Tests.Cases.DataFlow.ApplyTypeAnnotations+FromStringConstantWithGeneric`1[[Mono.Linker.Tests.Cases.DataFlow.ApplyTypeAnnotations+FromStringConstantWitGenericInnerMultiDimArray[,]]]");
+			RequireCombinationOnString ("Mono.Linker.Tests.Cases.DataFlow.ApplyTypeAnnotations+FromStringConstantWithMultiDimArray[,]");
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ApplyTypeAnnotations.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ApplyTypeAnnotations.cs
@@ -128,9 +128,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		{
 		}
 
-		// Issue: https://github.com/mono/linker/issues/1537
-		//[Kept]
-		//[KeptMember (".ctor()")]
+		[Kept]
+		[KeptMember (".ctor()")]
 		class FromStringConstantWithGenericInner
 		{
 		}
@@ -144,9 +143,34 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[Kept]
+		[KeptMember (".ctor()")]
+		class FromStringConstantWithGenericInnerInner
+		{
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		class FromStringConstantWithGenericInnerOne<T>
+		{
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		class FromStringConstantWithGenericInnerTwo
+		{
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		class FromStringConstantWithGenericTwoParameters<T, S>
+		{
+		}
+
+		[Kept]
 		static void TestFromStringConstantWithGeneric ()
 		{
 			RequireCombinationOnString ("Mono.Linker.Tests.Cases.DataFlow.ApplyTypeAnnotations+FromStringConstantWithGeneric`1[[Mono.Linker.Tests.Cases.DataFlow.ApplyTypeAnnotations+FromStringConstantWithGenericInner]]");
+			RequireCombinationOnString ("Mono.Linker.Tests.Cases.DataFlow.ApplyTypeAnnotations+FromStringConstantWithGenericTwoParameters`2[Mono.Linker.Tests.Cases.DataFlow.ApplyTypeAnnotations+FromStringConstantWithGenericInnerOne`1[Mono.Linker.Tests.Cases.DataFlow.ApplyTypeAnnotations+FromStringConstantWithGenericInnerInner],Mono.Linker.Tests.Cases.DataFlow.ApplyTypeAnnotations+FromStringConstantWithGenericInnerTwo]");
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ApplyTypeAnnotations.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ApplyTypeAnnotations.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ApplyTypeAnnotations.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ApplyTypeAnnotations.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
@@ -129,7 +130,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[Kept]
-		[KeptMember (".ctor()")]
 		class FromStringConstantWithGenericInner
 		{
 		}
@@ -143,21 +143,30 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[Kept]
-		[KeptMember (".ctor()")]
 		class FromStringConstantWithGenericInnerInner
 		{
+			[Kept]
+			public void Method ()
+			{
+			}
+
+			int unusedField;
 		}
 
 		[Kept]
-		[KeptMember (".ctor()")]
-		class FromStringConstantWithGenericInnerOne<T>
+		class FromStringConstantWithGenericInnerOne<
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+		T>
 		{
 		}
 
 		[Kept]
-		[KeptMember (".ctor()")]
 		class FromStringConstantWithGenericInnerTwo
 		{
+			void UnusedMethod ()
+			{
+			}
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ComplexTypeHandling.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ComplexTypeHandling.cs
@@ -80,7 +80,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		static void TestArrayOnGeneric ()
 		{
 			_ = new RequirePublicMethodsGeneric<ArrayElementInGenericType[]> ();
-			_ = new RequirePublicMethodsGeneric<int[]> ();
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ComplexTypeHandling.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ComplexTypeHandling.cs
@@ -95,7 +95,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[Kept]
 		sealed class ArrayGetTypeFromMethodParamElement
 		{
-			[Kept] // This is a bug - the method should not be marked, instead Array.* should be marked
+			// This method should not be marked, instead Array.* should be marked
 			public void PublicMethod () { }
 		}
 
@@ -114,7 +114,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[Kept]
 		sealed class ArrayGetTypeFromFieldElement
 		{
-			[Kept] // This is a bug - the method should not be marked, instead Array.* should be marked
+			// This method should not be marked, instead Array.* should be marked
 			public void PublicMethod () { }
 		}
 
@@ -130,7 +130,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[Kept]
 		sealed class ArrayTypeGetTypeElement
 		{
-			[Kept] // This is a bug - the method should not be marked, instead Array.* should be marked
+			// This method should not be marked, instead Array.* should be marked
 			public void PublicMethod () { }
 		}
 
@@ -140,10 +140,9 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			RequirePublicMethods (Type.GetType ("Mono.Linker.Tests.Cases.DataFlow.ComplexTypeHandling+ArrayTypeGetTypeElement[]"));
 		}
 
-		[Kept]
+		// Nothing should be marked as CreateInstance doesn't work on arrays
 		class ArrayCreateInstanceByNameElement
 		{
-			[Kept] // This is a bug - the .ctor should not be marked - in fact in this case nothing should be marked as CreateInstance doesn't work on arrays
 			public ArrayCreateInstanceByNameElement ()
 			{
 			}
@@ -158,7 +157,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[Kept]
 		class ArrayInAttributeParamElement
 		{
-			[Kept] // This is a bug - the method should not be marked, instead Array.* should be marked
+			// This method should not be marked, instead Array.* should be marked
 			public void PublicMethod () { }
 		}
 

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ComplexTypeHandling.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ComplexTypeHandling.cs
@@ -32,7 +32,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		{
 			public ArrayElementType () { }
 
-			[Kept]
 			public void PublicMethod () { }
 
 			private int _privateField;
@@ -61,7 +60,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		{
 			public ArrayElementInGenericType () { }
 
-			[Kept]
 			public void PublicMethod () { }
 
 			private int _privateField;
@@ -71,8 +69,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[KeptMember (".ctor()")]
 		class RequirePublicMethodsGeneric<
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
-		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
-		T>
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			T>
 		{
 		}
 

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ComplexTypeHandling.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ComplexTypeHandling.cs
@@ -69,8 +69,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[KeptMember (".ctor()")]
 		class RequirePublicMethodsGeneric<
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
-			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
-			T>
+		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+		T>
 		{
 		}
 

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ComplexTypeHandling.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ComplexTypeHandling.cs
@@ -12,7 +12,6 @@ using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.DataFlow
 {
-	[IgnoreTestCase ("Active issue https://github.com/mono/linker/issues/1559")]
 	public class ComplexTypeHandling
 	{
 		public static void Main ()
@@ -81,6 +80,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		static void TestArrayOnGeneric ()
 		{
 			_ = new RequirePublicMethodsGeneric<ArrayElementInGenericType[]> ();
+			_ = new RequirePublicMethodsGeneric<int[]> ();
 		}
 
 		[Kept]
@@ -89,6 +89,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			RequirePublicMethodsOnArrayOfGenericParameter<ArrayElementInGenericType> ();
 		}
 
+		[Kept]
 		static void RequirePublicMethodsOnArrayOfGenericParameter<T> ()
 		{
 			_ = new RequirePublicMethodsGeneric<T[]> ();

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyFromCopiedAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyFromCopiedAssembly.cs
@@ -4,7 +4,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.DynamicDependencies
 {
-	[SetupLinkerAction ("link", "lib")]
+	[SetupLinkerAction ("copy", "lib")]
 	[SetupCompileBefore ("lib.dll", new[] { "Dependencies/DynamicDependencyInCopyAssembly.cs" })]
 	[KeptAllTypesAndMembersInAssembly ("lib.dll")]
 	public class DynamicDependencyFromCopiedAssembly
@@ -18,7 +18,6 @@ namespace Mono.Linker.Tests.Cases.DynamicDependencies
 		static void Test ()
 		{
 			var b = new DynamicDependencyInCopyAssembly ();
-			//var x = Foo.GetObject ();
 		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyFromCopiedAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyFromCopiedAssembly.cs
@@ -4,7 +4,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.DynamicDependencies
 {
-	[SetupLinkerAction ("copy", "lib")]
+	[SetupLinkerAction ("link", "lib")]
 	[SetupCompileBefore ("lib.dll", new[] { "Dependencies/DynamicDependencyInCopyAssembly.cs" })]
 	[KeptAllTypesAndMembersInAssembly ("lib.dll")]
 	public class DynamicDependencyFromCopiedAssembly
@@ -18,6 +18,7 @@ namespace Mono.Linker.Tests.Cases.DynamicDependencies
 		static void Test ()
 		{
 			var b = new DynamicDependencyInCopyAssembly ();
+			//var x = Foo.GetObject ();
 		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/Reflection/PropertyUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/PropertyUsedViaReflection.cs
@@ -17,6 +17,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestNullName ();
 			TestEmptyName ();
 			TestNonExistingName ();
+			TestPropertyOfArray ();
 			TestNullType ();
 			TestDataFlowType ();
 			TestIfElse (1);
@@ -80,6 +81,16 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		static void TestNonExistingName ()
 		{
 			var property = typeof (PropertyUsedViaReflection).GetProperty ("NonExisting");
+		}
+
+		[Kept]
+		[RecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetProperty), new Type[] { typeof (string) },
+			typeof (Array), nameof (Array.LongLength))]
+		static void TestPropertyOfArray ()
+		{
+			var property = typeof (int[]).GetProperty ("LongLength");
+			property.GetValue (null);
 		}
 
 		[Kept]


### PR DESCRIPTION
Currently, the linker won't mark the generic arguments of a dynamically accessed type that is passed as a string. For an example, see #1537.