### PR TITLE
Mark everything if BindingFlags are not recognized by the linker

### DIFF
--- a/src/linker/Linker.Dataflow/DynamicallyAccessedMembersBinder.cs
+++ b/src/linker/Linker.Dataflow/DynamicallyAccessedMembersBinder.cs
@@ -153,7 +153,7 @@ namespace Mono.Linker
 			}
 		}
 
-		public static IEnumerable<FieldDefinition> GetFieldsOnTypeHierarchy (this TypeDefinition type, Func<FieldDefinition, bool> filter, BindingFlags bindingFlags = BindingFlags.Default)
+		public static IEnumerable<FieldDefinition> GetFieldsOnTypeHierarchy (this TypeDefinition type, Func<FieldDefinition, bool> filter, BindingFlags? bindingFlags = BindingFlags.Default)
 		{
 			bool onBaseType = false;
 			while (type != null) {
@@ -189,7 +189,7 @@ namespace Mono.Linker
 			}
 		}
 
-		public static IEnumerable<TypeDefinition> GetNestedTypesOnType (this TypeDefinition type, Func<TypeDefinition, bool> filter, BindingFlags bindingFlags = BindingFlags.Default)
+		public static IEnumerable<TypeDefinition> GetNestedTypesOnType (this TypeDefinition type, Func<TypeDefinition, bool> filter, BindingFlags? bindingFlags = BindingFlags.Default)
 		{
 			foreach (var nestedType in type.NestedTypes) {
 				if (filter != null && !filter (nestedType))
@@ -209,7 +209,7 @@ namespace Mono.Linker
 			}
 		}
 
-		public static IEnumerable<PropertyDefinition> GetPropertiesOnTypeHierarchy (this TypeDefinition type, Func<PropertyDefinition, bool> filter, BindingFlags bindingFlags = BindingFlags.Default)
+		public static IEnumerable<PropertyDefinition> GetPropertiesOnTypeHierarchy (this TypeDefinition type, Func<PropertyDefinition, bool> filter, BindingFlags? bindingFlags = BindingFlags.Default)
 		{
 			bool onBaseType = false;
 			while (type != null) {
@@ -254,7 +254,7 @@ namespace Mono.Linker
 			}
 		}
 
