### PR TITLE
Add design doc for single-file unsupported attribute

### DIFF
--- a/docs/design/single-file-unsupported.md
+++ b/docs/design/single-file-unsupported.md
@@ -1,0 +1,63 @@
+# Single-file unsupported attribute
+
+Starting with .NET Core 3.0 users have the ability to bundle all files used by their applications into a single executable through the publish functionality, `PublishSingleFile`. Although most applications can be agnostic of whether they will be deployed as single-file, there exist some APIs that are known to be incompatible with this deployment mode and thus can cause single-file apps to crash.
+
+While the existing single-file analyzer can help us emit warnings whenever incompatible runtime library APIs are called from within user's code in a project that has been marked with the intent of being published as single-file (through setting `PublishSingleFile` to true in its .csproj), developers can still take a dependency on third-party components implementing functionality that inadvertently make their application no longer compatible with single-file.
+
+## User Experience
+
+For library authors, the new attribute will allow them to easily annotate APIs known to be problematic when used in the context of a single-file application.
+
+```C#
+
+```
+
+Consumers of this library who want to publish their application as a single-file binary will commonly do it through setting the corresponding property in the application’s .csproj:
+
+```XML
+<PropertyGroup>
+    <PublishSingleFile>true</PublishSingleFile>
+</PropertyGroup>
+```
+
+If the user now makes use of the problematic API, a warning will be produced:
+
+> ILLink: Single-file warning ILXXXX: Foo.Bar(): This method is not compatible with single-file. Url.
+```C#
+[SingleFileUnsupported("This method is not compatible with single-file", "https://help")]
+Bar()
+{
+    Assembly executingAssembly = Assembly.GetExecutingAssembly();
+    var codeBase = executingAssembly.CodeBase;
+    ...
+}
+```
+The linker will exercise implicit suppression of all other single-file related warnings produced by code within the incompatible method.
+
+If a user is confident that the used API does not pose a problem, the known warning suppression mechanisms can be used.
+
+## Goal
+
+By adding this attribute, we expect to improve users experience by giving library authors a way to annotate their single-file incompatible APIs such that consumers get useful diagnostics when using them. Developers who build applications meant to be published as single-file binaries should not have to wait until running their program to find out that they are using incompatible APIs.
+
+## Design
+
+```C#
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor, Inherited = false, AllowMultiple = false)]
+    public sealed class SingleFileUnsupportedAttribute : Attribute
+    {
+        public SingleFileUnsupportedAttribute(string message)
+        {
+            Message = message;
+        }
+
+        public string Message { get; }
+
+        public string Url { get; set; }
+    }
+}
+```
+
+## Q & A

--- a/docs/design/single-file-unsupported.md
+++ b/docs/design/single-file-unsupported.md
@@ -9,7 +9,13 @@ While the existing single-file analyzer can help us emit warnings whenever incom
 For library authors, the new attribute will allow them to easily annotate APIs known to be problematic when used in the context of a single-file application.
 
 ```C#
-
+[SingleFileUnsupported("'Bar' method is not compatible with single-file", "https://help")]
+void Bar()
+{
+    Assembly executingAssembly = Assembly.GetExecutingAssembly();
+    var codeBase = executingAssembly.CodeBase;
+    ...
+}
 ```
 
 Consumers of this library who want to publish their application as a single-file binary will commonly do it through setting the corresponding property in the application’s .csproj:
@@ -22,13 +28,12 @@ Consumers of this library who want to publish their application as a single-file
 
 If the user now makes use of the problematic API, a warning will be produced:
 
-> ILLink: Single-file warning ILXXXX: Foo.Bar(): This method is not compatible with single-file. Url.
+> File.cs(4,4): Single-file warning ILXXXX: Foo.CallBar(): 'Bar' method is not compatible with single-file. Url.
 ```C#
-[SingleFileUnsupported("This method is not compatible with single-file", "https://help")]
-Bar()
+void CallBar()
 {
-    Assembly executingAssembly = Assembly.GetExecutingAssembly();
-    var codeBase = executingAssembly.CodeBase;
+    ...
+    Bar();
     ...
 }
 ```

