### PR TITLE
Exclude Mono.Cecil.Pdb from package dependencies

### DIFF
--- a/src/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/src/ILLink.Tasks/ILLink.Tasks.csproj
@@ -40,6 +40,7 @@
     <ProjectReference Include="../linker/Mono.Linker.csproj" PrivateAssets="All" Condition=" '$(TargetFramework)' == 'net5.0' " />
     <PackageReference Condition="'$(UseCecilPackage)' == 'true'" Include="Mono.Cecil" Version="$(MonoCecilVersion)" PrivateAssets="All" Publish="True" />
     <ProjectReference Condition="'$(UseCecilPackage)' != 'true'" Include="../../external/cecil/Mono.Cecil.csproj" PrivateAssets="All" />
+    <ProjectReference Condition="('$(UseCecilPackage)' != 'true') And ('$(TargetFramework)' != 'net472')" Include="../../external/cecil/symbols/pdb/Mono.Cecil.Pdb.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/linker/Mono.Linker.csproj
+++ b/src/linker/Mono.Linker.csproj
@@ -41,7 +41,7 @@
   <ItemGroup>
     <PackageReference Condition="'$(UseCecilPackage)' == 'true'" Include="Mono.Cecil" Version="$(MonoCecilVersion)" />
     <ProjectReference Condition="'$(UseCecilPackage)' != 'true'" Include="..\..\external\cecil\Mono.Cecil.csproj" />
-    <ProjectReference Condition="'$(UseCecilPackage)' != 'true'" Include="..\..\external\cecil\symbols\pdb\Mono.Cecil.Pdb.csproj" />
+    <ProjectReference Condition="'$(UseCecilPackage)' != 'true'" Include="..\..\external\cecil\symbols\pdb\Mono.Cecil.Pdb.csproj" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(MonoBuild)' != ''">

--- a/test/ILLink.Tasks.Tests/ILLink.Tasks.Tests.csproj
+++ b/test/ILLink.Tasks.Tests/ILLink.Tasks.Tests.csproj
@@ -14,6 +14,8 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\ILLink.Tasks\ILLink.Tasks.csproj" />
     <ProjectReference Include="..\..\src\linker\Mono.Linker.csproj" />
+    <ProjectReference Condition="'$(UseCecilPackage)' != 'true'" Include="../../external/cecil/Mono.Cecil.csproj" PrivateAssets="All" />
+    <ProjectReference Condition="('$(UseCecilPackage)' != 'true') And ('$(TargetFramework)' != 'net472')" Include="../../external/cecil/symbols/pdb/Mono.Cecil.Pdb.csproj" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The goal is to build a package which has the ref assembly in it and a package dependency on Mono.Cecil package (which acts like ref for Mono.Cecil and Mono.Cecil.Pdb).

NuGet automatically converts all ProjectReferences into package dependencies - to avoid that PrivateAssets=all must be added.

Fixes https://github.com/mono/linker/issues/1579