### PR TITLE
Restrict embedded XML

### DIFF
--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -1511,3 +1511,29 @@ This is technically possible if a custom assembly defines `DynamicDependencyAttr
   [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
   object TestProperty { get; set; }
   ```
+
+### 'IL2100': XML may not contain wildcard for assembly fullname
+
+- A wildcard "fullname" for an assembly in XML is only valid for link attribute XML on the command-line, not for descriptor or substitution XML or for embedded attribute XML. Specify a specific assembly name instead.
+
+  ```XML
+  <!-- IL2100: XML may not contain wildcard for assembly fullname -->
+  <linker>
+    <assembly fullname="*">
+      <type fullname="MyType" />
+    </assembly>
+  </linker>
+  ```
+
+### 'IL2101': Embedded XML in assembly 'assembly' may not modify other assembly 'assembly'.
+
+- Embedded attribute or substitution XML may only contain elements that apply to the containing assembly. It is invalid to use these embedded XML files to modify other assemblies.
+
+  ```XML
+  <!-- IL2101: Embedded XML in assembly 'ContainingAssembly' may not modify other assembly 'OtherAssembly' -->
+  <linker>
+    <assembly fullname="OtherAssembly">
+      <type fullname="MyType" />
+    </assembly>
+  </linker>
+  ```

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -1512,12 +1512,12 @@ This is technically possible if a custom assembly defines `DynamicDependencyAttr
   object TestProperty { get; set; }
   ```
 
-### 'IL2100': XML may not contain wildcard for assembly fullname
+### 'IL2100': XML contains unsupported wildcard for assembly "fullname" attribute
 
 - A wildcard "fullname" for an assembly in XML is only valid for link attribute XML on the command-line, not for descriptor or substitution XML or for embedded attribute XML. Specify a specific assembly name instead.
 
   ```XML
-  <!-- IL2100: XML may not contain wildcard for assembly fullname -->
+  <!-- IL2100: XML contains unsupported wildcard for assembly "fullname" attribute -->
   <linker>
     <assembly fullname="*">
       <type fullname="MyType" />
@@ -1525,12 +1525,12 @@ This is technically possible if a custom assembly defines `DynamicDependencyAttr
   </linker>
   ```
 
-### 'IL2101': Embedded XML in assembly 'assembly' may not modify other assembly 'assembly'.
+### 'IL2101': Embedded XML in assembly 'assembly' contains assembly "fullname" attribute for another assembly 'assembly'
 
-- Embedded attribute or substitution XML may only contain elements that apply to the containing assembly. It is invalid to use these embedded XML files to modify other assemblies.
+- Embedded attribute or substitution XML may only contain elements that apply to the containing assembly. Attempting to modify another assembly will not have any effect.
 
   ```XML
-  <!-- IL2101: Embedded XML in assembly 'ContainingAssembly' may not modify other assembly 'OtherAssembly' -->
+  <!-- IL2101: Embedded XML in assembly 'ContainingAssembly' contains assembly "fullname" attribute for another assembly 'OtherAssembly' -->
   <linker>
     <assembly fullname="OtherAssembly">
       <type fullname="MyType" />

--- a/src/linker/Linker.Steps/BodySubstituterStep.cs
+++ b/src/linker/Linker.Steps/BodySubstituterStep.cs
@@ -24,10 +24,10 @@ namespace Mono.Linker.Steps
 			ProcessXml (Context.StripSubstitutions, Context.IgnoreSubstitutions);
 		}
 
-		protected override void ProcessAssembly (AssemblyDefinition assembly, XPathNodeIterator iterator, bool warnOnUnresolvedTypes)
+		protected override void ProcessAssembly (AssemblyDefinition assembly, XPathNavigator nav, bool warnOnUnresolvedTypes)
 		{
-			ProcessTypes (assembly, iterator, warnOnUnresolvedTypes);
-			ProcessResources (assembly, iterator.Current.SelectChildren ("resource", ""));
+			ProcessTypes (assembly, nav, warnOnUnresolvedTypes);
+			ProcessResources (assembly, nav.SelectChildren ("resource", ""));
 		}
 
 		protected override TypeDefinition ProcessExportedType (ExportedType exported, AssemblyDefinition assembly) => null;

--- a/src/linker/Linker.Steps/LinkAttributesStep.cs
+++ b/src/linker/Linker.Steps/LinkAttributesStep.cs
@@ -204,9 +204,9 @@ namespace Mono.Linker.Steps
 
 				// Corelib XML may contain assembly wildcard to support compiler-injected attribute types
 #if NETCOREAPP
-				var coreLib = "System.Private.CoreLib";
+				const string coreLib = "System.Private.CoreLib";
 #else
-				var coreLib = "mscorlib";
+				const string coreLib = "mscorlib";
 #endif
 				if (_resourceAssembly.Name.Name == coreLib)
 					return AllowedAssemblies.AllAssemblies;

--- a/src/linker/Linker.Steps/LinkAttributesStep.cs
+++ b/src/linker/Linker.Steps/LinkAttributesStep.cs
@@ -203,7 +203,11 @@ namespace Mono.Linker.Steps
 					return AllowedAssemblies.AllAssemblies;
 
 				// Corelib XML may contain assembly wildcard to support compiler-injected attribute types
-				string coreLib = _resourceAssembly.MainModule.TypeSystem.CoreLibrary.Name;
+#if NETCOREAPP
+				var coreLib = "System.Private.CoreLib";
+#else
+				var coreLib = "mscorlib";
+#endif
 				if (_resourceAssembly.Name.Name == coreLib)
 					return AllowedAssemblies.AllAssemblies;
 

--- a/src/linker/Linker.Steps/LinkAttributesStep.cs
+++ b/src/linker/Linker.Steps/LinkAttributesStep.cs
@@ -197,14 +197,14 @@ namespace Mono.Linker.Steps
 			ProcessXml (Context.StripLinkAttributes, Context.IgnoreLinkAttributes);
 		}
 
-		protected override bool AllowAllAssembliesSelector { get => true; }
+		protected override AllowedAssemblies AllowedAssemblySelector { get => _resourceAssembly != null ? AllowedAssemblies.ContainingAssembly : AllowedAssemblies.AllAssemblies; }
 
-		protected override void ProcessAssembly (AssemblyDefinition assembly, XPathNodeIterator iterator, bool warnOnUnresolvedTypes)
+		protected override void ProcessAssembly (AssemblyDefinition assembly, XPathNavigator nav, bool warnOnUnresolvedTypes)
 		{
-			IEnumerable<CustomAttribute> attributes = ProcessAttributes (iterator.Current, assembly);
+			IEnumerable<CustomAttribute> attributes = ProcessAttributes (nav, assembly);
 			if (attributes.Any ())
 				Context.CustomAttributes.AddCustomAttributes (assembly, attributes);
-			ProcessTypes (assembly, iterator, warnOnUnresolvedTypes);
+			ProcessTypes (assembly, nav, warnOnUnresolvedTypes);
 		}
 
 		protected override void ProcessType (TypeDefinition type, XPathNavigator nav)

--- a/src/linker/Linker.Steps/LinkAttributesStep.cs
+++ b/src/linker/Linker.Steps/LinkAttributesStep.cs
@@ -197,7 +197,19 @@ namespace Mono.Linker.Steps
 			ProcessXml (Context.StripLinkAttributes, Context.IgnoreLinkAttributes);
 		}
 