--- a/src/linker/Resources/Strings.Designer.cs
+++ b/src/linker/Resources/Strings.Designer.cs
@@ -61,7 +61,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in call to &apos;{1}&apos;. The parameter &apos;{2}&apos; of method &apos;{3}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; argument does not satisfy {4} in call to &apos;{1}&apos;. The parameter &apos;{2}&apos; of method &apos;{3}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2067 {
             get {
@@ -70,7 +70,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; method return value does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; requirements. The parameter &apos;{1}&apos; of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; method return value does not satisfy {3} requirements. The parameter &apos;{1}&apos; of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2068 {
             get {
@@ -79,7 +79,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; field does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; requirements. The parameter &apos;{1}&apos; of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to value stored in field &apos;{0}&apos; does not satisfy {3} requirements. The parameter &apos;{1}&apos; of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2069 {
             get {
@@ -88,7 +88,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;this&apos; argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in call to &apos;{0}&apos;. The parameter &apos;{1}&apos; of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;this&apos; argument does not satisfy {3} in call to &apos;{0}&apos;. The parameter &apos;{1}&apos; of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2070 {
             get {
@@ -97,7 +97,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; generic argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in &apos;{1}&apos;. The parameter &apos;{2}&apos; of method &apos;{3}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; generic argument does not satisfy {4} in &apos;{1}&apos;. The parameter &apos;{2}&apos; of method &apos;{3}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2071 {
             get {
@@ -106,7 +106,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in call to &apos;{1}&apos;. The return value of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; argument does not satisfy {3} in call to &apos;{1}&apos;. The return value of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2072 {
             get {
@@ -115,7 +115,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; method return value does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; requirements. The return value of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; method return value does not satisfy {2} requirements. The return value of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2073 {
             get {
@@ -124,7 +124,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; field does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; requirements. The return value of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to value stored in field &apos;{0}&apos; does not satisfy {2} requirements. The return value of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2074 {
             get {
@@ -133,7 +133,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;this&apos; argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in call to &apos;{0}&apos;. The return value of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;this&apos; argument does not satisfy {2} in call to &apos;{0}&apos;. The return value of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2075 {
             get {
@@ -142,7 +142,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; generic argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in &apos;{1}&apos;. The return value of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; generic argument does not satisfy {3} in &apos;{1}&apos;. The return value of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2076 {
             get {
@@ -151,7 +151,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in call to &apos;{1}&apos;. The field &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; argument does not satisfy {3} in call to &apos;{1}&apos;. The field &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2077 {
             get {
@@ -160,7 +160,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; method return value does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; requirements. The field &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; method return value does not satisfy {2} requirements. The field &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2078 {
             get {
@@ -169,7 +169,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; field does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; requirements. The field &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to value stored in field &apos;{0}&apos; does not satisfy {2} requirements. The field &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2079 {
             get {
@@ -178,7 +178,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;this&apos; argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in call to &apos;{0}&apos;. The field &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;this&apos; argument does not satisfy {2} in call to &apos;{0}&apos;. The field &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2080 {
             get {
@@ -187,7 +187,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; generic argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in &apos;{1}&apos;. The field &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; generic argument does not satisfy {3} in &apos;{1}&apos;. The field &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2081 {
             get {
@@ -196,7 +196,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in call to &apos;{1}&apos;. The implicit &apos;this&apos; argument of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; argument does not satisfy {3} in call to &apos;{1}&apos;. The implicit &apos;this&apos; argument of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2082 {
             get {
@@ -205,7 +205,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; method return value does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; requirements. The implicit &apos;this&apos; argument of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; method return value does not satisfy {2} requirements. The implicit &apos;this&apos; argument of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2083 {
             get {
@@ -214,7 +214,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; field does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; requirements. The implicit &apos;this&apos; argument of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to value stored in field &apos;{0}&apos; does not satisfy {2} requirements. The implicit &apos;this&apos; argument of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2084 {
             get {
@@ -223,7 +223,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;this&apos; argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in call to &apos;{0}&apos;. The implicit &apos;this&apos; argument of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;this&apos; argument does not satisfy {2} in call to &apos;{0}&apos;. The implicit &apos;this&apos; argument of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2085 {
             get {
@@ -232,7 +232,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; generic argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in &apos;{1}&apos;. The implicit &apos;this&apos; argument of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; generic argument does not satisfy {3} in &apos;{1}&apos;. The implicit &apos;this&apos; argument of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2086 {
             get {
@@ -241,7 +241,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in call to &apos;{1}&apos;. The generic parameter &apos;{2}&apos; of &apos;{3}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; argument does not satisfy {4} in call to &apos;{1}&apos;. The generic parameter &apos;{2}&apos; of &apos;{3}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2087 {
             get {
@@ -250,7 +250,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; method return value does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; requirements. The generic parameter &apos;{1}&apos; of &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; method return value does not satisfy {3} requirements. The generic parameter &apos;{1}&apos; of &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2088 {
             get {
@@ -259,7 +259,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; field does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; requirements. The generic parameter &apos;{1}&apos; of &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to value stored in field &apos;{0}&apos; does not satisfy {3} requirements. The generic parameter &apos;{1}&apos; of &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2089 {
             get {
@@ -268,7 +268,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;this&apos; argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in call to &apos;{0}&apos;. The generic parameter &apos;{1}&apos; of &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;this&apos; argument does not satisfy {3} in call to &apos;{0}&apos;. The generic parameter &apos;{1}&apos; of &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2090 {
             get {
@@ -277,7 +277,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; generic argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in &apos;{1}&apos;. The generic parameter &apos;{2}&apos; of &apos;{3}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; generic argument does not satisfy {4} in &apos;{1}&apos;. The generic parameter &apos;{2}&apos; of &apos;{3}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2091 {
             get {

--- a/src/linker/Resources/Strings.Designer.cs
+++ b/src/linker/Resources/Strings.Designer.cs
@@ -61,7 +61,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; argument does not satisfy {4} in call to &apos;{1}&apos;. The parameter &apos;{2}&apos; of method &apos;{3}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in call to &apos;{1}&apos;. The parameter &apos;{2}&apos; of method &apos;{3}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2067 {
             get {
@@ -70,7 +70,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; method return value does not satisfy {3} requirements. The parameter &apos;{1}&apos; of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; method return value does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; requirements. The parameter &apos;{1}&apos; of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2068 {
             get {
@@ -79,7 +79,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to value stored in field &apos;{0}&apos; does not satisfy {3} requirements. The parameter &apos;{1}&apos; of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; field does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; requirements. The parameter &apos;{1}&apos; of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2069 {
             get {
@@ -88,7 +88,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;this&apos; argument does not satisfy {3} in call to &apos;{0}&apos;. The parameter &apos;{1}&apos; of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;this&apos; argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in call to &apos;{0}&apos;. The parameter &apos;{1}&apos; of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2070 {
             get {
@@ -97,7 +97,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; generic argument does not satisfy {4} in &apos;{1}&apos;. The parameter &apos;{2}&apos; of method &apos;{3}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; generic argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in &apos;{1}&apos;. The parameter &apos;{2}&apos; of method &apos;{3}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2071 {
             get {
@@ -106,7 +106,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; argument does not satisfy {3} in call to &apos;{1}&apos;. The return value of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in call to &apos;{1}&apos;. The return value of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2072 {
             get {
@@ -115,7 +115,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; method return value does not satisfy {2} requirements. The return value of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; method return value does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; requirements. The return value of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2073 {
             get {
@@ -124,7 +124,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to value stored in field &apos;{0}&apos; does not satisfy {2} requirements. The return value of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; field does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; requirements. The return value of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2074 {
             get {
@@ -133,7 +133,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;this&apos; argument does not satisfy {2} in call to &apos;{0}&apos;. The return value of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;this&apos; argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in call to &apos;{0}&apos;. The return value of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2075 {
             get {
@@ -142,7 +142,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; generic argument does not satisfy {3} in &apos;{1}&apos;. The return value of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; generic argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in &apos;{1}&apos;. The return value of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2076 {
             get {
@@ -151,7 +151,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; argument does not satisfy {3} in call to &apos;{1}&apos;. The field &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in call to &apos;{1}&apos;. The field &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2077 {
             get {
@@ -160,7 +160,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; method return value does not satisfy {2} requirements. The field &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; method return value does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; requirements. The field &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2078 {
             get {
@@ -169,7 +169,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to value stored in field &apos;{0}&apos; does not satisfy {2} requirements. The field &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; field does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; requirements. The field &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2079 {
             get {
@@ -178,7 +178,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;this&apos; argument does not satisfy {2} in call to &apos;{0}&apos;. The field &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;this&apos; argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in call to &apos;{0}&apos;. The field &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2080 {
             get {
@@ -187,7 +187,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; generic argument does not satisfy {3} in &apos;{1}&apos;. The field &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; generic argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in &apos;{1}&apos;. The field &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2081 {
             get {
@@ -196,7 +196,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; argument does not satisfy {3} in call to &apos;{1}&apos;. The implicit &apos;this&apos; argument of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in call to &apos;{1}&apos;. The implicit &apos;this&apos; argument of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2082 {
             get {
@@ -205,7 +205,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; method return value does not satisfy {2} requirements. The implicit &apos;this&apos; argument of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; method return value does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; requirements. The implicit &apos;this&apos; argument of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2083 {
             get {
@@ -214,7 +214,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to value stored in field &apos;{0}&apos; does not satisfy {2} requirements. The implicit &apos;this&apos; argument of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; field does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; requirements. The implicit &apos;this&apos; argument of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2084 {
             get {
@@ -223,7 +223,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;this&apos; argument does not satisfy {2} in call to &apos;{0}&apos;. The implicit &apos;this&apos; argument of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;this&apos; argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in call to &apos;{0}&apos;. The implicit &apos;this&apos; argument of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2085 {
             get {
@@ -232,7 +232,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; generic argument does not satisfy {3} in &apos;{1}&apos;. The implicit &apos;this&apos; argument of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; generic argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in &apos;{1}&apos;. The implicit &apos;this&apos; argument of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2086 {
             get {
@@ -241,7 +241,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; argument does not satisfy {4} in call to &apos;{1}&apos;. The generic parameter &apos;{2}&apos; of &apos;{3}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in call to &apos;{1}&apos;. The generic parameter &apos;{2}&apos; of &apos;{3}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2087 {
             get {
@@ -250,7 +250,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; method return value does not satisfy {3} requirements. The generic parameter &apos;{1}&apos; of &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; method return value does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; requirements. The generic parameter &apos;{1}&apos; of &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2088 {
             get {
@@ -259,7 +259,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to value stored in field &apos;{0}&apos; does not satisfy {3} requirements. The generic parameter &apos;{1}&apos; of &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; field does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; requirements. The generic parameter &apos;{1}&apos; of &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2089 {
             get {
@@ -268,7 +268,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;this&apos; argument does not satisfy {3} in call to &apos;{0}&apos;. The generic parameter &apos;{1}&apos; of &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;this&apos; argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in call to &apos;{0}&apos;. The generic parameter &apos;{1}&apos; of &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2090 {
             get {
@@ -277,7 +277,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; generic argument does not satisfy {4} in &apos;{1}&apos;. The generic parameter &apos;{2}&apos; of &apos;{3}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; generic argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in &apos;{1}&apos;. The generic parameter &apos;{2}&apos; of &apos;{3}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2091 {
             get {


### PR DESCRIPTION
This goes a little bit further into explaining the rationale for adding this new attribute. Note that the tool responsible of the interpretation of such attribute will primarily be the linker, which has the possibility to perform whole-program analysis.