### PR TITLE
[analyzer] Break infinite loops

### DIFF
--- a/src/analyzer/ConsoleDependencyGraph.cs
+++ b/src/analyzer/ConsoleDependencyGraph.cs
@@ -80,15 +80,37 @@ namespace LinkerAnalyzer
 				Console.WriteLine ("Root dependency");
 			} else {
 				int i = 0;
+				var visited = new HashSet<int> ();
+
 				foreach (int index in vertex.parentIndexes) {
 					Console.WriteLine ("Dependency #{0}", ++i);
 					Console.WriteLine ($"\t{vertex.value}{SizeString (vertex)}");
+
 					var childVertex = Vertex (index);
 					Console.WriteLine ("\t| {0}{1}", childVertex.value, childVertex.DepsCount);
+
+					visited.Clear ();
+					visited.Add (index);
+
 					while (childVertex.parentIndexes != null) {
-						childVertex = Vertex (childVertex.parentIndexes [0]);
+						int pi = 0, childIdx;
+
+						do {
+							childIdx = childVertex.parentIndexes [pi];
+							pi++;
+						} while (visited.Contains (childIdx) && pi < childVertex.parentIndexes.Count);
+
+						childVertex = Vertex (childIdx);
+
+						if (visited.Contains (childIdx)) {
+							Console.WriteLine ($"\twarning: loop to {childVertex.value}");
+							break;
+						}
+
+						visited.Add (childIdx);
 						Console.WriteLine ("\t| {0}{1}", childVertex.value, childVertex.DepsCount);
 					}
+
 					if (Tree)
 						break;
 				}
@@ -175,7 +197,7 @@ namespace LinkerAnalyzer
 			Console.WriteLine ();
 		}
 
-		static public void Header (string header, params object[] values)
+		public static void Header (string header, params object[] values)
 		{
 			string formatted = string.Format (header, values);
 			Console.WriteLine ();


### PR DESCRIPTION
Avoid getting caught in infinite loops. I think these are related to
new `DynamicDependency` attributes. So stop graph traversal and report
the loop as warning.