-		protected override AllowedAssemblies AllowedAssemblySelector { get => _resourceAssembly != null ? AllowedAssemblies.ContainingAssembly : AllowedAssemblies.AllAssemblies; }
+		protected override AllowedAssemblies AllowedAssemblySelector {
+			get {
+				if (_resourceAssembly == null)
+					return AllowedAssemblies.AllAssemblies;
+
+				// Corelib XML may contain assembly wildcard to support compiler-injected attribute types
+				string coreLib = _resourceAssembly.MainModule.TypeSystem.CoreLibrary.Name;
+				if (_resourceAssembly.Name.Name == coreLib)
+					return AllowedAssemblies.AllAssemblies;
+
+				return AllowedAssemblies.ContainingAssembly;
+			}
+		}
 
 		protected override void ProcessAssembly (AssemblyDefinition assembly, XPathNavigator nav, bool warnOnUnresolvedTypes)
 		{

--- a/src/linker/Linker.Steps/ProcessLinkerXmlStepBase.cs
+++ b/src/linker/Linker.Steps/ProcessLinkerXmlStepBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -39,8 +39,6 @@ namespace Mono.Linker.Steps
 		{
 			_document = document;
 			_xmlDocumentLocation = xmlDocumentLocation;
-			if (!AllowedAssemblySelector.HasFlag (AllowedAssemblies.AnyAssembly) && _resourceAssembly == null)
-				throw new InvalidOperationException ("The containing assembly must be specified for XML which is restricted to modifying that assembly only.");
 		}
 
 		protected ProcessLinkerXmlStepBase (XPathDocument document, EmbeddedResource resource, AssemblyDefinition resourceAssembly, string xmlDocumentLocation)
@@ -54,6 +52,9 @@ namespace Mono.Linker.Steps
 
 		protected virtual void ProcessXml (bool stripResource, bool ignoreResource)
 		{
+			if (!AllowedAssemblySelector.HasFlag (AllowedAssemblies.AnyAssembly) && _resourceAssembly == null)
+				throw new InvalidOperationException ("The containing assembly must be specified for XML which is restricted to modifying that assembly only.");
+
 			try {
 				XPathNavigator nav = _document.CreateNavigator ();
 
@@ -89,7 +90,7 @@ namespace Mono.Linker.Steps
 			while (iterator.MoveNext ()) {
 				bool processAllAssemblies = GetFullName (iterator.Current) == AllAssembliesFullName;
 				if (processAllAssemblies && AllowedAssemblySelector != AllowedAssemblies.AllAssemblies) {
-					Context.LogWarning ($"XML may not contain wildcard for assembly fullname", 2100, _xmlDocumentLocation);
+					Context.LogWarning ($"XML contains unsupported wildcard for assembly \"fullname\" attribute", 2100, _xmlDocumentLocation);
 					continue;
 				}
 
@@ -100,7 +101,7 @@ namespace Mono.Linker.Steps
 				AssemblyDefinition assemblyToProcess = null;
 				if (!AllowedAssemblySelector.HasFlag (AllowedAssemblies.AnyAssembly)) {
 					if (_resourceAssembly.Name.Name != name.Name) {
-						Context.LogWarning ($"Embedded XML in assembly '{_resourceAssembly.Name.Name}' may not modify other assembly '{name}'", 2101, _xmlDocumentLocation);
+						Context.LogWarning ($"Embedded XML in assembly '{_resourceAssembly.Name.Name}' contains assembly \"fullname\" attribute for another assembly '{name}'", 2101, _xmlDocumentLocation);
 						continue;
 					}
 					assemblyToProcess = _resourceAssembly;

--- a/src/linker/Linker.Steps/ProcessLinkerXmlStepBase.cs
+++ b/src/linker/Linker.Steps/ProcessLinkerXmlStepBase.cs
@@ -7,6 +7,14 @@ using Mono.Cecil;
 
 namespace Mono.Linker.Steps
 {
+	[Flags]
+	public enum AllowedAssemblies
+	{
+		ContainingAssembly = 0x1,
+		AnyAssembly = 0x2 | ContainingAssembly,
+		AllAssemblies = 0x4 | AnyAssembly
+	}
+
 	public abstract class ProcessLinkerXmlStepBase : LoadReferencesStep
 	{
 		const string FullNameAttributeName = "fullname";
@@ -25,12 +33,14 @@ namespace Mono.Linker.Steps
 		protected readonly string _xmlDocumentLocation;
 		readonly XPathDocument _document;
 		readonly EmbeddedResource _resource;
-		readonly AssemblyDefinition _resourceAssembly;
+		protected readonly AssemblyDefinition _resourceAssembly;
 
 		protected ProcessLinkerXmlStepBase (XPathDocument document, string xmlDocumentLocation)
 		{
 			_document = document;
 			_xmlDocumentLocation = xmlDocumentLocation;
+			if (!AllowedAssemblySelector.HasFlag (AllowedAssemblies.AnyAssembly) && _resourceAssembly == null)
+				throw new InvalidOperationException ("The containing assembly must be specified for XML which is restricted to modifying that assembly only.");
 		}
 
 		protected ProcessLinkerXmlStepBase (XPathDocument document, EmbeddedResource resource, AssemblyDefinition resourceAssembly, string xmlDocumentLocation)
@@ -63,48 +73,65 @@ namespace Mono.Linker.Steps
 
 				ProcessAssemblies (nav.SelectChildren ("assembly", ""));
 
+				// For embedded XML, allow not specifying the assembly explicitly in XML.
+				if (_resourceAssembly != null)
+					ProcessAssembly (_resourceAssembly, nav, warnOnUnresolvedTypes: true);
+
 			} catch (Exception ex) when (!(ex is LinkerFatalErrorException)) {
 				throw new LinkerFatalErrorException (MessageContainer.CreateErrorMessage ($"Error processing '{_xmlDocumentLocation}'", 1013), ex);
 			}
 		}
 
-		protected virtual bool AllowAllAssembliesSelector { get => false; }
+		protected virtual AllowedAssemblies AllowedAssemblySelector { get => _resourceAssembly != null ? AllowedAssemblies.ContainingAssembly : AllowedAssemblies.AnyAssembly; }
 
 		protected virtual void ProcessAssemblies (XPathNodeIterator iterator)
 		{
 			while (iterator.MoveNext ()) {
-				bool processAllAssemblies = AllowAllAssembliesSelector && GetFullName (iterator.Current) == AllAssembliesFullName;
+				bool processAllAssemblies = GetFullName (iterator.Current) == AllAssembliesFullName;
+				if (processAllAssemblies && AllowedAssemblySelector != AllowedAssemblies.AllAssemblies) {
+					Context.LogWarning ($"XML may not contain wildcard for assembly fullname", 2100, _xmlDocumentLocation);
+					continue;
+				}
 
 				// Errors for invalid assembly names should show up even if this element will be
 				// skipped due to feature conditions.
 				var name = processAllAssemblies ? null : GetAssemblyName (iterator.Current);
+
+				AssemblyDefinition assemblyToProcess = null;
+				if (!AllowedAssemblySelector.HasFlag (AllowedAssemblies.AnyAssembly)) {
+					if (_resourceAssembly.Name.Name != name.Name) {
+						Context.LogWarning ($"Embedded XML in assembly '{_resourceAssembly.Name.Name}' may not modify other assembly '{name}'", 2101, _xmlDocumentLocation);
+						continue;
+					}
+					assemblyToProcess = _resourceAssembly;
+				}
 
 				if (!ShouldProcessElement (iterator.Current))
 					continue;
 
 				if (processAllAssemblies) {
 					foreach (AssemblyDefinition assembly in Context.GetAssemblies ())
-						ProcessAssembly (assembly, iterator, warnOnUnresolvedTypes: false);
+						ProcessAssembly (assembly, iterator.Current, warnOnUnresolvedTypes: false);
 				} else {
-					AssemblyDefinition assembly = GetAssembly (Context, name);
+					AssemblyDefinition assembly = assemblyToProcess ?? GetAssembly (Context, name);
 
 					if (assembly == null) {
 						Context.LogWarning ($"Could not resolve assembly '{name.Name}'", 2007, _xmlDocumentLocation);
 						continue;
 					}
 
-					ProcessAssembly (assembly, iterator, warnOnUnresolvedTypes: true);
+					ProcessAssembly (assembly, iterator.Current, warnOnUnresolvedTypes: true);
 				}
 			}
 		}
 
-		protected abstract void ProcessAssembly (AssemblyDefinition assembly, XPathNodeIterator iterator, bool warnOnUnresolvedTypes);
+		protected abstract void ProcessAssembly (AssemblyDefinition assembly, XPathNavigator nav, bool warnOnUnresolvedTypes);
 
-		protected virtual void ProcessTypes (AssemblyDefinition assembly, XPathNodeIterator iterator, bool warnOnUnresolvedTypes)
+		protected virtual void ProcessTypes (AssemblyDefinition assembly, XPathNavigator nav, bool warnOnUnresolvedTypes)
 		{
-			iterator = iterator.Current.SelectChildren (TypeElementName, XmlNamespace);
+			var iterator = nav.SelectChildren (TypeElementName, XmlNamespace);
 			while (iterator.MoveNext ()) {
-				XPathNavigator nav = iterator.Current;
+				nav = iterator.Current;
 
 				if (!ShouldProcessElement (nav))
 					continue;

--- a/src/linker/Linker.Steps/ResolveFromXmlStep.cs
+++ b/src/linker/Linker.Steps/ResolveFromXmlStep.cs
@@ -67,25 +67,27 @@ namespace Mono.Linker.Steps
 			ProcessXml (Context.StripDescriptors, Context.IgnoreDescriptors);
 		}
 
-		protected override void ProcessAssembly (AssemblyDefinition assembly, XPathNodeIterator iterator, bool warnOnUnresolvedTypes)
+		protected override AllowedAssemblies AllowedAssemblySelector { get => AllowedAssemblies.AnyAssembly; }
+
+		protected override void ProcessAssembly (AssemblyDefinition assembly, XPathNavigator nav, bool warnOnUnresolvedTypes)
 		{
 #if !FEATURE_ILLINK
-			if (IsExcluded (iterator.Current))
+			if (IsExcluded (nav))
 				return;
 #endif
 
-			if (GetTypePreserve (iterator.Current) == TypePreserve.All) {
+			if (GetTypePreserve (nav) == TypePreserve.All) {
 				foreach (var type in assembly.MainModule.Types)
 					MarkAndPreserveAll (type);
 			} else {
-				ProcessTypes (assembly, iterator, warnOnUnresolvedTypes);
-				ProcessNamespaces (assembly, iterator);
+				ProcessTypes (assembly, nav, warnOnUnresolvedTypes);
+				ProcessNamespaces (assembly, nav);
 			}
 		}
 
-		void ProcessNamespaces (AssemblyDefinition assembly, XPathNodeIterator iterator)
+		void ProcessNamespaces (AssemblyDefinition assembly, XPathNavigator nav)
 		{
-			iterator = iterator.Current.SelectChildren (NamespaceElementName, XmlNamespace);
+			var iterator = nav.SelectChildren (NamespaceElementName, XmlNamespace);
 			while (iterator.MoveNext ()) {
 				if (!ShouldProcessElement (iterator.Current))
 					continue;

--- a/test/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupCompileAfterAttribute.cs
+++ b/test/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupCompileAfterAttribute.cs
@@ -24,7 +24,7 @@ namespace Mono.Linker.Tests.Cases.Expectations.Metadata
 						if (stringArray.Length != 2)
 							throw new ArgumentException ("Entry in object[] cannot be a string[] unless it has exactly two elements, for the resource path and name", nameof (resources));
 						continue;
-					} 
+					}
 					throw new ArgumentException ("Each value in the object[] must be a string or a string[], either a resource path, or a path and name", nameof (resources));
 				}
 			}

--- a/test/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupCompileAfterAttribute.cs
+++ b/test/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupCompileAfterAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Mono.Linker.Tests.Cases.Expectations.Metadata
 {
@@ -8,13 +8,26 @@ namespace Mono.Linker.Tests.Cases.Expectations.Metadata
 	[AttributeUsage (AttributeTargets.Class, AllowMultiple = true)]
 	public class SetupCompileAfterAttribute : BaseMetadataAttribute
 	{
-		public SetupCompileAfterAttribute (string outputName, string[] sourceFiles, string[] references = null, string[] defines = null, string[] resources = null, string additionalArguments = null, string compilerToUse = null)
+		public SetupCompileAfterAttribute (string outputName, string[] sourceFiles, string[] references = null, string[] defines = null, object[] resources = null, string additionalArguments = null, string compilerToUse = null)
 		{
 			if (sourceFiles == null)
 				throw new ArgumentNullException (nameof (sourceFiles));
 
 			if (string.IsNullOrEmpty (outputName))
 				throw new ArgumentException ("Value cannot be null or empty.", nameof (outputName));
+
+			if (resources != null) {
+				foreach (var res in resources) {
+					if (res is string)
+						continue;
+					if (res is string[] stringArray) {
+						if (stringArray.Length != 2)
+							throw new ArgumentException ("Entry in object[] cannot be a string[] unless it has exactly two elements, for the resource path and name", nameof (resources));
+						continue;
+					} 
+					throw new ArgumentException ("Each value in the object[] must be a string or a string[], either a resource path, or a path and name", nameof (resources));
+				}
+			}
 		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupCompileBeforeAttribute.cs
+++ b/test/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupCompileBeforeAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Mono.Linker.Tests.Cases.Expectations.Metadata
 {
@@ -8,22 +8,48 @@ namespace Mono.Linker.Tests.Cases.Expectations.Metadata
 	[AttributeUsage (AttributeTargets.Class, AllowMultiple = true)]
 	public class SetupCompileBeforeAttribute : BaseMetadataAttribute
 	{
-		public SetupCompileBeforeAttribute (string outputName, string[] sourceFiles, string[] references = null, string[] defines = null, string[] resources = null, string additionalArguments = null, string compilerToUse = null, bool addAsReference = true, bool removeFromLinkerInput = false)
+		public SetupCompileBeforeAttribute (string outputName, string[] sourceFiles, string[] references = null, string[] defines = null, object[] resources = null, string additionalArguments = null, string compilerToUse = null, bool addAsReference = true, bool removeFromLinkerInput = false)
 		{
 			if (sourceFiles == null)
 				throw new ArgumentNullException (nameof (sourceFiles));
 
 			if (string.IsNullOrEmpty (outputName))
 				throw new ArgumentException ("Value cannot be null or empty.", nameof (outputName));
+
+			if (resources != null) {
+				foreach (var res in resources) {
+					if (res is string)
+						continue;
+					if (res is string[] stringArray) {
+						if (stringArray.Length != 2)
+							throw new ArgumentException ("Entry in object[] cannot be a string[] unless it has exactly two elements, for the resource path and name", nameof (resources));
+						continue;
+					}
+					throw new ArgumentException ("Each value in the object[] must be a string or a string[], either a resource path, or a path and name", nameof (resources));
+				}
+			}
 		}
 
-		public SetupCompileBeforeAttribute (string outputName, Type[] typesToIncludeSourceFor, string[] references = null, string[] defines = null, string[] resources = null, string additionalArguments = null, string compilerToUse = null, bool addAsReference = true, bool removeFromLinkerInput = false)
+		public SetupCompileBeforeAttribute (string outputName, Type[] typesToIncludeSourceFor, string[] references = null, string[] defines = null, object[] resources = null, string additionalArguments = null, string compilerToUse = null, bool addAsReference = true, bool removeFromLinkerInput = false)
 		{
 			if (typesToIncludeSourceFor == null)
 				throw new ArgumentNullException (nameof (typesToIncludeSourceFor));
 
 			if (string.IsNullOrEmpty (outputName))
 				throw new ArgumentException ("Value cannot be null or empty.", nameof (outputName));
+
+			if (resources != null) {
+				foreach (var res in resources) {
+					if (res is string)
+						continue;
+					if (res is string[] stringArray) {
+						if (stringArray.Length != 2)
+							throw new ArgumentException ("Entry in object[] cannot be a string[] unless it has exactly two elements, for the resource path and name", nameof (resources));
+						continue;
+					} 
+					throw new ArgumentException ("Each value in the object[] must be a string or a string[], either a resource path, or a path and name", nameof (resources));
+				}
+			}
 		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupCompileBeforeAttribute.cs
+++ b/test/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupCompileBeforeAttribute.cs
@@ -46,7 +46,7 @@ namespace Mono.Linker.Tests.Cases.Expectations.Metadata
 						if (stringArray.Length != 2)
 							throw new ArgumentException ("Entry in object[] cannot be a string[] unless it has exactly two elements, for the resource path and name", nameof (resources));
 						continue;
-					} 
+					}
 					throw new ArgumentException ("Each value in the object[] must be a string or a string[], either a resource path, or a path and name", nameof (resources));
 				}
 			}

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMethodInNonReferencedAssemblyWithEmbeddedXml.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMethodInNonReferencedAssemblyWithEmbeddedXml.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
@@ -15,7 +15,7 @@ namespace Mono.Linker.Tests.Cases.DynamicDependencies
 		"DynamicDependencyMethodInNonReferencedAssemblyLibrary.dll",
 		new[] { "Dependencies/DynamicDependencyMethodInNonReferencedAssemblyLibrary.cs" },
 		references: new[] { "base.dll" },
-		resources: new[] { "Dependencies/DynamicDependencyMethodInNonReferencedAssemblyLibrary.xml" },
+		resources: new object[] { "Dependencies/DynamicDependencyMethodInNonReferencedAssemblyLibrary.xml" },
 		addAsReference: false)]
 	[KeptAssembly ("base.dll")]
 	[RemovedMemberInAssembly ("DynamicDependencyMethodInNonReferencedAssemblyLibrary.dll", "Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies.DynamicDependencyMethodInNonReferencedAssemblyLibrary", "UnusedMethod()")]

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyOnUnusedMethodInNonReferencedAssemblyWithEmbeddedXml.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyOnUnusedMethodInNonReferencedAssemblyWithEmbeddedXml.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
@@ -15,7 +15,7 @@ namespace Mono.Linker.Tests.Cases.DynamicDependencies
 		"DynamicDependencyMethodInNonReferencedAssemblyLibrary.dll",
 		new[] { "Dependencies/DynamicDependencyMethodInNonReferencedAssemblyLibrary.cs" },
 		references: new[] { "base.dll" },
-		resources: new[] { "Dependencies/DynamicDependencyMethodInNonReferencedAssemblyLibrary.xml" },
+		resources: new object[] { "Dependencies/DynamicDependencyMethodInNonReferencedAssemblyLibrary.xml" },
 		addAsReference: false)]
 	[KeptAssembly ("base.dll")]
 	[RemovedAssembly ("DynamicDependencyMethodInNonReferencedAssemblyLibrary.dll")]

--- a/test/Mono.Linker.Tests.Cases/LinkAttributes/Dependencies/EmbeddedAttributeErrorCases.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkAttributes/Dependencies/EmbeddedAttributeErrorCases.cs
@@ -1,0 +1,6 @@
+namespace Mono.Linker.Tests.Cases.LinkAttributes.Dependencies
+{
+	public class EmbeddedAttributeErrorCases
+	{
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/LinkAttributes/Dependencies/EmbeddedAttributeErrorCases.xml
+++ b/test/Mono.Linker.Tests.Cases/LinkAttributes/Dependencies/EmbeddedAttributeErrorCases.xml
@@ -1,0 +1,10 @@
+<linker>
+  <!-- IL2100 -->
+  <assembly fullname="*" />
+  <!-- IL2101 -->
+  <assembly fullname="test">
+    <type fullname="Mono.Linker.Tests.Cases.LinkAttributes.LinkAttributeErrorCases/ReferencedFromOtherAssembly">
+      <attribute fullname="Mono.Linker.Tests.Cases.LinkAttributes.LinkAttributeErrorCases/FirstAttribute" />
+    </type>
+  </assembly>
+</linker>

--- a/test/Mono.Linker.Tests.Cases/LinkAttributes/Dependencies/MockCorelib.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkAttributes/Dependencies/MockCorelib.cs
@@ -1,0 +1,14 @@
+#if INCLUDE_MOCK_CORELIB
+
+using System;
+
+[assembly: MockCorelibAttributeToRemove]
+
+namespace System
+{
+	public class MockCorelibAttributeToRemove : Attribute
+	{
+	}
+}
+
+#endif

--- a/test/Mono.Linker.Tests.Cases/LinkAttributes/Dependencies/MockCorelib.xml
+++ b/test/Mono.Linker.Tests.Cases/LinkAttributes/Dependencies/MockCorelib.xml
@@ -1,0 +1,7 @@
+<linker>
+  <assembly fullname="*">
+    <type fullname="System.MockCorelibAttributeToRemove">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+  </assembly>
+</linker>

--- a/test/Mono.Linker.Tests.Cases/LinkAttributes/EmbeddedLinkAttributes.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkAttributes/EmbeddedLinkAttributes.cs
@@ -3,9 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
@@ -22,6 +20,7 @@ namespace Mono.Linker.Tests.Cases.LinkAttributes
 			var instance = new EmbeddedLinkAttributes ();
 
 			instance.ReadFromInstanceField ();
+			instance.ReadFromInstanceField2 ();
 		}
 
 		Type _typeWithPublicParameterlessConstructor;
@@ -49,6 +48,22 @@ namespace Mono.Linker.Tests.Cases.LinkAttributes
 
 		private static void RequireNonPublicConstructors (
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+			Type type)
+		{
+		}
+
+		Type _typeWithPublicFields;
+
+		[UnrecognizedReflectionAccessPattern (typeof (EmbeddedLinkAttributes), nameof (RequirePublicConstructors), new Type[] { typeof (Type) })]
+		[RecognizedReflectionAccessPattern]
+		private void ReadFromInstanceField2 ()
+		{
+			RequirePublicConstructors (_typeWithPublicFields);
+			RequirePublicFields (_typeWithPublicFields);
+		}
+
+		private static void RequirePublicFields (
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
 			Type type)
 		{
 		}

--- a/test/Mono.Linker.Tests.Cases/LinkAttributes/EmbeddedLinkAttributes.xml
+++ b/test/Mono.Linker.Tests.Cases/LinkAttributes/EmbeddedLinkAttributes.xml
@@ -8,4 +8,11 @@
       </field>
     </type>
   </assembly>
+  <type fullname="Mono.Linker.Tests.Cases.LinkAttributes.EmbeddedLinkAttributes">
+    <field name="_typeWithPublicFields">
+      <attribute fullname="System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute">
+        <argument>PublicFields</argument>
+      </attribute>
+    </field>
+  </type>
 </linker>

--- a/test/Mono.Linker.Tests.Cases/LinkAttributes/EmbeddedLinkAttributesInCorelib.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkAttributes/EmbeddedLinkAttributesInCorelib.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace System
+{
+	public class MockCorelibAttributeToRemove : Attribute
+	{
+	}
+}
+
+namespace Mono.Linker.Tests.Cases.LinkAttributes
+{
+	[IgnoreLinkAttributes (false)]
+	[SetupLinkerCoreAction ("link")] // Ensure that corelib gets linked so that its attribtues are processed
+	[SetupLinkerArgument ("--skip-unresolved", "true")] // Allow unresolved references to types missing from mock corelib
+	[SetupCompileBefore (PlatformAssemblies.CoreLib, new string[] { "Dependencies/MockCorelib.cs" },
+		resources: new object[] { new string[] { "Dependencies/MockCorelib.xml", "ILLink.LinkAttributes.xml" } },
+		defines: new[] { "INCLUDE_MOCK_CORELIB" })]
+#if NETCOREAPP
+	[RemovedAttributeInAssembly ("System.Private.CoreLib", "System.MockCorelibAttributeToRemove")]
+	[RemovedTypeInAssembly ("System.Private.CoreLib", "System.MockCorelibAttributeToRemove")]
+#else
+	[RemovedAttributeInAssembly ("mscorlib", "System.MockCorelibAttributeToRemove")]
+	[RemovedTypeInAssembly ("mscorlib", "System.MockCorelibAttributeToRemove")]
+#endif
+	class EmbeddedLinkAttributesInCorelib
+	{
+		public static void Main ()
+		{
+			AttributedMethod ();
+			var _ = new AttributedClass ();
+		}
+
+		[Kept]
+		[MockCorelibAttributeToRemove]
+		public static void AttributedMethod ()
+		{
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[MockCorelibAttributeToRemove]
+		public class AttributedClass
+		{
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/LinkAttributes/EmbeddedLinkAttributesInCorelib.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkAttributes/EmbeddedLinkAttributesInCorelib.cs
@@ -20,6 +20,7 @@ namespace Mono.Linker.Tests.Cases.LinkAttributes
 	[SetupCompileBefore (PlatformAssemblies.CoreLib, new string[] { "Dependencies/MockCorelib.cs" },
 		resources: new object[] { new string[] { "Dependencies/MockCorelib.xml", "ILLink.LinkAttributes.xml" } },
 		defines: new[] { "INCLUDE_MOCK_CORELIB" })]
+	[SkipPeVerify]
 #if NETCOREAPP
 	[RemovedAttributeInAssembly ("System.Private.CoreLib", "System.MockCorelibAttributeToRemove")]
 	[RemovedTypeInAssembly ("System.Private.CoreLib", "System.MockCorelibAttributeToRemove")]

--- a/test/Mono.Linker.Tests.Cases/LinkAttributes/LinkAttributeErrorCases.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkAttributes/LinkAttributeErrorCases.cs
@@ -1,14 +1,15 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.LinkAttributes.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.LinkAttributes
 {
 	[SetupLinkAttributesFile ("LinkAttributeErrorCases.xml")]
 	[IgnoreLinkAttributes (false)]
 	[SetupLinkerArgument ("--skip-unresolved", "true")]
+	[SetupCompileBefore ("library.dll", new string[] { "Dependencies/EmbeddedAttributeErrorCases.cs" },
+		resources: new object[] { new string[] { "Dependencies/EmbeddedAttributeErrorCases.xml", "ILLink.LinkAttributes.xml" } })]
 
 	[ExpectedWarning ("IL2007", "NonExistentAssembly2", FileName = "LinkAttributeErrorCases.xml")]
 	[ExpectedWarning ("IL2030", "NonExistentAssembly1", FileName = "LinkAttributeErrorCases.xml")]
@@ -24,11 +25,13 @@ namespace Mono.Linker.Tests.Cases.LinkAttributes
 	[ExpectedWarning ("IL2051", FileName = "LinkAttributeErrorCases.xml")]
 	[ExpectedWarning ("IL2052", "NonExistentPropertyName", FileName = "LinkAttributeErrorCases.xml")]
 	[ExpectedWarning ("IL2053", "StringValue", "IntProperty", FileName = "LinkAttributeErrorCases.xml")]
+	[ExpectedWarning ("IL2100", FileName = "ILLink.LinkAttributes.xml")]
+	[ExpectedWarning ("IL2101", "library", "test", FileName = "ILLink.LinkAttributes.xml")]
 	class LinkAttributeErrorCases
 	{
 		public static void Main ()
 		{
-
+			var _ = new EmbeddedAttributeErrorCases ();
 		}
 
 		public enum AttributeEnum
@@ -72,5 +75,9 @@ namespace Mono.Linker.Tests.Cases.LinkAttributes
 		public Type GetTypeMethod () => null;
 
 		public void MethodWithParameter (int methodParameter) { }
+
+		public class ReferencedFromOtherAssembly
+		{
+		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/LinkXml/EmbeddedLinkXmlFromCopyAssemblyIsProcessed.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/EmbeddedLinkXmlFromCopyAssemblyIsProcessed.cs
@@ -8,7 +8,7 @@ namespace Mono.Linker.Tests.Cases.LinkXml
 		new[] { "Dependencies/EmbeddedLinkXmlFromCopyAssemblyIsProcessed/OtherLibrary.cs" })]
 	[SetupCompileBefore ("CopyLibrary.dll",
 		new[] { "Dependencies/EmbeddedLinkXmlFromCopyAssemblyIsProcessed/CopyLibrary.cs" },
-		resources: new[] { "Dependencies/EmbeddedLinkXmlFromCopyAssemblyIsProcessed/CopyLibrary.xml" })]
+		resources: new object[] { "Dependencies/EmbeddedLinkXmlFromCopyAssemblyIsProcessed/CopyLibrary.xml" })]
 	[IgnoreDescriptors (false)]
 	[SetupLinkerAction ("copy", "CopyLibrary")]
 

--- a/test/Mono.Linker.Tests.Cases/LinkXml/EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod.cs
@@ -1,4 +1,4 @@
-﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.LinkXml.Dependencies.EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod;
 
@@ -9,7 +9,7 @@ namespace Mono.Linker.Tests.Cases.LinkXml
 	[SetupCompileBefore ("Library1.dll",
 		new[] { "Dependencies/EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod/Library1.cs" },
 		new[] { "Base.dll" },
-		resources: new[] { "Dependencies/EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod/Library1.xml" })]
+		resources: new object[] { "Dependencies/EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod/Library1.xml" })]
 	[SetupCompileBefore ("Library2.dll",
 		new[] { "Dependencies/EmbeddedLinkXmlPreservesAdditionalAssemblyWithOverriddenMethod/Library2.cs" },
 		new[] { "Base.dll" },

--- a/test/Mono.Linker.Tests.Cases/LinkXml/LinkXmlErrorCases.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/LinkXmlErrorCases.cs
@@ -20,6 +20,7 @@ namespace Mono.Linker.Tests.Cases.LinkXml
 	[ExpectedWarning ("IL2025", "Event", FileName = "LinkXmlErrorCases.xml")]
 	[ExpectedWarning ("IL2025", "Field", FileName = "LinkXmlErrorCases.xml")]
 	[ExpectedWarning ("IL2025", "Property", FileName = "LinkXmlErrorCases.xml")]
+	[ExpectedWarning ("IL2100", FileName = "LinkXmlErrorCases.xml")]
 	class LinkXmlErrorCases
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/LinkXml/LinkXmlErrorCases.xml
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/LinkXmlErrorCases.xml
@@ -43,4 +43,7 @@
   </assembly>
 
   <assembly fullname="NonExistentAssembly"/>
+
+  <!-- IL2100 -->
+  <assembly fullname="*" />
 </linker>

--- a/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethodInNonReferencedAssemblyWithEmbeddedXml.cs
+++ b/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethodInNonReferencedAssemblyWithEmbeddedXml.cs
@@ -15,7 +15,7 @@ namespace Mono.Linker.Tests.Cases.PreserveDependencies
 		"PreserveDependencyMethodInNonReferencedAssemblyLibrary.dll",
 		new[] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyLibrary.cs" },
 		references: new[] { "base.dll" },
-		resources: new object[] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyLibrary.xml",},
+		resources: new object[] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyLibrary.xml" },
 		addAsReference: false)]
 	[KeptAssembly ("base.dll")]
 	[RemovedMemberInAssembly ("PreserveDependencyMethodInNonReferencedAssemblyLibrary.dll", "Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyLibrary", "UnusedMethod()")]

--- a/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethodInNonReferencedAssemblyWithEmbeddedXml.cs
+++ b/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyMethodInNonReferencedAssemblyWithEmbeddedXml.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.CompilerServices;
+using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies;
@@ -15,7 +15,7 @@ namespace Mono.Linker.Tests.Cases.PreserveDependencies
 		"PreserveDependencyMethodInNonReferencedAssemblyLibrary.dll",
 		new[] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyLibrary.cs" },
 		references: new[] { "base.dll" },
-		resources: new[] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyLibrary.xml" },
+		resources: new object[] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyLibrary.xml",},
 		addAsReference: false)]
 	[KeptAssembly ("base.dll")]
 	[RemovedMemberInAssembly ("PreserveDependencyMethodInNonReferencedAssemblyLibrary.dll", "Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies.PreserveDependencyMethodInNonReferencedAssemblyLibrary", "UnusedMethod()")]

--- a/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithEmbeddedXml.cs
+++ b/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithEmbeddedXml.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.CompilerServices;
+using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies;
@@ -15,7 +15,7 @@ namespace Mono.Linker.Tests.Cases.PreserveDependencies
 		"PreserveDependencyMethodInNonReferencedAssemblyLibrary.dll",
 		new[] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyLibrary.cs" },
 		references: new[] { "base.dll" },
-		resources: new[] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyLibrary.xml" },
+		resources: new object[] { "Dependencies/PreserveDependencyMethodInNonReferencedAssemblyLibrary.xml" },
 		addAsReference: false)]
 	[KeptAssembly ("base.dll")]
 	[RemovedAssembly ("PreserveDependencyMethodInNonReferencedAssemblyLibrary.dll")]

--- a/test/Mono.Linker.Tests.Cases/Resources/Dependencies/EmbeddedLinkXmlFileIsProcessed.xml
+++ b/test/Mono.Linker.Tests.Cases/Resources/Dependencies/EmbeddedLinkXmlFileIsProcessed.xml
@@ -2,4 +2,5 @@
   <assembly fullname="test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
     <type fullname="Mono.Linker.Tests.Cases.Resources.EmbeddedLinkXmlFileIsProcessed/Unused" />
   </assembly>
+  <type fullname="Mono.Linker.Tests.Cases.Resources.EmbeddedLinkXmlFileIsProcessed/Unused2" />
 </linker>

--- a/test/Mono.Linker.Tests.Cases/Resources/EmbeddedLinkXmlFileInReferencedAssemblyIsNotProcessedIfActionIsCopy.cs
+++ b/test/Mono.Linker.Tests.Cases/Resources/EmbeddedLinkXmlFileInReferencedAssemblyIsNotProcessedIfActionIsCopy.cs
@@ -1,4 +1,4 @@
-﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Resources.Dependencies;
 
@@ -7,7 +7,7 @@ namespace Mono.Linker.Tests.Cases.Resources
 	[SetupCompileBefore (
 		"EmbeddedLinkXmlFileInReferencedAssemblyIsNotProcessedIfActionIsCopy_Lib1.dll",
 		new[] { "Dependencies/EmbeddedLinkXmlFileInReferencedAssemblyIsNotProcessedIfActionIsCopy_Lib1.cs" },
-		resources: new[] { "Dependencies/EmbeddedLinkXmlFileInReferencedAssemblyIsNotProcessedIfActionIsCopy_Lib1.xml" })]
+		resources: new object[] { "Dependencies/EmbeddedLinkXmlFileInReferencedAssemblyIsNotProcessedIfActionIsCopy_Lib1.xml" })]
 	[SetupLinkerAction ("copy", "EmbeddedLinkXmlFileInReferencedAssemblyIsNotProcessedIfActionIsCopy_Lib1")]
 	[IgnoreDescriptors (false)]
 

