### PR TITLE
[release/5.0] Fix linker crash on unresolved types in generic and attribute data flow handling

### DIFF
--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -114,7 +114,10 @@ namespace Mono.Linker.Dataflow
 			ValueNode valueNode;
 			if (argument.Type.Name == "Type") {
 				TypeDefinition referencedType = ((TypeReference) argument.Value).ResolveToMainTypeDefinition ();
-				valueNode = referencedType == null ? null : new SystemTypeValue (referencedType);
+				if (referencedType == null)
+					valueNode = UnknownValue.Instance;
+				else
+					valueNode = new SystemTypeValue (referencedType);
 			} else if (argument.Type.MetadataType == MetadataType.String) {
 				valueNode = new KnownStringValue ((string) argument.Value);
 			} else {
@@ -149,7 +152,10 @@ namespace Mono.Linker.Dataflow
 				if (genericArgumentTypeDef != null) {
 					return new SystemTypeValue (genericArgumentTypeDef);
 				} else {
-					throw new InvalidOperationException ();
+					// If we can't resolve the generic argument, it means we can't apply potential requirements on it
+					// so track it as unknown value. If we later on hit this unknown value as being used somewhere
+					// where we need to apply requirements on it, it will generate a warning.
+					return UnknownValue.Instance;
 				}
 			}
 		}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/Dependencies/UnresolvedLibrary.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/Dependencies/UnresolvedLibrary.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Mono.Linker.Tests.Cases.DataFlow.Dependencies
+{
+#if !EXCLUDE_STUFF
+	public class UnresolvedType
+	{
+		public static void Method () { }
+	}
+#endif
+}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/UnresolvedMembers.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/UnresolvedMembers.cs
@@ -10,6 +10,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 	[SetupCompileBefore ("UnresolvedLibrary.dll", new[] { "Dependencies/UnresolvedLibrary.cs" })]
 	[SetupCompileAfter ("UnresolvedLibrary.dll", new[] { "Dependencies/UnresolvedLibrary.cs" }, defines: new[] { "EXCLUDE_STUFF" })]
 	[SetupLinkerArgument ("--skip-unresolved", "true")]
