### PR TITLE
Refactor type members preservation coming from assembly roots.

### DIFF
--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -127,7 +127,7 @@ the error code. For example:
 
 #### `IL1037`: Invalid assembly root mode '{mode}'
 
-#### `IL1038`: Exported type '{type.Name}' cannot be rooted
+#### `IL1038`: Exported type '{type.Name}' cannot be resolved
 
 ----
 ## Warning Codes

--- a/src/linker/Linker.Steps/MarkExportedTypesTargetStep.cs
+++ b/src/linker/Linker.Steps/MarkExportedTypesTargetStep.cs
@@ -1,0 +1,40 @@
+// Licensed to the.NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Mono.Cecil;
+
+namespace Mono.Linker.Steps
+{
+	public class MarkExportedTypesTargetStep : BaseStep
+	{
+		protected override void ProcessAssembly (AssemblyDefinition assembly)
+		{
+			if (!assembly.MainModule.HasExportedTypes)
+				return;
+
+			foreach (var type in assembly.MainModule.ExportedTypes)
+				InitializeExportedType (type);
+		}
+
+		void InitializeExportedType (ExportedType exportedType)
+		{
+			if (!Annotations.IsMarked (exportedType))
+				return;
+
+			if (!Annotations.TryGetPreservedMembers (exportedType, out TypePreserveMembers members))
+				return;
+
+			TypeDefinition type = exportedType.Resolve ();
+			if (type == null) {
+				if (!Context.IgnoreUnresolved)
+					Context.LogError ($"Exported type '{type.Name}' cannot be resolved", 1038);
+
+				return;
+			}
+
+			Context.Annotations.Mark (type, new DependencyInfo (DependencyKind.ExportedType, exportedType));
+			Annotations.SetMembersPreserve (type, members);
+		}
+	}
+}

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -210,7 +210,6 @@ namespace Mono.Linker.Steps
 
 				foreach (TypeDefinition type in assembly.MainModule.Types)
 					InitializeType (type);
-
 				break;
 			}
 		}
@@ -2287,7 +2286,7 @@ namespace Mono.Linker.Steps
 				case TypePreserve.All:
 					MarkFields (type, true, di);
 					MarkMethods (type, di, type);