--- a/test/Mono.Linker.Tests.Cases/Resources/EmbeddedLinkXmlFileInReferencedAssemblyIsNotProcessedIfNameDoesNotMatchAnAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/Resources/EmbeddedLinkXmlFileInReferencedAssemblyIsNotProcessedIfNameDoesNotMatchAnAssembly.cs
@@ -1,4 +1,4 @@
-﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Resources.Dependencies;
 
@@ -7,7 +7,7 @@ namespace Mono.Linker.Tests.Cases.Resources
 	[SetupCompileBefore (
 		"library.dll",
 		new[] { "Dependencies/EmbeddedLinkXmlFileInReferencedAssemblyIsNotProcessedIfNameDoesNotMatchAnAssembly_Lib1.cs" },
-		resources: new[] { "Dependencies/EmbeddedLinkXmlFileInReferencedAssemblyIsNotProcessedIfNameDoesNotMatchAnAssembly_Lib1_NotMatchingName.xml" })]
+		resources: new object[] { "Dependencies/EmbeddedLinkXmlFileInReferencedAssemblyIsNotProcessedIfNameDoesNotMatchAnAssembly_Lib1_NotMatchingName.xml" })]
 	[IgnoreDescriptors (false)]
 
 	[KeptResourceInAssembly ("library.dll", "EmbeddedLinkXmlFileInReferencedAssemblyIsNotProcessedIfNameDoesNotMatchAnAssembly_Lib1_NotMatchingName.xml")]