-		public static IEnumerable<EventDefinition> GetEventsOnTypeHierarchy (this TypeDefinition type, Func<EventDefinition, bool> filter, BindingFlags bindingFlags = BindingFlags.Default)
+		public static IEnumerable<EventDefinition> GetEventsOnTypeHierarchy (this TypeDefinition type, Func<EventDefinition, bool> filter, BindingFlags? bindingFlags = BindingFlags.Default)
 		{
 			bool onBaseType = false;
 			while (type != null) {

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -847,9 +847,12 @@ namespace Mono.Linker.Dataflow
 						reflectionContext.AnalyzingPattern ();
 
 						var parameters = calledMethod.Parameters;
-						BindingFlags? bindingFlags = BindingFlags.Public | BindingFlags.Instance;
+						BindingFlags? bindingFlags;
 						if (parameters.Count > 1 && calledMethod.Parameters[0].ParameterType.Name == "BindingFlags")
-							bindingFlags = GetBindingFlags (methodParams[1]);
+							bindingFlags = GetBindingFlagsFromValue (methodParams[1]);
+						else
+							// Assume a default value for BindingFlags for methods that don't use BindingFlags as a parameter
+							bindingFlags = BindingFlags.Public | BindingFlags.Instance;
 
 						int? ctorParameterCount = parameters.Count switch
 						{
@@ -895,11 +898,14 @@ namespace Mono.Linker.Dataflow
 				case IntrinsicId.Type_GetMethod: {
 						reflectionContext.AnalyzingPattern ();
 
-						BindingFlags? bindingFlags = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public;
+						BindingFlags? bindingFlags;
 						if (calledMethod.Parameters.Count > 1 && calledMethod.Parameters[1].ParameterType.Name == "BindingFlags")
-							bindingFlags = GetBindingFlags (methodParams[2]);
+							bindingFlags = GetBindingFlagsFromValue (methodParams[2]);
 						else if (calledMethod.Parameters.Count > 2 && calledMethod.Parameters[2].ParameterType.Name == "BindingFlags")
-							bindingFlags = GetBindingFlags (methodParams[3]);
+							bindingFlags = GetBindingFlagsFromValue (methodParams[3]);
+						else
+							// Assume a default value for BindingFlags for methods that don't use BindingFlags as a parameter
+							bindingFlags = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public;
 						var requiredMemberTypes = GetDynamicallyAccessedMemberTypesFromBindingFlagsForMethods (bindingFlags);
 						foreach (var value in methodParams[0].UniqueValues ()) {
 							if (value is SystemTypeValue systemTypeValue) {
@@ -930,9 +936,12 @@ namespace Mono.Linker.Dataflow
 				case IntrinsicId.Type_GetNestedType: {
 						reflectionContext.AnalyzingPattern ();
 
-						BindingFlags? bindingFlags = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public;
+						BindingFlags? bindingFlags;
 						if (calledMethod.Parameters.Count > 1 && calledMethod.Parameters[1].ParameterType.Name == "BindingFlags")
-							bindingFlags = GetBindingFlags (methodParams[2]);
+							bindingFlags = GetBindingFlagsFromValue (methodParams[2]);
+						else
+							// Assume a default value for BindingFlags for methods that don't use BindingFlags as a parameter
+							bindingFlags = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public;
 
 						var requiredMemberTypes = GetDynamicallyAccessedMemberTypesFromBindingFlagsForNestedTypes (bindingFlags);
 						foreach (var value in methodParams[0].UniqueValues ()) {
@@ -1015,9 +1024,12 @@ namespace Mono.Linker.Dataflow
 					&& calledMethod.HasThis: {
 
 						reflectionContext.AnalyzingPattern ();
-						BindingFlags? bindingFlags = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public;
+						BindingFlags? bindingFlags;
 						if (calledMethod.Parameters.Count > 1 && calledMethod.Parameters[1].ParameterType.Name == "BindingFlags")
-							bindingFlags = GetBindingFlags (methodParams[2]);
+							bindingFlags = GetBindingFlagsFromValue (methodParams[2]);
+						else
+							// Assume a default value for BindingFlags for methods that don't use BindingFlags as a parameter
+							bindingFlags = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public;
 
 						DynamicallyAccessedMemberTypes memberTypes = fieldPropertyOrEvent switch
 						{
@@ -1654,7 +1666,7 @@ namespace Mono.Linker.Dataflow
 			reflectionContext.RecordHandledPattern ();
 		}
 
-		static BindingFlags? GetBindingFlags (ValueNode parameter) => (BindingFlags?) parameter.AsConstInt ();
+		static BindingFlags? GetBindingFlagsFromValue (ValueNode parameter) => (BindingFlags?) parameter.AsConstInt ();
 
 		static bool BindingFlagsAreUnsupported (BindingFlags? bindingFlags) => bindingFlags == null || (bindingFlags & BindingFlags.IgnoreCase) == BindingFlags.IgnoreCase || (int) bindingFlags > 255;
 

--- a/test/Mono.Linker.Tests.Cases/Reflection/ActivatorCreateInstance.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ActivatorCreateInstance.cs
@@ -16,7 +16,8 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			Activator.CreateInstance (typeof (Test1));
 			Activator.CreateInstance (typeof (Test2), true);
 			Activator.CreateInstance (typeof (Test3), BindingFlags.NonPublic | BindingFlags.Instance, null, null, null);
-			Activator.CreateInstance (typeof (Test4), new object[] { 1, "ss" });
+			Activator.CreateInstance (typeof (Test4), GetBindingFlags (), null, null, null);
+			Activator.CreateInstance (typeof (Test5), new object[] { 1, "ss" });
 
 			var p = new ActivatorCreateInstance ();
 
@@ -96,6 +97,30 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		{
 			[Kept]
 			public Test4 (int i, object o)
+			{
+			}
+
+			[Kept]
+			private Test4 (char b)
+			{
+			}
+
+			[Kept]
+			internal Test4 (int arg)
+			{
+			}
+
+			[Kept]
+			static Test4 ()
+			{
+			}
+		}
+
+		[Kept]
+		class Test5
+		{
+			[Kept]
+			public Test5 (int i, object o)
 			{
 			}
 		}
@@ -258,6 +283,12 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			private WithAssemblyNamePrivateOnly (int i, object o, int j)
 			{
 			}
+		}
+
+		[Kept]
+		private static BindingFlags GetBindingFlags ()
+		{
+			return BindingFlags.Public;
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/Reflection/ConstructorUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ConstructorUsedViaReflection.cs
@@ -12,6 +12,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		{
 			TestWithIntegerParameter ();
 			TestWithBindingFlags ();
+			TestWithUnknownBindingFlags (BindingFlags.Public);
 			TestWithCallingConvention ();
 			TestNullType ();
 			TestDataFlowType ();
@@ -35,6 +36,16 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		static void TestWithBindingFlags ()
 		{
 			var constructor = typeof (OnlyUsedViaReflection).GetConstructor (BindingFlags.Public, GetNullValue ("some argument", 2, 3), new Type[] { }, new ParameterModifier[] { });
+			constructor.Invoke (null, new object[] { });
+		}
+
+		[RecognizedReflectionAccessPattern (typeof (Type), nameof (Type.GetConstructor), new Type[] { typeof (BindingFlags), typeof (Binder), typeof (Type[]), typeof (ParameterModifier[]) },
+			typeof (UnknownBindingFlags), ".ctor", new Type[0])]
+		[Kept]
+		static void TestWithUnknownBindingFlags (BindingFlags bindingFlags)
+		{
+			// Since the binding flags are not known linker should mark all constructors on the type
+			var constructor = typeof (UnknownBindingFlags).GetConstructor (bindingFlags, GetNullValue ("some argument", 2, 3), new Type[] { }, new ParameterModifier[] { });
 			constructor.Invoke (null, new object[] { });
 		}
 
@@ -131,6 +142,30 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			{ }
 
 			internal OnlyUsedViaReflection (int foo, int bar, int baz)
+			{ }
+		}
+
+		[Kept]
+		private class UnknownBindingFlags
+		{
+			[Kept]
+			public UnknownBindingFlags ()
+			{ }
+
+			[Kept]
+			public UnknownBindingFlags (string bar)
+			{ }
+
+			[Kept]
+			private UnknownBindingFlags (int foo)
+			{ }
+
+			[Kept]
+			protected UnknownBindingFlags (int foo, int bar)
+			{ }
+
+			[Kept]
+			internal UnknownBindingFlags (int foo, int bar, int baz)
 			{ }
 		}
 

--- a/test/Mono.Linker.Tests.Cases/Reflection/EventUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/EventUsedViaReflection.cs
@@ -16,6 +16,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestInternalByName ();
 			TestNameBindingFlags ();
 			TestNameWrongBindingFlags ();
+			TestNameUnknownBindingFlags (BindingFlags.Public);
 			TestNullName ();
 			TestEmptyName ();
 			TestNonExistingName ();
@@ -61,6 +62,13 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		static void TestNameWrongBindingFlags ()
 		{
 			var eventInfo = typeof (Bar).GetEvent ("PublicEvent", BindingFlags.NonPublic);
+		}
+
+		[Kept]
+		static void TestNameUnknownBindingFlags (BindingFlags bindingFlags)
+		{
+			// Since the binding flags are not known linker should mark all events on the type
+			var eventInfo = typeof (UnknownBindingFlags).GetEvent ("PrivateEvent", bindingFlags);
 		}
 
 		[Kept]
@@ -186,6 +194,30 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			private event EventHandler<EventArgs> PrivateEvent;
+			public event EventHandler<EventArgs> PublicEvent;
+		}
+
+		class UnknownBindingFlags
+		{
+			[Kept]
+			[KeptBackingField]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
+			internal event EventHandler<EventArgs> InternalEvent;
+			[Kept]
+			[KeptBackingField]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
+			static event EventHandler<EventArgs> Static;
+			[Kept]
+			[KeptBackingField]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
+			private event EventHandler<EventArgs> PrivateEvent;
+			[Kept]
+			[KeptBackingField]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
 			public event EventHandler<EventArgs> PublicEvent;
 		}
 

--- a/test/Mono.Linker.Tests.Cases/Reflection/FieldUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/FieldUsedViaReflection.cs
@@ -15,6 +15,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestPrivateByName ();
 			TestNameBindingFlags ();
 			TestNameWrongBindingFlags ();
+			TestNameUnknownBindingFlags (BindingFlags.Public);
 			TestNullName ();
 			TestEmptyName ();
 			TestNonExistingName ();
@@ -57,6 +58,13 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		static void TestNameWrongBindingFlags ()
 		{
 			var field = typeof (Foo).GetField ("nonStatic", BindingFlags.Static);
+		}
+
+		[Kept]
+		static void TestNameUnknownBindingFlags (BindingFlags bindingFlags)
+		{
+			// Since the binding flags are not known linker should mark all fields on the type
+			var field = typeof (UnknownBindingFlags).GetField ("field", bindingFlags);
 		}
 
 		[Kept]
@@ -166,6 +174,17 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			public static int field;
 			public int nonStatic;
 			private static int nonKept;
+		}
+
+		[Kept]
+		private class UnknownBindingFlags
+		{
+			[Kept]
+			public static int field;
+			[Kept]
+			public int nonStatic;
+			[Kept]
+			private static int privatefield;
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/Reflection/MethodUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/MethodUsedViaReflection.cs
@@ -14,7 +14,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestName ();
 			TestNamePrivate ();
 			TestNameAndExplicitBindingFlags ();
-			// TestNameAndUnknownBindingFlags (BindingFlags.Public);
+			TestNameAndUnknownBindingFlags (BindingFlags.Public);
 			TestNameAndType ();
 			TestNameBindingFlagsAndParameterModifier ();
 			TestNameBindingFlagsCallingConventionParameterModifier ();
@@ -62,15 +62,14 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			method.Invoke (null, new object[] { });
 		}
 
-		// https://github.com/mono/linker/issues/1617
-		//[Kept]
-		//[RecognizedReflectionAccessPattern]
-		//static void TestNameAndUnknownBindingFlags (BindingFlags bindingFlags)
-		//{
-		//	// Since the binding flags are not known linker should mark all methods on the type
-		//	var method = typeof (TestNameAndUnknownBindingClass).GetMethod ("OnlyCalledViaReflection", bindingFlags);
-		//	method.Invoke (null, new object[] { });
-		//}
+		[Kept]
+		[RecognizedReflectionAccessPattern]
+		static void TestNameAndUnknownBindingFlags (BindingFlags bindingFlags)
+		{
+			// Since the binding flags are not known linker should mark all methods on the type
+			var method = typeof (TestNameAndUnknownBindingClass).GetMethod ("OnlyCalledViaReflection", bindingFlags);
+			method.Invoke (null, new object[] { });
+		}
 
 		[Kept]
 		[RecognizedReflectionAccessPattern (
@@ -294,33 +293,33 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			}
 		}
 
-		//[Kept]
-		//private class TestNameAndUnknownBindingClass
-		//{
-		//	[Kept]
-		//	private static int OnlyCalledViaReflection ()
-		//	{
-		//		return 42;
-		//	}
+		[Kept]
+		private class TestNameAndUnknownBindingClass
+		{
+			[Kept]
+			private static int OnlyCalledViaReflection ()
+			{
+				return 42;
+			}
 
-		//	[Kept]
-		//	private int OnlyCalledViaReflection (int foo)
-		//	{
-		//		return 43;
-		//	}
+			[Kept]
+			private int OnlyCalledViaReflection (int foo)
+			{
+				return 43;
+			}
 
-		//	[Kept]
-		//	public int OnlyCalledViaReflection (int foo, int bar)
-		//	{
-		//		return 44;
-		//	}
+			[Kept]
+			public int OnlyCalledViaReflection (int foo, int bar)
+			{
+				return 44;
+			}
 
-		//	[Kept]
-		//	public static int OnlyCalledViaReflection (int foo, int bar, int baz)
-		//	{
-		//		return 45;
-		//	}
-		//}
+			[Kept]
+			public static int OnlyCalledViaReflection (int foo, int bar, int baz)
+			{
+				return 45;
+			}
+		}
 
 		[Kept]
 		private class TestNameAndTypeClass

--- a/test/Mono.Linker.Tests.Cases/Reflection/NestedTypeUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/NestedTypeUsedViaReflection.cs
@@ -16,6 +16,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestByName ();
 			TestPrivateByName ();
 			TestByBindingFlags ();
+			TestByUnknownBindingFlags (BindingFlags.Public);
 			TestNonExistingName ();
 			TestNullType ();
 			TestIgnoreCaseBindingFlags ();
@@ -71,6 +72,16 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		}
 
 		[Kept]
+		[RecognizedReflectionAccessPattern (
+			typeof (Type), nameof (Type.GetNestedType), new Type[] { typeof (string), typeof (BindingFlags) },
+			typeof (UnknownBindingFlags.PublicNestedType), null, (Type[]) null)]
+		static void TestByUnknownBindingFlags (BindingFlags bindingFlags)
+		{
+			// Since the binding flags are not known linker should mark all nested types on the type
+			_ = typeof (UnknownBindingFlags).GetNestedType (nameof (PublicNestedType), bindingFlags);
+		}
+
+		[Kept]
 		static void TestNonExistingName ()
 		{
 			_ = typeof (NestedTypeUsedViaReflection).GetNestedType ("NonExisting");
@@ -102,6 +113,16 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		static void TestUnsupportedBindingFlags ()
 		{
 			_ = typeof (SuppressChangeTypeClass).GetNestedType ("SuppressChangeTypeNestedType", BindingFlags.SuppressChangeType);
+		}
+
+		[Kept]
+		private class UnknownBindingFlags
+		{
+			[Kept]
+			public static class PublicNestedType { }
+
+			[Kept]
+			private static class PrivateNestedType { }
 		}
 
 		[Kept]


### PR DESCRIPTION
-Add a flag to mark when the overload has a binding flag that the linker could not figure out
-Mark everything when an unknown binding flag is present
-Add tests

Fixes #1617