### PR TITLE
Fix running tests in VS

### DIFF
--- a/test/ILLink.Tasks.Tests/ILLink.Tasks.Tests.cs
+++ b/test/ILLink.Tasks.Tests/ILLink.Tasks.Tests.cs
@@ -366,7 +366,7 @@ namespace ILLink.Tasks.Tests
 
 		[Theory]
 		[MemberData (nameof (CustomDataCases))]
-		public void TestCustomDta (ITaskItem[] customData)
+		public void TestCustomData (ITaskItem[] customData)
 		{
 			var task = new MockTask () {
 				CustomData = customData

--- a/test/Mono.Linker.Tests/TestCasesRunner/MemberAssertionsCollector.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/MemberAssertionsCollector.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Mono.Cecil;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Extensions;
+using NUnit.Framework;
 
 namespace Mono.Linker.Tests.TestCasesRunner
 {
@@ -21,6 +22,16 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			var results = new List<(IMemberDefinition, CustomAttribute)> ();
 			CollectMemberAssertions (t, results);
 			return results;
+		}
+
+		public static IEnumerable<TestCaseData> GetMemberAssertionsData (Type type)
+		{
+			return GetMemberAssertions (type).Select (v => {
+				var testCaseData = new TestCaseData (v.member, v.ca);
+				// Sanitize test names to work around https://github.com/nunit/nunit3-vs-adapter/issues/691.
+				testCaseData.SetName ($"{{m}}({v.member.Name},{v.ca.AttributeType.Name})");
+				return testCaseData;
+			});
 		}
 
 		private static bool IsMemberAssertion (TypeReference attributeType)

--- a/test/Mono.Linker.Tests/Tests/DocumentationSignatureParserTests.cs
+++ b/test/Mono.Linker.Tests/Tests/DocumentationSignatureParserTests.cs
@@ -13,7 +13,7 @@ namespace Mono.Linker.Tests
 	[Parallelizable]
 	public class DocumentationSignatureParserTests
 	{
-		[TestCaseSource (nameof (GetMemberAssertionsAsArray), new object[] { typeof (DocumentationSignatureParserTests) })]
+		[TestCaseSource (nameof (GetMemberAssertions), new object[] { typeof (DocumentationSignatureParserTests) })]
 		public void TestSignatureParsing (IMemberDefinition member, CustomAttribute customAttribute)
 		{
 			var attributeString = (string) customAttribute.ConstructorArguments[0].Value;
@@ -35,10 +35,7 @@ namespace Mono.Linker.Tests
 			}
 		}
 
-		public static IEnumerable<object[]> GetMemberAssertionsAsArray (Type type)
-		{
-			return MemberAssertionsCollector.GetMemberAssertions (type).Select (v => new object[] { v.member, v.ca });
-		}
+		public static IEnumerable<TestCaseData> GetMemberAssertions (Type type) => MemberAssertionsCollector.GetMemberAssertionsData (type);
 
 		public static void CheckUniqueParsedString (IMemberDefinition member, string input)
 		{

--- a/test/Mono.Linker.Tests/Tests/GetDisplayNameTests.cs
+++ b/test/Mono.Linker.Tests/Tests/GetDisplayNameTests.cs
@@ -12,7 +12,7 @@ namespace Mono.Linker.Tests
 	[Parallelizable]
 	public class GetDisplayNameTests
 	{
-		[TestCaseSource (nameof (GetMemberAssertionsAsArray), new object[] { typeof (GetDisplayNameTests) })]
+		[TestCaseSource (nameof (GetMemberAssertions), new object[] { typeof (GetDisplayNameTests) })]
 		public void TestGetDisplayName (IMemberDefinition member, CustomAttribute customAttribute)
 		{
 			// The only intention with these tests is to check that the language elements that could
@@ -38,10 +38,7 @@ namespace Mono.Linker.Tests
 
 		}
 
-		public static IEnumerable<object[]> GetMemberAssertionsAsArray (Type type)
-		{
-			return MemberAssertionsCollector.GetMemberAssertions (type).Select (v => new object[] { v.member, v.ca });
-		}
+		public static IEnumerable<TestCaseData> GetMemberAssertions (Type type) => MemberAssertionsCollector.GetMemberAssertionsData (type);
 
 		[DisplayName ("Mono.Linker.Tests.GetDisplayNameTests.A")]
 		public class A


### PR DESCRIPTION
This works around bugs in communication between VS and nunit, allowing
tests to be run using "Run All Tests". Fixes https://github.com/mono/linker/issues/1259.

The workaround will remove namespace info from names of the testcases generated from the attributed test members, so some of them will have overlapping names. This was the best compromise I could find that let them be run in VS, without polluting the test hierarchy with an individual node under Mono.Linker.Tests for each DocumentationSignatureParser testcase. It's probably possible to do better by replacing characters in the test name, but I couldn't quickly figure out which character sequences were causing trouble for the test explorer or how the test explorer translates test names into the hierarchical view.