### PR TITLE
Better intrinsic handling of GetNestedType if input has All

### DIFF
--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Text;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Mono.Linker.Steps;
@@ -959,6 +958,7 @@ namespace Mono.Linker.Dataflow
 							bindingFlags = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public;
 
 						var requiredMemberTypes = GetDynamicallyAccessedMemberTypesFromBindingFlagsForNestedTypes (bindingFlags);
+						bool everyParentTypeHasAll = true;
 						foreach (var value in methodParams[0].UniqueValues ()) {
 							if (value is SystemTypeValue systemTypeValue) {
 								foreach (var stringParam in methodParams[1].UniqueValues ()) {
@@ -984,7 +984,18 @@ namespace Mono.Linker.Dataflow
 								// Otherwise fall back to the bitfield requirements
 								RequireDynamicallyAccessedMembers (ref reflectionContext, requiredMemberTypes, value, calledMethodDefinition);
 							}
+
+							if (value is not LeafValueWithDynamicallyAccessedMemberNode { DynamicallyAccessedMemberTypes: DynamicallyAccessedMemberTypes.All })
+								everyParentTypeHasAll = false;
 						}
+
+						// If the parent type (all the possible values) has DynamicallyAccessedMemberTypes.All it means its nested types are also fully marked
+						// (see MarkStep.MarkEntireType - it will recursively mark entire type on nested types). In that case we can annotated 
+						// the returned type (the nested type) with DynamicallyAccessedMemberTypes.All as well.
+						// Note it's OK to blindly overwrite any potential annotation on the return value from the method definition
+						// since DynamicallyAccessedMemberTypes.All is a superset of any other annotation.
+						if (everyParentTypeHasAll && methodReturnValue == null)
+							methodReturnValue = new MethodReturnValue (calledMethodDefinition.MethodReturnType, DynamicallyAccessedMemberTypes.All);
 					}
 					break;
 

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -985,9 +985,17 @@ namespace Mono.Linker.Dataflow
 								RequireDynamicallyAccessedMembers (ref reflectionContext, requiredMemberTypes, value, calledMethodDefinition);
 							}
 
-							var leafValueWithDynamicallyAccessedMemberNode = value is LeafValueWithDynamicallyAccessedMemberNode ? (LeafValueWithDynamicallyAccessedMemberNode) value : null;
-							if (leafValueWithDynamicallyAccessedMemberNode != null && leafValueWithDynamicallyAccessedMemberNode.DynamicallyAccessedMemberTypes != DynamicallyAccessedMemberTypes.All)
+							if (value is LeafValueWithDynamicallyAccessedMemberNode leafValueWithDynamicallyAccessedMember) {
+								if (leafValueWithDynamicallyAccessedMember.DynamicallyAccessedMemberTypes != DynamicallyAccessedMemberTypes.All)
+									everyParentTypeHasAll = false;
+							} else if (!(value is NullValue || value is SystemTypeValue)) {
+								// Known Type values are always OK - either they're fully resolved above and thus the return value
+								// is set to the known resolved type, or if they're not resolved, they won't exist at runtime
+								// and will cause exceptions - and thus don't introduce new requirements on marking.
+								// nulls are intentionally ignored as they will lead to exceptions at runtime
+								// and thus don't introduce new requirements on marking.
 								everyParentTypeHasAll = false;
+							}
 						}
 
 						// If the parent type (all the possible values) has DynamicallyAccessedMemberTypes.All it means its nested types are also fully marked

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -985,12 +985,13 @@ namespace Mono.Linker.Dataflow
 								RequireDynamicallyAccessedMembers (ref reflectionContext, requiredMemberTypes, value, calledMethodDefinition);
 							}
 
-							if (value is not LeafValueWithDynamicallyAccessedMemberNode { DynamicallyAccessedMemberTypes: DynamicallyAccessedMemberTypes.All })
+							var leafValueWithDynamicallyAccessedMemberNode = value is LeafValueWithDynamicallyAccessedMemberNode ? (LeafValueWithDynamicallyAccessedMemberNode) value : null;
+							if (leafValueWithDynamicallyAccessedMemberNode != null && leafValueWithDynamicallyAccessedMemberNode.DynamicallyAccessedMemberTypes != DynamicallyAccessedMemberTypes.All)
 								everyParentTypeHasAll = false;
 						}
 
 						// If the parent type (all the possible values) has DynamicallyAccessedMemberTypes.All it means its nested types are also fully marked
-						// (see MarkStep.MarkEntireType - it will recursively mark entire type on nested types). In that case we can annotated 
+						// (see MarkStep.MarkEntireType - it will recursively mark entire type on nested types). In that case we can annotate 
 						// the returned type (the nested type) with DynamicallyAccessedMemberTypes.All as well.
 						// Note it's OK to blindly overwrite any potential annotation on the return value from the method definition
 						// since DynamicallyAccessedMemberTypes.All is a superset of any other annotation.

--- a/test/Mono.Linker.Tests.Cases/DataFlow/GetNestedTypeOnAllAnnotatedType.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/GetNestedTypeOnAllAnnotatedType.cs
@@ -28,6 +28,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			TestWithNull ();
 			TestIfElse (1, typeof (GetNestedTypeOnAllAnnotatedType), typeof (GetNestedTypeOnAllAnnotatedType));
 			TestSwitchAllValid (1, typeof (GetNestedTypeOnAllAnnotatedType));