--- a/test/Mono.Linker.Tests.Cases/Resources/EmbeddedLinkXmlFileInReferencedAssemblyIsProcessedIfActionIsLink.cs
+++ b/test/Mono.Linker.Tests.Cases/Resources/EmbeddedLinkXmlFileInReferencedAssemblyIsProcessedIfActionIsLink.cs
@@ -1,4 +1,4 @@
-﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Resources.Dependencies;
 
@@ -7,7 +7,7 @@ namespace Mono.Linker.Tests.Cases.Resources
 	[SetupCompileBefore (
 		"EmbeddedLinkXmlFileInReferencedAssemblyIsProcessedIfActionIsLink_Lib1.dll",
 		new[] { "Dependencies/EmbeddedLinkXmlFileInReferencedAssemblyIsProcessedIfActionIsLink_Lib1.cs" },
-		resources: new[] { "Dependencies/EmbeddedLinkXmlFileInReferencedAssemblyIsProcessedIfActionIsLink_Lib1.xml" })]
+		resources: new object[] { "Dependencies/EmbeddedLinkXmlFileInReferencedAssemblyIsProcessedIfActionIsLink_Lib1.xml" })]
 	[SetupLinkerAction ("link", "EmbeddedLinkXmlFileInReferencedAssemblyIsProcessedIfActionIsLink_Lib1")]
 	[IgnoreDescriptors (false)]
 