+	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
 	public class UnresolvedMembers
 	{
 		static void Main ()

--- a/test/Mono.Linker.Tests.Cases/DataFlow/UnresolvedMembers.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/UnresolvedMembers.cs
@@ -12,7 +12,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	public class UnresolvedMembers
 	{
-		static void Main()
+		static void Main ()
 		{
 			UnresolvedGenericArgument ();
 			UnresolvedAttributeArgument ();
@@ -26,14 +26,14 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[KeptMember (".ctor()")]
 		class TypeWithUnresolvedGenericArgument<
 			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
-			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] T>
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] T>
 		{
 		}
 
 		[Kept]
 		static void MethodWithUnresolvedGenericArgument<
 			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
-			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] T> ()
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] T> ()
 		{ }
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/DataFlow/UnresolvedMembers.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/UnresolvedMembers.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.DataFlow
+{
+	[SetupCompileBefore ("UnresolvedLibrary.dll", new[] { "Dependencies/UnresolvedLibrary.cs" })]
+	[SetupCompileAfter ("UnresolvedLibrary.dll", new[] { "Dependencies/UnresolvedLibrary.cs" }, defines: new[] { "EXCLUDE_STUFF" })]
+	[SetupLinkerArgument ("--skip-unresolved", "true")]
+	public class UnresolvedMembers
+	{
+		static void Main()
+		{
+			UnresolvedGenericArgument ();
+			UnresolvedAttributeArgument ();
+			UnresolvedAttributePropertyValue ();
+			UnresolvedAttributeFieldValue ();
+			UnresolvedObjectGetType ();
+			UnresolvedMethodParameter ();
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		class TypeWithUnresolvedGenericArgument<
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] T>
+		{
+		}
+
+		[Kept]
+		static void MethodWithUnresolvedGenericArgument<
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] T> ()
+		{ }
+
+		[Kept]
+		[ExpectedWarning ("IL2066", "TypeWithUnresolvedGenericArgument")]
+		[ExpectedWarning ("IL2066", nameof (MethodWithUnresolvedGenericArgument))]
+		static void UnresolvedGenericArgument ()
+		{
+			var a = new TypeWithUnresolvedGenericArgument<Dependencies.UnresolvedType> ();
+			MethodWithUnresolvedGenericArgument<Dependencies.UnresolvedType> ();
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (Attribute))]
+		class AttributeWithRequirements : Attribute
+		{
+			[Kept]
+			[ExpectedWarning ("IL2065", nameof (PropertyWithRequirements))]
+			[ExpectedWarning ("IL2064", nameof (FieldWithRequirements))]
+			public AttributeWithRequirements (
+				[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+				[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type type)
+			{ }
+
+			[Kept]
+			[KeptBackingField]
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+			public Type PropertyWithRequirements { get; [Kept] set; }
+
+			[Kept]
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+			public Type FieldWithRequirements;
+		}
+
+		[Kept]
+		[KeptAttributeAttribute (typeof (AttributeWithRequirements))]
+		[AttributeWithRequirements (typeof (Dependencies.UnresolvedType))]
+		[ExpectedWarning ("IL2065", nameof (AttributeWithRequirements))]
+		static void UnresolvedAttributeArgument ()
+		{
+		}
+
+		[Kept]
+		[KeptAttributeAttribute (typeof (AttributeWithRequirements))]
+		[AttributeWithRequirements (typeof (EmptyType), PropertyWithRequirements = typeof (Dependencies.UnresolvedType))]
+		static void UnresolvedAttributePropertyValue ()
+		{
+		}
+
+		[Kept]
+		[KeptAttributeAttribute (typeof (AttributeWithRequirements))]
+		[AttributeWithRequirements (typeof (EmptyType), FieldWithRequirements = typeof (Dependencies.UnresolvedType))]
+		static void UnresolvedAttributeFieldValue ()
+		{
+		}
+
+		[Kept]
+		static Dependencies.UnresolvedType _unresolvedField;
+
+		[Kept]
+		[ExpectedWarning ("IL2072", nameof (Object.GetType))]
+		static void UnresolvedObjectGetType ()
+		{
+			RequirePublicMethods (_unresolvedField.GetType ());
+		}
+
+		[Kept]
+		[ExpectedWarning ("IL2072", nameof (Object.GetType))]
+		static void UnresolvedMethodParameter ()
+		{
+			RequirePublicMethods (typeof (Dependencies.UnresolvedType));
+		}
+
+		[Kept]
+		class EmptyType
+		{
+		}
+
+		[Kept]
+		static void RequirePublicMethods (
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+			Type t)
+		{
+		}
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/mono/linker/issues/1634
This is a servicing version of https://github.com/mono/linker/pull/1645
Only the necessary changes to make the fix - no cleanup, no better warnings, no new test features.

### Issue
If linker finds an unresolved type used in either attribute parameter, or generic parameter and the parameter has data flow annotations on it, linker will fail and cause the entire dotnet publish to fail as well.
Unresolved types are relatively common for linker and it should be able to handle these without failing.

### Impact
Any application which contains references to types which are not in the application closure may fail to link (depending on where and how the type is used). Missing types or assemblies are relatively common, for example even the core framework has references to assemblies which are not part of it in mscorlib and similar, but it's also relatively common in NuGets, especially if using NuGets which are targeted for .NET Framework on .NET Core.

### Changes
Unresolved types should be handled as "unknown" value nodes. This is already the case when they appear in a method body. But when they're used either as generic arguments or in attribute instantiations linker doesn't handle this case correctly.

For generics linker would fail with an exception. For attributes linker would ignore the type.

Both cases are wrong since linker needs to make sure to issue a warning if it can't guarantee to meet the requirements posed by the data flow annotations. So ignoring unresolved types is also wrong.

The change fixes these behaviors to treat the value as "unknown" which leads into warnings when used somewhere with data flow requirements.

### Risk
Low - the change will avoid throwing exception, so cases which always failed before, should now run through the linker.