### PR TITLE
Fix ArgumentOutOfRange in GetConstructor scanning

### DIFF
--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -842,7 +842,7 @@ namespace Mono.Linker.Dataflow
 						int? ctorParameterCount = parameters.Count switch
 						{
 							1 => (methodParams[1] as ArrayValue)?.Size.AsConstInt (),
-							2 => (methodParams[3] as ArrayValue)?.Size.AsConstInt (),
+							4 => (methodParams[3] as ArrayValue)?.Size.AsConstInt (),
 							5 => (methodParams[4] as ArrayValue)?.Size.AsConstInt (),
 							_ => null,
 						};

--- a/test/Mono.Linker.Tests.Cases/DataFlow/EmptyArrayIntrinsicsDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/EmptyArrayIntrinsicsDataFlow.cs
@@ -17,6 +17,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			TestGetPublicParameterlessConstructorWithEmptyTypes ();
 			TestGetPublicParameterlessConstructorWithArrayEmpty ();
 			TestGetPublicParameterlessConstructorWithUnknownArray ();
+			TestGetConstructorOverloads ();
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (Type), nameof (Type.GetMethod), new Type[] { typeof (string) }, messageCode: "IL2080")]
@@ -37,6 +38,14 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		static void TestGetPublicParameterlessConstructorWithUnknownArray ()
 		{
 			s_typeWithKeptPublicParameterlessConstructor.GetConstructor (s_localEmptyArrayInvisibleToAnalysis);
+		}
+
+		[UnrecognizedReflectionAccessPattern (typeof (Type), nameof (Type.GetMethod), new Type[] { typeof (string) }, messageCode: "IL2080")]
+		static void TestGetConstructorOverloads ()
+		{
+			s_typeWithKeptPublicParameterlessConstructor.GetConstructor (BindingFlags.Public, null, Type.EmptyTypes, null);
+			s_typeWithKeptPublicParameterlessConstructor.GetConstructor (BindingFlags.Public, null, CallingConventions.Any, Type.EmptyTypes, null);
+			s_typeWithKeptPublicParameterlessConstructor.GetMethod ("Foo");
 		}
 
 		static Type[] s_localEmptyArrayInvisibleToAnalysis = Type.EmptyTypes;


### PR DESCRIPTION
With https://github.com/dotnet/runtime/issues/42753, we are adding a new overload to Type.GetConstructor that only takes BindingFlags and Type[].

However, this new overload exposes a bug in the ILLinker where it is using the wrong parameter count to find how many constructor parameters are being used.

Fixing the issue by using the correct parameter count in the switch statement.

@vitek-karas @MichalStrehovsky @marek-safar 