### PR TITLE
Adding test case for RequiresUnreferencedCode on a method refered to only by reflection

### DIFF
--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
@@ -158,15 +158,15 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		{
 		}
 
-		[RequiresUnreferencedCode("Message for --RequiresUnreferencedCodeOnlyThroughReflection--")]
-		static void RequiresUnreferencedCodeOnlyThroughReflection()
+		[RequiresUnreferencedCode ("Message for --RequiresUnreferencedCodeOnlyThroughReflection--")]
+		static void RequiresUnreferencedCodeOnlyThroughReflection ()
 		{
 		}
 
 		// issue: https://github.com/mono/linker/issues/1607
 		// Linker currently doesn't report a warning in this case
 		// [ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeOnlyThroughReflection--")]
-		static void TestRequiresUnreferencedCodeOnlyThroughReflection()
+		static void TestRequiresUnreferencedCodeOnlyThroughReflection ()
 		{
 			typeof (RequiresUnreferencedCodeAttribute)
 				.GetMethod (nameof (RequiresUnreferencedCodeOnlyThroughReflection), System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic)

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
@@ -23,6 +23,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			TestRequiresOnPropertyGetterAndSetter ();
 			TestRequiresSuppressesWarningsFromReflectionAnalysis ();
 			TestDuplicateRequiresAttribute ();
+			TestRequiresUnreferencedCodeOnlyThroughReflection ();
 		}
 
 		[ExpectedWarning ("IL2026",
@@ -155,6 +156,21 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		[ExpectedWarning ("IL2027", "RequiresUnreferencedCodeAttribute", nameof (MethodWithDuplicateRequiresAttribute))]
 		static void MethodWithDuplicateRequiresAttribute ()
 		{
+		}
+
+		[RequiresUnreferencedCode("Message for --RequiresUnreferencedCodeOnlyThroughReflection--")]
+		static void RequiresUnreferencedCodeOnlyThroughReflection()
+		{
+		}
+
+		// issue: https://github.com/mono/linker/issues/1607
+		// Linker currently doesn't report a warning in this case
+		// [ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeOnlyThroughReflection--")]
+		static void TestRequiresUnreferencedCodeOnlyThroughReflection()
+		{
+			typeof (RequiresUnreferencedCodeAttribute)
+				.GetMethod (nameof (RequiresUnreferencedCodeOnlyThroughReflection), System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic)
+				.Invoke (null, new object[0]);
 		}
 	}
 }


### PR DESCRIPTION
Sample test for https://github.com/mono/linker/issues/1607 - test is disabled as it will fail currently.