### PR TITLE
Enable processing of dynamically referenced assemblies

### DIFF
--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -807,6 +807,7 @@ namespace Mono.Linker.Dataflow
 									// Intentionally ignore - it's not wrong for code to call Type.GetType on non-existing name, the code might expect null/exception back.
 									reflectionContext.RecordHandledPattern ();
 								} else {
+									_context.ProcessReferenceClosure (foundType.Module.Assembly);
 									reflectionContext.RecordRecognizedPattern (foundType, () => _markStep.MarkTypeVisibleToReflection (foundTypeRef, new DependencyInfo (DependencyKind.AccessedViaReflection, callingMethodDefinition), callingMethodDefinition));
 									methodReturnValue = MergePointValue.MergeValues (methodReturnValue, new SystemTypeValue (foundType));
 								}
@@ -1339,6 +1340,7 @@ namespace Mono.Linker.Dataflow
 								reflectionContext.RecordUnrecognizedPattern (2061, $"The assembly name '{assemblyNameStringValue.Contents}' passed to method '{calledMethod.GetDisplayName ()}' references assembly which is not available.");
 								continue;
 							}
+							_context.ProcessReferenceClosure (resolvedAssembly);
 
 							var typeRef = _context.TypeNameResolver.ResolveTypeName (resolvedAssembly, typeNameStringValue.Contents);
 							var resolvedType = typeRef?.Resolve ();