-					break;
+					return;
 
 				case TypePreserve.Fields:
 					if (!MarkFields (type, true, di, true))

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -258,8 +258,7 @@ namespace Mono.Linker.Steps
 
 		protected bool IsFullyPreserved (TypeDefinition type)
 		{
-			if (Annotations.TryGetPreserve (type, out TypePreserve preserve) && preserve == TypePreserve.All &&
-				Annotations.TryGetPreserveAccessibility (type, out preserve) && preserve == 0)
+			if (Annotations.TryGetPreserve (type, out TypePreserve preserve) && preserve == TypePreserve.All)
 				return true;
 
 			switch (Annotations.GetAction (type.Module.Assembly)) {
@@ -2281,16 +2280,31 @@ namespace Mono.Linker.Steps
 		{
 			ApplyPreserveMethods (type);
 
-			if (!Annotations.TryGetPreserve (type, out TypePreserve preserve))
-				return;
+			if (Annotations.TryGetPreserve (type, out TypePreserve preserve)) {
+				var di = new DependencyInfo (DependencyKind.TypePreserve, type);
 
-			var di = new DependencyInfo (DependencyKind.TypePreserve, type);
-
-			switch (preserve) {
-			case TypePreserve.All:
-				Annotations.TryGetPreserveAccessibility (type, out preserve);
 				switch (preserve) {
-				case TypePreserve.AccessibilityVisible:
+				case TypePreserve.All:
+					MarkFields (type, true, di);
+					MarkMethods (type, di, type);
+					break;
+
+				case TypePreserve.Fields:
+					if (!MarkFields (type, true, di, true))
+						_context.LogWarning ($"Type {type.GetDisplayName ()} has no fields to preserve", 2001, type);
+					break;
+				case TypePreserve.Methods:
+					if (!MarkMethods (type, di, type))
+						_context.LogWarning ($"Type {type.GetDisplayName ()} has no methods to preserve", 2002, type);
+					break;
+				}
+			}
+
+			if (Annotations.TryGetPreservedMembers (type, out TypePreserveMembers members)) {
+				var di = new DependencyInfo (DependencyKind.TypePreserve, type);
+
+				switch (members) {
+				case TypePreserveMembers.AllVisible:
 					if (type.HasMethods)
 						MarkMethodsIf (type.Methods, IsMethodVisible, di, type);
 
@@ -2298,7 +2312,7 @@ namespace Mono.Linker.Steps
 						MarkFieldsIf (type.Fields, IsFieldVisible, di);
 
 					break;
-				case TypePreserve.AccessibilityVisibleOrInternal:
+				case TypePreserveMembers.AllVisibleOrInternal:
 					if (type.HasMethods)
 						MarkMethodsIf (type.Methods, IsMethodVisibleOrInternal, di, type);
 
@@ -2306,21 +2320,7 @@ namespace Mono.Linker.Steps
 						MarkFieldsIf (type.Fields, IsFieldVisibleOrInternal, di);
 
 					break;
-				default:
-					MarkFields (type, true, di);
-					MarkMethods (type, di, type);
-					break;
 				}
-				break;
-
-			case TypePreserve.Fields:
-				if (!MarkFields (type, true, di, true))
-					_context.LogWarning ($"Type {type.GetDisplayName ()} has no fields to preserve", 2001, type);
-				break;
-			case TypePreserve.Methods:
-				if (!MarkMethods (type, di, type))
-					_context.LogWarning ($"Type {type.GetDisplayName ()} has no methods to preserve", 2002, type);
-				break;
 			}
 		}
 

--- a/src/linker/Linker.Steps/RootAssemblyInputStep.cs
+++ b/src/linker/Linker.Steps/RootAssemblyInputStep.cs
@@ -56,8 +56,7 @@ namespace Mono.Linker.Steps
 				Annotations.AddPreservedMethod (ep.DeclaringType, ep);
 				break;
 			case AssemblyRootMode.VisibleMembers:
-				TypePreserve preserve = TypePreserve.All |
-					(HasInternalsVisibleTo (assembly) ? TypePreserve.AccessibilityVisibleOrInternal : TypePreserve.AccessibilityVisible);
+				var preserve = HasInternalsVisibleTo (assembly) ? TypePreserveMembers.AllVisibleOrInternal : TypePreserveMembers.AllVisible;
 
 				var module = assembly.MainModule;
 				if (module.HasExportedTypes)
@@ -87,17 +86,17 @@ namespace Mono.Linker.Steps
 			return assembly;
 		}
 
-		void MarkAndPreserveVisible (TypeDefinition type, TypePreserve preserve)
+		void MarkAndPreserveVisible (TypeDefinition type, TypePreserveMembers preserve)
 		{
-			switch (preserve & TypePreserve.AccessibilityMask) {
-			case TypePreserve.AccessibilityVisible when !IsTypeVisible (type):
+			switch (preserve) {
+			case TypePreserveMembers.AllVisible when !IsTypeVisible (type):
 				return;
-			case TypePreserve.AccessibilityVisibleOrInternal when !IsTypeVisibleOrInternal (type):
+			case TypePreserveMembers.AllVisibleOrInternal when !IsTypeVisibleOrInternal (type):
 				return;
 			}
 
 			Annotations.Mark (type, new DependencyInfo (DependencyKind.RootAssembly, type.Module.Assembly));
-			Annotations.SetPreserve (type, preserve);
+			Annotations.SetMembersPreserve (type, preserve);
 
 			if (!type.HasNestedTypes)
 				return;
@@ -106,7 +105,7 @@ namespace Mono.Linker.Steps
 				MarkAndPreserveVisible (nested, preserve);
 		}
 
-		void MarkAndPreserveVisible (AssemblyDefinition assembly, ExportedType type, TypePreserve preserve)
+		void MarkAndPreserveVisible (AssemblyDefinition assembly, ExportedType type, TypePreserveMembers preserve)
 		{
 			Context.MarkingHelpers.MarkExportedType (type, assembly.MainModule, new DependencyInfo (DependencyKind.ExportedType, type));
 

--- a/src/linker/Linker.Steps/RootAssemblyInputStep.cs
+++ b/src/linker/Linker.Steps/RootAssemblyInputStep.cs
@@ -107,16 +107,10 @@ namespace Mono.Linker.Steps
 
 		void MarkAndPreserveVisible (AssemblyDefinition assembly, ExportedType type, TypePreserveMembers preserve)
 		{
-			Context.MarkingHelpers.MarkExportedType (type, assembly.MainModule, new DependencyInfo (DependencyKind.ExportedType, type));
-
-			TypeDefinition td = type.Resolve ();
-			if (td != null) {
-				MarkAndPreserveVisible (td, preserve);
-				return;
-			}
-
-			if (!Context.IgnoreUnresolved)
-				Context.LogError ($"Exported type '{type.Name}' cannot be rooted", 1038);
+			var di = new DependencyInfo (DependencyKind.RootAssembly, assembly);
+			Context.Annotations.Mark (type, di);
+			Context.Annotations.Mark (assembly.MainModule, di);
+			Annotations.SetMembersPreserve (type, preserve);
 		}
 
 		static bool IsTypeVisible (TypeDefinition type)

--- a/src/linker/Linker.Steps/SweepStep.cs
+++ b/src/linker/Linker.Steps/SweepStep.cs
@@ -689,8 +689,11 @@ namespace Mono.Linker.Steps
 			{
 				foreach (var f in forwarders) {
 					TypeDefinition td = f.Resolve ();
-					if (td == null)
-						throw new InternalErrorException ("Unresolved exported type is never marked");
+					if (td == null) {
+						// Forwarded type cannot be resolved but it was marked
+						// linker is running in --skip-unresolved true mode
+						return;
+					}
 
 					var tr = assembly.MainModule.ImportReference (td);
 					if (f.Scope != tr.Scope)

--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -314,15 +314,15 @@ namespace Mono.Linker
 
 		public void SetMembersPreserve (ExportedType type, TypePreserveMembers preserve)
 		{
-			if (preserved_etype_members.TryGetValue (type, out TypePreserveMembers existing))
-				preserved_etype_members[type] = CombineMembers (existing, preserve);
+			if (preserved_exportedtype_members.TryGetValue (type, out TypePreserveMembers existing))
+				preserved_exportedtype_members[type] = CombineMembers (existing, preserve);
 			else
-				preserved_etype_members.Add (type, preserve);
+				preserved_exportedtype_members.Add (type, preserve);
 		}
 
 		public bool TryGetPreservedMembers (ExportedType type, out TypePreserveMembers preserve)
 		{
-			return preserved_etype_members.TryGetValue (type, out preserve);
+			return preserved_exportedtype_members.TryGetValue (type, out preserve);
 		}
 
 		public bool TryGetMethodStubValue (MethodDefinition method, out object value)

--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -53,6 +53,7 @@ namespace Mono.Linker
 		protected readonly HashSet<IMetadataTokenProvider> processed = new HashSet<IMetadataTokenProvider> ();
 		protected readonly Dictionary<TypeDefinition, TypePreserve> preserved_types = new Dictionary<TypeDefinition, TypePreserve> ();
 		protected readonly Dictionary<TypeDefinition, TypePreserveMembers> preserved_type_members = new ();
+		protected readonly Dictionary<ExportedType, TypePreserveMembers> preserved_etype_members = new ();
 		protected readonly Dictionary<IMemberDefinition, List<MethodDefinition>> preserved_methods = new Dictionary<IMemberDefinition, List<MethodDefinition>> ();
 		protected readonly HashSet<IMetadataTokenProvider> public_api = new HashSet<IMetadataTokenProvider> ();
 		protected readonly Dictionary<AssemblyDefinition, ISymbolReader> symbol_readers = new Dictionary<AssemblyDefinition, ISymbolReader> ();
@@ -290,25 +291,38 @@ namespace Mono.Linker
 				preserved_type_members[type] = CombineMembers (existing, preserve);
 			else
 				preserved_type_members.Add (type, preserve);
+		}
 
-			static TypePreserveMembers CombineMembers (TypePreserveMembers left, TypePreserveMembers right)
-			{
-				Debug.Assert (left != 0);
-				Debug.Assert (right != 0);
+		static TypePreserveMembers CombineMembers (TypePreserveMembers left, TypePreserveMembers right)
+		{
+			Debug.Assert (left != 0);
+			Debug.Assert (right != 0);
 
-				if (left == TypePreserveMembers.AllVisible)
-					return right;
+			if (left == TypePreserveMembers.AllVisible)
+				return right;
 
-				if (right == TypePreserveMembers.AllVisible)
-					return left;
+			if (right == TypePreserveMembers.AllVisible)
+				return left;
 
-				return TypePreserveMembers.AllVisibleOrInternal;
-			}
+			return TypePreserveMembers.AllVisibleOrInternal;
 		}
 
 		public bool TryGetPreservedMembers (TypeDefinition type, out TypePreserveMembers preserve)
 		{
 			return preserved_type_members.TryGetValue (type, out preserve);
+		}
+
+		public void SetMembersPreserve (ExportedType type, TypePreserveMembers preserve)
+		{
+			if (preserved_etype_members.TryGetValue (type, out TypePreserveMembers existing))
+				preserved_etype_members[type] = CombineMembers (existing, preserve);
+			else
+				preserved_etype_members.Add (type, preserve);
+		}
+
+		public bool TryGetPreservedMembers (ExportedType type, out TypePreserveMembers preserve)
+		{
+			return preserved_etype_members.TryGetValue (type, out preserve);
 		}
 
 		public bool TryGetMethodStubValue (MethodDefinition method, out object value)

--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -53,7 +53,7 @@ namespace Mono.Linker
 		protected readonly HashSet<IMetadataTokenProvider> processed = new HashSet<IMetadataTokenProvider> ();
 		protected readonly Dictionary<TypeDefinition, TypePreserve> preserved_types = new Dictionary<TypeDefinition, TypePreserve> ();
 		protected readonly Dictionary<TypeDefinition, TypePreserveMembers> preserved_type_members = new ();
-		protected readonly Dictionary<ExportedType, TypePreserveMembers> preserved_etype_members = new ();
+		protected readonly Dictionary<ExportedType, TypePreserveMembers> preserved_exportedtype_members = new ();
 		protected readonly Dictionary<IMemberDefinition, List<MethodDefinition>> preserved_methods = new Dictionary<IMemberDefinition, List<MethodDefinition>> ();
 		protected readonly HashSet<IMetadataTokenProvider> public_api = new HashSet<IMetadataTokenProvider> ();
 		protected readonly Dictionary<AssemblyDefinition, ISymbolReader> symbol_readers = new Dictionary<AssemblyDefinition, ISymbolReader> ();

--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -52,6 +52,7 @@ namespace Mono.Linker
 		protected readonly HashSet<IMetadataTokenProvider> marked = new HashSet<IMetadataTokenProvider> ();
 		protected readonly HashSet<IMetadataTokenProvider> processed = new HashSet<IMetadataTokenProvider> ();
 		protected readonly Dictionary<TypeDefinition, TypePreserve> preserved_types = new Dictionary<TypeDefinition, TypePreserve> ();
+		protected readonly Dictionary<TypeDefinition, TypePreserveMembers> preserved_type_members = new ();
 		protected readonly Dictionary<IMemberDefinition, List<MethodDefinition>> preserved_methods = new Dictionary<IMemberDefinition, List<MethodDefinition>> ();
 		protected readonly HashSet<IMetadataTokenProvider> public_api = new HashSet<IMetadataTokenProvider> ();
 		protected readonly Dictionary<AssemblyDefinition, ISymbolReader> symbol_readers = new Dictionary<AssemblyDefinition, ISymbolReader> ();
@@ -249,11 +250,6 @@ namespace Mono.Linker
 			return processed.Contains (provider);
 		}
 
-		public bool IsPreserved (TypeDefinition type)
-		{
-			return preserved_types.ContainsKey (type);
-		}
-
 		public void SetPreserve (TypeDefinition type, TypePreserve preserve)
 		{
 			if (preserved_types.TryGetValue (type, out TypePreserve existing))
@@ -285,22 +281,34 @@ namespace Mono.Linker
 
 		public bool TryGetPreserve (TypeDefinition type, out TypePreserve preserve)
 		{
-			if (preserved_types.TryGetValue (type, out preserve)) {
-				preserve &= ~TypePreserve.AccessibilityMask;
-				return true;
-			}
-
-			return false;
+			return preserved_types.TryGetValue (type, out preserve);
 		}
 
-		public bool TryGetPreserveAccessibility (TypeDefinition type, out TypePreserve preserve)
+		public void SetMembersPreserve (TypeDefinition type, TypePreserveMembers preserve)
 		{
-			if (preserved_types.TryGetValue (type, out preserve)) {
-				preserve &= TypePreserve.AccessibilityMask;
-				return true;
-			}
+			if (preserved_type_members.TryGetValue (type, out TypePreserveMembers existing))
+				preserved_type_members[type] = CombineMembers (existing, preserve);
+			else
+				preserved_type_members.Add (type, preserve);
 
-			return false;
+			static TypePreserveMembers CombineMembers (TypePreserveMembers left, TypePreserveMembers right)
+			{
+				Debug.Assert (left != 0);
+				Debug.Assert (right != 0);
+
+				if (left == TypePreserveMembers.AllVisible)
+					return right;
+
+				if (right == TypePreserveMembers.AllVisible)
+					return left;
+
+				return TypePreserveMembers.AllVisibleOrInternal;
+			}
+		}
+
+		public bool TryGetPreservedMembers (TypeDefinition type, out TypePreserveMembers preserve)
+		{
+			return preserved_type_members.TryGetValue (type, out preserve);
 		}
 
 		public bool TryGetMethodStubValue (MethodDefinition method, out object value)

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -653,6 +653,8 @@ namespace Mono.Linker
 				p.AddStepBefore (typeof (MarkStep), new RemoveSecurityStep ());
 
 			p.AddStepBefore (typeof (MarkStep), new RemoveUnreachableBlocksStep ());
+			p.AddStepBefore (typeof (MarkStep), new MarkExportedTypesTargetStep ());
+
 			p.AddStepBefore (typeof (OutputStep), new SealerStep ());
 
 			//
@@ -669,7 +671,8 @@ namespace Mono.Linker
 			// DynamicDependencyLookupStep
 			// BodySubstituterStep [optional]
 			// RemoveSecurityStep [optional]
-			// RemoveUnreachableBlocksStep [optional]
+			// RemoveUnreachableBlocksStep
+			// MarkExportedTypesTargetStep
 			// MarkStep
 			// ReflectionBlockedStep [optional]
 			// ProcessWarningsStep

--- a/src/linker/Linker/TypePreserve.cs
+++ b/src/linker/Linker/TypePreserve.cs
@@ -34,10 +34,6 @@ namespace Mono.Linker
 		Nothing, // This is actually Declaration
 		All,
 		Fields,
-		Methods,
-
-		AccessibilityVisible = 1 << 8,
-		AccessibilityVisibleOrInternal = 1 << 9,
-		AccessibilityMask = AccessibilityVisible | AccessibilityVisibleOrInternal,
+		Methods
 	}
 }

--- a/src/linker/Linker/TypePreserveMembers.cs
+++ b/src/linker/Linker/TypePreserveMembers.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Mono.Linker
+{
+	public enum TypePreserveMembers
+	{
+		AllVisible = 1,
+		AllVisibleOrInternal,
+	}
+}

--- a/test/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptMemberInAssemblyAttribute.cs
+++ b/test/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptMemberInAssemblyAttribute.cs
@@ -6,7 +6,6 @@ namespace Mono.Linker.Tests.Cases.Expectations.Assertions
 	[AttributeUsage (AttributeTargets.Class | AttributeTargets.Delegate, AllowMultiple = true, Inherited = false)]
 	public class KeptMemberInAssemblyAttribute : BaseInAssemblyAttribute
 	{
-
 		public KeptMemberInAssemblyAttribute (string assemblyFileName, Type type, params string[] memberNames)
 		{
 			if (string.IsNullOrEmpty (assemblyFileName))
@@ -26,5 +25,7 @@ namespace Mono.Linker.Tests.Cases.Expectations.Assertions
 			if (memberNames == null)
 				throw new ArgumentNullException (nameof (memberNames));
 		}
+
+		public string ExpectationAssemblyName { get; set; }
 	}
 }

--- a/test/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupCompileBeforeAttribute.cs
+++ b/test/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupCompileBeforeAttribute.cs
@@ -8,7 +8,7 @@ namespace Mono.Linker.Tests.Cases.Expectations.Metadata
 	[AttributeUsage (AttributeTargets.Class, AllowMultiple = true)]
 	public class SetupCompileBeforeAttribute : BaseMetadataAttribute
 	{
-		public SetupCompileBeforeAttribute (string outputName, string[] sourceFiles, string[] references = null, string[] defines = null, object[] resources = null, string additionalArguments = null, string compilerToUse = null, bool addAsReference = true, bool removeFromLinkerInput = false)
+		public SetupCompileBeforeAttribute (string outputName, string[] sourceFiles, string[] references = null, string[] defines = null, object[] resources = null, string additionalArguments = null, string compilerToUse = null, bool addAsReference = true, bool removeFromLinkerInput = false, string outputSubFolder = null)
 		{
 			if (sourceFiles == null)
 				throw new ArgumentNullException (nameof (sourceFiles));

--- a/test/Mono.Linker.Tests.Cases/Libraries/CanLinkPublicApisOfLibrary.cs
+++ b/test/Mono.Linker.Tests.Cases/Libraries/CanLinkPublicApisOfLibrary.cs
@@ -9,15 +9,27 @@ namespace Mono.Linker.Tests.Cases.Libraries
 	[KeptMember (".ctor()")]
 	public class CanLinkPublicApisOfLibrary
 	{
-		// Kept because by default libraries their action set to copy
 		[Kept]
 		public static void Main ()
 		{
-			// Main is needed for the test collector to find and treat as a test
 		}
 
 		[Kept]
 		public void UnusedPublicMethod ()
+		{
+		}
+
+		[Kept]
+		protected void UnusedProtectedMethod ()
+		{
+		}
+
+		[Kept]
+		protected internal void UnusedProtectedInternalMethod ()
+		{
+		}
+
+		internal void UnunsedInternalMethod ()
 		{
 		}
 

--- a/test/Mono.Linker.Tests.Cases/Libraries/Dependencies/RootLibraryVisibleForwarders_Lib.cs
+++ b/test/Mono.Linker.Tests.Cases/Libraries/Dependencies/RootLibraryVisibleForwarders_Lib.cs
@@ -2,4 +2,7 @@ using System.Runtime.CompilerServices;
 
 public class ExternalPublic
 {
+	protected void ProtectedMethod ()
+	{
+	}
 }

--- a/test/Mono.Linker.Tests.Cases/Libraries/RootLibraryVisibleAndDescriptor.cs
+++ b/test/Mono.Linker.Tests.Cases/Libraries/RootLibraryVisibleAndDescriptor.cs
@@ -2,12 +2,6 @@ using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
-#if RootLibraryInternalsWithIVT
-[assembly: InternalsVisibleToAttribute ("somename")]
-
-[assembly: KeptAttributeAttribute (typeof (InternalsVisibleToAttribute))]
-#endif
-
 namespace Mono.Linker.Tests.Cases.Libraries
 {
 #if !NETCOREAPP
@@ -16,9 +10,12 @@ namespace Mono.Linker.Tests.Cases.Libraries
 	[Kept]
 	[KeptMember (".ctor()")]
 	[SetupLinkerLinkPublicAndFamily]
-	[Define ("RootLibraryInternalsWithIVT")]
-	public class RootLibraryInternalsWithIVT
+	[SetupLinkerDescriptorFile ("RootLibraryVisibleAndDescriptor.xml")]
+	public class RootLibraryVisibleAndDescriptor
 	{
+		[Kept]
+		private int field;
+
 		[Kept]
 		public static void Main ()
 		{
@@ -39,12 +36,16 @@ namespace Mono.Linker.Tests.Cases.Libraries
 		{
 		}
 
-		[Kept]
-		internal void UnunsedInternalMethod ()
+		internal void UnusedInternalMethod ()
 		{
 		}
 
 		private void UnusedPrivateMethod ()
+		{
+		}
+
+		[Kept]
+		internal void UnusedInternalMethod_Descriptor ()
 		{
 		}
 	}

--- a/test/Mono.Linker.Tests.Cases/Libraries/RootLibraryVisibleAndDescriptor.xml
+++ b/test/Mono.Linker.Tests.Cases/Libraries/RootLibraryVisibleAndDescriptor.xml
@@ -1,0 +1,7 @@
+<linker>
+  <assembly fullname="test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+    <type fullname="Mono.Linker.Tests.Cases.Libraries.RootLibraryVisibleAndDescriptor" preserve="fields" >
+      <method name="UnusedInternalMethod_Descriptor" />
+    </type>
+  </assembly>
+</linker>

--- a/test/Mono.Linker.Tests.Cases/Libraries/RootLibraryVisibleForwardersWithoutReference.cs
+++ b/test/Mono.Linker.Tests.Cases/Libraries/RootLibraryVisibleForwardersWithoutReference.cs
@@ -11,15 +11,15 @@ namespace Mono.Linker.Tests.Cases.Libraries
 #if !NETCOREAPP
 	[IgnoreTestCase ("Build with illink")]
 #endif
-	[SetupCompileBefore ("library.dll", new[] { "Dependencies/RootLibraryVisibleForwarders_Lib.cs" })]
+	[SetupCompileBefore ("library.dll", new[] { "Dependencies/RootLibraryVisibleForwarders_Lib.cs" }, outputSubFolder: "isolated")]
 	[SetupLinkerLinkPublicAndFamily]
+	[SetupLinkerArgument ("-a", "isolated/library.dll", "visible")] // Checks for no-eager exported type resolving
 	[Define ("RootLibraryVisibleForwarders")]
 
 	[Kept]
 	[KeptMember (".ctor()")]
 	[KeptExportedType (typeof (ExternalPublic))]
-	[KeptMemberInAssembly ("library.dll", typeof (ExternalPublic), "ProtectedMethod()")]
-	public class RootLibraryVisibleForwarders
+	public class RootLibraryVisibleForwardersWithoutReference
 	{
 		[Kept]
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/LinkXml/Dependencies/UsedNonRequiredExportedTypeIsKeptWhenRooted_fwd.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/Dependencies/UsedNonRequiredExportedTypeIsKeptWhenRooted_fwd.cs
@@ -1,0 +1,4 @@
+using System.Runtime.CompilerServices;
+using Mono.Linker.Tests.Cases.LinkXml;
+
+[assembly: TypeForwardedTo (typeof (UsedNonRequiredExportedTypeIsKeptWhenRooted_Used))]

--- a/test/Mono.Linker.Tests.Cases/LinkXml/Dependencies/UsedNonRequiredExportedTypeIsKeptWhenRooted_lib.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/Dependencies/UsedNonRequiredExportedTypeIsKeptWhenRooted_lib.cs
@@ -1,0 +1,23 @@
+
+namespace Mono.Linker.Tests.Cases.LinkXml
+{
+	public class UsedNonRequiredExportedTypeIsKeptWhenRooted_Used
+	{
+		public int field;
+
+		public void Method ()
+		{
+		}
+	}
+
+	public class OtherType
+	{
+		public int field;
+
+		public void Method ()
+		{
+		}
+
+		public int Property { get; set; }
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/LinkXml/Dependencies/UsedNonRequiredExportedTypeIsKept_fwd.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/Dependencies/UsedNonRequiredExportedTypeIsKept_fwd.cs
@@ -1,0 +1,6 @@
+using System.Runtime.CompilerServices;
+using Mono.Linker.Tests.Cases.LinkXml;
+
+[assembly: TypeForwardedTo (typeof (UsedNonRequiredExportedTypeIsKept_Used1))]
+[assembly: TypeForwardedTo (typeof (UsedNonRequiredExportedTypeIsKept_Used2))]
+[assembly: TypeForwardedTo (typeof (UsedNonRequiredExportedTypeIsKept_Used3))]

--- a/test/Mono.Linker.Tests.Cases/LinkXml/Dependencies/UsedNonRequiredExportedTypeIsKept_lib.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/Dependencies/UsedNonRequiredExportedTypeIsKept_lib.cs
@@ -1,0 +1,36 @@
+
+namespace Mono.Linker.Tests.Cases.LinkXml
+{
+	public class UsedNonRequiredExportedTypeIsKept_Used1
+	{
+		public int field;
+
+		public void Method ()
+		{
+		}
+
+		public int Property { get; set; }
+	}
+
+	public class UsedNonRequiredExportedTypeIsKept_Used2
+	{
+		public int field;
+
+		public void Method ()
+		{
+		}
+
+		public int Property { get; set; }
+	}
+
+	public class UsedNonRequiredExportedTypeIsKept_Used3
+	{
+		public int field;
+
+		public void Method ()
+		{
+		}
+
+		public int Property { get; set; }
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/LinkXml/UsedNonRequiredExportedTypeIsKept.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/UsedNonRequiredExportedTypeIsKept.cs
@@ -1,0 +1,26 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.LinkXml
+{
+	[SetupLinkerDescriptorFile ("UsedNonRequiredExportedTypeIsKept.xml")]
+
+	[SetupCompileBefore ("lib.dll", new[] { "Dependencies/UsedNonRequiredExportedTypeIsKept_lib.cs" })]
+	[SetupCompileAfter ("libfwd.dll", new[] { "Dependencies/UsedNonRequiredExportedTypeIsKept_lib.cs" })]
+	[SetupCompileAfter ("lib.dll", new[] { "Dependencies/UsedNonRequiredExportedTypeIsKept_fwd.cs" }, references: new[] { "libfwd.dll" })]
+
+	[KeptAssembly ("libfwd.dll")]
+	[KeptMemberInAssembly ("libfwd.dll", typeof (UsedNonRequiredExportedTypeIsKept_Used1), "field", ExpectationAssemblyName = "lib.dll")]
+	[KeptMemberInAssembly ("libfwd.dll", typeof (UsedNonRequiredExportedTypeIsKept_Used2), "Method()", ExpectationAssemblyName = "lib.dll")]
+	[KeptMemberInAssembly ("libfwd.dll", typeof (UsedNonRequiredExportedTypeIsKept_Used3), "Method()", ExpectationAssemblyName = "lib.dll")]
+	[RemovedAssembly ("lib.dll")]
+	public class UsedNonRequiredExportedTypeIsKept
+	{
+		public static void Main ()
+		{
+			var tmp = typeof (UsedNonRequiredExportedTypeIsKept_Used1).ToString ();
+			tmp = typeof (UsedNonRequiredExportedTypeIsKept_Used2).ToString ();
+			tmp = typeof (UsedNonRequiredExportedTypeIsKept_Used3).ToString ();
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/LinkXml/UsedNonRequiredExportedTypeIsKept.xml
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/UsedNonRequiredExportedTypeIsKept.xml
@@ -1,0 +1,7 @@
+<linker>
+    <assembly fullname="lib">
+        <type fullname="Mono.Linker.Tests.Cases.LinkXml.UsedNonRequiredExportedTypeIsKept_Used1" preserve="fields" required="false"/>
+        <type fullname="Mono.Linker.Tests.Cases.LinkXml.UsedNonRequiredExportedTypeIsKept_Used2" preserve="methods" required="false"/>
+        <type fullname="Mono.Linker.Tests.Cases.LinkXml.UsedNonRequiredExportedTypeIsKept_Used3" preserve="all" required="false"/>
+    </assembly>
+</linker>

--- a/test/Mono.Linker.Tests.Cases/LinkXml/UsedNonRequiredExportedTypeIsKeptWhenRooted.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/UsedNonRequiredExportedTypeIsKeptWhenRooted.cs
@@ -1,0 +1,24 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.LinkXml
+{
+	[SetupLinkerDescriptorFile ("UsedNonRequiredExportedTypeIsKeptWhenRooted.xml")]
+	[SetupLinkerArgument ("-a", "lib.dll", "visible")]
+
+	[SetupCompileBefore ("lib.dll", new[] { "Dependencies/UsedNonRequiredExportedTypeIsKeptWhenRooted_lib.cs" })]
+	[SetupCompileAfter ("libfwd.dll", new[] { "Dependencies/UsedNonRequiredExportedTypeIsKeptWhenRooted_lib.cs" })]
+	[SetupCompileAfter ("lib.dll", new[] { "Dependencies/UsedNonRequiredExportedTypeIsKeptWhenRooted_fwd.cs" }, references: new[] { "libfwd.dll" })]
+
+	[KeptAssembly ("libfwd.dll")]
+	[KeptAssembly ("lib.dll")]
+	[KeptMemberInAssembly ("libfwd.dll", typeof (UsedNonRequiredExportedTypeIsKeptWhenRooted_Used), "field", ExpectationAssemblyName = "lib.dll")]
+	[KeptMemberInAssembly ("libfwd.dll", typeof (UsedNonRequiredExportedTypeIsKeptWhenRooted_Used), "Method()", ExpectationAssemblyName = "lib.dll")]
+	public class UsedNonRequiredExportedTypeIsKeptWhenRooted
+	{
+		public static void Main ()
+		{
+			var tmp = typeof (UsedNonRequiredExportedTypeIsKeptWhenRooted_Used).ToString ();
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/LinkXml/UsedNonRequiredExportedTypeIsKeptWhenRooted.xml
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/UsedNonRequiredExportedTypeIsKeptWhenRooted.xml
@@ -1,0 +1,5 @@
+<linker>
+    <assembly fullname="lib">
+        <type fullname="Mono.Linker.Tests.Cases.LinkXml.UsedNonRequiredExportedTypeIsKeptWhenRooted_Used" preserve="fields" required="false"/>
+    </assembly>
+</linker>

--- a/test/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/test/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -17,6 +17,8 @@
   <ItemGroup>
     <Compile Remove="Attributes\OnlyKeepUsed\Dependencies\UnusedAttributeWithTypeForwarderIsRemoved_Forwarder.cs" />
     <Compile Remove="LinkXml\Dependencies\CanPreserveAnExportedType_Forwarder.cs" />
+    <Compile Remove="LinkXml\Dependencies\UsedNonRequiredExportedTypeIsKept_fwd.cs" />
+    <Compile Remove="LinkXml\Dependencies\UsedNonRequiredExportedTypeIsKeptWhenRooted_fwd.cs" />
     <Compile Remove="TypeForwarding\Dependencies\ForwarderLibrary.cs" />
     <Compile Remove="TypeForwarding\Dependencies\ForwarderLibrary_2.cs" />
     <Compile Remove="TypeForwarding\Dependencies\ForwarderLibrary_3.cs" />

--- a/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -1030,7 +1030,13 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 		protected TypeDefinition GetOriginalTypeFromInAssemblyAttribute (CustomAttribute inAssemblyAttribute)
 		{
-			return GetOriginalTypeFromInAssemblyAttribute (inAssemblyAttribute.ConstructorArguments[0].Value.ToString (), inAssemblyAttribute.ConstructorArguments[1].Value);
+			string assemblyName;
+			if (inAssemblyAttribute.HasProperties && inAssemblyAttribute.Properties[0].Name == "ExpectationAssemblyName")
+				assemblyName = inAssemblyAttribute.Properties[0].Argument.Value.ToString ();
+			else
+				assemblyName = inAssemblyAttribute.ConstructorArguments[0].Value.ToString ();
+
+			return GetOriginalTypeFromInAssemblyAttribute (assemblyName, inAssemblyAttribute.ConstructorArguments[1].Value);
 		}
 
 		protected TypeDefinition GetOriginalTypeFromInAssemblyAttribute (string assemblyName, object typeOrTypeName)

--- a/test/Mono.Linker.Tests/TestCasesRunner/SetupCompileInfo.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/SetupCompileInfo.cs
@@ -14,5 +14,6 @@ namespace Mono.Linker.Tests.TestCasesRunner
 		public string CompilerToUse;
 		public bool AddAsReference;
 		public bool RemoveFromLinkerInput;
+		public string OutputSubFolder;
 	}
 }

--- a/test/Mono.Linker.Tests/TestCasesRunner/TestCaseCompiler.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestCaseCompiler.cs
@@ -108,9 +108,17 @@ namespace Mono.Linker.Tests.TestCasesRunner
 		private IEnumerable<NPath> CompileBeforeTestCaseAssemblies (NPath outputDirectory, NPath[] references, string[] defines, IList<NPath> removeFromLinkerInputAssemblies)
 		{
 			foreach (var setupCompileInfo in _metadataProvider.GetSetupCompileAssembliesBefore ()) {
+				NPath outputFolder;
+				if (setupCompileInfo.OutputSubFolder == null) {
+					outputFolder = outputDirectory;
+				} else {
+					outputFolder = outputDirectory.Combine (setupCompileInfo.OutputSubFolder);
+					Directory.CreateDirectory (outputFolder.ToString ());
+				}
+
 				var options = CreateOptionsForSupportingAssembly (
 					setupCompileInfo,
-					outputDirectory,
+					outputFolder,
 					CollectSetupBeforeSourcesFiles (setupCompileInfo),
 					references,
 					defines,

--- a/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadaProvider.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadaProvider.cs
@@ -341,7 +341,8 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				AdditionalArguments = (string) ctorArguments[5].Value,
 				CompilerToUse = (string) ctorArguments[6].Value,
 				AddAsReference = ctorArguments.Count >= 8 ? (bool) ctorArguments[7].Value : true,
-				RemoveFromLinkerInput = ctorArguments.Count >= 9 ? (bool) ctorArguments[8].Value : false
+				RemoveFromLinkerInput = ctorArguments.Count >= 9 ? (bool) ctorArguments[8].Value : false,
+				OutputSubFolder = ctorArguments.Count >= 10 ? (string) ctorArguments[9].Value : null
 			};
 		}
 

--- a/test/Mono.Linker.Tests/Tests/PreserveActionComparisonTests.cs
+++ b/test/Mono.Linker.Tests/Tests/PreserveActionComparisonTests.cs
@@ -20,11 +20,6 @@ namespace Mono.Linker.Tests
 		[TestCase (TypePreserve.Nothing, TypePreserve.All, TypePreserve.All)]
 		[TestCase (TypePreserve.Nothing, TypePreserve.Methods, TypePreserve.Methods)]
 		[TestCase (TypePreserve.Nothing, TypePreserve.Fields, TypePreserve.Fields)]
-		[TestCase (TypePreserve.All, TypePreserve.All | TypePreserve.AccessibilityVisible, TypePreserve.All)]
-		[TestCase (TypePreserve.AccessibilityVisibleOrInternal, TypePreserve.All, TypePreserve.All)]
-		[TestCase (TypePreserve.All | TypePreserve.AccessibilityVisible, TypePreserve.All | TypePreserve.AccessibilityVisible, TypePreserve.All | TypePreserve.AccessibilityVisible)]
-		[TestCase (TypePreserve.Nothing, TypePreserve.All | TypePreserve.AccessibilityVisible, TypePreserve.All | TypePreserve.AccessibilityVisible)]
-		[TestCase (TypePreserve.All | TypePreserve.AccessibilityVisibleOrInternal, TypePreserve.Nothing, TypePreserve.All | TypePreserve.AccessibilityVisibleOrInternal)]
 		public void VerifyBehaviorOfChoosePreserveActionWhichPreservesTheMost (TypePreserve left, TypePreserve right, TypePreserve expected)
 		{
 			Assert.That (expected, Is.EqualTo (AnnotationStore.ChoosePreserveActionWhichPreservesTheMost (left, right)));


### PR DESCRIPTION
- It'd be too messy to track inside single enum
- Delay resolving exported types to the point where all references are known

Contributes to #1610
