### PR TITLE
Add support for single file analysis

### DIFF
--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -489,7 +489,7 @@ namespace Mono.Linker.Dataflow
 				// System.Reflection.Assembly.Location ()
 				"get_Location" when calledMethod.IsDeclaredOnType ("System.Reflection", "Assembly")
 					&& calledMethod.Parameters.Count == 0
-				    => IntrinsicId.Assembly_Location,
+					=> IntrinsicId.Assembly_Location,
 
 				// System.Reflection.Assembly.CodeBase ()
 				"get_CodeBase" when calledMethod.IsDeclaredOnType ("System.Reflection", "AssemblyName")
@@ -504,12 +504,12 @@ namespace Mono.Linker.Dataflow
 				// System.Reflection.Assembly.GetFile (string)
 				"GetFile" when calledMethod.IsDeclaredOnType ("System.Reflection", "Assembly")
 					&& calledMethod.HasParameterOfType (0, "System", "String")
-				    => IntrinsicId.Assembly_GetFile,
+					=> IntrinsicId.Assembly_GetFile,
 
-                // System.Reflection.Assembly.GetFiles ()
+				// System.Reflection.Assembly.GetFiles ()
 				"GetFiles" when calledMethod.IsDeclaredOnType ("System.Reflection", "Assembly")
-                    && calledMethod.Parameters.Count == 0
-                    => IntrinsicId.Assembly_GetFiles,
+					&& calledMethod.Parameters.Count == 0
+					=> IntrinsicId.Assembly_GetFiles,
 
 				// System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor (RuntimeTypeHandle type)
 				"RunClassConstructor" when calledMethod.IsDeclaredOnType ("System.Runtime.CompilerServices", "RuntimeHelpers")
@@ -1293,12 +1293,12 @@ namespace Mono.Linker.Dataflow
 					_context.LogWarning ($"Assemblies embedded in a single-file app cannot have additional files in the manifest.", 3001, callingMethodDefinition);
 					break;
 
-                //
-                // System.Reflection.Assembly
-                //
-                // GetFiles ()
-                //
-                case IntrinsicId.Assembly_GetFiles when _context.SingleFileAnalysis == true:
+				//
+				// System.Reflection.Assembly
+				//
+				// GetFiles ()
+				//
+				case IntrinsicId.Assembly_GetFiles when _context.SingleFileAnalysis == true:
 					_context.LogWarning ($"Assemblies embedded in a single-file app cannot have additional files in the manifest.", 3001, callingMethodDefinition);
 					break;
 

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -453,6 +453,12 @@ namespace Mono.Linker
 						context.NoWarn.UnionWith (ProcessWarningCodes (noWarnArgument));
 						continue;
 
+					case "--single-file-analysis":
+						if (!GetBoolParam (token, l => context.SingleFileAnalysis = l))
+							return -1;
+
+						continue;
+
 					case "--warnaserror":
 					case "--warnaserror+":
 						var warningList = GetNextStringValue ();

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -54,6 +54,7 @@ namespace Mono.Linker
 		readonly Dictionary<string, string> _parameters;
 		bool _linkSymbols;
 		bool _keepTypeForwarderOnlyAssemblies;
+		bool _singleFileAnalysis;
 		bool _ignoreUnresolved;
 
 		readonly AssemblyResolver _resolver;
@@ -104,6 +105,11 @@ namespace Mono.Linker
 		public bool KeepTypeForwarderOnlyAssemblies {
 			get { return _keepTypeForwarderOnlyAssemblies; }
 			set { _keepTypeForwarderOnlyAssemblies = value; }
+		}
+
+		public bool SingleFileAnalysis {
+			get { return _singleFileAnalysis; }
+			set { _singleFileAnalysis = value; }
 		}
 
 #if FEATURE_ILLINK