@@ -1579,6 +1581,7 @@ namespace Mono.Linker.Dataflow
 						// Intentionally ignore - it's not wrong for code to call Type.GetType on non-existing name, the code might expect null/exception back.
 						reflectionContext.RecordHandledPattern ();
 					} else {
+						_context.ProcessReferenceClosure (foundType.Module.Assembly);
 						MarkType (ref reflectionContext, typeRef);
 						MarkTypeForDynamicallyAccessedMembers (ref reflectionContext, foundType, requiredMemberTypes);
 					}

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -1335,14 +1335,17 @@ namespace Mono.Linker.Dataflow
 				if (assemblyNameValue is KnownStringValue assemblyNameStringValue) {
 					foreach (var typeNameValue in methodParams[methodParamsOffset + 1].UniqueValues ()) {
 						if (typeNameValue is KnownStringValue typeNameStringValue) {
-							var resolvedAssembly = _context.GetLoadedAssembly (assemblyNameStringValue.Contents);
+							AssemblyDefinition resolvedAssembly = null;
+							try {
+								resolvedAssembly = _context.Resolve (assemblyNameStringValue.Contents);
+							} catch (AssemblyResolutionException) { }
 							if (resolvedAssembly == null) {
 								reflectionContext.RecordUnrecognizedPattern (2061, $"The assembly name '{assemblyNameStringValue.Contents}' passed to method '{calledMethod.GetDisplayName ()}' references assembly which is not available.");
 								continue;
 							}
 							_context.ProcessReferenceClosure (resolvedAssembly);
 
-							var typeRef = _context.TypeNameResolver.ResolveTypeName (resolvedAssembly, typeNameStringValue.Contents);
+							var typeRef = _context.TypeNameResolver.ResolveTypeNameInAssembly (resolvedAssembly, typeNameStringValue.Contents);
 							var resolvedType = typeRef?.Resolve ();
 							if (resolvedType == null || typeRef is ArrayType) {
 								// It's not wrong to have a reference to non-existing type - the code may well expect to get an exception in this case

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -1335,10 +1335,7 @@ namespace Mono.Linker.Dataflow
 				if (assemblyNameValue is KnownStringValue assemblyNameStringValue) {
 					foreach (var typeNameValue in methodParams[methodParamsOffset + 1].UniqueValues ()) {
 						if (typeNameValue is KnownStringValue typeNameStringValue) {
-							AssemblyDefinition resolvedAssembly = null;
-							try {
-								resolvedAssembly = _context.Resolve (assemblyNameStringValue.Contents);
-							} catch (AssemblyResolutionException) { }
+							var resolvedAssembly = _context.TryResolve (assemblyNameStringValue.Contents);
 							if (resolvedAssembly == null) {
 								reflectionContext.RecordUnrecognizedPattern (2061, $"The assembly name '{assemblyNameStringValue.Contents}' passed to method '{calledMethod.GetDisplayName ()}' references assembly which is not available.");
 								continue;

--- a/src/linker/Linker.Steps/DynamicDependencyLookupStep.cs
+++ b/src/linker/Linker.Steps/DynamicDependencyLookupStep.cs
@@ -4,14 +4,13 @@
 
 using System;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using Mono.Cecil;
 
 #nullable enable
 
 namespace Mono.Linker.Steps
 {
-	public class DynamicDependencyLookupStep : LoadReferencesStep
+	public class DynamicDependencyLookupStep : BaseStep
 	{
 		protected override void ProcessAssembly (AssemblyDefinition assembly)
 		{
@@ -74,7 +73,7 @@ namespace Mono.Linker.Steps
 					var assembly = Context.Resolve (new AssemblyNameReference (assemblyName, new Version ()));
 					if (assembly == null)
 						continue;
-					ProcessReferences (assembly);
+					Context.ProcessReferenceClosure (assembly);
 				}
 			}
 
@@ -90,8 +89,7 @@ namespace Mono.Linker.Steps
 					Context.LogWarning ($"Unresolved assembly '{dynamicDependency.AssemblyName}' in 'DynamicDependencyAttribute'", 2035, member);
 					continue;
 				}
-
-				ProcessReferences (assembly);
+				Context.ProcessReferenceClosure (assembly);
 			}
 		}
 

--- a/src/linker/Linker.Steps/IAssemblyStep.cs
+++ b/src/linker/Linker.Steps/IAssemblyStep.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Mono.Cecil;
 using System.Collections.Generic;
+using Mono.Cecil;
 
 namespace Mono.Linker.Steps
 {

--- a/src/linker/Linker.Steps/IAssemblyStep.cs
+++ b/src/linker/Linker.Steps/IAssemblyStep.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Mono.Cecil;
+using System.Collections.Generic;
+
+namespace Mono.Linker.Steps
+{
+	public interface IAssemblyStep
+	{
+		void Initialize (LinkContext context);
+		void ProcessAssemblies (HashSet<AssemblyDefinition> assembly);
+	}
+}

--- a/src/linker/Linker.Steps/IAssemblyStep.cs
+++ b/src/linker/Linker.Steps/IAssemblyStep.cs
@@ -10,6 +10,6 @@ namespace Mono.Linker.Steps
 	public interface IAssemblyStep
 	{
 		void Initialize (LinkContext context);
-		void ProcessAssemblies (HashSet<AssemblyDefinition> assembly);
+		void ProcessAssemblies (HashSet<AssemblyDefinition> assemblies);
 	}
 }

--- a/src/linker/Linker.Steps/LinkAttributesStep.cs
+++ b/src/linker/Linker.Steps/LinkAttributesStep.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -173,6 +173,8 @@ namespace Mono.Linker.Steps
 				}
 
 				attributeType = Context.TypeNameResolver.ResolveTypeName (assembly, attributeFullName)?.Resolve ();
+				if (attributeType != null)
+					Context.ProcessReferenceClosure (attributeType.Module.Assembly);
 			}
 
 			if (attributeType == null) {
@@ -341,8 +343,7 @@ namespace Mono.Linker.Steps
 		{
 			var assembly = context.Resolve (assemblyName);
 			if (assembly != null)
-				ProcessReferences (assembly);
-
+				context.ProcessReferenceClosure (assembly);
 			return assembly;
 		}
 	}

--- a/src/linker/Linker.Steps/LinkAttributesStep.cs
+++ b/src/linker/Linker.Steps/LinkAttributesStep.cs
@@ -172,9 +172,7 @@ namespace Mono.Linker.Steps
 					return false;
 				}
 
-				attributeType = Context.TypeNameResolver.ResolveTypeName (assembly, attributeFullName)?.Resolve ();
-				if (attributeType != null)
-					Context.ProcessReferenceClosure (attributeType.Module.Assembly);
+				attributeType = Context.TypeNameResolver.ResolveTypeNameInAssembly (assembly, attributeFullName)?.Resolve ();
 			}
 
 			if (attributeType == null) {

--- a/src/linker/Linker.Steps/LoadReferencesStep.cs
+++ b/src/linker/Linker.Steps/LoadReferencesStep.cs
@@ -36,8 +36,6 @@ namespace Mono.Linker.Steps
 	{
 		LinkContext _context;
 
-		LinkContext Context => _context;
-
 		readonly HashSet<AssemblyNameDefinition> references = new HashSet<AssemblyNameDefinition> ();
 
 		readonly HashSet<AssemblyDefinition> newReferences = new HashSet<AssemblyDefinition> ();
@@ -68,9 +66,9 @@ namespace Mono.Linker.Steps
 
 			newReferences.Add (assembly);
 
-			Context.RegisterAssembly (assembly);
+			_context.RegisterAssembly (assembly);
 
-			foreach (AssemblyDefinition referenceDefinition in Context.ResolveReferences (assembly)) {
+			foreach (AssemblyDefinition referenceDefinition in _context.ResolveReferences (assembly)) {
 				try {
 					ProcessReferences (referenceDefinition);
 				} catch (Exception ex) {

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1675,9 +1675,9 @@ namespace Mono.Linker.Steps
 			TypeDefinition tdef = null;
 			switch (attribute.ConstructorArguments[0].Value) {
 			case string s:
-				tdef = _context.TypeNameResolver.ResolveTypeName (s)?.Resolve ();
-				if (tdef != null)
-					_context.ProcessReferenceClosure (tdef.Module.Assembly);
+				tdef = _context.TypeNameResolver.ResolveTypeName (s, out AssemblyDefinition foundAssembly)?.Resolve ();
+				if (foundAssembly != null)
+					_context.ProcessReferenceClosure (foundAssembly);
 				// ResolveTypeName might resolve an assembly (or multiple assemblies for generic arguments...)
 				break;
 			case TypeReference type:

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -636,11 +636,7 @@ namespace Mono.Linker.Steps
 			Debug.Assert (context is MethodDefinition || context is FieldDefinition);
 			AssemblyDefinition assembly;
 			if (dynamicDependency.AssemblyName != null) {
-				try {
-					assembly = _context.Resolve (dynamicDependency.AssemblyName);
-				} catch (AssemblyResolutionException) {
-					assembly = null;
-				}
+				assembly = _context.TryResolve (dynamicDependency.AssemblyName);
 				if (assembly == null) {
 					_context.LogWarning ($"Unresolved assembly '{dynamicDependency.AssemblyName}' in 'DynamicDependencyAttribute'", 2035, context);
 					return;
@@ -749,11 +745,7 @@ namespace Mono.Linker.Steps
 			AssemblyDefinition assembly;
 			var args = ca.ConstructorArguments;
 			if (args.Count >= 3 && args[2].Value is string assemblyName) {
-				try {
-					assembly = _context.Resolve (assemblyName);
-				} catch (AssemblyResolutionException) {
-					assembly = null;
-				}
+				assembly = _context.TryResolve (assemblyName);
 				if (assembly == null) {
 					_context.LogWarning (
 						$"Could not resolve dependency assembly '{assemblyName}' specified in a 'PreserveDependency' attribute", 2003, context.Resolve ());
@@ -1582,12 +1574,7 @@ namespace Mono.Linker.Steps
 					TypeName typeName = TypeParser.ParseTypeName (targetTypeName);
 					TypeDefinition typeDef;
 					if (typeName is AssemblyQualifiedTypeName assemblyQualifiedTypeName) {
-						AssemblyDefinition assembly;
-						try {
-							assembly = _context.Resolve (assemblyQualifiedTypeName.AssemblyName.Name);
-						} catch (AssemblyResolutionException) {
-							assembly = null;
-						}
+						AssemblyDefinition assembly = _context.TryResolve (assemblyQualifiedTypeName.AssemblyName.Name);
 						if (assembly != null)
 							_context.ProcessReferenceClosure (assembly);
 						typeDef = _context.TypeNameResolver.ResolveTypeNameInAssembly (assembly, assemblyQualifiedTypeName.TypeName)?.Resolve ();

--- a/src/linker/Linker.Steps/ProcessLinkerXmlStepBase.cs
+++ b/src/linker/Linker.Steps/ProcessLinkerXmlStepBase.cs
@@ -7,7 +7,7 @@ using Mono.Cecil;
 
 namespace Mono.Linker.Steps
 {
-	public abstract class ProcessLinkerXmlStepBase : LoadReferencesStep
+	public abstract class ProcessLinkerXmlStepBase : BaseStep
 	{
 		const string FullNameAttributeName = "fullname";
 		const string LinkerElementName = "linker";

--- a/src/linker/Linker.Steps/ResolveFromAssemblyStep.cs
+++ b/src/linker/Linker.Steps/ResolveFromAssemblyStep.cs
@@ -67,6 +67,7 @@ namespace Mono.Linker.Steps
 			Context.Resolver.IgnoreUnresolved = false;
 			AssemblyDefinition assembly = _assembly ?? Context.Resolve (_file);
 			Context.Resolver.IgnoreUnresolved = ignoreUnresolved;
+			Context.ProcessReferenceClosure (assembly);
 
 			if (_rootVisibility != RootVisibility.Any && HasInternalsVisibleTo (assembly))
 				_rootVisibility = RootVisibility.PublicAndFamilyAndAssembly;

--- a/src/linker/Linker.Steps/ResolveFromXmlStep.cs
+++ b/src/linker/Linker.Steps/ResolveFromXmlStep.cs
@@ -320,8 +320,7 @@ namespace Mono.Linker.Steps
 		{
 			var assembly = context.Resolve (assemblyName);
 			if (assembly != null)
-				ProcessReferences (assembly);
-
+				context.ProcessReferenceClosure (assembly);
 			return assembly;
 		}
 

--- a/src/linker/Linker.Steps/TypeMapStep.cs
+++ b/src/linker/Linker.Steps/TypeMapStep.cs
@@ -32,13 +32,22 @@ using Mono.Cecil;
 namespace Mono.Linker.Steps
 {
 
-	public class TypeMapStep : BaseStep
+	public class TypeMapStep : IAssemblyStep
 	{
+		LinkContext _context;
+		AnnotationStore Annotations => _context.Annotations;
 
-		protected override void ProcessAssembly (AssemblyDefinition assembly)
+		public void Initialize (LinkContext context)
 		{
-			foreach (TypeDefinition type in assembly.MainModule.Types)
-				MapType (type);
+			_context = context;
+		}
+
+		public void ProcessAssemblies (HashSet<AssemblyDefinition> assemblies)
+		{
+			foreach (var assembly in assemblies) {
+				foreach (TypeDefinition type in assembly.MainModule.Types)
+					MapType (type);
+			}
 		}
 
 		protected virtual void MapType (TypeDefinition type)

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -665,7 +665,7 @@ namespace Mono.Linker
 				p.AddStepAfter (typeof (MarkStep), new ReflectionBlockedStep ());
 
 #if !FEATURE_ILLINK
-			p.AddStepAfter (typeof (LoadReferencesStep), new LoadI18nAssemblies (assemblies));
+			p.AddStepBefore (typeof (BlacklistStep), new LoadI18nAssemblies (assemblies));
 
 			if (assemblies != I18nAssemblies.None)
 				p.AddStepAfter (typeof (DynamicDependencyLookupStep), new PreserveCalendarsStep (assemblies));

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -701,7 +701,6 @@ namespace Mono.Linker
 			// ResolveFromAssemblyStep [optional, possibly many]
 			// ResolveFromXmlStep [optional, possibly many]
 			// [mono only] ResolveFromXApiStep [optional, possibly many]
-			// LoadReferencesStep
 			// [mono only] LoadI18nAssemblies
 			// BlacklistStep
 			//   dynamically adds steps:
@@ -711,7 +710,6 @@ namespace Mono.Linker
 			// LinkAttributesStep [optional, possibly many]
 			// DynamicDependencyLookupStep
 			// [mono only] PreserveCalendarsStep [optional]
-			// TypeMapStep
 			// BodySubstituterStep [optional]
 			// RemoveSecurityStep [optional]
 			// [mono only] RemoveFeaturesStep [optional]
@@ -726,6 +724,12 @@ namespace Mono.Linker
 			// RegenerateGuidStep [optional]
 			// SealerStep
 			// OutputStep
+
+			//
+			// Pipeline Steps which run when new assemblies are processed
+			//
+			// LoadReferencesStep
+			// TypeMapStep
 			//
 
 			foreach (string custom_step in custom_steps) {
@@ -1202,10 +1206,8 @@ namespace Mono.Linker
 		static Pipeline GetStandardPipeline ()
 		{
 			Pipeline p = new Pipeline ();
-			p.AppendStep (new LoadReferencesStep ());
 			p.AppendStep (new BlacklistStep ());
 			p.AppendStep (new DynamicDependencyLookupStep ());
-			p.AppendStep (new TypeMapStep ());
 			p.AppendStep (new MarkStep ());
 			p.AppendStep (new ValidateVirtualMethodAnnotationsStep ());
 			p.AppendStep (new ProcessWarningsStep ());
@@ -1214,6 +1216,8 @@ namespace Mono.Linker
 			p.AppendStep (new CleanStep ());
 			p.AppendStep (new RegenerateGuidStep ());
 			p.AppendStep (new OutputStep ());
+			p.AppendAssemblyStep (new LoadReferencesStep ());
+			p.AppendAssemblyStep (new TypeMapStep ());
 			return p;
 		}
 

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -326,6 +326,15 @@ namespace Mono.Linker
 			return Resolve (new AssemblyNameReference (name, new Version ()));
 		}
 
+		public AssemblyDefinition TryResolve (string name)
+		{
+			try {
+				return Resolve (name);
+			} catch (AssemblyResolutionException) {
+				return null;
+			}
+		}
+
 		public AssemblyDefinition Resolve (IMetadataScope scope)
 		{
 			AssemblyNameReference reference = GetReference (scope);

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -304,6 +304,15 @@ namespace Mono.Linker
 			return assembly.MainModule.GetType (fullName);
 		}
 
+		// Run the per-assembly logic on a new assembly.
+		// Each step may modify the context of assemblies passed to the next.
+		public void ProcessReferenceClosure (AssemblyDefinition assembly)
+		{
+			var assemblies = new HashSet<AssemblyDefinition> { assembly };
+			foreach (var step in Pipeline.GetAssemblySteps ())
+				step.ProcessAssemblies (assemblies);
+		}
+
 		public AssemblyDefinition Resolve (string name)
 		{
 			if (File.Exists (name)) {

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -309,7 +309,7 @@ namespace Mono.Linker
 		public void ProcessReferenceClosure (AssemblyDefinition assembly)
 		{
 			var assemblies = new HashSet<AssemblyDefinition> { assembly };
-			foreach (var step in Pipeline.GetAssemblySteps ())
+			foreach (var step in Pipeline.AssemblySteps)
 				step.ProcessAssemblies (assemblies);
 		}
 

--- a/src/linker/Linker/Pipeline.cs
+++ b/src/linker/Linker/Pipeline.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Pipeline.cs
 //
 // Author:
@@ -39,6 +39,8 @@ namespace Mono.Linker
 
 		readonly List<IStep> _steps;
 		readonly List<IAssemblyStep> _assemblySteps;
+
+		public IEnumerable<IAssemblyStep> AssemblySteps => _assemblySteps;
 
 		public Pipeline ()
 		{
@@ -148,11 +150,6 @@ namespace Mono.Linker
 		public IStep[] GetSteps ()
 		{
 			return _steps.ToArray ();
-		}
-
-		public IAssemblyStep[] GetAssemblySteps ()
-		{
-			return _assemblySteps.ToArray ();
 		}
 
 		public bool ContainsStep (Type type)

--- a/src/linker/Linker/Pipeline.cs
+++ b/src/linker/Linker/Pipeline.cs
@@ -38,10 +38,12 @@ namespace Mono.Linker
 	{
 
 		readonly List<IStep> _steps;
+		readonly List<IAssemblyStep> _assemblySteps;
 
 		public Pipeline ()
 		{
 			_steps = new List<IStep> ();
+			_assemblySteps = new List<IAssemblyStep> ();
 		}
 
 		public void PrependStep (IStep step)
@@ -52,6 +54,11 @@ namespace Mono.Linker
 		public void AppendStep (IStep step)
 		{
 			_steps.Add (step);
+		}
+
+		public void AppendAssemblyStep (IAssemblyStep step)
+		{
+			_assemblySteps.Add (step);
 		}
 
 		public void AddStepBefore (Type target, IStep step)
@@ -123,6 +130,9 @@ namespace Mono.Linker
 
 		public void Process (LinkContext context)
 		{
+			foreach (var step in _assemblySteps)
+				step.Initialize (context);
+
 			while (_steps.Count > 0) {
 				IStep step = _steps[0];
 				ProcessStep (context, step);
@@ -138,6 +148,11 @@ namespace Mono.Linker
 		public IStep[] GetSteps ()
 		{
 			return _steps.ToArray ();
+		}
+
+		public IAssemblyStep[] GetAssemblySteps ()
+		{
+			return _assemblySteps.ToArray ();
 		}
 
 		public bool ContainsStep (Type type)

--- a/src/linker/Linker/TypeNameResolver.cs
+++ b/src/linker/Linker/TypeNameResolver.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection.Runtime.TypeParsing;
 using Mono.Cecil;
 
@@ -49,7 +49,7 @@ namespace Mono.Linker
 		{
 			if (typeName is AssemblyQualifiedTypeName assemblyQualifiedTypeName) {
 				// In this case we ignore the assembly parameter since the type name has assembly in it
-				var assemblyFromName = _context.GetLoadedAssembly (assemblyQualifiedTypeName.AssemblyName.Name);
+				var assemblyFromName = _context.Resolve (assemblyQualifiedTypeName.AssemblyName.Name);
 				return ResolveTypeName (assemblyFromName, assemblyQualifiedTypeName.TypeName);
 			}
 

--- a/src/linker/Linker/TypeNameResolver.cs
+++ b/src/linker/Linker/TypeNameResolver.cs
@@ -98,12 +98,9 @@ namespace Mono.Linker
 			if (typeName is AssemblyQualifiedTypeName assemblyQualifiedTypeName) {
 				// In this case we ignore the assembly parameter since the type name has assembly in it
 				// Resolving a type name should never throw.
-				AssemblyDefinition assemblyFromName;
-				try {
-					assemblyFromName = _context.Resolve (assemblyQualifiedTypeName.AssemblyName.Name);
-				} catch (AssemblyResolutionException) {
+				AssemblyDefinition assemblyFromName = _context.TryResolve (assemblyQualifiedTypeName.AssemblyName.Name);
+				if (assemblyFromName == null)
 					return null;
-				}
 				return ResolveTypeName (assemblyFromName, assemblyQualifiedTypeName.TypeName);
 			}
 

--- a/test/Mono.Linker.Tests.Cases/Attributes/CoreLibraryAssemblyAttributesAreKept.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes/CoreLibraryAssemblyAttributesAreKept.cs
@@ -7,6 +7,9 @@ namespace Mono.Linker.Tests.Cases.Attributes
 {
 	[Reference ("System.dll")]
 	[SetupLinkerCoreAction ("link")]
+	// IComponent has TypeConverterAttribute referencing System.dll, which has
+	// unresolved references to Win32 assemblies.
+	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[KeptAttributeInAssembly (PlatformAssemblies.CoreLib, typeof (AssemblyDescriptionAttribute))]
 	[KeptAttributeInAssembly (PlatformAssemblies.CoreLib, typeof (AssemblyCompanyAttribute))]
 #if !NETCOREAPP

--- a/test/Mono.Linker.Tests.Cases/CoreLink/CopyOfCoreLibrariesKeepsUnusedTypes.cs
+++ b/test/Mono.Linker.Tests.Cases/CoreLink/CopyOfCoreLibrariesKeepsUnusedTypes.cs
@@ -5,6 +5,9 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.CoreLink
 {
 	[SetupLinkerCoreAction ("copy")]
+	// Color has TypeConverterAttribute referencing System.Drawing.dll, which has
+	// unresolved reference to System.Drawing.Common.
+	[SetupLinkerArgument ("--skip-unresolved")]
 
 	[KeptAssembly (PlatformAssemblies.CoreLib)]
 	[KeptAllTypesAndMembersInAssembly (PlatformAssemblies.CoreLib)]

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ApplyTypeAnnotations.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ApplyTypeAnnotations.cs
@@ -203,11 +203,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[Kept]
-		// This is a workaround for the inability to lazy load assemblies. The type name resolver will not load new assemblies
-		// and since the KeptAttribute is otherwise not referenced by the test anywhere (the test-validation attributes are removed before processing normally)
-		// it would not resolve from name - since its assembly is not loaded.
-		// Adding DynamicDependency solves this problem as it is basically the only attribute which has the ability to load new assemblies.
-		[DynamicDependency (DynamicallyAccessedMemberTypes.None, typeof (KeptAttribute))]
 		static void TestFromStringConstantWithGenericAndAssemblyQualified ()
 		{
 			RequireCombinationOnString ("Mono.Linker.Tests.Cases.DataFlow.ApplyTypeAnnotations+FromStringConstantWithGenericAndAssemblyQualified`1[[Mono.Linker.Tests.Cases.Expectations.Assertions.KeptAttribute,Mono.Linker.Tests.Cases.Expectations]]");

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/Dependencies/AssemblyDependency.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/Dependencies/AssemblyDependency.cs
@@ -1,0 +1,17 @@
+﻿namespace Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies
+{
+	public class AssemblyDependency
+	{
+		public AssemblyDependency ()
+		{
+		}
+
+		public static void UsedToKeepReferenceAtCompileTime ()
+		{
+		}
+
+		class TypeThatIsUsedViaReflection
+		{
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/Dependencies/AssemblyDependencyWithMultipleReferences.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/Dependencies/AssemblyDependencyWithMultipleReferences.cs
@@ -1,6 +1,6 @@
 ﻿namespace Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies
 {
-	public class AssemblyDependencyWithReference : AssemblyDependency
+	public class AssemblyDependencyWithMultipleReferences : AssemblyDependency
 	{
 	}
 

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/Dependencies/AssemblyDependencyWithReference.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/Dependencies/AssemblyDependencyWithReference.cs
@@ -1,4 +1,4 @@
-﻿namespace Mono.Linker.Tests.Cases.Reflection.Dependencies
+﻿namespace Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies
 {
 	public class AssemblyDependencyWithReference : AssemblyDependency
 	{

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/Dependencies/DynamicDependencyMethodInNonReferencedAssemblyChainedLibrary.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/Dependencies/DynamicDependencyMethodInNonReferencedAssemblyChainedLibrary.cs
@@ -11,7 +11,7 @@ namespace Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies
 			return "Dependency";
 		}
 
-		[DynamicDependency (".ctor()", "Mono.Linker.Tests.Cases.Advanced.Dependencies.DynamicDependencyMethodInNonReferencedAssemblyBase2", "base2")]
+		[DynamicDependency ("#ctor()", "Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies.DynamicDependencyMethodInNonReferencedAssemblyBase2", "base2")]
 		public static void Dependency ()
 		{
 		}

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/Dependencies/UnusedAssemblyDependency.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/Dependencies/UnusedAssemblyDependency.cs
@@ -1,0 +1,13 @@
+﻿namespace Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies
+{
+	public class UnusedAssemblyDependency
+	{
+		public UnusedAssemblyDependency ()
+		{
+		}
+
+		public static void UsedToKeepReferenceAtCompileTime ()
+		{
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMethodInNonReferencedAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMethodInNonReferencedAssembly.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMethodInNonReferencedAssemblyChained.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMethodInNonReferencedAssemblyChained.cs
@@ -1,12 +1,10 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.DynamicDependencies
 {
-	[IgnoreTestCase ("Currently failing")]
 	[SetupCompileBefore ("base.dll", new[] { "Dependencies/DynamicDependencyMethodInNonReferencedAssemblyBase.cs" })]
 	[SetupCompileBefore ("base2.dll", new[] { "Dependencies/DynamicDependencyMethodInNonReferencedAssemblyBase2.cs" }, references: new[] { "base.dll" }, addAsReference: false)]
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/DynamicDependencyMethodInNonReferencedAssemblyChainedLibrary.cs" }, references: new[] { "base.dll" }, addAsReference: false)]
@@ -26,7 +24,7 @@ namespace Mono.Linker.Tests.Cases.DynamicDependencies
 		}
 
 		[Kept]
-		[DynamicDependency (".ctor()", "Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies.DynamicDependencyMethodInNonReferencedAssemblyChainedLibrary", "library")]
+		[DynamicDependency ("#ctor()", "Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies.DynamicDependencyMethodInNonReferencedAssemblyChainedLibrary", "library")]
 		static void Dependency ()
 		{
 		}

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMethodInNonReferencedAssemblyChainedReference.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMethodInNonReferencedAssemblyChainedReference.cs
@@ -1,12 +1,10 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.DynamicDependencies
 {
-	[IgnoreTestCase ("Currently failing")]
 	[SetupCompileBefore ("base.dll", new[] { "Dependencies/DynamicDependencyMethodInNonReferencedAssemblyBase.cs" })]
 	[SetupCompileBefore ("base2.dll", new[] { "Dependencies/DynamicDependencyMethodInNonReferencedAssemblyBase2.cs" }, references: new[] { "base.dll" }, addAsReference: false)]
 	[SetupCompileBefore ("reference.dll", new[] { "Dependencies/DynamicDependencyMethodInNonReferencedAssemblyChainedLibrary.cs" }, references: new[] { "base.dll" }, addAsReference: false)]
@@ -29,7 +27,7 @@ namespace Mono.Linker.Tests.Cases.DynamicDependencies
 		}
 
 		[Kept]
-		[DynamicDependency (".ctor()", "Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies.DynamicDependencyMethodInNonReferencedAssemblyChainedReferenceLibrary", "library")]
+		[DynamicDependency ("#ctor()", "Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies.DynamicDependencyMethodInNonReferencedAssemblyChainedReferenceLibrary", "library")]
 		static void Dependency ()
 		{
 		}

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMethodInNonReferencedAssemblyWithSweptReferences.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMethodInNonReferencedAssemblyWithSweptReferences.cs
@@ -1,7 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
+using Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
-using Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.DynamicDependencies
 {
@@ -26,7 +26,7 @@ namespace Mono.Linker.Tests.Cases.DynamicDependencies
 
 		static void ReferenceUnusedAssemblyDependency ()
 		{
-			UnusedAssemblyDependency.UsedToKeepReferenceAtCompileTime();
+			UnusedAssemblyDependency.UsedToKeepReferenceAtCompileTime ();
 		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMethodInNonReferencedAssemblyWithSweptReferences.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMethodInNonReferencedAssemblyWithSweptReferences.cs
@@ -8,7 +8,7 @@ namespace Mono.Linker.Tests.Cases.DynamicDependencies
 	[SetupCSharpCompilerToUse ("csc")]
 	[SetupCompileBefore ("unusedreference.dll", new[] { "Dependencies/UnusedAssemblyDependency.cs" })]
 	[SetupCompileBefore ("reference.dll", new[] { "Dependencies/AssemblyDependency.cs" }, addAsReference: false)]
-	[SetupCompileBefore ("library.dll", new[] { "Dependencies/AssemblyDependencyWithReference.cs" }, new[] { "reference.dll", "unusedreference.dll" }, addAsReference: false)]
+	[SetupCompileBefore ("library.dll", new[] { "Dependencies/AssemblyDependencyWithMultipleReferences.cs" }, new[] { "reference.dll", "unusedreference.dll" }, addAsReference: false)]
 	// TODO: keep library even if type is not found in it
 	// [KeptAssembly ("library")]
 	public class DynamicDependencyMethodInNonReferencedAssemblyWithSweptReferences

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMethodInNonReferencedAssemblyWithSweptReferences.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMethodInNonReferencedAssemblyWithSweptReferences.cs
@@ -1,0 +1,32 @@
+using System.Diagnostics.CodeAnalysis;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.DynamicDependencies
+{
+	[SetupCSharpCompilerToUse ("csc")]
+	[SetupCompileBefore ("unusedreference.dll", new[] { "Dependencies/UnusedAssemblyDependency.cs" })]
+	[SetupCompileBefore ("reference.dll", new[] { "Dependencies/AssemblyDependency.cs" }, addAsReference: false)]
+	[SetupCompileBefore ("library.dll", new[] { "Dependencies/AssemblyDependencyWithReference.cs" }, new[] { "reference.dll", "unusedreference.dll" }, addAsReference: false)]
+	// TODO: keep library even if type is not found in it
+	// [KeptAssembly ("library")]
+	public class DynamicDependencyMethodInNonReferencedAssemblyWithSweptReferences
+	{
+		public static void Main ()
+		{
+			DynamicDependencyOnNonExistingTypeInAssembly ();
+		}
+
+		[Kept]
+		[DynamicDependency ("#ctor()", "DoesntExist", "library")]
+		static void DynamicDependencyOnNonExistingTypeInAssembly ()
+		{
+		}
+
+		static void ReferenceUnusedAssemblyDependency ()
+		{
+			UnusedAssemblyDependency.UsedToKeepReferenceAtCompileTime();
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.VirtualMethods/VirtualMethodGetsPreservedIfBaseMethodGetsInvoked.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.VirtualMethods/VirtualMethodGetsPreservedIfBaseMethodGetsInvoked.cs
@@ -2,7 +2,7 @@
 
 namespace Mono.Linker.Tests.Cases.Inheritance.VirtualMethods
 {
-	class VirtualMethodGetsPerservedIfBaseMethodGetsInvoked
+	class VirtualMethodGetsPreservedIfBaseMethodGetsInvoked
 	{
 		public static void Main ()
 		{

--- a/test/Mono.Linker.Tests.Cases/PreserveDependencies/Dependencies/PreserveDependencyMethodInNonReferencedAssemblyChainedLibrary.cs
+++ b/test/Mono.Linker.Tests.Cases/PreserveDependencies/Dependencies/PreserveDependencyMethodInNonReferencedAssemblyChainedLibrary.cs
@@ -10,7 +10,7 @@ namespace Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies
 			return "Dependency";
 		}
 
-		[PreserveDependency (".ctor()", "Mono.Linker.Tests.Cases.Advanced.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyBase2", "base2")]
+		[PreserveDependency (".ctor()", "Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyBase2", "base2")]
 		public static void Dependency ()
 		{
 		}

--- a/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyErrorCases.cs
+++ b/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyErrorCases.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethodInNonReferencedAssemblyChained.cs
+++ b/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethodInNonReferencedAssemblyChained.cs
@@ -5,11 +5,10 @@ using Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.PreserveDependencies
 {
-	[IgnoreTestCase ("Currently failing")]
 	[SetupCompileBefore ("FakeSystemAssembly.dll", new[] { "Dependencies/PreserveDependencyAttribute.cs" })]
 	[SetupCompileBefore ("base.dll", new[] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyBase.cs" })]
 	[SetupCompileBefore ("base2.dll", new[] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyBase2.cs" }, references: new[] { "base.dll" }, addAsReference: false)]
-	[SetupCompileBefore ("library.dll", new[] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyChainedLibrary.cs" }, references: new[] { "base.dll" }, addAsReference: false)]
+	[SetupCompileBefore ("library.dll", new[] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyChainedLibrary.cs" }, references: new[] { "base.dll", "FakeSystemAssembly.dll" }, addAsReference: false)]
 	[KeptAssembly ("base.dll")]
 	[KeptAssembly ("base2.dll")]
 	[KeptAssembly ("library.dll")]

--- a/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethodInNonReferencedAssemblyChainedReference.cs
+++ b/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethodInNonReferencedAssemblyChainedReference.cs
@@ -5,11 +5,10 @@ using Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.PreserveDependencies
 {
-	[IgnoreTestCase ("Currently failing")]
 	[SetupCompileBefore ("FakeSystemAssembly.dll", new[] { "Dependencies/PreserveDependencyAttribute.cs" })]
 	[SetupCompileBefore ("base.dll", new[] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyBase.cs" })]
 	[SetupCompileBefore ("base2.dll", new[] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyBase2.cs" }, references: new[] { "base.dll" }, addAsReference: false)]
-	[SetupCompileBefore ("reference.dll", new[] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyChainedLibrary.cs" }, references: new[] { "base.dll" }, addAsReference: false)]
+	[SetupCompileBefore ("reference.dll", new[] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyChainedLibrary.cs" }, references: new[] { "base.dll", "FakeSystemAssembly.dll" }, addAsReference: false)]
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyChainedReferenceLibrary.cs" }, references: new[] { "base.dll", "reference.dll" }, addAsReference: false)]
 	[KeptAssembly ("base.dll")]
 	[KeptAssembly ("base2.dll")]

--- a/test/Mono.Linker.Tests.Cases/Reflection/ActivatorCreateInstance.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ActivatorCreateInstance.cs
@@ -272,6 +272,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			WithNonExistingAssemblyName ();
 			WithAssemblyAndUnknownTypeName ();
 			WithAssemblyAndNonExistingTypeName ();
+			WithAssemblyAndAssemblyQualifiedTypeName ();
 		}
 
 		[Kept]
@@ -306,6 +307,18 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		private static void WithAssemblyAndNonExistingTypeName ()
 		{
 			Activator.CreateInstance ("test", "NonExistingType", new object[] { });
+		}
+
+		class WithAssemblyQualifiedTypeName
+		{
+		}
+
+		[Kept]
+		[RecognizedReflectionAccessPattern]
+		private static void WithAssemblyAndAssemblyQualifiedTypeName ()
+		{
+			// CreateInstance with assembly and assembly-qualified type name will throw.
+			Activator.CreateInstance ("test", "Mono.Linker.Tests.Cases.Reflection.ActivatorCreateInstance+WithAssemblyQualifiedTypeName, test");
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/Reflection/AssemblyImportedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/AssemblyImportedViaReflection.cs
@@ -5,7 +5,6 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Reflection
 {
-	[IgnoreTestCase ("Requires support for using a type in an unreferences assembly via reflection")]
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/AssemblyDependency.cs" }, addAsReference: false)]
 	[KeptAssembly ("library.dll")]
 	[KeptTypeInAssembly ("library.dll", "Mono.Linker.Tests.Cases.Reflection.Dependencies.AssemblyDependency")]

--- a/test/Mono.Linker.Tests.Cases/Reflection/AssemblyImportedViaReflectionWithDerivedType.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/AssemblyImportedViaReflectionWithDerivedType.cs
@@ -5,7 +5,6 @@ using Mono.Linker.Tests.Cases.Reflection.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Reflection
 {
-	[IgnoreTestCase ("Requires support for using a type in an unreferences assembly via reflection")]
 	[SetupCompileBefore ("base.dll", new[] { "Dependencies/AssemblyImportedViaReflectionWithDerivedType_Base.cs" })]
 	[SetupCompileBefore ("reflection.dll", new[] { "Dependencies/AssemblyImportedViaReflectionWithDerivedType_Reflect.cs" }, references: new[] { "base.dll" }, addAsReference: false)]
 	[KeptAssembly ("base.dll")]

--- a/test/Mono.Linker.Tests.Cases/Reflection/AssemblyImportedViaReflectionWithReference.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/AssemblyImportedViaReflectionWithReference.cs
@@ -4,7 +4,6 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Reflection
 {
-	[IgnoreTestCase ("Requires support for using a type in an unreferences assembly via reflection")]
 	[SetupCompileBefore ("reference.dll", new[] { "Dependencies/AssemblyDependency.cs" }, addAsReference: false)]
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/AssemblyDependencyWithReference.cs" }, references: new[] { "reference.dll" }, addAsReference: false)]
 	[KeptAssembly ("reference.dll")]

--- a/test/Mono.Linker.Tests.Cases/Reflection/AssemblyImportedViaReflectionWithSweptReferences.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/AssemblyImportedViaReflectionWithSweptReferences.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Reflection.Dependencies;
@@ -8,7 +8,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 	[SetupCSharpCompilerToUse ("csc")]
 	[SetupCompileBefore ("unusedreference.dll", new[] { "Dependencies/UnusedAssemblyDependency.cs" })]
 	[SetupCompileBefore ("reference.dll", new[] { "Dependencies/AssemblyDependency.cs" }, addAsReference: false)]
-	[SetupCompileBefore ("library.dll", new[] { "Dependencies/AssemblyDependencyWithReference.cs" }, new[] { "reference.dll", "unusedreference.dll" }, addAsReference: false)]
+	[SetupCompileBefore ("library.dll", new[] { "Dependencies/AssemblyDependencyWithMultipleReferences.cs" }, new[] { "reference.dll", "unusedreference.dll" }, addAsReference: false)]
 	// TODO: keep library even if type is not found in it
 	// [KeptAssembly ("library")]
 	public class AssemblyImportedViaReflectionWithSweptReferences

--- a/test/Mono.Linker.Tests.Cases/Reflection/AssemblyImportedViaReflectionWithSweptReferences.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/AssemblyImportedViaReflectionWithSweptReferences.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Reflection.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.Reflection
+{
+	[SetupCSharpCompilerToUse ("csc")]
+	[SetupCompileBefore ("unusedreference.dll", new[] { "Dependencies/UnusedAssemblyDependency.cs" })]
+	[SetupCompileBefore ("reference.dll", new[] { "Dependencies/AssemblyDependency.cs" }, addAsReference: false)]
+	[SetupCompileBefore ("library.dll", new[] { "Dependencies/AssemblyDependencyWithReference.cs" }, new[] { "reference.dll", "unusedreference.dll" }, addAsReference: false)]
+	// TODO: keep library even if type is not found in it
+	// [KeptAssembly ("library")]
+	public class AssemblyImportedViaReflectionWithSweptReferences
+	{
+		public static void Main ()
+		{
+			AccessNonExistingTypeInAssembly ();
+		}
+
+		[Kept]
+		[RecognizedReflectionAccessPattern]
+
+		static void AccessNonExistingTypeInAssembly ()
+		{
+			// Import the library without marking it.
+			var typeName = "DoesntExist, library";
+			var typeKept = Type.GetType (typeName, false);
+		}
+
+		static void ReferenceUnusedAssemblyDependency ()
+		{
+			UnusedAssemblyDependency.UsedToKeepReferenceAtCompileTime();
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Reflection/AssemblyImportedViaReflectionWithSweptReferences.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/AssemblyImportedViaReflectionWithSweptReferences.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Reflection.Dependencies;
@@ -30,7 +30,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
 		static void ReferenceUnusedAssemblyDependency ()
 		{
-			UnusedAssemblyDependency.UsedToKeepReferenceAtCompileTime();
+			UnusedAssemblyDependency.UsedToKeepReferenceAtCompileTime ();
 		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/Reflection/Dependencies/AssemblyDependencyWithMultipleReferences.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/Dependencies/AssemblyDependencyWithMultipleReferences.cs
@@ -1,0 +1,10 @@
+﻿namespace Mono.Linker.Tests.Cases.Reflection.Dependencies
+{
+	public class AssemblyDependencyWithMultipleReferences : AssemblyDependency
+	{
+	}
+
+	public class UsedToReferenceUnusedAssembly : UnusedAssemblyDependency
+	{
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Reflection/Dependencies/AssemblyDependencyWithReference.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/Dependencies/AssemblyDependencyWithReference.cs
@@ -3,8 +3,4 @@
 	public class AssemblyDependencyWithReference : AssemblyDependency
 	{
 	}
-
-	public class UsedToReferenceUnusedAssembly : UnusedAssemblyDependency
-	{
-	}
 }

--- a/test/Mono.Linker.Tests.Cases/Reflection/Dependencies/UnusedAssemblyDependency.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/Dependencies/UnusedAssemblyDependency.cs
@@ -1,16 +1,12 @@
 ﻿namespace Mono.Linker.Tests.Cases.Reflection.Dependencies
 {
-	public class AssemblyDependency
+	public class UnusedAssemblyDependency
 	{
-		public AssemblyDependency ()
+		public UnusedAssemblyDependency ()
 		{
 		}
 
 		public static void UsedToKeepReferenceAtCompileTime ()
-		{
-		}
-
-		class TypeThatIsUsedViaReflection
 		{
 		}
 	}

--- a/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflectionAssemblyDoesntExist.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflectionAssemblyDoesntExist.cs
@@ -6,7 +6,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 	{
 		public static void Main ()
 		{
-			var typeName = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflectionAssemblyDoesntExist+DoesntExist, test";
+			var typeName = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflectionAssemblyDoesntExist+Full, DoesntExist";
 			var typeKept = Type.GetType (typeName, false);
 		}
 

--- a/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflectionTypeDoesntExist.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflectionTypeDoesntExist.cs
@@ -10,7 +10,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 	{
 		public static void Main ()
 		{
-			var typeName = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflectionTypeDoesntExist+Full, DoesntExist";
+			var typeName = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflectionTypeDoesntExist+DoesntExist, test";
 			var typeKept = Type.GetType (typeName, false);
 		}
 


### PR DESCRIPTION
This introduces the ability to add assemblies to LinkContext lazily and have them
processed in MarkStep. For now, the only additional processing is to
load references and run the TypeMap logic. Later, embedded XML processing and
constant propagation will also happen for lazy assemblies.

This is Phase 1 outlined in https://github.com/mono/linker/issues/1164#issuecomment-714732178.

Fixes #943
Fixes #1079

This still needs a bit of work to handle a case where a dynamic assembly is resolved but not marked (for example when using `GetType` for an assembly-qualified type where the assembly exists, but the type doesn't). In this case, SweepStep can make some false assumptions.