### PR TITLE
[release/5.0] Fix nullref caused by unknown value to the ignoreCase parameter of Type.GetType

### DIFF
--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -795,9 +795,8 @@ namespace Mono.Linker.Dataflow
 						reflectionContext.AnalyzingPattern ();
 
 						var parameters = calledMethod.Parameters;
-						if ((parameters.Count == 3 && (methodParams[2].Kind == ValueNodeKind.MethodReturn || methodParams[2].Kind == ValueNodeKind.ConstInt || methodParams[2].Kind == ValueNodeKind.LoadField)
-							&& (methodParams[2].AsConstInt () == null || methodParams[2].AsConstInt () != 0)) ||
-							(parameters.Count == 5 && (methodParams[4].AsConstInt () == null || methodParams[4].AsConstInt () != 0))) {
+						if ((parameters.Count == 3 && parameters[2].ParameterType.MetadataType == MetadataType.Boolean && methodParams[2].AsConstInt () != 0) ||
+							(parameters.Count == 5 && methodParams[4].AsConstInt () != 0)) {
 							reflectionContext.RecordUnrecognizedPattern (2096, $"Call to '{calledMethod.GetDisplayName ()}' can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types");
 							break;
 						}

--- a/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflection.cs
@@ -35,6 +35,9 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestTypeOverloadWith4Parameters ();
 			TestTypeOverloadWith5ParametersWithIgnoreCase ();
 			TestTypeOverloadWith5ParametersWithoutIgnoreCase ();
+			TestInvalidTypeName ();
+			TestUnkownIgnoreCase3Params (1);
+			TestUnkownIgnoreCase5Params (1);
 		}
 
 		[Kept]
@@ -308,6 +311,15 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			var typeKept = Type.GetType (reflectionTypeKeptString, AssemblyResolver, GetTypeFromAssembly, false, false);
 		}
 
+		/// <summary>
+		/// This test verifies that if `TypeParser.ParseTypeName` hits an exception and returns null that the linker doesn't fail
+		/// </summary>
+		[Kept]
+		static void TestInvalidTypeName ()
+		{
+			var type = Type.GetType ("System.Collections.Generic.List`1[GenericClass`1[System.String]+Nested]");
+		}
+
 		[Kept]
 		static Assembly AssemblyResolver (AssemblyName assemblyName)
 		{
@@ -318,6 +330,24 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		static Type GetTypeFromAssembly (Assembly assembly, string name, bool caseSensitive)
 		{
 			return assembly == null ? Type.GetType (name, caseSensitive) : assembly.GetType (name, caseSensitive);
+		}
+
+		[Kept]
+		[ExpectedWarning ("IL2096", "'System.Type.GetType(String,Boolean,Boolean)'")]
+		static void TestUnkownIgnoreCase3Params (int num)
+		{
+			const string reflectionTypeKeptString = "mono.linker.tests.cases.reflection.TypeUsedViaReflection+CaseUnknown2, test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null";
+			bool unknownValue = num + 1 == 1;
+			var typeKept = Type.GetType (reflectionTypeKeptString, false, unknownValue);
+		}
+
+		[Kept]
+		[ExpectedWarning ("IL2096", "'System.Type.GetType(String,Func<AssemblyName,Assembly>,Func<Assembly,String,Boolean,Type>,Boolean,Boolean)'")]
+		static void TestUnkownIgnoreCase5Params (int num)
+		{
+			const string reflectionTypeKeptString = "mono.linker.tests.cases.reflection.TypeUsedViaReflection+CaseUnknown2, test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null";
+			bool unknownValue = num + 1 == 1;
+			var typeKept = Type.GetType (reflectionTypeKeptString, AssemblyResolver, GetTypeFromAssembly, false, unknownValue);
 		}
 	}
 }


### PR DESCRIPTION
5.0 port of #1752 

Fix for #1741 