### PR TITLE
Updating the Linker Analyzer readme to use _TrimmerDumpDependencies

### DIFF
--- a/src/analyzer/README.md
+++ b/src/analyzer/README.md
@@ -16,12 +16,12 @@ can be retrieved by enabling dependencies dumping during linking of a
 Xamarin.Android or a Xamarin.iOS project.
 
 That can be done on the command line by setting
-`LinkerDumpDependencies` property to `true` and building the
+`_TrimmerDumpDependencies` property to `true` and building the
 project. (make sure the LinkAssemblies task is called, it might
 require cleaning the project sometimes) Usually it is enough to build
 the project like this:
 
-```msbuild /p:LinkerDumpDependencies=true /p:Configuration=Release YourAppProject.csproj```
+```msbuild /p:_TrimmerDumpDependencies=true /p:Configuration=Release YourAppProject.csproj```
 
 After a successful build, there will be a linker-dependencies.xml.gz
 file created, containing the information for the analyzer.

--- a/src/analyzer/README.md
+++ b/src/analyzer/README.md
@@ -13,13 +13,17 @@ etc. The edges represent the dependencies.
 
 The linker analyzer needs a linker dependencies file as an input. It
 can be retrieved by enabling dependencies dumping during linking of a
-Xamarin.Android or a Xamarin.iOS project.
+Xamarin.Android, Xamarin.iOS, or .NET SDK style project.
 
-That can be done on the command line by setting
-`_TrimmerDumpDependencies` property to `true` and building the
+For Xamarin.Android and Xamarin.iOS, that can be done on the command line by setting
+`LinkerDumpDependencies` property to `true` and building the
 project. (make sure the LinkAssemblies task is called, it might
 require cleaning the project sometimes) Usually it is enough to build
 the project like this:
+
+```msbuild /p:LinkerDumpDependencies=true /p:Configuration=Release YourAppProject.csproj```
+
+For .NET SDK style projects, you will want to use `_TrimmerDumpDependencies` instead:
 
 ```msbuild /p:_TrimmerDumpDependencies=true /p:Configuration=Release YourAppProject.csproj```
 


### PR DESCRIPTION
As per the actual property checked in https://github.com/dotnet/sdk/blob/master/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets#L122