--- a/test/Mono.Linker.Tests.Cases/Resources/EmbeddedLinkXmlFileIsProcessed.cs
+++ b/test/Mono.Linker.Tests.Cases/Resources/EmbeddedLinkXmlFileIsProcessed.cs
@@ -19,5 +19,11 @@ namespace Mono.Linker.Tests.Cases.Resources
 		public class Unused
 		{
 		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		public class Unused2
+		{
+		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/Substitutions/Dependencies/EmbeddedSubstitutions.xml
+++ b/test/Mono.Linker.Tests.Cases/Substitutions/Dependencies/EmbeddedSubstitutions.xml
@@ -4,4 +4,7 @@
       <method signature="System.Void ConvertToThrowMethod()" body="remove" />
     </type>
   </assembly>
+  <type fullname="Mono.Linker.Tests.Cases.Substitutions.EmbeddedSubstitutions">
+    <method signature="System.Void ConvertToThrowMethod2()" body="remove" />
+  </type>
 </linker>

--- a/test/Mono.Linker.Tests.Cases/Substitutions/Dependencies/EmbeddedSubstitutionsErrorCases.cs
+++ b/test/Mono.Linker.Tests.Cases/Substitutions/Dependencies/EmbeddedSubstitutionsErrorCases.cs
@@ -1,0 +1,6 @@
+namespace Mono.Linker.Tests.Cases.Substitutions.Dependencies
+{
+	public class EmbeddedSubstitutionsErrorCases
+	{
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Substitutions/Dependencies/EmbeddedSubstitutionsErrorCases.xml
+++ b/test/Mono.Linker.Tests.Cases/Substitutions/Dependencies/EmbeddedSubstitutionsErrorCases.xml
@@ -1,0 +1,8 @@
+<linker>
+  <!-- IL2101 -->
+  <assembly fullname="test">
+    <type fullname="Mono.Linker.Tests.Cases.Substitutions.SubstitutionsErrorCases/ReferencedFromOtherAssembly">
+      <method signature="System.Int32 TestMethod()" body="stub" value="1" />
+    </type>
+  </assembly>
+</linker>

--- a/test/Mono.Linker.Tests.Cases/Substitutions/EmbeddedSubstitutions.cs
+++ b/test/Mono.Linker.Tests.Cases/Substitutions/EmbeddedSubstitutions.cs
@@ -11,6 +11,7 @@ namespace Mono.Linker.Tests.Cases.Substitutions
 		public static void Main ()
 		{
 			ConvertToThrowMethod ();
+			ConvertToThrowMethod2 ();
 		}
 
 		[Kept]
@@ -20,6 +21,16 @@ namespace Mono.Linker.Tests.Cases.Substitutions
 			"throw"
 		})]
 		public static void ConvertToThrowMethod ()
+		{
+		}
+
+		[Kept]
+		[ExpectedInstructionSequence (new[] {
+			"ldstr",
+			"newobj",
+			"throw"
+		})]
+		public static void ConvertToThrowMethod2 ()
 		{
 		}
 	}

