### PR TITLE
Fix nullref caused by unknown value to the ignoreCase parameter of Type.GetType

### DIFF
--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -820,8 +820,7 @@ namespace Mono.Linker.Dataflow
 						reflectionContext.AnalyzingPattern ();
 
 						var parameters = calledMethod.Parameters;
-						if ((parameters.Count == 3 && (methodParams[2].Kind == ValueNodeKind.MethodReturn || methodParams[2].Kind == ValueNodeKind.ConstInt || methodParams[2].Kind == ValueNodeKind.LoadField)
-							&& (methodParams[2].AsConstInt () == null || methodParams[2].AsConstInt () != 0)) ||
+						if ((parameters.Count == 3 && parameters[2].ParameterType.IsTypeOf ("System", "Boolean") && (methodParams[2].AsConstInt () == null || methodParams[2].AsConstInt () != 0)) ||
 							(parameters.Count == 5 && (methodParams[4].AsConstInt () == null || methodParams[4].AsConstInt () != 0))) {
 							reflectionContext.RecordUnrecognizedPattern (2096, $"Call to '{calledMethod.GetDisplayName ()}' can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types");
 							break;

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -820,7 +820,7 @@ namespace Mono.Linker.Dataflow
 						reflectionContext.AnalyzingPattern ();
 
 						var parameters = calledMethod.Parameters;
-						if ((parameters.Count == 3 && parameters[2].ParameterType.IsTypeOf ("System", "Boolean") && (methodParams[2].AsConstInt () == null || methodParams[2].AsConstInt () != 0)) ||
+						if ((parameters.Count == 3 && parameters[2].ParameterType.MetadataType == MetadataType.Boolean && (methodParams[2].AsConstInt () == null || methodParams[2].AsConstInt () != 0)) ||
 							(parameters.Count == 5 && (methodParams[4].AsConstInt () == null || methodParams[4].AsConstInt () != 0))) {
 							reflectionContext.RecordUnrecognizedPattern (2096, $"Call to '{calledMethod.GetDisplayName ()}' can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types");
 							break;

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -820,8 +820,8 @@ namespace Mono.Linker.Dataflow
 						reflectionContext.AnalyzingPattern ();
 
 						var parameters = calledMethod.Parameters;
-						if ((parameters.Count == 3 && parameters[2].ParameterType.MetadataType == MetadataType.Boolean && (methodParams[2].AsConstInt () == null || methodParams[2].AsConstInt () != 0)) ||
-							(parameters.Count == 5 && (methodParams[4].AsConstInt () == null || methodParams[4].AsConstInt () != 0))) {
+						if ((parameters.Count == 3 && parameters[2].ParameterType.MetadataType == MetadataType.Boolean && methodParams[2].AsConstInt () != 0) ||
+							(parameters.Count == 5 && methodParams[4].AsConstInt () != 0)) {
 							reflectionContext.RecordUnrecognizedPattern (2096, $"Call to '{calledMethod.GetDisplayName ()}' can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types");
 							break;
 						}

--- a/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflection.cs
@@ -38,6 +38,8 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestTypeOverloadWith5ParametersWithIgnoreCase ();
 			TestTypeOverloadWith5ParametersWithoutIgnoreCase ();
 			TestInvalidTypeName ();
+			TestUnkownIgnoreCase3Params (1);
+			TestUnkownIgnoreCase5Params (1);
 		}
 
 		[Kept]
@@ -358,6 +360,24 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		static Type GetTypeFromAssembly (Assembly assembly, string name, bool caseSensitive)
 		{
 			return assembly == null ? Type.GetType (name, caseSensitive) : assembly.GetType (name, caseSensitive);
+		}
+
+		[Kept]
+		[ExpectedWarning ("IL2096", "'System.Type.GetType(String,Boolean,Boolean)'")]
+		static void TestUnkownIgnoreCase3Params (int num)
+		{
+			const string reflectionTypeKeptString = "mono.linker.tests.cases.reflection.TypeUsedViaReflection+CaseUnknown2, test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null";
+			bool unknownValue = num + 1 == 1;
+			var typeKept = Type.GetType (reflectionTypeKeptString, false, unknownValue);
+		}
+
+		[Kept]
+		[ExpectedWarning ("IL2096", "'System.Type.GetType(String,Func<AssemblyName,Assembly>,Func<Assembly,String,Boolean,Type>,Boolean,Boolean)'")]
+		static void TestUnkownIgnoreCase5Params (int num)
+		{
+			const string reflectionTypeKeptString = "mono.linker.tests.cases.reflection.TypeUsedViaReflection+CaseUnknown2, test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null";
+			bool unknownValue = num + 1 == 1;
+			var typeKept = Type.GetType (reflectionTypeKeptString, AssemblyResolver, GetTypeFromAssembly, false, unknownValue);
 		}
 	}
 }


### PR DESCRIPTION
We have special handling for cases where ignoreCase is not constant false (since linker won't be able to correctly mark the required types). This handling was written such that it assumed the value for the parameter was "known" that is we know at least something about it. If it's completely unknown, that's represented as null and the code crashes on it.

Added a test case for this and made the fix.

Fixes #1741 