### PR TITLE
Add a test for attribute removal using wildcard and lazy loading

### DIFF
--- a/test/Mono.Linker.Tests.Cases/LinkAttributes/Dependencies/LinkerAttributeRemovalEmbeddedAndLazyLoad.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkAttributes/Dependencies/LinkerAttributeRemovalEmbeddedAndLazyLoad.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Mono.Linker.Tests.Cases.LinkAttributes.Dependencies
+{
+	[EmbeddedAttributeToBeRemoved]
+	public class TypeWithEmbeddedAttributeToBeRemoved
+	{
+		public TypeWithEmbeddedAttributeToBeRemoved () { }
+	}
+
+	public class EmbeddedAttributeToBeRemoved : Attribute
+	{
+		public EmbeddedAttributeToBeRemoved () { }
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/LinkAttributes/LinkerAttributeRemoval.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkAttributes/LinkerAttributeRemoval.cs
@@ -28,6 +28,10 @@ namespace Mono.Linker.Tests.Cases.LinkAttributes
 #endif
 	[SetupLinkerAction ("copy", "copyassembly")]
 
+	[SetupCompileBefore (
+		"LinkerAttributeRemovalEmbeddedAndLazyLoad.dll",
+		new[] { "Dependencies/LinkerAttributeRemovalEmbeddedAndLazyLoad.cs" })]
+
 	// The test here is that the TypeOnCopyAssemblyWithAttributeUsage has an attribute TestAttributeUsedFromCopyAssemblyAttribute
 	// which is marked for removal by the LinkerAttributeRemoval.xml. Normally that would mean that the attribute usage
 	// as well as the type (and assembly since it's the only type in it) would be removed as there are no other usages of the attribute type.
@@ -45,6 +49,13 @@ namespace Mono.Linker.Tests.Cases.LinkAttributes
 
 	[KeptAssembly ("copyattribute.dll")]
 	[KeptTypeInAssembly ("copyattribute.dll", typeof (AttributeFromCopyAssemblyAttribute))]
+
+	[KeptAssembly ("LinkerAttributeRemovalEmbeddedAndLazyLoad.dll")]
+	[KeptTypeInAssembly ("LinkerAttributeRemovalEmbeddedAndLazyLoad.dll", typeof (TypeWithEmbeddedAttributeToBeRemoved))]
+	// This needs to fixed with lazy loading assembly refactoring - currently the assembly="*" only applies to assemblies in initial closure
+	// The attribute should be removed and not kept as it is now
+	// [RemovedAttributeInAssembly ("LinkerAttributeRemovalEmbeddedAndLazyLoad.dll", typeof (EmbeddedAttributeToBeRemoved), typeof (TypeWithEmbeddedAttributeToBeRemoved))]
+	[KeptAttributeInAssembly ("LinkerAttributeRemovalEmbeddedAndLazyLoad", typeof (EmbeddedAttributeToBeRemoved), typeof (TypeWithEmbeddedAttributeToBeRemoved))]
 
 	[LogContains ("IL2045: Mono.Linker.Tests.Cases.LinkAttributes.LinkerAttributeRemoval.TestType(): Attribute 'System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute'")]
 	[LogContains ("IL2045: Mono.Linker.Tests.Cases.LinkAttributes.Dependencies.TypeOnCopyAssemblyWithAttributeUsage.TypeOnCopyAssemblyWithAttributeUsage(): Attribute 'Mono.Linker.Tests.Cases.LinkAttributes.Dependencies.TestAttributeReferencedAsTypeFromCopyAssemblyAttribute'")]
@@ -68,11 +79,15 @@ namespace Mono.Linker.Tests.Cases.LinkAttributes
 			TestAttributeUsageRemovedEvenIfAttributeIsKeptForOtherReasons ();
 
 			TestAttributeFromCopyAssembly ();
+
+			TestEmbeddedAttributeLazyLoadRemoved ();
 		}
 
+#pragma warning disable CS0414
 		[Kept]
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 		Type _fieldWithCustomAttribute;
+#pragma warning restore CS0414
 
 		[Kept]
 		[KeptAttributeAttribute (typeof (TestDontRemoveAttribute))]
@@ -101,6 +116,18 @@ namespace Mono.Linker.Tests.Cases.LinkAttributes
 		[AttributeFromCopyAssembly]
 		static void TestAttributeFromCopyAssembly ()
 		{
+		}
+
+		[Kept]
+		// This attribute should be removed once the assembly lazy loading is implemented
+		[DynamicDependency (
+			DynamicallyAccessedMemberTypes.PublicConstructors,
+			"Mono.Linker.Tests.Cases.LinkAttributes.Dependencies.TypeWithEmbeddedAttributeToBeRemoved",
+			"LinkerAttributeRemovalEmbeddedAndLazyLoad")]
+		static void TestEmbeddedAttributeLazyLoadRemoved ()
+		{
+			// This needs the DynamicDependency above otherwise linker will not load the assembly at all
+			Activator.CreateInstance(Type.GetType ("Mono.Linker.Tests.Cases.LinkAttributes.Dependencies.TypeWithEmbeddedAttributeToBeRemoved, LinkerAttributeRemovalEmbeddedAndLazyLoad"));
 		}
 	}
 

--- a/test/Mono.Linker.Tests.Cases/LinkAttributes/LinkerAttributeRemoval.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkAttributes/LinkerAttributeRemoval.cs
@@ -127,7 +127,7 @@ namespace Mono.Linker.Tests.Cases.LinkAttributes
 		static void TestEmbeddedAttributeLazyLoadRemoved ()
 		{
 			// This needs the DynamicDependency above otherwise linker will not load the assembly at all
-			Activator.CreateInstance(Type.GetType ("Mono.Linker.Tests.Cases.LinkAttributes.Dependencies.TypeWithEmbeddedAttributeToBeRemoved, LinkerAttributeRemovalEmbeddedAndLazyLoad"));
+			Activator.CreateInstance (Type.GetType ("Mono.Linker.Tests.Cases.LinkAttributes.Dependencies.TypeWithEmbeddedAttributeToBeRemoved, LinkerAttributeRemovalEmbeddedAndLazyLoad"));
 		}
 	}
 

--- a/test/Mono.Linker.Tests.Cases/LinkAttributes/LinkerAttributeRemoval.xml
+++ b/test/Mono.Linker.Tests.Cases/LinkAttributes/LinkerAttributeRemoval.xml
@@ -8,6 +8,11 @@
       <!-- Must use wildcard assembly for this type since it can come either from System.Private.CoreLib or mscorlib -->
       <attribute internal="RemoveAttributeInstances"/>
     </type>
+
+    <!-- Intentionally uses wildcard assembly to verify that lazy loading assembly still applies these attributes -->
+    <type fullname="Mono.Linker.Tests.Cases.LinkAttributes.Dependencies.EmbeddedAttributeToBeRemoved">
+      <attribute internal="RemoveAttributeInstances"/>
+    </type>
   </assembly>
   <assembly fullname="test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
     <!-- IL2049 -->


### PR DESCRIPTION
Currently this doesn't work as it should, the test is to cover the scenario - once we fully implement lazy loading this should be fixed.