### PR TITLE
Make the MessageOrigin..ctor which takes a member reference public

### DIFF
--- a/src/linker/ref/Linker/MessageOrigin.cs
+++ b/src/linker/ref/Linker/MessageOrigin.cs
@@ -2,11 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Mono.Cecil;
+
 namespace Mono.Linker
 {
 	public readonly struct MessageOrigin
 	{
 		public MessageOrigin (string fileName, int sourceLine = 0, int sourceColumn = 0)
+		{
+		}
+
+		public MessageOrigin (IMemberDefinition memberDefinition, int? ilOffset = null)
 		{
 		}
 	}


### PR DESCRIPTION
This makes it much easier for custom steps to log messages pointing to code. Linker has the code to figure out source/line information from member reference and IL offset, opening this .ctor makes this code available to custom steps.