### PR TITLE
Try to resolve type from exported types

### DIFF
--- a/src/linker/Linker/DocumentationSignatureParser.cs
+++ b/src/linker/Linker/DocumentationSignatureParser.cs
@@ -500,7 +500,7 @@ namespace Mono.Linker
 			Debug.Assert (module != null);
 
 			if (declaringType == null) {
-				var type = module.GetType (name);
+				var type = module.GetType (name) ?? module.ExportedTypes?.FirstOrDefault (et => et.FullName == name)?.Resolve ();
 				if (type != null) {
 					results.Add (type);
 				}

--- a/src/linker/Linker/DocumentationSignatureParser.cs
+++ b/src/linker/Linker/DocumentationSignatureParser.cs
@@ -500,7 +500,7 @@ namespace Mono.Linker
 			Debug.Assert (module != null);
 
 			if (declaringType == null) {
-				var type = module.GetType (name) ?? module.ExportedTypes?.FirstOrDefault (et => et.FullName == name)?.Resolve ();
+				var type = module.ResolveType (name);
 				if (type != null) {
 					results.Add (type);
 				}

--- a/src/linker/Linker/ModuleDefinitionExtensions.cs
+++ b/src/linker/Linker/ModuleDefinitionExtensions.cs
@@ -10,5 +10,25 @@ namespace Mono.Linker
 			return (module.Attributes & ModuleAttributes.ILOnly) == 0 &&
 				(module.Attributes & ModuleAttributes.ILLibrary) != 0;
 		}
+
+		public static TypeDefinition ResolveType (this ModuleDefinition module, string typeFullName)
+		{
+			if (typeFullName == null)
+				return null;
+
+			var type = module.GetType (typeFullName);
+			if (type != null)
+				return type;
+
+			if (!module.HasExportedTypes)
+				return null;
+
+			int idx = typeFullName.LastIndexOf ('.');
+			(string typeNamespace, string typeName) = idx > 0 ? (typeFullName.Substring (0, idx), typeFullName.Substring (idx + 1)) :
+				(string.Empty, typeFullName);
+
+			TypeReference typeReference = new TypeReference (typeNamespace, typeName, module, module);
+			return typeReference.Resolve ();
+		}
 	}
 }

--- a/src/linker/Linker/ModuleDefinitionExtensions.cs
+++ b/src/linker/Linker/ModuleDefinitionExtensions.cs
@@ -23,6 +23,7 @@ namespace Mono.Linker
 			if (!module.HasExportedTypes)
 				return null;
 
+			// When resolving a forwarded type from a string, typeFullName should be a simple type name.
 			int idx = typeFullName.LastIndexOf ('.');
 			(string typeNamespace, string typeName) = idx > 0 ? (typeFullName.Substring (0, idx), typeFullName.Substring (idx + 1)) :
 				(string.Empty, typeFullName);

--- a/src/linker/Linker/TypeNameResolver.cs
+++ b/src/linker/Linker/TypeNameResolver.cs
@@ -88,8 +88,7 @@ namespace Mono.Linker
 				};
 			}
 
-			return assembly.MainModule.GetType (typeName.ToString ()) ??
-				assembly.MainModule.ExportedTypes?.FirstOrDefault (et => et.FullName == typeName.ToString ())?.Resolve ();
+			return assembly.MainModule.ResolveType (typeName.ToString ());
 		}
 	}
 }

--- a/src/linker/Linker/TypeNameResolver.cs
+++ b/src/linker/Linker/TypeNameResolver.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Reflection.Runtime.TypeParsing;
 using Mono.Cecil;
 
@@ -87,7 +88,8 @@ namespace Mono.Linker
 				};
 			}
 
-			return assembly.MainModule.GetType (typeName.ToString ());
+			return assembly.MainModule.GetType (typeName.ToString ()) ??
+				assembly.MainModule.ExportedTypes?.FirstOrDefault (et => et.FullName == typeName.ToString ())?.Resolve ();
 		}
 	}
 }

--- a/src/linker/Linker/TypeNameResolver.cs
+++ b/src/linker/Linker/TypeNameResolver.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Reflection.Runtime.TypeParsing;
 using Mono.Cecil;
 

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/Dependencies/FacadeAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/Dependencies/FacadeAssembly.cs
@@ -4,4 +4,5 @@
 
 using System.Runtime.CompilerServices;
 
