### PR TITLE
[release/5.0] Mark generic arguments of dynamically accessed types

### DIFF
--- a/src/linker/Linker.Dataflow/MethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/MethodBodyScanner.cs
@@ -714,7 +714,7 @@ namespace Mono.Linker.Dataflow
 			}
 
 			if (operation.Operand is TypeReference typeReference) {
-				var resolvedReference = typeReference.Resolve ();
+				var resolvedReference = typeReference.ResolveToMainTypeDefinition ();
 				if (resolvedReference != null) {
 					StackSlot slot = new StackSlot (new RuntimeTypeHandleValue (resolvedReference));
 					currentStack.Push (slot);

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -797,8 +797,7 @@ namespace Mono.Linker.Dataflow
 						}
 						foreach (var typeNameValue in methodParams[0].UniqueValues ()) {
 							if (typeNameValue is KnownStringValue knownStringValue) {
-								TypeReference typeRef = AssemblyUtilities.ResolveFullyQualifiedTypeName (_context, knownStringValue.Contents);
-								TypeDefinition foundType = typeRef.ResolveToMainTypeDefinition ();
+								TypeDefinition foundType = AssemblyUtilities.ResolveFullyQualifiedTypeName (_context, knownStringValue.Contents);
 								if (foundType == null) {
 									// Intentionally ignore - it's not wrong for code to call Type.GetType on non-existing name, the code might expect null/exception back.
 									reflectionContext.RecordHandledPattern ();
@@ -1336,9 +1335,8 @@ namespace Mono.Linker.Dataflow
 								continue;
 							}
 
-							TypeReference typeRef = resolvedAssembly.MainModule.GetType (typeNameStringValue.Contents.ToCecilName ());
-							var resolvedType = typeRef?.Resolve ();
-							if (resolvedType == null || typeRef is ArrayType) {
+							var resolvedType = resolvedAssembly.FindType (typeNameStringValue.Contents);
+							if (resolvedType == null) {
 								// It's not wrong to have a reference to non-existing type - the code may well expect to get an exception in this case
 								// Note that we did find the assembly, so it's not a linker config problem, it's either intentional, or wrong versions of assemblies
 								// but linker can't know that.
@@ -1569,13 +1567,12 @@ namespace Mono.Linker.Dataflow
 				} else if (uniqueValue is SystemTypeValue systemTypeValue) {
 					MarkTypeForDynamicallyAccessedMembers (ref reflectionContext, systemTypeValue.TypeRepresented, requiredMemberTypes);
 				} else if (uniqueValue is KnownStringValue knownStringValue) {
-					TypeReference typeRef = AssemblyUtilities.ResolveFullyQualifiedTypeName (_context, knownStringValue.Contents);
-					TypeDefinition foundType = typeRef?.ResolveToMainTypeDefinition ();
+					TypeDefinition foundType = AssemblyUtilities.ResolveFullyQualifiedTypeName (_context, knownStringValue.Contents);
 					if (foundType == null) {
 						// Intentionally ignore - it's not wrong for code to call Type.GetType on non-existing name, the code might expect null/exception back.
 						reflectionContext.RecordHandledPattern ();
 					} else {
-						MarkType (ref reflectionContext, typeRef);
+						MarkType (ref reflectionContext, foundType);
 						MarkTypeForDynamicallyAccessedMembers (ref reflectionContext, foundType, requiredMemberTypes);
 					}
 				} else if (uniqueValue == NullValue.Instance) {

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -113,7 +113,7 @@ namespace Mono.Linker.Dataflow
 		{
 			ValueNode valueNode;
 			if (argument.Type.Name == "Type") {
-				TypeDefinition referencedType = ((TypeReference) argument.Value).Resolve ();
+				TypeDefinition referencedType = ((TypeReference) argument.Value).ResolveToMainTypeDefinition ();
 				valueNode = referencedType == null ? null : new SystemTypeValue (referencedType);
 			} else if (argument.Type.MetadataType == MetadataType.String) {
 				valueNode = new KnownStringValue ((string) argument.Value);
@@ -130,7 +130,7 @@ namespace Mono.Linker.Dataflow
 			var annotation = _context.Annotations.FlowAnnotations.GetGenericParameterAnnotation (genericParameter);
 			Debug.Assert (annotation != DynamicallyAccessedMemberTypes.None);
 
-			ValueNode valueNode = GetValueNodeFromGenericArgument (genericArgument);
+			ValueNode valueNode = GetTypeValueNodeFromGenericArgument (genericArgument);
 			bool enableReflectionPatternReporting = !(source is MethodDefinition sourceMethod) || ShouldEnableReflectionPatternReporting (sourceMethod);
 
 			var reflectionContext = new ReflectionPatternContext (_context, enableReflectionPatternReporting, source, genericParameter);
@@ -138,14 +138,14 @@ namespace Mono.Linker.Dataflow
 			RequireDynamicallyAccessedMembers (ref reflectionContext, annotation, valueNode, genericParameter);
 		}
 
-		ValueNode GetValueNodeFromGenericArgument (TypeReference genericArgument)
+		ValueNode GetTypeValueNodeFromGenericArgument (TypeReference genericArgument)
 		{
 			if (genericArgument is GenericParameter inputGenericParameter) {
 				// Technically this should be a new value node type as it's not a System.Type instance representation, but just the generic parameter
 				// That said we only use it to perform the dynamically accessed members checks and for that purpose treating it as System.Type is perfectly valid.
 				return new SystemTypeForGenericParameterValue (inputGenericParameter, _context.Annotations.FlowAnnotations.GetGenericParameterAnnotation (inputGenericParameter));
 			} else {
-				TypeDefinition genericArgumentTypeDef = genericArgument.Resolve ();
+				TypeDefinition genericArgumentTypeDef = genericArgument.ResolveToMainTypeDefinition ();
 				if (genericArgumentTypeDef != null) {
 					return new SystemTypeValue (genericArgumentTypeDef);
 				} else {
@@ -748,13 +748,13 @@ namespace Mono.Linker.Dataflow
 								if (methodParam.ParameterIndex == 0) {
 									staticType = callingMethodDefinition.DeclaringType;
 								} else {
-									staticType = callingMethodDefinition.Parameters[methodParam.ParameterIndex - 1].ParameterType.Resolve ();
+									staticType = callingMethodDefinition.Parameters[methodParam.ParameterIndex - 1].ParameterType.ResolveToMainTypeDefinition ();
 								}
 							} else {
-								staticType = callingMethodDefinition.Parameters[methodParam.ParameterIndex].ParameterType.Resolve ();
+								staticType = callingMethodDefinition.Parameters[methodParam.ParameterIndex].ParameterType.ResolveToMainTypeDefinition ();
 							}
 						} else if (methodParams[0] is LoadFieldValue loadedField) {
-							staticType = loadedField.Field.FieldType.Resolve ();
+							staticType = loadedField.Field.FieldType.ResolveToMainTypeDefinition ();
 						}
 
 						if (staticType != null) {
@@ -797,7 +797,8 @@ namespace Mono.Linker.Dataflow
 						}
 						foreach (var typeNameValue in methodParams[0].UniqueValues ()) {
 							if (typeNameValue is KnownStringValue knownStringValue) {
-								TypeDefinition foundType = AssemblyUtilities.ResolveFullyQualifiedTypeName (_context, knownStringValue.Contents);
+								TypeReference typeRef = AssemblyUtilities.ResolveFullyQualifiedTypeName (_context, knownStringValue.Contents);
+								TypeDefinition foundType = typeRef.ResolveToMainTypeDefinition ();
 								if (foundType == null) {
 									// Intentionally ignore - it's not wrong for code to call Type.GetType on non-existing name, the code might expect null/exception back.
 									reflectionContext.RecordHandledPattern ();
@@ -1156,7 +1157,7 @@ namespace Mono.Linker.Dataflow
 						RequireDynamicallyAccessedMembers (
 							ref reflectionContext,
 							DynamicallyAccessedMemberTypes.PublicParameterlessConstructor,
-							GetValueNodeFromGenericArgument (genericCalledMethod.GenericArguments[0]),
+							GetTypeValueNodeFromGenericArgument (genericCalledMethod.GenericArguments[0]),
 							calledMethodDefinition.GenericParameters[0]);
 					}
 					break;
@@ -1335,8 +1336,9 @@ namespace Mono.Linker.Dataflow
 								continue;
 							}
 
-							var resolvedType = resolvedAssembly.FindType (typeNameStringValue.Contents);
-							if (resolvedType == null) {
+							TypeReference typeRef = resolvedAssembly.MainModule.GetType (typeNameStringValue.Contents.ToCecilName ());
+							var resolvedType = typeRef?.Resolve ();
+							if (resolvedType == null || typeRef is ArrayType) {
 								// It's not wrong to have a reference to non-existing type - the code may well expect to get an exception in this case
 								// Note that we did find the assembly, so it's not a linker config problem, it's either intentional, or wrong versions of assemblies
 								// but linker can't know that.
@@ -1567,11 +1569,13 @@ namespace Mono.Linker.Dataflow
 				} else if (uniqueValue is SystemTypeValue systemTypeValue) {
 					MarkTypeForDynamicallyAccessedMembers (ref reflectionContext, systemTypeValue.TypeRepresented, requiredMemberTypes);
 				} else if (uniqueValue is KnownStringValue knownStringValue) {
-					TypeDefinition foundType = AssemblyUtilities.ResolveFullyQualifiedTypeName (_context, knownStringValue.Contents);
+					TypeReference typeRef = AssemblyUtilities.ResolveFullyQualifiedTypeName (_context, knownStringValue.Contents);
+					TypeDefinition foundType = typeRef?.ResolveToMainTypeDefinition ();
 					if (foundType == null) {
 						// Intentionally ignore - it's not wrong for code to call Type.GetType on non-existing name, the code might expect null/exception back.
 						reflectionContext.RecordHandledPattern ();
 					} else {
+						MarkType (ref reflectionContext, typeRef);
 						MarkTypeForDynamicallyAccessedMembers (ref reflectionContext, foundType, requiredMemberTypes);
 					}
 				} else if (uniqueValue == NullValue.Instance) {
@@ -1643,6 +1647,12 @@ namespace Mono.Linker.Dataflow
 					break;
 				}
 			}
+		}
+
+		void MarkType (ref ReflectionPatternContext reflectionContext, TypeReference typeReference)
+		{
+			var source = reflectionContext.Source;
+			reflectionContext.RecordRecognizedPattern (typeReference?.Resolve (), () => _markStep.MarkTypeVisibleToReflection (typeReference, new DependencyInfo (DependencyKind.AccessedViaReflection, source), source));
 		}
 
 		void MarkMethod (ref ReflectionPatternContext reflectionContext, MethodDefinition method)

--- a/src/linker/Linker/TypeReferenceExtensions.cs
+++ b/src/linker/Linker/TypeReferenceExtensions.cs
@@ -375,5 +375,17 @@ namespace Mono.Linker
 
 			return false;
 		}
+
+		// Array types that are dynamically accessed should resolve to System.Array instead of its element type - which is what Cecil resolves to.
+		// Any data flow annotations placed on a type parameter which receives an array type apply to the array itself. None of the members in its
+		// element type should be marked.
+		public static TypeDefinition ResolveToMainTypeDefinition (this TypeReference type)
+		{
+			return type switch
+			{
+				ArrayType _ => type.Module.ImportReference (typeof (Array))?.Resolve (),
+				_ => type?.Resolve ()
+			};
+		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ComplexTypeHandling.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ComplexTypeHandling.cs
@@ -1,0 +1,194 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.DataFlow
+{
+	public class ComplexTypeHandling
+	{
+		public static void Main ()
+		{
+			TestArray ();
+			TestArrayOnGeneric ();
+			TestGenericArray ();
+			TestGenericArrayOnGeneric ();
+			TestArrayGetTypeFromMethodParam ();
+			TestArrayGetTypeFromField ();
+			TestArrayTypeGetType ();
+			TestArrayCreateInstanceByName ();
+			TestArrayInAttributeParameter ();
+		}
+
+		[Kept]
+		class ArrayElementType
+		{
+			public ArrayElementType () { }
+
+			public void PublicMethod () { }
+
+			private int _privateField;
+		}
+
+		[Kept]
+		static void TestArray ()
+		{
+			RequirePublicMethods (typeof (ArrayElementType[]));
+		}
+
+		[Kept]
+		static void TestGenericArray ()
+		{
+			RequirePublicMethodsOnArrayOfGeneric<ArrayElementType> ();
+		}
+
+		[Kept]
+		static void RequirePublicMethodsOnArrayOfGeneric<T> ()
+		{
+			RequirePublicMethods (typeof (T[]));
+		}
+
+		[Kept]
+		class ArrayElementInGenericType
+		{
+			public ArrayElementInGenericType () { }
+
+			public void PublicMethod () { }
+
+			private int _privateField;
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		class RequirePublicMethodsGeneric<
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+		T>
+		{
+		}
+
+		[Kept]
+		static void TestArrayOnGeneric ()
+		{
+			_ = new RequirePublicMethodsGeneric<ArrayElementInGenericType[]> ();
+		}
+
+		[Kept]
+		static void TestGenericArrayOnGeneric ()
+		{
+			RequirePublicMethodsOnArrayOfGenericParameter<ArrayElementInGenericType> ();
+		}
+
+		[Kept]
+		static void RequirePublicMethodsOnArrayOfGenericParameter<T> ()
+		{
+			_ = new RequirePublicMethodsGeneric<T[]> ();
+		}
+
+		[Kept]
+		sealed class ArrayGetTypeFromMethodParamElement
+		{
+			// This method should not be marked, instead Array.* should be marked
+			public void PublicMethod () { }
+		}
+
+		[Kept]
+		static void TestArrayGetTypeFromMethodParamHelper (ArrayGetTypeFromMethodParamElement[] p)
+		{
+			RequirePublicMethods (p.GetType ());
+		}
+
+		[Kept]
+		static void TestArrayGetTypeFromMethodParam ()
+		{
+			TestArrayGetTypeFromMethodParamHelper (null);
+		}
+
+		[Kept]
+		sealed class ArrayGetTypeFromFieldElement
+		{
+			// This method should not be marked, instead Array.* should be marked
+			public void PublicMethod () { }
+		}
+
+		[Kept]
+		static ArrayGetTypeFromFieldElement[] _arrayGetTypeFromField;
+
+		[Kept]
+		static void TestArrayGetTypeFromField ()
+		{
+			RequirePublicMethods (_arrayGetTypeFromField.GetType ());
+		}
+
+		[Kept]
+		sealed class ArrayTypeGetTypeElement
+		{
+			// This method should not be marked, instead Array.* should be marked
+			[Kept]
+			public void PublicMethod () { }
+		}
+
+		[Kept]
+		static void TestArrayTypeGetType ()
+		{
+			RequirePublicMethods (Type.GetType ("Mono.Linker.Tests.Cases.DataFlow.ComplexTypeHandling+ArrayTypeGetTypeElement[]"));
+		}
+
+		// Nothing should be marked as CreateInstance doesn't work on arrays
+		class ArrayCreateInstanceByNameElement
+		{
+			public ArrayCreateInstanceByNameElement ()
+			{
+			}
+		}
+
+		[Kept]
+		static void TestArrayCreateInstanceByName ()
+		{
+			Activator.CreateInstance ("test", "Mono.Linker.Tests.Cases.DataFlow.ComplexTypeHandling+ArrayCreateInstanceByNameElement[]");
+		}
+
+		[Kept]
+		class ArrayInAttributeParamElement
+		{
+			// This method should not be marked, instead Array.* should be marked
+			public void PublicMethod () { }
+		}
+
+		[Kept]
+		[KeptAttributeAttribute (typeof (RequiresPublicMethodAttribute))]
+		[RequiresPublicMethod (typeof (ArrayInAttributeParamElement[]))]
+		static void TestArrayInAttributeParameter ()
+		{
+		}
+
+
+		[Kept]
+		private static void RequirePublicMethods (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			Type type)
+		{
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (Attribute))]
+		class RequiresPublicMethodAttribute : Attribute
+		{
+			[Kept]
+			public RequiresPublicMethodAttribute (
+				[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+				[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+				Type t)
+			{
+			}
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Reflection/PropertyUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/PropertyUsedViaReflection.cs
@@ -1,7 +1,7 @@
-﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using System;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
+﻿using System;
 using System.Reflection;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Reflection
 {
@@ -17,6 +17,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestNullName ();
 			TestEmptyName ();
 			TestNonExistingName ();
+			TestPropertyOfArray ();
 			TestNullType ();
 			TestDataFlowType ();
 			TestIfElse (1);
@@ -80,6 +81,16 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		static void TestNonExistingName ()
 		{
 			var property = typeof (PropertyUsedViaReflection).GetProperty ("NonExisting");
+		}
+
+		[Kept]
+		[RecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetProperty), new Type[] { typeof (string) },
+			typeof (Array), nameof (Array.LongLength))]
+		static void TestPropertyOfArray ()
+		{
+			var property = typeof (int[]).GetProperty ("LongLength");
+			property.GetValue (null);
 		}
 
 		[Kept]


### PR DESCRIPTION
This PR mimics the behavior of #1566 without making use of the new type name parser introduced in #1472.