### PR TITLE
Fix handling of newlines in warning arguments

### DIFF
--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -85,8 +85,8 @@ namespace Mono.Linker
 				if (arg.StartsWith ("@")) {
 					try {
 						string responseFileName = arg.Substring (1);
-						IEnumerable<string> responseFileLines = File.ReadLines (responseFileName);
-						ParseResponseFileLines (responseFileLines, result);
+						using (var responseFileText = new StreamReader (responseFileName))
+							ParseResponseFile (responseFileText, result);
 					} catch (Exception e) {
 						Console.Error.WriteLine ("Cannot read response file due to '{0}'", e.Message);
 						return false;
@@ -99,49 +99,54 @@ namespace Mono.Linker
 			return true;
 		}
 
-		public static void ParseResponseFileLines (IEnumerable<string> responseFileLines, Queue<string> result)
+		public static void ParseResponseFile (TextReader reader, Queue<string> result)
 		{
-			foreach (var rawResponseFileText in responseFileLines) {
-				var responseFileText = rawResponseFileText.Trim ();
-				int idx = 0;
-				while (idx < responseFileText.Length) {
-					while (idx < responseFileText.Length && char.IsWhiteSpace (responseFileText[idx])) {
-						idx++;
-					}
-					if (idx == responseFileText.Length) {
+			int cur;
+			while ((cur = reader.Read ()) > 0) {
+				// skip whitespace
+				while (char.IsWhiteSpace ((char)cur)) {
+					if ((cur = reader.Read ()) < 0)
 						break;
-					}
-					StringBuilder argBuilder = new StringBuilder ();
-					bool inquote = false;
-					while (true) {
-						bool copyChar = true;
-						int numBackslash = 0;
-						while (idx < responseFileText.Length && responseFileText[idx] == '\\') {
-							numBackslash++;
-							idx++;
-						}
-						if (idx < responseFileText.Length && responseFileText[idx] == '"') {
-							if ((numBackslash % 2) == 0) {
-								if (inquote && (idx + 1) < responseFileText.Length && responseFileText[idx + 1] == '"') {
-									idx++;
-								} else {
-									copyChar = false;
-									inquote = !inquote;
-								}
-							}
-							numBackslash /= 2;
-						}
-						argBuilder.Append (new String ('\\', numBackslash));
-						if (idx == responseFileText.Length || (!inquote && Char.IsWhiteSpace (responseFileText[idx]))) {
-							break;
-						}
-						if (copyChar) {
-							argBuilder.Append (responseFileText[idx]);
-						}
-						idx++;
-					}
-					result.Enqueue (argBuilder.ToString ());
 				}
+				if (cur < 0) // EOF
+					break;
+
+				StringBuilder argBuilder = new StringBuilder ();
+				bool inquote = false;
+
+				// build up an argument one character at a time
+				while (true) {
+					bool copyChar = true;
+					int numBackslash = 0;
+
+					// count backslashes
+					while (cur == '\\') {
+						numBackslash++;
+						if ((cur = reader.Read ()) < 0)
+							break;
+					}
+					if (cur == '"') {
+						if ((numBackslash % 2) == 0) {
+							if (inquote && (reader.Peek () == '"')) {
+								// handle "" escape sequence in a quote
+								cur = reader.Read ();
+							} else {
+								// unescaped " begins/ends a quote
+								copyChar = false;
+								inquote = !inquote;
+							}
+						}
+						// treat backslashes before " as escapes
+						numBackslash /= 2;
+					}
+					argBuilder.Append (new String ('\\', numBackslash));
+					if (cur < 0 || (!inquote && char.IsWhiteSpace ((char) cur)))
+						break;
+					if (copyChar)
+						argBuilder.Append ((char)cur);
+					cur = reader.Read ();
+				}
+				result.Enqueue (argBuilder.ToString ());
 			}
 		}
 
@@ -788,7 +793,7 @@ namespace Mono.Linker
 			}
 
 			value = Unquote (value);
-			string[] values = value.Split (new char[] { ',', ';', ' ' }, StringSplitOptions.RemoveEmptyEntries);
+			string[] values = value.Split (new char[] { ',', ';', ' ', '\n' }, StringSplitOptions.RemoveEmptyEntries);
 			foreach (string id in values) {
 				if (!id.StartsWith ("IL", StringComparison.Ordinal) || !ushort.TryParse (id.Substring (2), out ushort code))
 					continue;

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -102,7 +102,7 @@ namespace Mono.Linker
 		public static void ParseResponseFile (TextReader reader, Queue<string> result)
 		{
 			int cur;
-			while ((cur = reader.Read ()) > 0) {
+			while ((cur = reader.Read ()) >= 0) {
 				// skip whitespace
 				while (char.IsWhiteSpace ((char) cur)) {
 					if ((cur = reader.Read ()) < 0)

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -793,8 +793,9 @@ namespace Mono.Linker
 			}
 
 			value = Unquote (value);
-			string[] values = value.Split (new char[] { ',', ';', ' ', '\n' }, StringSplitOptions.RemoveEmptyEntries);
-			foreach (string id in values) {
+			string[] values = value.Split (new char[] { ',', ';', ' ' }, StringSplitOptions.RemoveEmptyEntries);
+			foreach (string v in values) {
+				var id = v.Trim ();
 				if (!id.StartsWith ("IL", StringComparison.Ordinal) || !ushort.TryParse (id.Substring (2), out ushort code))
 					continue;
 

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -104,7 +104,7 @@ namespace Mono.Linker
 			int cur;
 			while ((cur = reader.Read ()) > 0) {
 				// skip whitespace
-				while (char.IsWhiteSpace ((char)cur)) {
+				while (char.IsWhiteSpace ((char) cur)) {
 					if ((cur = reader.Read ()) < 0)
 						break;
 				}
@@ -143,7 +143,7 @@ namespace Mono.Linker
 					if (cur < 0 || (!inquote && char.IsWhiteSpace ((char) cur)))
 						break;
 					if (copyChar)
-						argBuilder.Append ((char)cur);
+						argBuilder.Append ((char) cur);
 					cur = reader.Read ();
 				}
 				result.Enqueue (argBuilder.ToString ());

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -139,7 +139,8 @@ namespace Mono.Linker
 						// treat backslashes before " as escapes
 						numBackslash /= 2;
 					}
-					argBuilder.Append (new String ('\\', numBackslash));
+					if (numBackslash > 0)
+						argBuilder.Append (new String ('\\', numBackslash));
 					if (cur < 0 || (!inquote && char.IsWhiteSpace ((char) cur)))
 						break;
 					if (copyChar)

--- a/test/ILLink.Tasks.Tests/ILLink.Tasks.Tests.cs
+++ b/test/ILLink.Tasks.Tests/ILLink.Tasks.Tests.cs
@@ -276,7 +276,7 @@ namespace ILLink.Tasks.Tests
 		[InlineData ("IL2001,IL2002;IL2003 IL2004", 4)]
 		[InlineData ("IL2001,IL2002,IL8000,IL1003", 4)]
 		[InlineData ("IL20000,IL02000", 2)]
-		[InlineData ("IL2001\nIL2002;\nIL2003", 3)]
+		[InlineData ("   IL2001\n  IL2002;\n \tIL2003", 3)]
 		public void TestValidNoWarn (string noWarn, int validNoWarns)
 		{
 			var task = new MockTask () {
@@ -314,7 +314,7 @@ namespace ILLink.Tasks.Tests
 			new int[] { 3000 }, new int[] { 2005, 3005 })]
 		[InlineData (true, null, "IL2067", new int[] { }, new int[] { 2067 })]
 		[InlineData (true, "IL2001", "IL2001", new int[] { }, new int[] { 2001 })]
-		[InlineData (false, "IL1001;\nIL1002\nIL1003", null,
+		[InlineData (false, "IL1001;\n\t IL1002\n\t IL1003", null,
 			new int[] { 1001, 1002, 1003 }, new int[] { })]
 		public void TestWarningsAsErrors (bool treatWarningsAsErrors, string? warningsAsErrors, string? warningsNotAsErrors, int[] warnAsError, int[] warnNotAsError)
 		{

--- a/test/ILLink.Tasks.Tests/ILLink.Tasks.Tests.cs
+++ b/test/ILLink.Tasks.Tests/ILLink.Tasks.Tests.cs
@@ -276,6 +276,7 @@ namespace ILLink.Tasks.Tests
 		[InlineData ("IL2001,IL2002;IL2003 IL2004", 4)]
 		[InlineData ("IL2001,IL2002,IL8000,IL1003", 4)]
 		[InlineData ("IL20000,IL02000", 2)]
+		[InlineData ("IL2001\nIL2002;\nIL2003", 3)]
 		public void TestValidNoWarn (string noWarn, int validNoWarns)
 		{
 			var task = new MockTask () {
@@ -313,6 +314,8 @@ namespace ILLink.Tasks.Tests
 			new int[] { 3000 }, new int[] { 2005, 3005 })]
 		[InlineData (true, null, "IL2067", new int[] { }, new int[] { 2067 })]
 		[InlineData (true, "IL2001", "IL2001", new int[] { }, new int[] { 2001 })]
+		[InlineData (false, "IL1001;\nIL1002\nIL1003", null,
+			new int[] { 1001, 1002, 1003 }, new int[] { })]
 		public void TestWarningsAsErrors (bool treatWarningsAsErrors, string? warningsAsErrors, string? warningsNotAsErrors, int[] warnAsError, int[] warnNotAsError)
 		{
 			var task = new MockTask () {

--- a/test/ILLink.Tasks.Tests/Mock.cs
+++ b/test/ILLink.Tasks.Tests/Mock.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Build.Framework;
@@ -24,10 +25,11 @@ namespace ILLink.Tasks.Tests
 
 		public MockDriver CreateDriver ()
 		{
-			string[] responseFileLines = GenerateResponseFileCommands ().Split (Environment.NewLine);
-			var arguments = new Queue<string> ();
-			Driver.ParseResponseFileLines (responseFileLines, arguments);
-			return new MockDriver (arguments);
+			using (var responseFileText = new StringReader (GenerateResponseFileCommands ())) {
+				var arguments = new Queue<string> ();
+				Driver.ParseResponseFile (responseFileText, arguments);
+				return new MockDriver (arguments);
+			}
 		}
 
 		public static string[] OptimizationNames {

--- a/test/Mono.Linker.Tests/Tests/ParseResponseFileLinesTests.cs
+++ b/test/Mono.Linker.Tests/Tests/ParseResponseFileLinesTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.IO;
 using NUnit.Framework;
 
 namespace Mono.Linker.Tests
@@ -46,6 +47,12 @@ def", new string[] { @"abc", @"def" });
 		[Test]
 		public void TestTwoSlashesWithQuote ()
 		{
+			TestParseResponseFileLines (@"""Slashes \\ In Quote""", new string[] { @"Slashes \\ In Quote" });
+		}
+
+		[Test]
+		public void TestTwoSlashesAtEndOfQuote ()
+		{
 			TestParseResponseFileLines (@"""Trailing Slash\\""", new string[] { @"Trailing Slash\" });
 		}
 
@@ -79,10 +86,31 @@ def", new string[] { @"abc", @"def" });
 			TestParseResponseFileLines (@"""a b""=c", new string[] { @"a b=c" });
 		}
 
+		[Test]
+		public void TestEscapedQuoteWithBackslash ()
+		{
+			TestParseResponseFileLines (@"""a \"" b""", new string[] { @"a "" b" });
+		}
+
+		[Test]
+		public void TestEscapedQuoteSequence ()
+		{
+			TestParseResponseFileLines (@"""a """" b""", new string[] { @"a "" b" });
+		}
+
+		[Test]
+		public void TestQuotedNewline ()
+		{
+			TestParseResponseFileLines (@"""a
+b""", new string[] { @"a
+b" });
+		}
+
 		private void TestParseResponseFileLines (string v1, string[] v2)
 		{
 			var result = new Queue<string> ();
-			Driver.ParseResponseFileLines (v1.Split ('\n'), result);
+			using (var reader = new StringReader (v1))
+				Driver.ParseResponseFile (reader, result);
 			Assert.That (result, Is.EquivalentTo (v2));
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/mono/linker/issues/1638

The generated response file has newlines and whitespace like this:
```
--warnaserror "
                    CS8600;
                    CS8601;
                "
```
but the response file parser assumed that each argument was on a single line:
https://github.com/mono/linker/blob/bfab847356063d21eb15e79f2b6c03df5bd6ef3d/src/linker/Linker/Driver.cs#L88

This fixes the parser to handle newlines correctly, and allows more whitespace between the warning codes.