--- a/test/Mono.Linker.Tests.Cases/SingleFileAnalysis/SingleFileAnalysisIsNotSet.cs
+++ b/test/Mono.Linker.Tests.Cases/SingleFileAnalysis/SingleFileAnalysisIsNotSet.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.SingleFileAnalysis
+{
+	public class SingleFileAnalysisIsNotSet
+	{
+		public static void Main ()
+		{
+			AssemblyLocationDoesNotWarn ();
+			AssemblyGetFileDoesNotWarn ();
+		}
+
+		[Kept]
+		[LogDoesNotContain ("IL3000")]
+		static string AssemblyLocationDoesNotWarn () => Assembly.GetExecutingAssembly ().Location;
+
+		[Kept]
+		[LogDoesNotContain ("IL3001")]
+		static void AssemblyGetFileDoesNotWarn ()
+		{
+			var a = Assembly.GetExecutingAssembly ();
+			_ = a.GetFile ("/some/file/path");
+			_ = a.GetFiles ();
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/SingleFileAnalysis/WarnOnSingleFileDangerousPatterns.cs
+++ b/test/Mono.Linker.Tests.Cases/SingleFileAnalysis/WarnOnSingleFileDangerousPatterns.cs
@@ -27,13 +27,13 @@ namespace Mono.Linker.Tests.Cases.SingleFileAnalysis
 		}
 
 		[Kept]
-		[ExpectedWarning ("IL3000", 
+		[ExpectedWarning ("IL3000",
 			"'System.Reflection.Assembly.Location.get' always returns an empty string for assemblies embedded " +
 			"in a single-file app. If the path to the app directory is needed, consider calling 'System.AppContext.BaseDirectory'")]
 		static string GetExecutingAssemblyLocation () => Assembly.GetExecutingAssembly ().Location;
 
 		[Kept]
-		[ExpectedWarning ("IL3000", 
+		[ExpectedWarning ("IL3000",
 			"'System.Reflection.Assembly.Location.get' always returns an empty string for assemblies embedded " +
 			"in a single-file app. If the path to the app directory is needed, consider calling 'System.AppContext.BaseDirectory'")]
 		static void AssemblyProperties ()
@@ -46,9 +46,9 @@ namespace Mono.Linker.Tests.Cases.SingleFileAnalysis
 		}
 
 		[Kept]
-		[ExpectedWarning ("IL3001", 
+		[ExpectedWarning ("IL3001",
 			"Assemblies embedded in a single-file app cannot have additional files in the manifest.")]
-		[ExpectedWarning ("IL3001", 
+		[ExpectedWarning ("IL3001",
 			"Assemblies embedded in a single-file app cannot have additional files in the manifest.")]
 		static void AssemblyMethods ()
 		{
@@ -58,10 +58,10 @@ namespace Mono.Linker.Tests.Cases.SingleFileAnalysis
 		}
 
 		[Kept]
-		[ExpectedWarning ("IL3000", 
+		[ExpectedWarning ("IL3000",
 			"'System.Reflection.AssemblyName.CodeBase.get' always returns an empty string for assemblies embedded " +
 			"in a single-file app. If the path to the app directory is needed, consider calling 'System.AppContext.BaseDirectory'.")]
-		[ExpectedWarning ("IL3000", 
+		[ExpectedWarning ("IL3000",
 			"'System.Reflection.AssemblyName.EscapedCodeBase.get' always returns an empty string for assemblies embedded " +
 			"in a single-file app. If the path to the app directory is needed, consider calling 'System.AppContext.BaseDirectory'.")]
 
@@ -75,10 +75,10 @@ namespace Mono.Linker.Tests.Cases.SingleFileAnalysis
 		// This is an OK use of Location and GetFile since these assemblies were loaded from
 		// a file, but the linker is conservative
 		[Kept]
-		[ExpectedWarning ("IL3000", 
+		[ExpectedWarning ("IL3000",
 			"'System.Reflection.Assembly.Location.get' always returns an empty string for assemblies embedded " +
 			"in a single-file app. If the path to the app directory is needed, consider calling 'System.AppContext.BaseDirectory'")]
-		[ExpectedWarning ("IL3001", 
+		[ExpectedWarning ("IL3001",
 			"Assemblies embedded in a single-file app cannot have additional files in the manifest.")]
 		static void FalsePositive ()
 		{

--- a/test/Mono.Linker.Tests.Cases/SingleFileAnalysis/WarnOnSingleFileDangerousPatterns.cs
+++ b/test/Mono.Linker.Tests.Cases/SingleFileAnalysis/WarnOnSingleFileDangerousPatterns.cs
@@ -1,0 +1,90 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.SingleFileAnalysis
+{
+	[SetupLinkerArgument ("--single-file-analysis", "true")]
+	public class WarnOnSingleFileDangerousPatterns
+	{
+		public static void Main ()
+		{
+			GetExecutingAssemblyLocation ();
+			AssemblyProperties ();
+			AssemblyMethods ();
+			AssemblyNameAttributes ();
+			FalsePositive ();
+		}
+
+		[Kept]
+		[ExpectedWarning ("IL3000", 
+			"'System.Reflection.Assembly.Location.get' always returns an empty string for assemblies embedded " +
+			"in a single-file app. If the path to the app directory is needed, consider calling 'System.AppContext.BaseDirectory'")]
+		static string GetExecutingAssemblyLocation () => Assembly.GetExecutingAssembly ().Location;
+
+		[Kept]
+		[ExpectedWarning ("IL3000", 
+			"'System.Reflection.Assembly.Location.get' always returns an empty string for assemblies embedded " +
+			"in a single-file app. If the path to the app directory is needed, consider calling 'System.AppContext.BaseDirectory'")]
+		static void AssemblyProperties ()
+		{
+			var a = Assembly.GetExecutingAssembly ();
+			_ = a.Location;
+			// below methods are marked as obsolete in 5.0
+			// _ = a.CodeBase;
+			// _ = a.EscapedCodeBase;
+		}
+
+		[Kept]
+		[ExpectedWarning ("IL3001", 
+			"Assemblies embedded in a single-file app cannot have additional files in the manifest.")]
+		[ExpectedWarning ("IL3001", 
+			"Assemblies embedded in a single-file app cannot have additional files in the manifest.")]
+		static void AssemblyMethods ()
+		{
+			var a = Assembly.GetExecutingAssembly ();
+			_ = a.GetFile ("/some/file/path");
+			_ = a.GetFiles ();
+		}
+
+		[Kept]
+		[ExpectedWarning ("IL3000", 
+			"'System.Reflection.AssemblyName.CodeBase.get' always returns an empty string for assemblies embedded " +
+			"in a single-file app. If the path to the app directory is needed, consider calling 'System.AppContext.BaseDirectory'.")]
+		[ExpectedWarning ("IL3000", 
+			"'System.Reflection.AssemblyName.EscapedCodeBase.get' always returns an empty string for assemblies embedded " +
+			"in a single-file app. If the path to the app directory is needed, consider calling 'System.AppContext.BaseDirectory'.")]
+
+		static void AssemblyNameAttributes ()
+		{
+			var a = Assembly.GetExecutingAssembly ().GetName ();
+			_ = a.CodeBase;
+			_ = a.EscapedCodeBase;
+		}
+
+		// This is an OK use of Location and GetFile since these assemblies were loaded from
+		// a file, but the linker is conservative
+		[Kept]
+		[ExpectedWarning ("IL3000", 
+			"'System.Reflection.Assembly.Location.get' always returns an empty string for assemblies embedded " +
+			"in a single-file app. If the path to the app directory is needed, consider calling 'System.AppContext.BaseDirectory'")]
+		[ExpectedWarning ("IL3001", 
+			"Assemblies embedded in a single-file app cannot have additional files in the manifest.")]
+		static void FalsePositive ()
+		{
+			var a = Assembly.LoadFrom ("/some/path/not/in/bundle");
+			_ = a.Location;
+			_ = a.GetFiles ();
+		}
+	}
+}

--- a/test/Mono.Linker.Tests/TestCases/TestDatabase.cs
+++ b/test/Mono.Linker.Tests/TestCases/TestDatabase.cs
@@ -208,6 +208,11 @@ namespace Mono.Linker.Tests.TestCases
 			return NUnitCasesBySuiteName ("LinkAttributes");
 		}
 
+		public static IEnumerable<TestCaseData> SingleFileAnalysisTests ()
+		{
+			return NUnitCasesBySuiteName ("SingleFileAnalysis");
+		}
+
 		public static TestCaseCollector CreateCollector ()
 		{
 			GetDirectoryPaths (out string rootSourceDirectory, out string testCaseAssemblyPath);

--- a/test/Mono.Linker.Tests/TestCases/TestSuites.cs
+++ b/test/Mono.Linker.Tests/TestCases/TestSuites.cs
@@ -248,6 +248,12 @@ namespace Mono.Linker.Tests.TestCases
 			Run (testCase);
 		}
 
+		[TestCaseSource (typeof (TestDatabase), nameof (TestDatabase.SingleFileAnalysisTests))]
+		public void SingleFileAnalysisTests (TestCase testCase)
+		{
+			Run (testCase);
+		}
+
 		protected virtual void Run (TestCase testCase)
 		{
 			var runner = new TestRunner (new ObjectFactory ());


### PR DESCRIPTION
This change allows the linker to produce warnings using the ReflectionMethodBodyScanner when the flag --single-file-analysis is used. On this first PR is only allowed to print single file warnings only if trimming is also enabled. Future PR should pursue the end goal of enabling linker analysis without trimming, so we could print single file warnings even when the app is not going to be trimmed

-Add flag for single file analysis in the linker
-Add single file dangerous patterns to the ReflectionMethodBodyScanner list
-Add test for single file dangerous patterns