-[assembly: TypeForwardedTo (typeof(Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies.ImplementationLibrary))]
+[assembly: TypeForwardedTo (typeof (Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies.ImplementationLibrary))]
+[assembly: TypeForwardedTo (typeof (Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies.ImplementationLibraryGenericType<,>))]

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/Dependencies/FacadeAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/Dependencies/FacadeAssembly.cs
@@ -1,0 +1,7 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: TypeForwardedTo (typeof(Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies.ImplementationLibrary))]

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/Dependencies/ImplementationLibrary.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/Dependencies/ImplementationLibrary.cs
@@ -6,6 +6,9 @@ namespace Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies
 {
 	public class ImplementationLibrary
 	{
+		public class NestedType
+		{
+		}
 	}
 
 	public class ImplementationLibraryGenericType<T, S>

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/Dependencies/ImplementationLibrary.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/Dependencies/ImplementationLibrary.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies
+{
+	public class ImplementationLibrary
+	{
+		public ImplementationLibrary()
+		{
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/Dependencies/ImplementationLibrary.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/Dependencies/ImplementationLibrary.cs
@@ -6,8 +6,9 @@ namespace Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies
 {
 	public class ImplementationLibrary
 	{
-		public ImplementationLibrary()
-		{
-		}
+	}
+
+	public class ImplementationLibraryGenericType<T, S>
+	{
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/Dependencies/ReferenceImplementationLibrary.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/Dependencies/ReferenceImplementationLibrary.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies
+{
+	[NotATestCase]
+	public class ReferenceImplementationLibrary
+	{
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyOnForwardedType.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyOnForwardedType.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.DynamicDependencies
+{
+	[LogDoesNotContain ("IL2036")]
+	class DynamicDependencyOnForwardedType
+	{
+		[DynamicDependency (".ctor", "System.Xml.Linq.XElement", "System.Xml.Linq")]
+		static void Main ()
+		{
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyOnForwardedType.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyOnForwardedType.cs
@@ -9,13 +9,18 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.DynamicDependencies
 {
+	[SetupCSharpCompilerToUse ("csc")]
+	[SetupCompileBefore ("FacadeAssembly.dll", new[] { "Dependencies/ReferenceImplementationLibrary.cs" })]
+	[SetupCompileAfter ("ImplementationLibrary.dll", new[] { "Dependencies/ImplementationLibrary.cs" })]
+	[SetupCompileAfter ("FacadeAssembly.dll", new[] { "Dependencies/FacadeAssembly.cs" }, new[] { "ImplementationLibrary.dll" })]
 	[LogDoesNotContain ("IL2036")]
-	class DynamicDependencyOnForwardedType
+	public class DynamicDependencyOnForwardedType
 	{
-		[DynamicDependency (".ctor", "System.Xml.Linq.XElement", "System.Xml.Linq")]
+		[DynamicDependency (".ctor", "Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies.ImplementationLibrary", "FacadeAssembly")]
 		static void Main ()
 		{
 		}

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyOnForwardedType.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyOnForwardedType.cs
@@ -21,6 +21,7 @@ namespace Mono.Linker.Tests.Cases.DynamicDependencies
 	public class DynamicDependencyOnForwardedType
 	{
 		[DynamicDependency (".ctor", "Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies.ImplementationLibrary", "FacadeAssembly")]
+		[DynamicDependency (".ctor", "Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies.ImplementationLibraryGenericType`2", "FacadeAssembly")]
 		static void Main ()
 		{
 		}

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyOnForwardedType.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyOnForwardedType.cs
@@ -22,6 +22,7 @@ namespace Mono.Linker.Tests.Cases.DynamicDependencies
 	{
 		[DynamicDependency (".ctor", "Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies.ImplementationLibrary", "FacadeAssembly")]
 		[DynamicDependency (".ctor", "Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies.ImplementationLibraryGenericType`2", "FacadeAssembly")]
+		[DynamicDependency (".ctor", "Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies.ImplementationLibrary.NestedType", "FacadeAssembly")]
 		static void Main ()
 		{
 		}

--- a/test/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/test/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -30,6 +30,7 @@
     <Compile Remove="CommandLine\Dependencies\CustomStepUser.cs" />
     <Compile Remove="Logging\Dependencies\LogStep.cs" />
     <Compile Remove="Extensibility\Dependencies\*.cs" />
+    <Compile Remove="DynamicDependencies\Dependencies\FacadeAssembly.cs" />
     <Compile Remove="Warnings\Dependencies\CustomStep.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The linker currently fails to resolve forwarded types that were passed as strings since these exist in a module's exported types, which we never look into.