### PR TITLE
Keep types marked with DynamicInterfaceCastableImplementationAttribute when any interface they implement is kept

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -245,7 +245,7 @@ namespace Mono.Linker.Steps
 					InitializeType (nested);
 			}
 
-			if (TypeHasDynamicInterfaceCastableImplementationAttribute (type)) {
+			if (TypeHasDynamicInterfaceCastableImplementationAttribute (type) && type.Interfaces.Count > 0) {
 				_dynamicInterfaceCastableImplementationTypes.Add (type);
 			}
 

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -829,7 +829,8 @@ namespace Mono.Linker.Steps
 
 		protected static AssemblyDefinition GetAssemblyFromCustomAttributeProvider (ICustomAttributeProvider provider)
 		{
-			return provider switch {
+			return provider switch
+			{
 				MemberReference mr => mr.Module.Assembly,
 				AssemblyDefinition ad => ad,
 				ModuleDefinition md => md.Assembly,
@@ -1427,7 +1428,8 @@ namespace Mono.Linker.Steps
 
 			var parent = field.DeclaringType;
 			if (!Annotations.HasPreservedStaticCtor (parent)) {
-				var cctorReason = reason.Kind switch {
+				var cctorReason = reason.Kind switch
+				{
 					// Report an edge directly from the method accessing the field to the static ctor it triggers
 					DependencyKind.FieldAccess => new DependencyInfo (DependencyKind.TriggersCctorThroughFieldAccess, reason.Source),
 					_ => new DependencyInfo (DependencyKind.CctorForField, field)
@@ -3000,7 +3002,8 @@ namespace Mono.Linker.Steps
 				break;
 
 			case OperandType.InlineMethod: {
-					DependencyKind dependencyKind = instruction.OpCode.Code switch {
+					DependencyKind dependencyKind = instruction.OpCode.Code switch
+					{
 						Code.Jmp => DependencyKind.DirectCall,
 						Code.Call => DependencyKind.DirectCall,
 						Code.Callvirt => DependencyKind.VirtualCall,

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -228,7 +228,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		static bool TypeHasDynamicInterfaceCastableImplementationAttribute(TypeDefinition type)
+		static bool TypeHasDynamicInterfaceCastableImplementationAttribute (TypeDefinition type)
 		{
 			foreach (var ca in type.CustomAttributes) {
 				TypeDefinition caType = ca.AttributeType.Resolve ();
@@ -488,7 +488,7 @@ namespace Mono.Linker.Steps
 					continue;
 
 				foreach (var iface in type.Interfaces) {
-					if (Annotations.IsMarked(iface.InterfaceType)) {
+					if (Annotations.IsMarked (iface.InterfaceType)) {
 						MarkType (type, new DependencyInfo (DependencyKind.DynamicInterfaceCastableImplementation, iface.InterfaceType), type);
 						_dynamicInterfaceCastableImplementationTypes.RemoveAt (i--);
 						break;
@@ -786,8 +786,7 @@ namespace Mono.Linker.Steps
 
 		protected static AssemblyDefinition GetAssemblyFromCustomAttributeProvider (ICustomAttributeProvider provider)
 		{
-			return provider switch
-			{
+			return provider switch {
 				MemberReference mr => mr.Module.Assembly,
 				AssemblyDefinition ad => ad,
 				ModuleDefinition md => md.Assembly,
@@ -1385,8 +1384,7 @@ namespace Mono.Linker.Steps
 
 			var parent = field.DeclaringType;
 			if (!Annotations.HasPreservedStaticCtor (parent)) {
-				var cctorReason = reason.Kind switch
-				{
+				var cctorReason = reason.Kind switch {
 					// Report an edge directly from the method accessing the field to the static ctor it triggers
 					DependencyKind.FieldAccess => new DependencyInfo (DependencyKind.TriggersCctorThroughFieldAccess, reason.Source),
 					_ => new DependencyInfo (DependencyKind.CctorForField, field)
@@ -2959,8 +2957,7 @@ namespace Mono.Linker.Steps
 				break;
 
 			case OperandType.InlineMethod: {
-					DependencyKind dependencyKind = instruction.OpCode.Code switch
-					{
+					DependencyKind dependencyKind = instruction.OpCode.Code switch {
 						Code.Jmp => DependencyKind.DirectCall,
 						Code.Call => DependencyKind.DirectCall,
 						Code.Callvirt => DependencyKind.VirtualCall,

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -118,6 +118,7 @@ namespace Mono.Linker.Steps
 			DependencyKind.ParameterMarshalSpec,
 			DependencyKind.FieldMarshalSpec,
 			DependencyKind.ReturnTypeMarshalSpec,
+			DependencyKind.DynamicInterfaceCastableImplementation,
 		};
 
 		static readonly DependencyKind[] _methodReasons = new DependencyKind[] {
@@ -232,7 +233,10 @@ namespace Mono.Linker.Steps
 					InitializeType (nested);
 			}
 
-			if (!Annotations.IsMarked (type))
+			if (type.CustomAttributes.Any(ca => ca.AttributeType.Resolve().Name == "DynamicInterfaceCastableImplementationAttribute")) {
+				MarkType (type, DependencyInfo.DynamicInterfaceCastableImplementation, type);
+			}
+			else if (!Annotations.IsMarked (type))
 				return;
 
 			// We may get here for a type marked by an earlier step, or by a type

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -786,7 +786,8 @@ namespace Mono.Linker.Steps
 
 		protected static AssemblyDefinition GetAssemblyFromCustomAttributeProvider (ICustomAttributeProvider provider)
 		{
-			return provider switch {
+			return provider switch
+			{
 				MemberReference mr => mr.Module.Assembly,
 				AssemblyDefinition ad => ad,
 				ModuleDefinition md => md.Assembly,
@@ -1384,7 +1385,8 @@ namespace Mono.Linker.Steps
 
 			var parent = field.DeclaringType;
 			if (!Annotations.HasPreservedStaticCtor (parent)) {
-				var cctorReason = reason.Kind switch {
+				var cctorReason = reason.Kind switch
+				{
 					// Report an edge directly from the method accessing the field to the static ctor it triggers
 					DependencyKind.FieldAccess => new DependencyInfo (DependencyKind.TriggersCctorThroughFieldAccess, reason.Source),
 					_ => new DependencyInfo (DependencyKind.CctorForField, field)
@@ -2957,7 +2959,8 @@ namespace Mono.Linker.Steps
 				break;
 
 			case OperandType.InlineMethod: {
-					DependencyKind dependencyKind = instruction.OpCode.Code switch {
+					DependencyKind dependencyKind = instruction.OpCode.Code switch
+					{
 						Code.Jmp => DependencyKind.DirectCall,
 						Code.Call => DependencyKind.DirectCall,
 						Code.Callvirt => DependencyKind.VirtualCall,

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -484,8 +484,11 @@ namespace Mono.Linker.Steps
 
 				Debug.Assert (TypeHasDynamicInterfaceCastableImplementationAttribute (type));
 
-				if (Annotations.IsMarked (type))
+				// If the type has already been marked, we can remove it from this list.
+				if (Annotations.IsMarked (type)) {
+					_dynamicInterfaceCastableImplementationTypes.RemoveAt (i--);
 					continue;
+				}
 
 				foreach (var iface in type.Interfaces) {
 					if (Annotations.IsMarked (iface.InterfaceType)) {

--- a/src/linker/Linker/DependencyInfo.cs
+++ b/src/linker/Linker/DependencyInfo.cs
@@ -127,7 +127,7 @@ namespace Mono.Linker
 		// Linker internals, requirements for certain optimizations
 		UnreachableBodyRequirement = 77, // method -> well-known type required for unreachable bodies optimization
 		DisablePrivateReflectionRequirement = 78, // null -> DisablePrivateReflectionAttribute type/methods (note that no specific source is reported)
-		DynamicInterfaceCastableImplementation = 79, // null -> type is marked with IDynamicInterfaceCastableImplementationAttribute
+		DynamicInterfaceCastableImplementation = 79, // type -> type is marked with IDynamicInterfaceCastableImplementationAttribute and implements the provided interface
 		AlreadyMarked = 80, // null -> member that has already been marked for a particular reason (used to propagate reasons internally, not reported)
 	}
 
@@ -139,7 +139,6 @@ namespace Mono.Linker
 		public static readonly DependencyInfo Unspecified = new DependencyInfo (DependencyKind.Unspecified, null);
 		public static readonly DependencyInfo AlreadyMarked = new DependencyInfo (DependencyKind.AlreadyMarked, null);
 		public static readonly DependencyInfo DisablePrivateReflectionRequirement = new DependencyInfo (DependencyKind.DisablePrivateReflectionRequirement, null);
-		public static readonly DependencyInfo DynamicInterfaceCastableImplementation = new DependencyInfo (DependencyKind.DynamicInterfaceCastableImplementation, null);
 		public bool Equals (DependencyInfo other) => (Kind, Source) == (other.Kind, other.Source);
 		public override bool Equals (Object obj) => obj is DependencyInfo info && this.Equals (info);
 		public override int GetHashCode () => (Kind, Source).GetHashCode ();

--- a/src/linker/Linker/DependencyInfo.cs
+++ b/src/linker/Linker/DependencyInfo.cs
@@ -127,7 +127,8 @@ namespace Mono.Linker
 		// Linker internals, requirements for certain optimizations
 		UnreachableBodyRequirement = 77, // method -> well-known type required for unreachable bodies optimization
 		DisablePrivateReflectionRequirement = 78, // null -> DisablePrivateReflectionAttribute type/methods (note that no specific source is reported)
-		AlreadyMarked = 79, // null -> member that has already been marked for a particular reason (used to propagate reasons internally, not reported)
+		DynamicInterfaceCastableImplementation = 79, // null -> type is marked with IDynamicInterfaceCastableImplementationAttribute
+		AlreadyMarked = 80, // null -> member that has already been marked for a particular reason (used to propagate reasons internally, not reported)
 	}
 
 	public readonly struct DependencyInfo : IEquatable<DependencyInfo>
@@ -138,6 +139,7 @@ namespace Mono.Linker
 		public static readonly DependencyInfo Unspecified = new DependencyInfo (DependencyKind.Unspecified, null);
 		public static readonly DependencyInfo AlreadyMarked = new DependencyInfo (DependencyKind.AlreadyMarked, null);
 		public static readonly DependencyInfo DisablePrivateReflectionRequirement = new DependencyInfo (DependencyKind.DisablePrivateReflectionRequirement, null);
+		public static readonly DependencyInfo DynamicInterfaceCastableImplementation = new DependencyInfo (DependencyKind.DynamicInterfaceCastableImplementation, null);
 		public bool Equals (DependencyInfo other) => (Kind, Source) == (other.Kind, other.Source);
 		public override bool Equals (Object obj) => obj is DependencyInfo info && this.Equals (info);
 		public override int GetHashCode () => (Kind, Source).GetHashCode ();

--- a/test/Mono.Linker.Tests.Cases/Attributes/TypeWithDynamicInterfaceCastableImplementationAttributeIsKept.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes/TypeWithDynamicInterfaceCastableImplementationAttributeIsKept.cs
@@ -12,15 +12,21 @@ using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Attributes
 {
+#if !NETCOREAPP
+	[IgnoreTestCase ("Requires support for default interface methods")]
+#endif
 	public class TypeWithDynamicInterfaceCastableImplementationAttributeIsKept
 	{
 		public static void Main ()
 		{
+#if NETCOREAPP
 			Foo foo = new Foo ();
 			GetBar (foo).Bar ();
 			IReferenced baz = GetBaz (foo);
+#endif
 		}
 
+#if NETCOREAPP
 		[Kept]
 		private static IReferencedAndCalled GetBar (object obj)
 		{
@@ -32,8 +38,10 @@ namespace Mono.Linker.Tests.Cases.Attributes
 		{
 			return (IReferenced) obj;
 		}
+#endif
 	}
 
+#if NETCOREAPP
 	[Kept]
 	[KeptMember (".ctor()")]
 	class Foo : IDynamicInterfaceCastable
@@ -111,4 +119,5 @@ namespace Mono.Linker.Tests.Cases.Attributes
 	{
 		void IReferencedInIDynamicInterfaceCastableType.Foo () { }
 	}
+#endif
 }

--- a/test/Mono.Linker.Tests.Cases/Attributes/TypeWithDynamicInterfaceCastableImplementationAttributeIsKept.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes/TypeWithDynamicInterfaceCastableImplementationAttributeIsKept.cs
@@ -14,13 +14,13 @@ namespace Mono.Linker.Tests.Cases.Attributes
 {
 	public class TypeWithDynamicInterfaceCastableImplementationAttributeIsKept
 	{
-		public static void Main()
+		public static void Main ()
 		{
 			Foo foo = new Foo ();
 			GetBar (foo).Bar ();
 			IReferenced baz = GetBaz (foo);
 		}
-		
+
 		[Kept]
 		private static IReferencedAndCalled GetBar (object obj)
 		{
@@ -41,7 +41,7 @@ namespace Mono.Linker.Tests.Cases.Attributes
 		[Kept]
 		public RuntimeTypeHandle GetInterfaceImplementation (RuntimeTypeHandle interfaceType)
 		{
-			if (interfaceType.Equals(typeof(IReferencedInIDynamicInterfaceCastableType).TypeHandle)) {
+			if (interfaceType.Equals (typeof (IReferencedInIDynamicInterfaceCastableType).TypeHandle)) {
 				return typeof (IReferencedInIDynamicInterfaceCastableTypeImpl).TypeHandle;
 			}
 			return default;
@@ -62,8 +62,8 @@ namespace Mono.Linker.Tests.Cases.Attributes
 	}
 
 	[Kept]
-	[KeptAttributeAttribute (typeof(DynamicInterfaceCastableImplementationAttribute))]
-	[KeptInterface(typeof(IReferencedAndCalled))]
+	[KeptAttributeAttribute (typeof (DynamicInterfaceCastableImplementationAttribute))]
+	[KeptInterface (typeof (IReferencedAndCalled))]
 	[DynamicInterfaceCastableImplementation]
 	interface IReferencedAndCalledImpl : IReferencedAndCalled
 	{
@@ -100,7 +100,7 @@ namespace Mono.Linker.Tests.Cases.Attributes
 	[Kept]
 	interface IReferencedInIDynamicInterfaceCastableType
 	{
-		void Foo() { }
+		void Foo () { }
 	}
 
 	[Kept]

--- a/test/Mono.Linker.Tests.Cases/Attributes/TypeWithDynamicInterfaceCastableImplementationAttributeIsKept.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes/TypeWithDynamicInterfaceCastableImplementationAttributeIsKept.cs
@@ -1,0 +1,96 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Attributes
+{
+	public class TypeWithDynamicInterfaceCastableImplementationAttributeIsKept
+	{
+		public static void Main()
+		{
+			Foo foo = new Foo ();
+			GetIBar (foo).Bar ();
+			IBaz baz = GetIBaz (foo);
+		}
+		
+		[Kept]
+		private static IBar GetIBar (object obj)
+		{
+			return (IBar) obj;
+		}
+
+		[Kept]
+		private static IBaz GetIBaz (object obj)
+		{
+			return (IBaz) obj;
+		}
+	}
+
+	[Kept]
+	[KeptMember (".ctor()")]
+	class Foo : IDynamicInterfaceCastable
+	{
+		[Kept]
+		public RuntimeTypeHandle GetInterfaceImplementation (RuntimeTypeHandle interfaceType)
+		{
+			throw new NotImplementedException ();
+		}
+
+		[Kept]
+		public bool IsInterfaceImplemented (RuntimeTypeHandle interfaceType, bool throwIfNotImplemented)
+		{
+			throw new NotImplementedException ();
+		}
+	}
+
+	[Kept]
+	interface IBar
+	{
+		[Kept]
+		void Bar ();
+	}
+
+	[Kept]
+	[KeptAttributeAttribute (typeof(DynamicInterfaceCastableImplementationAttribute))]
+	[KeptInterface(typeof(IBar))]
+	[DynamicInterfaceCastableImplementation]
+	interface IBarImpl : IBar
+	{
+		[Kept]
+		void IBar.Bar () { }
+	}
+
+	[Kept]
+	interface IBaz
+	{
+		void Baz ();
+	}
+
+	[Kept]
+	[KeptAttributeAttribute (typeof (DynamicInterfaceCastableImplementationAttribute))]
+	[KeptInterface (typeof (IBaz))]
+	[DynamicInterfaceCastableImplementation]
+	interface IBazImpl : IBaz
+	{
+		void IBaz.Baz () { }
+	}
+
+	interface IFrob
+	{
+		void Frob () { }
+	}
+
+	[DynamicInterfaceCastableImplementation]
+	interface IFrobImpl : IFrob
+	{
+		void IFrob.Frob () { }
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Attributes/TypeWithDynamicInterfaceCastableImplementationAttributeIsKept.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes/TypeWithDynamicInterfaceCastableImplementationAttributeIsKept.cs
@@ -17,20 +17,20 @@ namespace Mono.Linker.Tests.Cases.Attributes
 		public static void Main()
 		{
 			Foo foo = new Foo ();
-			GetIBar (foo).Bar ();
-			IBaz baz = GetIBaz (foo);
+			GetBar (foo).Bar ();
+			IReferenced baz = GetBaz (foo);
 		}
 		
 		[Kept]
-		private static IBar GetIBar (object obj)
+		private static IReferencedAndCalled GetBar (object obj)
 		{
-			return (IBar) obj;
+			return (IReferencedAndCalled) obj;
 		}
 
 		[Kept]
-		private static IBaz GetIBaz (object obj)
+		private static IReferenced GetBaz (object obj)
 		{
-			return (IBaz) obj;
+			return (IReferenced) obj;
 		}
 	}
 
@@ -41,18 +41,21 @@ namespace Mono.Linker.Tests.Cases.Attributes
 		[Kept]
 		public RuntimeTypeHandle GetInterfaceImplementation (RuntimeTypeHandle interfaceType)
 		{
-			throw new NotImplementedException ();
+			if (interfaceType.Equals(typeof(IReferencedInIDynamicInterfaceCastableType).TypeHandle)) {
+				return typeof (IReferencedInIDynamicInterfaceCastableTypeImpl).TypeHandle;
+			}
+			return default;
 		}
 
 		[Kept]
 		public bool IsInterfaceImplemented (RuntimeTypeHandle interfaceType, bool throwIfNotImplemented)
 		{
-			throw new NotImplementedException ();
+			return interfaceType.Equals (typeof (IReferencedInIDynamicInterfaceCastableType).TypeHandle);
 		}
 	}
 
 	[Kept]
-	interface IBar
+	interface IReferencedAndCalled
 	{
 		[Kept]
 		void Bar ();
@@ -60,37 +63,52 @@ namespace Mono.Linker.Tests.Cases.Attributes
 
 	[Kept]
 	[KeptAttributeAttribute (typeof(DynamicInterfaceCastableImplementationAttribute))]
-	[KeptInterface(typeof(IBar))]
+	[KeptInterface(typeof(IReferencedAndCalled))]
 	[DynamicInterfaceCastableImplementation]
-	interface IBarImpl : IBar
+	interface IReferencedAndCalledImpl : IReferencedAndCalled
 	{
 		[Kept]
-		void IBar.Bar () { }
+		void IReferencedAndCalled.Bar () { }
 	}
 
 	[Kept]
-	interface IBaz
+	interface IReferenced
 	{
 		void Baz ();
 	}
 
 	[Kept]
 	[KeptAttributeAttribute (typeof (DynamicInterfaceCastableImplementationAttribute))]
-	[KeptInterface (typeof (IBaz))]
+	[KeptInterface (typeof (IReferenced))]
 	[DynamicInterfaceCastableImplementation]
-	interface IBazImpl : IBaz
+	interface IReferencedImpl : IReferenced
 	{
-		void IBaz.Baz () { }
+		void IReferenced.Baz () { }
 	}
 
-	interface IFrob
+	interface IUnreferenced
 	{
 		void Frob () { }
 	}
 
 	[DynamicInterfaceCastableImplementation]
-	interface IFrobImpl : IFrob
+	interface IUnreferencedImpl : IUnreferenced
 	{
-		void IFrob.Frob () { }
+		void IUnreferenced.Frob () { }
+	}
+
+	[Kept]
+	interface IReferencedInIDynamicInterfaceCastableType
+	{
+		void Foo() { }
+	}
+
+	[Kept]
+	[KeptAttributeAttribute (typeof (DynamicInterfaceCastableImplementationAttribute))]
+	[KeptInterface (typeof (IReferencedInIDynamicInterfaceCastableType))]
+	[DynamicInterfaceCastableImplementation]
+	interface IReferencedInIDynamicInterfaceCastableTypeImpl : IReferencedInIDynamicInterfaceCastableType
+	{
+		void IReferencedInIDynamicInterfaceCastableType.Foo () { }
 	}
 }


### PR DESCRIPTION
This PR adds support to the linker for IDynamicInterfaceCastable implementation types. These types might be referenced statically in an IDynamicInterfaceCastable implementation (custom targeted COM wrappers scenario), but they also may be dynamically discovered via reflection (C#/WinRT scenario).

This PR collects a list of all types with the `DynamicInterfaceCastableImplementationAttribute` applied that implement at least one interface and only marks them if any interface they implement is marked.

By collecting the list of types to mark in this way at initialization time, we handle both the dynamic and static cases at once.

Fixes #1244 