### PR TITLE
Add test cases for complex type data flow tests

### DIFF
--- a/test/Mono.Linker.Tests.Cases/DataFlow/ComplexTypeHandling.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ComplexTypeHandling.cs
@@ -102,7 +102,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[Kept]
-		static void TestArrayGetTypeFromMethodParamHelper(ArrayGetTypeFromMethodParamElement[] p)
+		static void TestArrayGetTypeFromMethodParamHelper (ArrayGetTypeFromMethodParamElement[] p)
 		{
 			RequirePublicMethods (p.GetType ());
 		}
@@ -146,13 +146,13 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		class ArrayCreateInstanceByNameElement
 		{
 			[Kept] // This is a bug - the .ctor should not be marked - in fact in this case nothing should be marked as CreateInstance doesn't work on arrays
-			public ArrayCreateInstanceByNameElement()
+			public ArrayCreateInstanceByNameElement ()
 			{
 			}
 		}
 
 		[Kept]
-		static void TestArrayCreateInstanceByName()
+		static void TestArrayCreateInstanceByName ()
 		{
 			Activator.CreateInstance ("test", "Mono.Linker.Tests.Cases.DataFlow.ComplexTypeHandling+ArrayCreateInstanceByNameElement[]");
 		}
@@ -165,9 +165,9 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[Kept]
-		[KeptAttributeAttribute(typeof(RequiresPublicMethodAttribute))]
-		[RequiresPublicMethod(typeof(ArrayInAttributeParamElement[]))]
-		static void TestArrayInAttributeParameter()
+		[KeptAttributeAttribute (typeof (RequiresPublicMethodAttribute))]
+		[RequiresPublicMethod (typeof (ArrayInAttributeParamElement[]))]
+		static void TestArrayInAttributeParameter ()
 		{
 		}
 
@@ -181,11 +181,11 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[Kept]
-		[KeptBaseType(typeof(Attribute))]
+		[KeptBaseType (typeof (Attribute))]
 		class RequiresPublicMethodAttribute : Attribute
 		{
 			[Kept]
-			public RequiresPublicMethodAttribute(
+			public RequiresPublicMethodAttribute (
 				[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
 				[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
 				Type t)

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ComplexTypeHandling.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ComplexTypeHandling.cs
@@ -21,6 +21,11 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			TestArrayOnGeneric ();
 			TestGenericArray ();
 			TestGenericArrayOnGeneric ();
+			TestArrayGetTypeFromMethodParam ();
+			TestArrayGetTypeFromField ();
+			TestArrayTypeGetType ();
+			TestArrayCreateInstanceByName ();
+			TestArrayInAttributeParameter ();
 		}
 
 		[Kept]
@@ -50,14 +55,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		static void RequirePublicMethodsOnArrayOfGeneric<T> ()
 		{
 			RequirePublicMethods (typeof (T[]));
-		}
-
-		[Kept]
-		private static void RequirePublicMethods (
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
-			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
-			Type type)
-		{
 		}
 
 		[Kept]
@@ -95,6 +92,105 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		static void RequirePublicMethodsOnArrayOfGenericParameter<T> ()
 		{
 			_ = new RequirePublicMethodsGeneric<T[]> ();
+		}
+
+		[Kept]
+		sealed class ArrayGetTypeFromMethodParamElement
+		{
+			[Kept] // This is a bug - the method should not be marked, instead Array.* should be marked
+			public void PublicMethod () { }
+		}
+
+		[Kept]
+		static void TestArrayGetTypeFromMethodParamHelper(ArrayGetTypeFromMethodParamElement[] p)
+		{
+			RequirePublicMethods (p.GetType ());
+		}
+
+		[Kept]
+		static void TestArrayGetTypeFromMethodParam ()
+		{
+			TestArrayGetTypeFromMethodParamHelper (null);
+		}
+
+		[Kept]
+		sealed class ArrayGetTypeFromFieldElement
+		{
+			[Kept] // This is a bug - the method should not be marked, instead Array.* should be marked
+			public void PublicMethod () { }
+		}
+
+		[Kept]
+		static ArrayGetTypeFromFieldElement[] _arrayGetTypeFromField;
+
+		[Kept]
+		static void TestArrayGetTypeFromField ()
+		{
+			RequirePublicMethods (_arrayGetTypeFromField.GetType ());
+		}
+
+		[Kept]
+		sealed class ArrayTypeGetTypeElement
+		{
+			[Kept] // This is a bug - the method should not be marked, instead Array.* should be marked
+			public void PublicMethod () { }
+		}
+
+		[Kept]
+		static void TestArrayTypeGetType ()
+		{
+			RequirePublicMethods (Type.GetType ("Mono.Linker.Tests.Cases.DataFlow.ComplexTypeHandling+ArrayTypeGetTypeElement[]"));
+		}
+
+		[Kept]
+		class ArrayCreateInstanceByNameElement
+		{
+			[Kept] // This is a bug - the .ctor should not be marked - in fact in this case nothing should be marked as CreateInstance doesn't work on arrays
+			public ArrayCreateInstanceByNameElement()
+			{
+			}
+		}
+
+		[Kept]
+		static void TestArrayCreateInstanceByName()
+		{
+			Activator.CreateInstance ("test", "Mono.Linker.Tests.Cases.DataFlow.ComplexTypeHandling+ArrayCreateInstanceByNameElement[]");
+		}
+
+		[Kept]
+		class ArrayInAttributeParamElement
+		{
+			[Kept] // This is a bug - the method should not be marked, instead Array.* should be marked
+			public void PublicMethod () { }
+		}
+
+		[Kept]
+		[KeptAttributeAttribute(typeof(RequiresPublicMethodAttribute))]
+		[RequiresPublicMethod(typeof(ArrayInAttributeParamElement[]))]
+		static void TestArrayInAttributeParameter()
+		{
+		}
+
+
+		[Kept]
+		private static void RequirePublicMethods (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type type)
+		{
+		}
+
+		[Kept]
+		[KeptBaseType(typeof(Attribute))]
+		class RequiresPublicMethodAttribute : Attribute
+		{
+			[Kept]
+			public RequiresPublicMethodAttribute(
+				[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+				[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+				Type t)
+			{
+			}
 		}
 	}
 }


### PR DESCRIPTION
Mostly array resolution issue related to https://github.com/mono/linker/pull/1566

Note that all of these are disabled - even though I wrote them to pass since the other tests in this class crash the linker for now.