### PR TITLE
Fix pointer type forwarding

### DIFF
--- a/src/linker/Linker.Steps/SweepStep.cs
+++ b/src/linker/Linker.Steps/SweepStep.cs
@@ -449,14 +449,21 @@ namespace Mono.Linker.Steps
 			if (type.IsWindowsRuntimeProjection)
 				return;
 
-			if (type is TypeSpecification ts) {
-				UpdateTypeScope (ts.ElementType, assembly);
-				if (type is GenericInstanceType git) {
-					foreach (var ga in git.GenericArguments)
-						UpdateTypeScope (ga, assembly);
-				}
-
+			switch (type) {
+			case GenericInstanceType git:
+				UpdateTypeScope (git.ElementType, assembly);
+				foreach (var ga in git.GenericArguments)
+					UpdateTypeScope (ga, assembly);
 				return;
+			case ArrayType at:
+				UpdateTypeScope (at.ElementType, assembly);
+				return;
+			case PointerType pt:
+				UpdateTypeScope (pt.ElementType, assembly);
+				return;
+			case FunctionPointerType fpt:
+				// Currently not possible with C#: https://github.com/dotnet/roslyn/issues/48765
+				throw new InternalErrorException ($"Function pointer type in custom attribute argument '{fpt}' - currently not supported.");
 			}
 
 			TypeDefinition td = type.Resolve ();

--- a/src/linker/Linker.Steps/SweepStep.cs
+++ b/src/linker/Linker.Steps/SweepStep.cs
@@ -449,15 +449,13 @@ namespace Mono.Linker.Steps
 			if (type.IsWindowsRuntimeProjection)
 				return;
 
-			if (type is GenericInstanceType git && git.HasGenericArguments) {
-				UpdateTypeScope (git.ElementType, assembly);
-				foreach (var ga in git.GenericArguments)
-					UpdateTypeScope (ga, assembly);
-				return;
-			}
+			if (type is TypeSpecification ts) {
+				UpdateTypeScope (ts.ElementType, assembly);
+				if (type is GenericInstanceType git) {
+					foreach (var ga in git.GenericArguments)
+						UpdateTypeScope (ga, assembly);
+				}
 
-			if (type is ArrayType at) {
-				UpdateTypeScope (at.ElementType, assembly);
 				return;
 			}
 

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/AttributeArgumentForwarded.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/AttributeArgumentForwarded.cs
@@ -22,50 +22,52 @@ namespace Mono.Linker.Tests.Cases.TypeForwarding
 
 	[RemovedAssembly ("Forwarder.dll")]
 	[KeptMemberInAssembly ("Implementation.dll", typeof (ImplementationLibrary))]
+	[KeptMemberInAssembly ("Implementation.dll", typeof (ImplementationStruct))]
 	class AttributeArgumentForwarded
 	{
 		static void Main ()
 		{
-			Test_1 ();
-			Test_1b ();
-			Test_1c ();
-			Test_2 ();
-			Test_3 ();
-			Test_3a ();
+			Test_Parameter_TypeRef ();
+			Test_Parameter_TypeRefMDArray ();
+			Test_Parameter_PointerTypeRef ();
+			Test_Property_ArrayOfTypeRefs ();
+			Test_Field_GenericOfTypeRefArray ();
+			Test_Field_OpenGeneric ();
+			Test_Field_ArrayOfPointerTypeRef ();
 		}
 
 		[Kept]
 		[KeptAttributeAttribute (typeof (TestTypeAttribute))]
 		[TestType (typeof (ImplementationLibrary))]
-		public static void Test_1 ()
+		public static void Test_Parameter_TypeRef ()
 		{
 		}
 
 		[Kept]
 		[KeptAttributeAttribute (typeof (TestTypeAttribute))]
 		[TestType (typeof (ImplementationLibrary[,][]))]
-		public static void Test_1b ()
+		public static void Test_Parameter_TypeRefMDArray ()
 		{
 		}
 
 		[Kept]
 		[KeptAttributeAttribute (typeof (TestTypeAttribute))]
-		[TestType (typeof (ImplementationLibrary[,][]))]
-		public static void Test_1c ()
+		[TestType (typeof (ImplementationStruct*))]
+		public static void Test_Parameter_PointerTypeRef ()
 		{
 		}
 
 		[Kept]
 		[KeptAttributeAttribute (typeof (TestTypeAttribute))]
 		[TestType (TestProperty = new object[] { typeof (ImplementationLibrary) })]
-		public static void Test_2 ()
+		public static void Test_Property_ArrayOfTypeRefs ()
 		{
 		}
 
 		[Kept]
 		[KeptAttributeAttribute (typeof (TestTypeAttribute))]
 		[TestType (TestField = typeof (SomeGenericType<ImplementationLibrary[]>))]
-		public static void Test_3 ()
+		public static void Test_Field_GenericOfTypeRefArray ()
 		{
 		}
 
@@ -73,7 +75,14 @@ namespace Mono.Linker.Tests.Cases.TypeForwarding
 		[Kept]
 		[KeptAttributeAttribute (typeof (TestTypeAttribute))]
 		[TestType (TestField = typeof (SomeGenericType<>))]
-		public static void Test_3a ()
+		public static void Test_Field_OpenGeneric ()
+		{
+		}
+
+		[Kept]
+		[KeptAttributeAttribute (typeof (TestTypeAttribute))]
+		[TestType (TestField = new object[] { typeof (ImplementationStruct*) })]
+		public static void Test_Field_ArrayOfPointerTypeRef ()
 		{
 		}
 	}

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/AttributeArgumentForwarded.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/AttributeArgumentForwarded.cs
@@ -85,6 +85,14 @@ namespace Mono.Linker.Tests.Cases.TypeForwarding
 		public static void Test_Field_ArrayOfPointerTypeRef ()
 		{
 		}
+
+		// This hits Roslyn bug https://github.com/dotnet/roslyn/issues/48765
+		//[Kept]
+		//[KeptAttributeAttribute (typeof (TestTypeAttribute))]
+		//[TestType (TestField = new object[] { typeof (delegate*<int, void>) })]
+		//public static void Test_Field_ArrayOfFunctionPointer ()
+		//{
+		//}
 	}
 
 	[KeptBaseType (typeof (Attribute))]

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/ForwarderLibrary.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/ForwarderLibrary.cs
@@ -1,3 +1,4 @@
 ﻿using System;
 
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo (typeof (Mono.Linker.Tests.Cases.TypeForwarding.Dependencies.ImplementationLibrary))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo (typeof(Mono.Linker.Tests.Cases.TypeForwarding.Dependencies.ImplementationStruct))]

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/ForwarderLibrary.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/ForwarderLibrary.cs
@@ -1,4 +1,4 @@
 ﻿using System;
 
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo (typeof (Mono.Linker.Tests.Cases.TypeForwarding.Dependencies.ImplementationLibrary))]
-[assembly: System.Runtime.CompilerServices.TypeForwardedTo (typeof(Mono.Linker.Tests.Cases.TypeForwarding.Dependencies.ImplementationStruct))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo (typeof (Mono.Linker.Tests.Cases.TypeForwarding.Dependencies.ImplementationStruct))]

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/ImplementationLibrary.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/ImplementationLibrary.cs
@@ -13,4 +13,9 @@ namespace Mono.Linker.Tests.Cases.TypeForwarding.Dependencies
 			return "Hello";
 		}
 	}
+
+	public struct ImplementationStruct
+	{
+		public int Field;
+	}
 }

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/ReferenceImplementationLibrary.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/ReferenceImplementationLibrary.cs
@@ -15,5 +15,10 @@ namespace Mono.Linker.Tests.Cases.TypeForwarding.Dependencies
 			return null;
 		}
 	}
+
+	public struct ImplementationStruct
+	{
+		public int Field;
+	}
 #endif
 }


### PR DESCRIPTION
Sweep step resolves type forwarders and replaces them with direct type refs. There were already special cases for generic instantiations and array, but other type specifications were missing, most notably pointer types.
Added handling of all type specifications and added some tests.

Fixes #1673