### PR TITLE
Use artifacts folder as a location for test cases artefacts.

### DIFF
--- a/test/Mono.Linker.Tests/TestCasesRunner/TestCaseSandbox.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestCaseSandbox.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Extensions;
 using Mono.Linker.Tests.TestCases;
@@ -12,8 +13,19 @@ namespace Mono.Linker.Tests.TestCasesRunner
 		protected readonly TestCase _testCase;
 		protected readonly NPath _directory;
 
+		static readonly string _linkerAssemblyPath = typeof (Driver).Assembly.Location;
+
+		static NPath GetArtifactsTestPath ()
+		{
+			// Converts paths like /root-folder/linker/artifacts/bin/Mono.Linker.Tests/Debug/net5.0/illink.dll
+			// to /root-folder/linker/artifacts/testcases/
+			string artifacts = Path.GetFullPath (Path.Combine (Path.GetDirectoryName (_linkerAssemblyPath), "..", "..", "..", ".."));
+			string tests = Path.Combine (artifacts, "testcases");
+			return new NPath (tests);
+		}
+
 		public TestCaseSandbox (TestCase testCase)
-			: this (testCase, NPath.SystemTemp)
+			: this (testCase, GetArtifactsTestPath (), Path.GetFileNameWithoutExtension (_linkerAssemblyPath))
 		{
 		}
 
@@ -30,8 +42,17 @@ namespace Mono.Linker.Tests.TestCasesRunner
 		public TestCaseSandbox (TestCase testCase, NPath rootTemporaryDirectory, string namePrefix)
 		{
 			_testCase = testCase;
-			var name = string.IsNullOrEmpty (namePrefix) ? "linker_tests" : $"{namePrefix}_linker_tests";
-			_directory = rootTemporaryDirectory.Combine (name);
+
+			_directory = rootTemporaryDirectory.Combine (string.IsNullOrEmpty (namePrefix) ? "linker_tests" : namePrefix);
+
+			const string tcases_name = "Mono.Linker.Tests.Cases";
+			var location = testCase.SourceFile.Parent.ToString ();
+			int idx = location.IndexOf (tcases_name + Path.DirectorySeparatorChar);
+			if (idx < 0)
+				throw new ArgumentException ("Unknown test cases location");
+
+			_directory = _directory.Combine (location.Substring (idx + tcases_name.Length + 1));
+			_directory = _directory.Combine (testCase.SourceFile.FileNameWithoutExtension);
 
 			_directory.DeleteContents ();
 


### PR DESCRIPTION
It makes failing tests diagnostics much easier.