### PR TITLE
Add intrinsic handling of AsType and String.Empty

### DIFF
--- a/test/Mono.Linker.Tests.Cases/DataFlow/GetTypeDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/GetTypeDataFlow.cs
@@ -115,7 +115,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[RecognizedReflectionAccessPattern]
-		static void TestStringEmpty()
+		static void TestStringEmpty ()
 		{
 			Type.GetType (string.Empty);
 		}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/GetTypeDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/GetTypeDataFlow.cs
@@ -28,6 +28,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			TestMultipleConstantValues ();
 			TestMultipleMixedValues ();
 
+			TestStringEmpty ();
+
 			// TODO:
 			// Test multi-value returns
 			//    Type.GetType over a constant and a param
@@ -110,6 +112,12 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			}
 
 			Type.GetType (typeName);
+		}
+
+		[RecognizedReflectionAccessPattern]
+		static void TestStringEmpty()
+		{
+			Type.GetType (string.Empty);
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (GetTypeDataFlow), nameof (RequireNonPublicConstructors), new Type[] { typeof (Type) },

--- a/test/Mono.Linker.Tests.Cases/Reflection/AsType.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/AsType.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Reflection
+{
+	class AsType
+	{
+		public static void Main ()
+		{
+			_ = typeof (TypeUsedWithAsType).GetTypeInfo().AsType().GetMethod (nameof (TypeUsedWithAsType.Method));
+		}
+
+		[Kept]
+		static class TypeUsedWithAsType
+		{
+			[Kept]
+			public static void Method () { }
+
+			public static void OtherMethod () { }
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Reflection/AsType.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/AsType.cs
@@ -16,7 +16,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 	{
 		public static void Main ()
 		{
-			_ = typeof (TypeUsedWithAsType).GetTypeInfo().AsType().GetMethod (nameof (TypeUsedWithAsType.Method));
+			_ = typeof (TypeUsedWithAsType).GetTypeInfo ().AsType ().GetMethod (nameof (TypeUsedWithAsType.Method));
 		}
 
 		[Kept]


### PR DESCRIPTION
These popped up in an app that I was analyzing. The string.Empty occurence causes a spurious warning in framework code (https://github.com/dotnet/runtime/blob/1d9e50cb4735df46d3de0cee5791e97295eaf588/src/libraries/System.ObjectModel/src/System/ComponentModel/TypeConverterAttribute.cs#L27).