### PR TITLE
Ensure that CopyUsed entry point gets marked

### DIFF
--- a/src/linker/Linker.Steps/RootAssemblyInputStep.cs
+++ b/src/linker/Linker.Steps/RootAssemblyInputStep.cs
@@ -26,11 +26,11 @@ namespace Mono.Linker.Steps
 
 			AssemblyAction action = Context.Annotations.GetAction (assembly);
 			switch (action) {
-			case AssemblyAction.CopyUsed:
 			case AssemblyAction.Copy:
 				Annotations.Mark (assembly.MainModule, di);
 				// Mark Step will take care of marking whole assembly
 				return;
+			case AssemblyAction.CopyUsed:
 			case AssemblyAction.Link:
 				break;
 			default:

--- a/test/Mono.Linker.Tests.Cases/Libraries/CopyUsedAssemblyWithMainEntryRoot.cs
+++ b/test/Mono.Linker.Tests.Cases/Libraries/CopyUsedAssemblyWithMainEntryRoot.cs
@@ -1,5 +1,6 @@
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Libraries.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Libraries
 {
@@ -9,11 +10,16 @@ namespace Mono.Linker.Tests.Cases.Libraries
 	[Kept]
 	[KeptMember (".ctor()")]
 	[SetupLinkerAction ("copyused", "test")]
+	[SetupCompileBefore ("lib.dll", new[] { "Dependencies/CopyUsedAssemblyWithMainEntryRoot_Lib.cs" })]
+	[KeptMemberInAssembly ("lib.dll", typeof (CopyUsedAssemblyWithMainEntryRoot_Lib), "Used()")]
+	// Marked CopyUsed assemblies are not fully marked like Copy assemblies, so the Unused dependency is not kept.
+	[RemovedMemberInAssembly ("lib.dll", typeof (CopyUsedAssemblyWithMainEntryRoot_Lib), "Unused()")]
 	public class CopyUsedAssemblyWithMainEntryRoot
 	{
 		[Kept]
 		public static void Main ()
 		{
+			CopyUsedAssemblyWithMainEntryRoot_Lib.Used ();
 		}
 
 		[Kept]
@@ -24,6 +30,7 @@ namespace Mono.Linker.Tests.Cases.Libraries
 		[Kept]
 		private void UnusedPrivateMethod ()
 		{
+			CopyUsedAssemblyWithMainEntryRoot_Lib.Unused ();
 		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/Libraries/Dependencies/CopyUsedAssemblyWithMainEntryRoot_Lib.cs
+++ b/test/Mono.Linker.Tests.Cases/Libraries/Dependencies/CopyUsedAssemblyWithMainEntryRoot_Lib.cs
@@ -2,10 +2,12 @@ namespace Mono.Linker.Tests.Cases.Libraries.Dependencies
 {
 	public static class CopyUsedAssemblyWithMainEntryRoot_Lib
 	{
-		public static void Used () {
+		public static void Used ()
+		{
 		}
 
-		public static void Unused () {
+		public static void Unused ()
+		{
 		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/Libraries/Dependencies/CopyUsedAssemblyWithMainEntryRoot_Lib.cs
+++ b/test/Mono.Linker.Tests.Cases/Libraries/Dependencies/CopyUsedAssemblyWithMainEntryRoot_Lib.cs
@@ -1,0 +1,11 @@
+namespace Mono.Linker.Tests.Cases.Libraries.Dependencies
+{
+	public static class CopyUsedAssemblyWithMainEntryRoot_Lib
+	{
+		public static void Used () {
+		}
+
+		public static void Unused () {
+		}
+	}
+}


### PR DESCRIPTION
I noticed this when some of my lazy loading tests started failing after a rebase: an explicit copyused root assembly doesn't get the entry point marked because of the missing case in Initialize. It looks like the bug has been there for a while, but it didn't show up because our tests used `[SetupLinkerUserAction ("copyused")]` - in this case, `ResolveFromAssemblyStep` would change the action of a root assembly to `link`. But when copyused is set explicitly for an assembly via "-p", we forget to root it.

This change fixes it by treating `copyused` the same as `link` in the root step - this will also have the side effect of changing the action to `copy` if the root mode was `AllMembers`.