### PR TITLE
Test clean up

### DIFF
--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyFromAttributeXmlOnNonReferencedAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyFromAttributeXmlOnNonReferencedAssembly.cs
@@ -2,12 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/test/Mono.Linker.Tests.Cases/LinkAttributes/Dependencies/LinkerAttributeRemovalCopyAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkAttributes/Dependencies/LinkerAttributeRemovalCopyAssembly.cs
@@ -2,10 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Text;
 using Mono.Linker.Tests.Cases.LinkAttributes.Dependencies;
 
 [assembly: TestAnotherAttributeUsedFromCopyAssembly]

--- a/test/Mono.Linker.Tests.Cases/LinkAttributes/LinkerAttributeRemoval.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkAttributes/LinkerAttributeRemoval.cs
@@ -21,7 +21,11 @@ namespace Mono.Linker.Tests.Cases.LinkAttributes
 	[SetupCompileBefore ("attribute.dll", new[] { "Dependencies/LinkerAttributeRemovalAttributeToRemove.cs" })]
 	[SetupCompileBefore ("copyattribute.dll", new[] { "Dependencies/LinkerAttributeRemovalAttributeFromCopyAssembly.cs" })]
 	[SetupLinkerAction ("copy", "copyattribute")]
+#if !ILLINK
+	[SetupCompileBefore ("copyassembly.dll", new[] { "Dependencies/LinkerAttributeRemovalCopyAssembly.cs" }, references: new[] { "System.dll", "attribute.dll" })]
+#else
 	[SetupCompileBefore ("copyassembly.dll", new[] { "Dependencies/LinkerAttributeRemovalCopyAssembly.cs" }, references: new[] { "attribute.dll" })]
+#endif
 	[SetupLinkerAction ("copy", "copyassembly")]
 
 	// The test here is that the TypeOnCopyAssemblyWithAttributeUsage has an attribute TestAttributeUsedFromCopyAssemblyAttribute

--- a/test/Mono.Linker.Tests.Cases/Warnings/Individual/WarningsAreSorted.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/Individual/WarningsAreSorted.cs
@@ -13,7 +13,11 @@ namespace Mono.Linker.Tests.Cases.Warnings.Individual
 {
 	[SkipRemainingErrorsValidation]
 	[SetupLinkerCoreAction ("skip")]
-	[SetupCompileBefore ("library.dll", new[] { "../Dependencies/TriggerWarnings_Lib.cs" })]
+#if !ILLINK
+	[SetupCompileBefore ("library.dll", new[] { typeof (TriggerWarnings_Lib) }, new[] { "System.Core.dll" })]
+#else
+	[SetupCompileBefore ("library.dll", new[] { typeof (TriggerWarnings_Lib) })]
+#endif
 	[KeptAssembly ("library.dll")]
 	[SetupLinkerAction ("link", "library.dll")]
 	[SetupLinkerArgument ("--verbose")]

--- a/test/Mono.Linker.Tests/TestCases/IndividualTests.cs
+++ b/test/Mono.Linker.Tests/TestCases/IndividualTests.cs
@@ -13,7 +13,6 @@ using Mono.Linker.Tests.Cases.Warnings.Individual;
 using Mono.Linker.Tests.Extensions;
 using Mono.Linker.Tests.TestCasesRunner;
 using NUnit.Framework;
-using NUnit.Framework.Internal;
 
 namespace Mono.Linker.Tests.TestCases
 {
@@ -69,7 +68,7 @@ namespace Mono.Linker.Tests.TestCases
 				if (!outputPath.Exists ())
 					Assert.Fail ($"A cs file with a list of UnconditionalSuppressMessage attributes was expected to exist at {outputPath}");
 
-				Assert.IsTrue (File.ReadAllLines (outputPath).SequenceEqual (
+				Assert.That (File.ReadAllLines (outputPath), Is.EquivalentTo (
 					File.ReadAllLines (TestsDirectory.Combine ($"TestCases/Dependencies/WarningSuppressionExpectations{i + 1}.cs"))));
 			}
 		}
@@ -83,7 +82,7 @@ namespace Mono.Linker.Tests.TestCases
 			if (!outputPath.Exists ())
 				Assert.Fail ($"An XML file with a list of UnconditionalSuppressMessage attributes was expected to exist at {outputPath}");
 
-			Assert.IsTrue (File.ReadAllLines (outputPath).SequenceEqual (
+			Assert.That (File.ReadAllLines (outputPath), Is.EquivalentTo (
 				File.ReadAllLines (TestsDirectory.Combine ($"TestCases/Dependencies/WarningSuppressionExpectations3.xml"))));
 		}
 
@@ -96,8 +95,8 @@ namespace Mono.Linker.Tests.TestCases
 				.Where (lm => lm.Category != MessageCategory.Info && lm.Category != MessageCategory.Diagnostic).ToList ();
 			loggedMessages.Sort ();
 
-			Assert.IsTrue (string.Join (Environment.NewLine, loggedMessages).SequenceEqual (
-				File.ReadAllText (TestsDirectory.Combine ($"TestCases/Dependencies/SortedWarnings.txt"))));
+			Assert.That (loggedMessages.Select (m => m.ToString ()), Is.EquivalentTo (
+				File.ReadAllLines (TestsDirectory.Combine ($"TestCases/Dependencies/SortedWarnings.txt"))));
 		}
 
 		[Test]


### PR DESCRIPTION
* Remove unused usings from `DynamicDependencyFromAttributeXmlOnNonReferencedAssembly` the extra usings were resulting in a compile error

* Replace some Assert.IsTrue usages with Assert.That and Is.EquivalentTo.  The failure message from Assert.IsTrue is generally not helpful.

* Eliminate line ending mismatch vulnerability from the assert in `WarningsAreSorted`