### PR TITLE
Support for RequiresAndCallsOtherRequiresMethods

### DIFF
--- a/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
@@ -76,26 +76,22 @@ namespace ILLink.RoslynAnalyzer
 					IMethodSymbol method,
 					Location location)
 				{
-					var attributes = method.GetAttributes ();
-
-					foreach (var attr in attributes) {
-						if (attr.AttributeClass is { } attrClass &&
-							IsNamedType (attrClass, "System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute") &&
-							attr.ConstructorArguments.Length == 1 &&
-							attr.ConstructorArguments[0] is { Type: { SpecialType: SpecialType.System_String } } ctorArg) {
-
-							string urlArgument = "";
-							foreach (var namedArgument in attr.NamedArguments) {
-								if (namedArgument.Key == "Url")
-									urlArgument = namedArgument.Value.Value?.ToString () ?? "";
-							}
-							operationContext.ReportDiagnostic (Diagnostic.Create (
-								s_rule,
-								location,
-								method.OriginalDefinition.ToString (),
-								(string) ctorArg.Value!,
-								urlArgument));
+					AttributeData? attribute = GetRequiresUnreferencedCodeAttribute (operationContext.ContainingSymbol.GetAttributes ());
+					if (attribute != null)
+						return;
+					attribute = GetRequiresUnreferencedCodeAttribute (method.GetAttributes ());
+					if (attribute != null) {
+						string urlArgument = "";
+						foreach (var namedArgument in attribute.NamedArguments) {
+							if (namedArgument.Key == "Url")
+								urlArgument = namedArgument.Value.Value?.ToString () ?? "";
 						}
+						operationContext.ReportDiagnostic (Diagnostic.Create (
+							s_rule,
+							location,
+							method.OriginalDefinition.ToString (),
+							(string) attribute.ConstructorArguments[0].Value!,
+							urlArgument));
 					}
 				}
 			});
@@ -120,6 +116,22 @@ namespace ILLink.RoslynAnalyzer
 			}
 
 			return true;
+		}
+
+		/// <summary>
+		/// Returns a RequiresUnreferencedCodeAttribute if found
+		/// </summary>
+		static AttributeData? GetRequiresUnreferencedCodeAttribute (ImmutableArray<AttributeData> attributes)
+		{
+			foreach (var attr in attributes) {
+				if (attr.AttributeClass is { } attrClass &&
+					IsNamedType (attrClass, "System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute") &&
+					attr.ConstructorArguments.Length == 1 &&
+					attr.ConstructorArguments[0] is { Type: { SpecialType: SpecialType.System_String } } ctorArg) {
+					return attr;
+				}
+			}
+			return null;
 		}
 	}
 }

--- a/test/ILLink.RoslynAnalyzer.Tests/LinkerTestCases.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/LinkerTestCases.cs
@@ -18,7 +18,6 @@ namespace ILLink.RoslynAnalyzer.Tests
 		public void RequiresCapability (MethodDeclarationSyntax m, List<AttributeSyntax> attrs)
 		{
 			switch (m.Identifier.ValueText) {
-			case "RequiresAndCallsOtherRequiresMethods":
 			case "MethodWithDuplicateRequiresAttribute":
 				return;
 			}


### PR DESCRIPTION
-Check for the parent to see if it has any UnreferencedCodeAttribute
-Since AllowMultiple is disabled by default, only check the attributes until first UnreferencedCodeAttribute is found