--- a/test/Mono.Linker.Tests.Cases/Substitutions/SubstitutionsErrorCases.cs
+++ b/test/Mono.Linker.Tests.Cases/Substitutions/SubstitutionsErrorCases.cs
@@ -1,10 +1,13 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Substitutions.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Substitutions
 {
 	[SetupLinkerSubstitutionFile ("SubstitutionsErrorCases.xml")]
+	[IgnoreSubstitutions (false)]
+	[SetupCompileBefore ("library.dll", new string[] { "Dependencies/EmbeddedSubstitutionsErrorCases.cs" },
+		resources: new object[] { new string[] { "Dependencies/EmbeddedSubstitutionsErrorCases.xml", "ILLink.Substitutions.xml" } })]
 
 	[ExpectedWarning ("IL2010", "TestMethod_1", "stub", FileName = "SubstitutionsErrorCases.xml")]
 	[ExpectedWarning ("IL2011", "TestMethod_2", "noaction", FileName = "SubstitutionsErrorCases.xml")]
@@ -12,6 +15,8 @@ namespace Mono.Linker.Tests.Cases.Substitutions
 	[ExpectedWarning ("IL2014", "SubstitutionsErrorCases::IntField", FileName = "SubstitutionsErrorCases.xml")]
 	[ExpectedWarning ("IL2015", "SubstitutionsErrorCases::IntField", "NonNumber", FileName = "SubstitutionsErrorCases.xml")]
 	[ExpectedWarning ("IL2007", "NonExistentAssembly", FileName = "SubstitutionsErrorCases.xml")]
+	[ExpectedWarning ("IL2100", FileName = "SubstitutionsErrorCases.xml")]
+	[ExpectedWarning ("IL2101", "library", "test", FileName = "ILLink.Substitutions.xml")]
 
 	[KeptMember (".ctor()")]
 	class SubstitutionsErrorCases
@@ -24,6 +29,8 @@ namespace Mono.Linker.Tests.Cases.Substitutions
 			var instance = new SubstitutionsErrorCases ();
 			instance.InstanceField = 42;
 			IntField = 42;
+
+			var _ = new EmbeddedSubstitutionsErrorCases ();
 		}
 
 		[Kept]
