### PR TITLE
Package ILLink.RoslynAnalyzer for SDK

### DIFF
--- a/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj
+++ b/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj
@@ -6,14 +6,27 @@
     <OutputType>Library</OutputType>
     <Nullable>enable</Nullable>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+    <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+  </PropertyGroup>
+
+  <!-- Analyzer package properties -->
+  <PropertyGroup>
     <IsPackable>true</IsPackable>
     <PackageId>Microsoft.NET.ILLink.Analyzers</PackageId>
-    <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
+    <Authors>Microsoft</Authors>
+    <RepositoryUrl>https://github.com/mono/linker</RepositoryUrl>
+    <Description>Description of the package</Description>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
   </PropertyGroup>
 
   <ItemGroup>
     <EmbeddedResource Include="Resources.resx" GenerateSource="true" />
-    <PackageReference Include="microsoft.codeanalysis.csharp" Version="3.7.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.7.0" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
 
 </Project>

--- a/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj
+++ b/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj
@@ -25,7 +25,9 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.7.0" PrivateAssets="all" />
   </ItemGroup>
 
-  <Target Name="IncludeAnalyzerAssembliesInPkg" AfterTargets="AfterBuild">
+  <Target Name="IncludeAnalyzerAssembliesInPkg"
+          AfterTargets="AfterBuild"
+          BeforeTargets="_GetPackageFiles">
     <ItemGroup>
       <None Include="$(OutputPath)\**\*.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     </ItemGroup>

--- a/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj
+++ b/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj
@@ -26,8 +26,8 @@
   </ItemGroup>
 
   <Target Name="IncludeAnalyzerAssembliesInPkg"
-          AfterTargets="AfterBuild"
-          BeforeTargets="_GetPackageFiles">
+          DependsOnTargets="InitializeStandardNuspecProperties"
+          AfterTargets="AfterBuild">
     <ItemGroup>
       <None Include="$(OutputPath)\**\*.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     </ItemGroup>

--- a/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj
+++ b/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj
@@ -2,9 +2,13 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>8</LangVersion>
+    <LangVersion>latest</LangVersion>
+    <OutputType>Library</OutputType>
     <Nullable>enable</Nullable>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+    <IsPackable>true</IsPackable>
+    <PackageId>Microsoft.NET.ILLink.Analyzers</PackageId>
+    <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj
+++ b/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj
@@ -25,8 +25,10 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.7.0" PrivateAssets="all" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
-  </ItemGroup>
+  <Target Name="IncludeAnalyzerAssembliesInPkg" AfterTargets="AfterBuild">
+    <ItemGroup>
+      <None Include="$(OutputPath)\**\*.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj
+++ b/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj
@@ -16,7 +16,7 @@
     <PackageId>Microsoft.NET.ILLink.Analyzers</PackageId>
     <Authors>Microsoft</Authors>
     <RepositoryUrl>https://github.com/mono/linker</RepositoryUrl>
-    <Description>Description of the package</Description>
+    <Description>Analyzer utilities for ILLink attributes and single-file</Description>
     <NoPackageAnalysis>true</NoPackageAnalysis>
   </PropertyGroup>
 


### PR DESCRIPTION
This packs the analyzer build so that we can integrate it with the SDK and remove the single-file analyzer from dotnet/roslyn-analyzers.