### PR TITLE
Recognize UnderlyingSystemType as an intrinsic

### DIFF
--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -232,6 +232,7 @@ namespace Mono.Linker.Dataflow
 			Type_GetEvent,
 			Type_GetNestedType,
 			Type_get_AssemblyQualifiedName,
+			Type_get_UnderlyingSystemType,
 			Expression_Call,
 			Expression_Field,
 			Expression_Property,
@@ -375,6 +376,12 @@ namespace Mono.Linker.Dataflow
 					&& !calledMethod.HasParameters
 					&& calledMethod.HasThis
 					=> IntrinsicId.Type_get_AssemblyQualifiedName,
+
+				// System.Type.UnderlyingSystemType
+				"get_UnderlyingSystemType" when calledMethod.IsDeclaredOnType ("System", "Type")
+					&& !calledMethod.HasParameters
+					&& calledMethod.HasThis
+					=> IntrinsicId.Type_get_UnderlyingSystemType,
 
 				// System.Type.GetProperty (string)
 				// System.Type.GetProperty (string, BindingFlags)
@@ -975,6 +982,15 @@ namespace Mono.Linker.Dataflow
 						if (transformedResult != null) {
 							methodReturnValue = transformedResult;
 						}
+					}
+					break;
+
+				//
+				// UnderlyingSystemType
+				//
+				case IntrinsicId.Type_get_UnderlyingSystemType: {
+						// This is identity for the purposes of the analysis.
+						methodReturnValue = methodParams[0];
 					}
 					break;
 

--- a/test/Mono.Linker.Tests.Cases/Reflection/UnderlyingSystemType.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/UnderlyingSystemType.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Reflection
+{
+	class UnderlyingSystemType
+	{
+		public static void Main()
+		{
+			_ = typeof (TypeUsedWithUnderlyingSystemType).UnderlyingSystemType.GetMethod (nameof (TypeUsedWithUnderlyingSystemType.Method));
+		}
+
+		[Kept]
+		static class TypeUsedWithUnderlyingSystemType
+		{
+			[Kept]
+			public static void Method () { }
+			
+			public static void OtherMethod() { }
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Reflection/UnderlyingSystemType.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/UnderlyingSystemType.cs
@@ -13,7 +13,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 {
 	class UnderlyingSystemType
 	{
-		public static void Main()
+		public static void Main ()
 		{
 			_ = typeof (TypeUsedWithUnderlyingSystemType).UnderlyingSystemType.GetMethod (nameof (TypeUsedWithUnderlyingSystemType.Method));
 		}
@@ -23,8 +23,8 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		{
 			[Kept]
 			public static void Method () { }
-			
-			public static void OtherMethod() { }
+
+			public static void OtherMethod () { }
 		}
 	}
 }


### PR DESCRIPTION
This is used in CoreLib a lot and we shouldn't lose tracking for this.