@@ -37,5 +44,10 @@ namespace Mono.Linker.Tests.Cases.Substitutions
 
 		[Kept]
 		public static int IntField;
+
+		public class ReferencedFromOtherAssembly
+		{
+			public static int TestMethod () { return 42; }
+		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/Substitutions/SubstitutionsErrorCases.xml
+++ b/test/Mono.Linker.Tests.Cases/Substitutions/SubstitutionsErrorCases.xml
@@ -11,4 +11,6 @@
     </type>
   </assembly>
   <assembly fullname="NonExistentAssembly" />
+  <!-- IL2100 -->
+  <assembly fullname="*" />
 </linker>

--- a/test/Mono.Linker.Tests.Cases/TestFramework/CanCompileReferencesWithResources.cs
+++ b/test/Mono.Linker.Tests.Cases/TestFramework/CanCompileReferencesWithResources.cs
@@ -1,4 +1,4 @@
-﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.TestFramework.Dependencies;
 
@@ -6,12 +6,12 @@ namespace Mono.Linker.Tests.Cases.TestFramework
 {
 	[SetupCompileBefore ("library.dll",
 		new[] { "Dependencies/CanCompileReferencesWithResources_Lib1.cs" },
-		resources: new[] { "Dependencies/CanCompileReferencesWithResources_Lib1.txt" })]
+		resources: new object[] { "Dependencies/CanCompileReferencesWithResources_Lib1.txt" })]
 
 	// Compile the same assembly again with another resource to get coverage on SetupCompileAfter
 	[SetupCompileAfter ("library.dll",
 		new[] { "Dependencies/CanCompileReferencesWithResources_Lib1.cs" },
-		resources: new[] { "Dependencies/CanCompileReferencesWithResources_Lib1.txt", "Dependencies/CanCompileReferencesWithResources_Lib1.log" })]
+		resources: new object[] { "Dependencies/CanCompileReferencesWithResources_Lib1.txt", "Dependencies/CanCompileReferencesWithResources_Lib1.log" })]
 
 	[KeptResourceInAssembly ("library.dll", "CanCompileReferencesWithResources_Lib1.txt")]
 	[KeptResourceInAssembly ("library.dll", "CanCompileReferencesWithResources_Lib1.log")]

--- a/test/Mono.Linker.Tests.Cases/TestFramework/CanCompileReferencesWithResourcesWithCsc.cs
+++ b/test/Mono.Linker.Tests.Cases/TestFramework/CanCompileReferencesWithResourcesWithCsc.cs
@@ -1,4 +1,4 @@
-﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.TestFramework.Dependencies;
 
@@ -6,13 +6,13 @@ namespace Mono.Linker.Tests.Cases.TestFramework
 {
 	[SetupCompileBefore ("library.dll",
 		new[] { "Dependencies/CanCompileReferencesWithResources_Lib1.cs" },
-		resources: new[] { "Dependencies/CanCompileReferencesWithResources_Lib1.txt" },
+		resources: new object[] { "Dependencies/CanCompileReferencesWithResources_Lib1.txt" },
 		compilerToUse: "csc")]
 
 	// Compile the same assembly again with another resource to get coverage on SetupCompileAfter
 	[SetupCompileAfter ("library.dll",
 		new[] { "Dependencies/CanCompileReferencesWithResources_Lib1.cs" },
-		resources: new[] { "Dependencies/CanCompileReferencesWithResources_Lib1.txt", "Dependencies/CanCompileReferencesWithResources_Lib1.log" },
+		resources: new object[] { "Dependencies/CanCompileReferencesWithResources_Lib1.txt", "Dependencies/CanCompileReferencesWithResources_Lib1.log" },
 		compilerToUse: "csc")]
 
 	[KeptResourceInAssembly ("library.dll", "CanCompileReferencesWithResources_Lib1.txt")]

--- a/test/Mono.Linker.Tests.Cases/TestFramework/CanCompileReferencesWithResourcesWithMcs.cs
+++ b/test/Mono.Linker.Tests.Cases/TestFramework/CanCompileReferencesWithResourcesWithMcs.cs
@@ -1,4 +1,4 @@
-﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.TestFramework.Dependencies;
 
@@ -9,13 +9,13 @@ namespace Mono.Linker.Tests.Cases.TestFramework
 #endif
 	[SetupCompileBefore ("library.dll",
 		new[] { "Dependencies/CanCompileReferencesWithResources_Lib1.cs" },
-		resources: new[] { "Dependencies/CanCompileReferencesWithResources_Lib1.txt" },
+		resources: new object[] { "Dependencies/CanCompileReferencesWithResources_Lib1.txt" },
 		compilerToUse: "mcs")]
 
 	// Compile the same assembly again with another resource to get coverage on SetupCompileAfter
 	[SetupCompileAfter ("library.dll",
 		new[] { "Dependencies/CanCompileReferencesWithResources_Lib1.cs" },
-		resources: new[] { "Dependencies/CanCompileReferencesWithResources_Lib1.txt", "Dependencies/CanCompileReferencesWithResources_Lib1.log" },
+		resources: new object[] { "Dependencies/CanCompileReferencesWithResources_Lib1.txt", "Dependencies/CanCompileReferencesWithResources_Lib1.log" },
 		compilerToUse: "mcs")]
 
 	[KeptResourceInAssembly ("library.dll", "CanCompileReferencesWithResources_Lib1.txt")]

--- a/test/Mono.Linker.Tests/Extensions/CecilExtensions.cs
+++ b/test/Mono.Linker.Tests/Extensions/CecilExtensions.cs
@@ -109,7 +109,7 @@ namespace Mono.Linker.Tests.Extensions
 			if (type.BaseType.Name == baseTypeName)
 				return true;
 
-			return type.BaseType.Resolve ().DerivesFrom (baseTypeName);
+			return type.BaseType.Resolve ()?.DerivesFrom (baseTypeName) ?? false;
 		}
 
 		public static PropertyDefinition GetPropertyDefinition (this MethodDefinition method)