+			TestOnKnownTypeOnly ();
 		}
 
 		[RecognizedReflectionAccessPattern]
@@ -89,7 +90,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[RecognizedReflectionAccessPattern]
 		static void TestSwitchAllValid (int number, [DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] Type parentWithAll)
 		{
-			Type typeOfParent = number switch {
+			Type typeOfParent = number switch
+			{
 				1 => parentWithAll,
 				2 => null,
 				3 => typeof (GetNestedTypeOnAllAnnotatedType)
@@ -97,6 +99,12 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 			var nestedType = typeOfParent.GetNestedType (nameof (NestedType));
 			RequiresAll (nestedType);
+		}
+
+		[RecognizedReflectionAccessPattern]
+		static void TestOnKnownTypeOnly ()
+		{
+			RequiresAll (typeof (GetNestedTypeOnAllAnnotatedType).GetNestedType (nameof (NestedType)));
 		}
 
 		static void RequiresAll ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] Type type)

--- a/test/Mono.Linker.Tests.Cases/DataFlow/GetNestedTypeOnAllAnnotatedType.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/GetNestedTypeOnAllAnnotatedType.cs
@@ -25,8 +25,9 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			TestWithBindingFlags (typeof (GetNestedTypeOnAllAnnotatedType));
 			TestWithUnknownBindingFlags (BindingFlags.Public, typeof (GetNestedTypeOnAllAnnotatedType));
 			TestUnsupportedBindingFlags (typeof (GetNestedTypeOnAllAnnotatedType));
-			TestWithNull (null);
+			TestWithNull ();
 			TestIfElse (1, typeof (GetNestedTypeOnAllAnnotatedType), typeof (GetNestedTypeOnAllAnnotatedType));
+			TestSwitchAllValid (1, typeof (GetNestedTypeOnAllAnnotatedType));
 		}
 
 		[RecognizedReflectionAccessPattern]
@@ -65,8 +66,9 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[RecognizedReflectionAccessPattern]
-		static void TestWithNull ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] Type parentType)
+		static void TestWithNull ()
 		{
+			Type parentType = null;
 			var nestedType = parentType.GetNestedType (nameof (NestedType));
 			RequiresAll (nestedType);
 		}
@@ -80,6 +82,19 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			} else {
 				typeOfParent = parentWithoutAll;
 			}
+			var nestedType = typeOfParent.GetNestedType (nameof (NestedType));
+			RequiresAll (nestedType);
+		}
+
+		[RecognizedReflectionAccessPattern]
+		static void TestSwitchAllValid (int number, [DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] Type parentWithAll)
+		{
+			Type typeOfParent = number switch {
+				1 => parentWithAll,
+				2 => null,
+				3 => typeof (GetNestedTypeOnAllAnnotatedType)
+			};
+
 			var nestedType = typeOfParent.GetNestedType (nameof (NestedType));
 			RequiresAll (nestedType);
 		}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/GetNestedTypeOnAllAnnotatedType.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/GetNestedTypeOnAllAnnotatedType.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.DataFlow
+{
+	[RecognizedReflectionAccessPattern]
+	[SkipKeptItemsValidation]
+	class GetNestedTypeOnAllAnnotatedType
+	{
+		[RecognizedReflectionAccessPattern]
+		static void Main ()
+		{
+			TestOnAllAnnotatedParameter (typeof(GetNestedTypeOnAllAnnotatedType));
+			TestOnNonAllAnnotatedParameter (typeof (GetNestedTypeOnAllAnnotatedType));
+		}
+
+		[RecognizedReflectionAccessPattern]
+		static void TestOnAllAnnotatedParameter ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] Type parentType)
+		{
+			var nestedType = parentType.GetNestedType (nameof (NestedType));
+			RequiresAll (nestedType);
+		}
+
+		[UnrecognizedReflectionAccessPattern(typeof(GetNestedTypeOnAllAnnotatedType), nameof(RequiresAll), new Type[] { typeof (Type) }, messageCode: "IL2072")]
+		static void TestOnNonAllAnnotatedParameter ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicNestedTypes)] Type parentType)
+		{
+			var nestedType = parentType.GetNestedType (nameof (NestedType));
+			RequiresAll (nestedType);
+		}
+
+		static void RequiresAll([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] Type type)
+		{
+		}
+
+		class NestedType
+		{
+			NestedType () { }
+			public static int PublicStaticInt;
+			public void Method () { }
+			int Prop { get; set; }
+		}
+	}
+}


### PR DESCRIPTION
If the parent type value is annotated with `DynamicallyAccessedMemberTypes.All` then the GetNestedType can return a value also annotated with `DynamicallyAccessedMemberTypes.All` since the `All` is recursively applied to nested types (`MarkStep.MarkEntireType` basically recursively calls `MarkEntireType` on nested types).

This helps with patterns like:
```C#
void Test([DynamicallyAccessedMembers(All)] parentType)
{
    parentType.GetNestedType("KnownNestedType").GetFields();
}
```

Without this there would be no way to do this without warning suppressions, even though it's a perfectly valid code as per the rules around `All`.