### PR TITLE
[release/5.0] Unresolved attribute fixes

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -580,7 +580,13 @@ namespace Mono.Linker.Steps
 					if (UnconditionalSuppressMessageAttributeState.TypeRefHasUnconditionalSuppressions (ca.Constructor.DeclaringType))
 						_context.Suppressions.AddSuppression (ca, provider);
 
-					if (_context.Annotations.HasLinkerAttribute<RemoveAttributeInstancesAttribute> (ca.AttributeType.Resolve ()) && providerInLinkedAssembly)
+					var resolvedAttributeType = ca.AttributeType.Resolve ();
+					if (resolvedAttributeType == null) {
+						HandleUnresolvedType (ca.AttributeType);
+						continue;
+					}
+
+					if (_context.Annotations.HasLinkerAttribute<RemoveAttributeInstancesAttribute> (resolvedAttributeType) && providerInLinkedAssembly)
 						continue;
 
 					MarkCustomAttribute (ca, reason, sourceLocationMember);
@@ -845,19 +851,7 @@ namespace Mono.Linker.Steps
 			if (!provider.HasCustomAttributes)
 				return;
 
-			bool providerInLinkedAssembly = Annotations.GetAction (GetAssemblyFromCustomAttributeProvider (provider)) == AssemblyAction.Link;
-
 			foreach (CustomAttribute ca in provider.CustomAttributes) {
-				TypeDefinition type = ca.AttributeType.Resolve ();
-
-				if (type == null) {
-					HandleUnresolvedType (ca.AttributeType);
-					continue;
-				}
-
-				if (_context.Annotations.HasLinkerAttribute<RemoveAttributeInstancesAttribute> (type) && providerInLinkedAssembly)
-					continue;
-
 				_assemblyLevelAttributes.Enqueue (new AttributeProviderPair (ca, provider));
 			}
 		}
@@ -1193,6 +1187,9 @@ namespace Mono.Linker.Steps
 					HandleUnresolvedMethod (customAttribute.Constructor);
 					continue;
 				}
+
+				if (_context.Annotations.HasLinkerAttribute<RemoveAttributeInstancesAttribute> (resolved.DeclaringType) && Annotations.GetAction (GetAssemblyFromCustomAttributeProvider (assemblyLevelAttribute.Provider)) == AssemblyAction.Link)
+					continue;
 
 				if (!ShouldMarkTopLevelCustomAttribute (assemblyLevelAttribute, resolved)) {
 					skippedItems.Add (assemblyLevelAttribute);
@@ -1584,8 +1581,13 @@ namespace Mono.Linker.Steps
 
 			foreach (CustomAttribute attribute in type.CustomAttributes) {
 				var attrType = attribute.Constructor.DeclaringType;
+				var resolvedAttributeType = attrType.Resolve ();
+				if (resolvedAttributeType == null) {
+					HandleUnresolvedType (attrType);
+					continue;
+				}
 
-				if (_context.Annotations.HasLinkerAttribute<RemoveAttributeInstancesAttribute> (attrType.Resolve ()) && Annotations.GetAction (type.Module.Assembly) == AssemblyAction.Link)
+				if (_context.Annotations.HasLinkerAttribute<RemoveAttributeInstancesAttribute> (resolvedAttributeType) && Annotations.GetAction (type.Module.Assembly) == AssemblyAction.Link)
 					continue;
 
 				switch (attrType.Name) {


### PR DESCRIPTION
Backport of #1535

> When we fail to resolve a type we try and recreate it and keep the IL valid rather than fail.  We have a test that ensures an unresolved attribute on an AssemblyDefinition can be recreated.  It started failing with the sync up.   LazyMarkCustomAttributes should not skip any attributes.  This would give inconsistent behavior with references that only have attributes marked.  It was also problematic because LazyMarkCustomAttributes would call HandleUnresolvedType on the type where as ProcessLazyAttributes will call HandleUnresolvedMethod. A call to HandleUnresolvedMethod is necessary for us to recreate valid IL.

> I went ahead and added null checks to other places that were missing them.