--- a/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -708,7 +708,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 		{
 			foreach (var typeWithRemoveInAssembly in original.AllDefinedTypes ()) {
 				foreach (var attr in typeWithRemoveInAssembly.CustomAttributes) {
-					if (attr.AttributeType.Resolve ().Name == nameof (DependencyRecordedAttribute)) {
+					if (attr.AttributeType.Resolve ()?.Name == nameof (DependencyRecordedAttribute)) {
 						var expectedSource = (string) attr.ConstructorArguments[0].Value;
 						var expectedTarget = (string) attr.ConstructorArguments[1].Value;
 						var expectedMarked = (string) attr.ConstructorArguments[2].Value;
@@ -758,7 +758,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			foreach (var expectedSourceMemberDefinition in original.MainModule.AllDefinedTypes ().SelectMany (t => t.AllMembers ().Append (t)).Distinct ()) {
 				bool foundAttributesToVerify = false;
 				foreach (var attr in expectedSourceMemberDefinition.CustomAttributes) {
-					if (attr.AttributeType.Resolve ().Name == nameof (RecognizedReflectionAccessPatternAttribute)) {
+					if (attr.AttributeType.Resolve ()?.Name == nameof (RecognizedReflectionAccessPatternAttribute)) {
 						foundAttributesToVerify = true;
 
 						// Special case for default .ctor - just trigger the overall verification on the method
@@ -800,7 +800,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 								$"Potential patterns matching the reflection member: {Environment.NewLine}{reflectionMemberCandidates}{Environment.NewLine}" +
 								$"If there's no matches, try to specify just a part of the source member or reflection member name and rerun the test to get potential matches.");
 						}
-					} else if (attr.AttributeType.Resolve ().Name == nameof (UnrecognizedReflectionAccessPatternAttribute) &&
+					} else if (attr.AttributeType.Resolve ()?.Name == nameof (UnrecognizedReflectionAccessPatternAttribute) &&
 						attr.ConstructorArguments[0].Type.MetadataType != MetadataType.String) {
 						foundAttributesToVerify = true;
 						string expectedSourceMember = GetFullMemberNameFromDefinition (expectedSourceMemberDefinition);
@@ -881,7 +881,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 			foreach (var typeToVerify in original.MainModule.AllDefinedTypes ()) {
 				foreach (var attr in typeToVerify.CustomAttributes) {
-					if (attr.AttributeType.Resolve ().Name == nameof (VerifyAllReflectionAccessPatternsAreValidatedAttribute)) {
+					if (attr.AttributeType.Resolve ()?.Name == nameof (VerifyAllReflectionAccessPatternsAreValidatedAttribute)) {
 						// By now all verified recorded patterns were removed from the test recorder lists, so validate
 						// that there are no remaining patterns for this type.
 						var recognizedPatternsForType = reflectionPatternRecorder.RecognizedPatterns
@@ -1071,7 +1071,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 		bool IsTypeInOtherAssemblyAssertion (CustomAttribute attr)
 		{
-			return attr.AttributeType.Resolve ().DerivesFrom (nameof (BaseInAssemblyAttribute));
+			return attr.AttributeType.Resolve ()?.DerivesFrom (nameof (BaseInAssemblyAttribute)) ?? false;
 		}
 
 		bool HasAttribute (ICustomAttributeProvider caProvider, string attributeName)

--- a/test/Mono.Linker.Tests/TestCasesRunner/SetupCompileInfo.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/SetupCompileInfo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Mono.Linker.Tests.Extensions;
 
 namespace Mono.Linker.Tests.TestCasesRunner
@@ -9,7 +9,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 		public NPath[] SourceFiles;
 		public string[] Defines;
 		public string[] References;
-		public NPath[] Resources;
+		public SourceAndDestinationPair[] Resources;
 		public string AdditionalArguments;
 		public string CompilerToUse;
 		public bool AddAsReference;

--- a/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadaProvider.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadaProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -329,7 +329,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				SourceFiles = SourceFilesForAttributeArgument (ctorArguments[1]),
 				References = ((CustomAttributeArgument[]) ctorArguments[2].Value)?.Select (arg => arg.Value.ToString ()).ToArray (),
 				Defines = ((CustomAttributeArgument[]) ctorArguments[3].Value)?.Select (arg => arg.Value.ToString ()).ToArray (),
-				Resources = ((CustomAttributeArgument[]) ctorArguments[4].Value)?.Select (arg => MakeSourceTreeFilePathAbsolute (arg.Value.ToString ())).ToArray (),
+				Resources = ResourcesForAttributeArgument (ctorArguments[4]),
 				AdditionalArguments = (string) ctorArguments[5].Value,
 				CompilerToUse = (string) ctorArguments[6].Value,
 				AddAsReference = ctorArguments.Count >= 8 ? (bool) ctorArguments[7].Value : true,
@@ -348,6 +348,27 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				.Select (attributeArg => SourceFileForAttributeArgumentValue (attributeArg.Value))
 				.Distinct ()
 				.ToArray ();
+		}
+
+		protected SourceAndDestinationPair[] ResourcesForAttributeArgument (CustomAttributeArgument attributeArgument)
+		{
+			return ((CustomAttributeArgument[]) attributeArgument.Value)
+				?.Select (arg => {
+					var referenceArg = (CustomAttributeArgument) arg.Value;
+					if (referenceArg.Value is string source) {
+						var fullSource = MakeSourceTreeFilePathAbsolute (source);
+						return new SourceAndDestinationPair {
+							Source = fullSource,
+							DestinationFileName = fullSource.FileName
+						};
+					}
+					var sourceAndDestination = (CustomAttributeArgument[]) referenceArg.Value;
+					return new SourceAndDestinationPair  {	
+						Source = MakeSourceTreeFilePathAbsolute (sourceAndDestination[0].Value.ToString()),
+						DestinationFileName = sourceAndDestination[1].Value.ToString()
+					};
+				})
+				?.ToArray ();
 		}
 
 		protected virtual NPath SourceFileForAttributeArgumentValue (object value)

--- a/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadaProvider.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadaProvider.cs
@@ -363,9 +363,9 @@ namespace Mono.Linker.Tests.TestCasesRunner
 						};
 					}
 					var sourceAndDestination = (CustomAttributeArgument[]) referenceArg.Value;
-					return new SourceAndDestinationPair  {	
-						Source = MakeSourceTreeFilePathAbsolute (sourceAndDestination[0].Value.ToString()),
-						DestinationFileName = sourceAndDestination[1].Value.ToString()
+					return new SourceAndDestinationPair {
+						Source = MakeSourceTreeFilePathAbsolute (sourceAndDestination[0].Value.ToString ()),
+						DestinationFileName = sourceAndDestination[1].Value.ToString ()
 					};
 				})
 				?.ToArray ();

--- a/test/Mono.Linker.Tests/TestCasesRunner/TestCaseSandbox.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestCaseSandbox.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
@@ -113,7 +113,12 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				compileRefInfo.SourceFiles.Copy (destination);
 
 				destination = BeforeReferenceResourceDirectoryFor (compileRefInfo.OutputName).EnsureDirectoryExists ();
-				compileRefInfo.Resources?.Copy (destination);
+
+				if (compileRefInfo.Resources == null)
+					continue;
+
+				foreach (var res in compileRefInfo.Resources)
+					res.Source.FileMustExist ().Copy (destination.Combine (res.DestinationFileName));
 			}
 
 			foreach (var compileRefInfo in metadataProvider.GetSetupCompileAssembliesAfter ()) {
@@ -121,7 +126,12 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				compileRefInfo.SourceFiles.Copy (destination);
 
 				destination = AfterReferenceResourceDirectoryFor (compileRefInfo.OutputName).EnsureDirectoryExists ();
-				compileRefInfo.Resources?.Copy (destination);
+
+				if (compileRefInfo.Resources == null)
+					continue;
+
+				foreach (var res in compileRefInfo.Resources)
+					res.Source.FileMustExist ().Copy (destination.Combine (res.DestinationFileName));
 			}
 		}
 


### PR DESCRIPTION
This restricts the embedded XML to prevent modification of assemblies other than the containing assembly. Specifically:
- Descriptor XML may still mark types in other assemblies since it is purely additive
- Substitution XML may not rewrite methods/fields defined in other assemblies
- Attribute XML may not add attributes to other assemblies. (RemoveAttributeInstances may only be specified by embedded XML in the assembly that defines the attribute type)
- Embedded attribute XML may not use '*' to select all assemblies
- Embedded XML of any kind may leave out the `assemby` tag, instead specifying types of the containing assembly directly under `<linker>`
- XML specified on the command-line is unchanged

(I'm separating the XML changes out from the rest of https://github.com/mono/linker/pull/1666.)