### PR TITLE
Add help link for IL3000 and IL3001

### DIFF
--- a/src/ILLink.RoslynAnalyzer/SingleFileAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/SingleFileAnalyzer.cs
@@ -28,7 +28,8 @@ namespace ILLink.RoslynAnalyzer
 				Resources.ResourceManager, typeof (Resources)),
 			DiagnosticCategory.SingleFile,
 			DiagnosticSeverity.Warning,
-			isEnabledByDefault: true);
+			isEnabledByDefault: true,
+			helpLinkUri: "https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000");
 
 		private static readonly DiagnosticDescriptor GetFilesRule = new DiagnosticDescriptor (
 			IL3001,
@@ -38,7 +39,8 @@ namespace ILLink.RoslynAnalyzer
 				Resources.ResourceManager, typeof (Resources)),
 			DiagnosticCategory.SingleFile,
 			DiagnosticSeverity.Warning,
-			isEnabledByDefault: true);
+			isEnabledByDefault: true,
+			helpLinkUri: "https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3001");
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create (LocationRule, GetFilesRule);
 


### PR DESCRIPTION
These rules had a help link when they were in roslyn-analyzers repository (see https://github.com/dotnet/roslyn-analyzers/pull/4680/), but the help link was lost after porting it here.

This PR adds the help link back.

Tagging @mavasani in case he wants the documentation to be ported from dotnet/docs to somewhere else.