### PR TITLE
Stub void return ETW bodies instead of throw

### DIFF
--- a/test/Mono.Linker.Tests.Cases/BCLFeatures/ETW/BaseRemovedEventSource.cs
+++ b/test/Mono.Linker.Tests.Cases/BCLFeatures/ETW/BaseRemovedEventSource.cs
@@ -53,9 +53,7 @@ namespace Mono.Linker.Tests.Cases.BCLFeatures.ETW
 		[Kept]
 		[ExpectedInstructionSequence (new[]
 		{
-			"ldstr",
-			"newobj",
-			"throw",
+			"ret",
 		})]
 		protected override void OnEventCommand (EventCommandEventArgs command)
 		{
@@ -69,9 +67,7 @@ namespace Mono.Linker.Tests.Cases.BCLFeatures.ETW
 		[Kept]
 		[ExpectedInstructionSequence (new[]
 		{
-			"ldstr",
-			"newobj",
-			"throw",
+			"ret",
 		})]
 		[Event (8)]
 		public void SomeMethod ()

--- a/test/Mono.Linker.Tests.Cases/BCLFeatures/ETW/BaseRemovedEventSourceEmptyBody.cs
+++ b/test/Mono.Linker.Tests.Cases/BCLFeatures/ETW/BaseRemovedEventSourceEmptyBody.cs
@@ -50,17 +50,19 @@ namespace Mono.Linker.Tests.Cases.BCLFeatures.ETW
 		}
 
 		[Kept]
+		[ExpectedInstructionSequence (new[]
+		{
+			"ret"
+		})]
 		protected override void OnEventCommand (EventCommandEventArgs command)
 		{
-			// Not converted to throw because the body is empty
+			// A nop is removed
 		}
 
 		[Kept]
 		[ExpectedInstructionSequence (new[]
 		{
-			"ldstr",
-			"newobj",
-			"throw",
+			"ret"
 		})]
 		[Event (8)]
 		public void SomeMethod ()

--- a/test/Mono.Linker.Tests.Cases/BCLFeatures/ETW/BaseRemovedEventSourceNonVoidReturn.cs
+++ b/test/Mono.Linker.Tests.Cases/BCLFeatures/ETW/BaseRemovedEventSourceNonVoidReturn.cs
@@ -1,0 +1,71 @@
+using System.Diagnostics.Tracing;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.BCLFeatures.ETW
+{
+#if NETCOREAPP
+	[IgnoreTestCase ("--exclude-feature is not supported on .NET Core")]
+#endif
+	[SetupLinkerArgument ("--exclude-feature", "etw")]
+	// Keep framework code that calls EventSource methods like OnEventCommand
+	[SetupLinkerCoreAction ("skip")]
+	public class BaseRemovedEventSourceNonVoidReturn
+	{
+		public static void Main ()
+		{
+			var b = CustomCtorEventSourceNonVoidReturn.Log.IsEnabled ();
+			if (b)
+				CustomCtorEventSourceNonVoidReturn.Log.SomeMethod ();
+		}
+	}
+
+	[Kept]
+	[KeptBaseType (typeof (EventSource))]
+	[KeptMember (".ctor()")]
+	[KeptMember (".cctor()")]
+	[EventSource (Name = "MyCompany")]
+	class CustomCtorEventSourceNonVoidReturn : EventSource
+	{
+		public class Keywords
+		{
+			public const EventKeywords Page = (EventKeywords) 1;
+
+			public int Unused;
+		}
+
+		[Kept]
+		public static CustomCtorEventSourceNonVoidReturn Log = new MyEventSourceBasedOnCustomCtorEventSourceNonVoidReturn (1);
+
+		[Kept]
+		[ExpectedInstructionSequence (new[] { "ldarg.0", "call", "ret", })]
+		public CustomCtorEventSourceNonVoidReturn (int value)
+		{
+			Removed ();
+		}
+
+		[Kept]
+		[ExpectedInstructionSequence (new[] { "ldstr", "newobj", "throw" })]
+		[ExpectLocalsModified]
+		[Event (8)]
+		public int SomeMethod ()
+		{
+			return Removed ();
+		}
+
+		public int Removed ()
+		{
+			return 0;
+		}
+	}
+
+	[Kept]
+	[KeptBaseType (typeof (CustomCtorEventSourceNonVoidReturn))]
+	class MyEventSourceBasedOnCustomCtorEventSourceNonVoidReturn : CustomCtorEventSourceNonVoidReturn
+	{
+		[Kept]
+		public MyEventSourceBasedOnCustomCtorEventSourceNonVoidReturn (int value) : base (value)
+		{
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/BCLFeatures/ETW/Excluded.cs
+++ b/test/Mono.Linker.Tests.Cases/BCLFeatures/ETW/Excluded.cs
@@ -43,9 +43,7 @@ namespace Mono.Linker.Tests.Cases.BCLFeatures.ETW
 		[Kept]
 		[ExpectedInstructionSequence (new[]
 		{
-			"ldstr",
-			"newobj",
-			"throw",
+			"ret",
 		})]
 		protected override void OnEventCommand (EventCommandEventArgs command)
 		{
@@ -59,9 +57,7 @@ namespace Mono.Linker.Tests.Cases.BCLFeatures.ETW
 		[Kept]
 		[ExpectedInstructionSequence (new[]
 		{
-			"ldstr",
-			"newobj",
-			"throw",
+			"ret",
 		})]
 		[Event (8)]
 		public void SomeMethod ()

--- a/test/Mono.Linker.Tests.Cases/BCLFeatures/ETW/NonEventWithLog.cs
+++ b/test/Mono.Linker.Tests.Cases/BCLFeatures/ETW/NonEventWithLog.cs
@@ -39,9 +39,7 @@ namespace Mono.Linker.Tests.Cases.BCLFeatures.ETW
 		[Kept]
 		[ExpectedInstructionSequence (new[]
 		{
-			"ldstr",
-			"newobj",
-			"throw",
+			"ret"
 		})]
 		private void Test2 ()
 		{

--- a/test/Mono.Linker.Tests.Cases/BCLFeatures/ETW/StubbedMethodWithExceptionHandlers.cs
+++ b/test/Mono.Linker.Tests.Cases/BCLFeatures/ETW/StubbedMethodWithExceptionHandlers.cs
@@ -43,9 +43,7 @@ namespace Mono.Linker.Tests.Cases.BCLFeatures.ETW
 		[Kept]
 		[ExpectedInstructionSequence (new[]
 		{
-			"ldstr",
-			"newobj",
-			"throw",
+			"ret"
 		})]
 		[ExpectedExceptionHandlerSequence (new string[0])]
 		protected override void OnEventCommand (EventCommandEventArgs command)
@@ -66,9 +64,7 @@ namespace Mono.Linker.Tests.Cases.BCLFeatures.ETW
 		[Kept]
 		[ExpectedInstructionSequence (new[]
 		{
-			"ldstr",
-			"newobj",
-			"throw",
+			"ret"
 		})]
 		[Event (8)]
 		public void SomeMethod ()


### PR DESCRIPTION
It is somewhat common for the ETW pattern to be incorrectly implemented.  For example the `IsEnabled` check can be inside of the method on the EventSource type.  When we replace the body with a throw this leads to
runtime exceptions.  Let's just clear the bodies of the methods on the EventSource type when the return type is void.  For non-void returning methods let's continue to add a throw since replacing the body with something like `return null` could result in unexpected errors later down the line.