### PR TITLE
Reenable default UnreachableBodies optimization

### DIFF
--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -235,13 +235,13 @@ namespace Mono.Linker
 			WarnAsError = new Dictionary<int, bool> ();
 			WarnVersion = WarnVersion.Latest;
 
-			// See https://github.com/mono/linker/issues/612
 			const CodeOptimizations defaultOptimizations =
 				CodeOptimizations.BeforeFieldInit |
 				CodeOptimizations.OverrideRemoval |
 				CodeOptimizations.UnusedInterfaces |
 				CodeOptimizations.UnusedTypeChecks |
-				CodeOptimizations.IPConstantPropagation;
+				CodeOptimizations.IPConstantPropagation |
+				CodeOptimizations.UnreachableBodies;
 
 			Optimizations = new CodeOptimizationsSettings (defaultOptimizations);
 		}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MemberTypes.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MemberTypes.cs
@@ -8,9 +8,11 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.DataFlow
 {
+	[SetupCompileArgument ("/optimize+")]
 	public class MemberTypes
 	{
 		public static void Main ()
@@ -288,25 +290,23 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			public void HideMethod () { }
 
 			[Kept]
-			[KeptBackingField]
-			public bool PublicPropertyOnBase { [Kept] get; [Kept] set; }
+			public bool PublicPropertyOnBase { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
 			protected bool ProtectedPropertyOnBase { get; set; }
 			private bool PrivatePropertyOnBase { get; set; }
 			[Kept]
-			[KeptBackingField]
-			public bool HideProperty { [Kept] get; [Kept] set; }
+			public bool HideProperty { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
 
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			public event EventHandler<EventArgs> PublicEventOnBase;
 			protected event EventHandler<EventArgs> ProtectedEventOnBase;
 			private event EventHandler<EventArgs> PrivateEventOnBase;
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			public event EventHandler<EventArgs> HideEvent;
 
 			[Kept]
@@ -357,25 +357,23 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			public void HideMethod () { }
 
 			[Kept]
-			[KeptBackingField]
-			public bool PublicProperty { [Kept] get; [Kept] set; }
+			public bool PublicProperty { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
 			protected bool ProtectedProperty { get; set; }
 			private bool PrivateProperty { get; set; }
 			[Kept]
-			[KeptBackingField]
-			public bool HideProperty { [Kept] get; [Kept] set; }
+			public bool HideProperty { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
 
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			public event EventHandler<EventArgs> PublicEvent;
 			protected event EventHandler<EventArgs> ProtectedEvent;
 			private event EventHandler<EventArgs> PrivateEvent;
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			public event EventHandler<EventArgs> HideEvent;
 
 			[Kept]
@@ -428,16 +426,15 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 			public bool PublicPropertyOnBase { get; set; }
 			[Kept]
-			[KeptBackingField]
-			protected bool ProtectedPropertyOnBase { [Kept] get; [Kept] set; }
+			protected bool ProtectedPropertyOnBase { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
 			private bool PrivatePropertyOnBase { get; set; }
 			public bool HideProperty { get; set; }
 
 			public event EventHandler<EventArgs> PublicEventOnBase;
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			protected event EventHandler<EventArgs> ProtectedEventOnBase;
 			private event EventHandler<EventArgs> PrivateEventOnBase;
 			public event EventHandler<EventArgs> HideEvent;
@@ -484,23 +481,21 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 			public bool PublicProperty { get; set; }
 			[Kept]
-			[KeptBackingField]
-			protected bool ProtectedProperty { [Kept] get; [Kept] set; }
+			protected bool ProtectedProperty { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
 			[Kept]
-			[KeptBackingField]
-			private bool PrivateProperty { [Kept] get; [Kept] set; }
+			private bool PrivateProperty { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
 			public bool HideProperty { get; set; }
 
 			public event EventHandler<EventArgs> PublicEvent;
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			protected event EventHandler<EventArgs> ProtectedEvent;
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			private event EventHandler<EventArgs> PrivateEvent;
 			public event EventHandler<EventArgs> HideEvent;
 
@@ -557,31 +552,28 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			public void HideMethod () { }
 
 			[Kept]
-			[KeptBackingField]
-			public bool PublicPropertyOnBase { [Kept] get; [Kept] set; }
+			public bool PublicPropertyOnBase { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
 			[Kept]
-			[KeptBackingField]
-			protected bool ProtectedPropertyOnBase { [Kept] get; [Kept] set; }
+			protected bool ProtectedPropertyOnBase { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
 			private bool PrivatePropertyOnBase { get; set; }
 			[Kept]
-			[KeptBackingField]
-			public bool HideProperty { [Kept] get; [Kept] set; }
+			public bool HideProperty { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
 
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			public event EventHandler<EventArgs> PublicEventOnBase;
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			protected event EventHandler<EventArgs> ProtectedEventOnBase;
 			private event EventHandler<EventArgs> PrivateEventOnBase;
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			public event EventHandler<EventArgs> HideEvent;
 
 			[Kept]
@@ -642,37 +634,33 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			public void HideMethod () { }
 
 			[Kept]
-			[KeptBackingField]
-			public bool PublicProperty { [Kept] get; [Kept] set; }
+			public bool PublicProperty { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
 			[Kept]
-			[KeptBackingField]
-			protected bool ProtectedProperty { [Kept] get; [Kept] set; }
+			protected bool ProtectedProperty { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
 			[Kept]
-			[KeptBackingField]
-			private bool PrivateProperty { [Kept] get; [Kept] set; }
+			private bool PrivateProperty { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
 			[Kept]
-			[KeptBackingField]
-			public bool HideProperty { [Kept] get; [Kept] set; }
+			public bool HideProperty { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
 
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			public event EventHandler<EventArgs> PublicEvent;
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			protected event EventHandler<EventArgs> ProtectedEvent;
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			private event EventHandler<EventArgs> PrivateEvent;
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			public event EventHandler<EventArgs> HideEvent;
 
 			[Kept]
@@ -1170,8 +1158,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		class PublicPropertiesBaseType
 		{
 			[Kept]
-			[KeptBackingField]
-			public bool PublicPropertyOnBase { [Kept] get; [Kept] set; }
+			public bool PublicPropertyOnBase { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
 			[Kept]
 			public bool PublicPropertyGetterOnBase { [Kept] get { return false; } [Kept] private set { } }
 			[Kept]
@@ -1183,8 +1170,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			protected bool ProtectedPropertyOnBase { get; set; }
 			private bool PrivatePropertyOnBase { get; set; }
 			[Kept]
-			[KeptBackingField]
-			public bool HideProperty { [Kept] get; [Kept] set; }
+			public bool HideProperty { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
 
 			[Kept]
 			[KeptBackingField]
@@ -1201,8 +1187,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		class PublicPropertiesType : PublicPropertiesBaseType
 		{
 			[Kept]
-			[KeptBackingField]
-			public bool PublicProperty { [Kept] get; [Kept] set; }
+			public bool PublicProperty { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
 			[Kept]
 			public bool PublicPropertyGetter { [Kept] get { return false; } [Kept] private set { } }
 			[Kept]
@@ -1214,8 +1199,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			protected bool ProtectedProperty { get; set; }
 			private bool PrivateProperty { get; set; }
 			[Kept]
-			[KeptBackingField]
-			public bool HideProperty { [Kept] get; [Kept] set; }
+			public bool HideProperty { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
 
 			[Kept]
 			[KeptBackingField]
@@ -1245,8 +1229,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			public bool PublicPropertyOnlyGetterOnBase { get { return false; } }
 			public bool PublicPropertyOnlySetterOnBase { set { } }
 			[Kept]
-			[KeptBackingField]
-			protected bool ProtectedPropertyOnBase { [Kept] get; [Kept] set; }
+			protected bool ProtectedPropertyOnBase { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
 			private bool PrivatePropertyOnBase { get; set; }
 			public bool HideProperty { get; set; }
 
@@ -1268,11 +1251,9 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			public bool PublicPropertyOnlyGetter { get { return false; } }
 			public bool PublicPropertyOnlySetter { set { } }
 			[Kept]
-			[KeptBackingField]
-			protected bool ProtectedProperty { [Kept] get; [Kept] set; }
+			protected bool ProtectedProperty { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
 			[Kept]
-			[KeptBackingField]
-			private bool PrivateProperty { [Kept] get; [Kept] set; }
+			private bool PrivateProperty { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
 			public bool HideProperty { get; set; }
 
 			static public bool PublicStaticProperty { get; set; }
@@ -1297,8 +1278,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		class AllPropertiesBaseType
 		{
 			[Kept]
-			[KeptBackingField]
-			public bool PublicPropertyOnBase { [Kept] get; [Kept] set; }
+			public bool PublicPropertyOnBase { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
 			[Kept]
 			public bool PublicPropertyGetterOnBase { [Kept] get { return false; } [Kept] private set { } }
 			[Kept]
@@ -1308,12 +1288,10 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[Kept]
 			public bool PublicPropertyOnlySetterOnBase { [Kept] set { } }
 			[Kept]
-			[KeptBackingField]
-			protected bool ProtectedPropertyOnBase { [Kept] get; [Kept] set; }
+			protected bool ProtectedPropertyOnBase { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
 			private bool PrivatePropertyOnBase { get; set; }
 			[Kept]
-			[KeptBackingField]
-			public bool HideProperty { [Kept] get; [Kept] set; }
+			public bool HideProperty { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
 
 			[Kept]
 			[KeptBackingField]
@@ -1332,8 +1310,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		class AllPropertiesType : AllPropertiesBaseType
 		{
 			[Kept]
-			[KeptBackingField]
-			public bool PublicProperty { [Kept] get; [Kept] set; }
+			public bool PublicProperty { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
 			[Kept]
 			public bool PublicPropertyGetter { [Kept] get { return false; } [Kept] private set { } }
 			[Kept]
@@ -1343,14 +1320,11 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[Kept]
 			public bool PublicPropertyOnlySetter { [Kept] set { } }
 			[Kept]
-			[KeptBackingField]
-			protected bool ProtectedProperty { [Kept] get; [Kept] set; }
+			protected bool ProtectedProperty { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
 			[Kept]
-			[KeptBackingField]
-			private bool PrivateProperty { [Kept] get; [Kept] set; }
+			private bool PrivateProperty { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
 			[Kept]
-			[KeptBackingField]
-			public bool HideProperty { [Kept] get; [Kept] set; }
+			public bool HideProperty { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
 
 			[Kept]
 			[KeptBackingField]
@@ -1379,16 +1353,16 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		class PublicEventsBaseType
 		{
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			public event EventHandler<EventArgs> PublicEventOnBase;
 			protected event EventHandler<EventArgs> ProtectedEventOnBase;
 			private event EventHandler<EventArgs> PrivateEventOnBase;
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			public event EventHandler<EventArgs> HideEvent;
 
 			[Kept]
@@ -1410,16 +1384,16 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		class PublicEventsType : PublicEventsBaseType
 		{
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			public event EventHandler<EventArgs> PublicEvent;
 			protected event EventHandler<EventArgs> ProtectedEvent;
 			private event EventHandler<EventArgs> PrivateEvent;
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			public event EventHandler<EventArgs> HideEvent;
 
 			[Kept]
@@ -1450,9 +1424,9 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		{
 			public event EventHandler<EventArgs> PublicEventOnBase;
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			protected event EventHandler<EventArgs> ProtectedEventOnBase;
 			private event EventHandler<EventArgs> PrivateEventOnBase;
 			public event EventHandler<EventArgs> HideEvent;
@@ -1473,14 +1447,14 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		{
 			public event EventHandler<EventArgs> PublicEvent;
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			protected event EventHandler<EventArgs> ProtectedEvent;
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			private event EventHandler<EventArgs> PrivateEvent;
 			public event EventHandler<EventArgs> HideEvent;
 
@@ -1510,20 +1484,20 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		class AllEventsBaseType
 		{
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			public event EventHandler<EventArgs> PublicEventOnBase;
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			protected event EventHandler<EventArgs> ProtectedEventOnBase;
 			private event EventHandler<EventArgs> PrivateEventOnBase;
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			public event EventHandler<EventArgs> HideEvent;
 
 			[Kept]
@@ -1549,24 +1523,24 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		class AllEventsType : AllEventsBaseType
 		{
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			public event EventHandler<EventArgs> PublicEvent;
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			protected event EventHandler<EventArgs> ProtectedEvent;
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			private event EventHandler<EventArgs> PrivateEvent;
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			public event EventHandler<EventArgs> HideEvent;
 
 			[Kept]
@@ -1748,6 +1722,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		[Kept]
 		[KeptBaseType (typeof (AllBaseType))]
+		[AddedPseudoAttributeAttribute ((uint) TypeAttributes.BeforeFieldInit)]
 		class AllType : AllBaseType
 		{
 			[Kept]

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MethodThisDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MethodThisDataFlow.cs
@@ -19,6 +19,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 	{
 		public static void Main ()
 		{
+			new MethodThisDataFlowTypeTest ();
+
 			PropagateToThis ();
 			PropagateToThisWithGetters ();
 			PropagateToThisWithSetters ();

--- a/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMemberTypes.cs
+++ b/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMemberTypes.cs
@@ -177,8 +177,7 @@ namespace Mono.Linker.Tests.Cases.DynamicDependencies
 		class TypeWithPublicProperty
 		{
 			[Kept]
-			[KeptBackingField]
-			public int Property { [Kept] get; [Kept] set; }
+			public int Property { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
 
 			int NonPublicProperty { get; set; }
 
@@ -188,8 +187,7 @@ namespace Mono.Linker.Tests.Cases.DynamicDependencies
 		class TypeWithNonPublicProperty
 		{
 			[Kept]
-			[KeptBackingField]
-			int NonPublicProperty { [Kept] get; [Kept] set; }
+			int NonPublicProperty { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
 
 			public int PublicProperty { get; set; }
 
@@ -199,9 +197,9 @@ namespace Mono.Linker.Tests.Cases.DynamicDependencies
 		class TypeWithPublicEvent
 		{
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			public event EventHandler PublicEvent;
 
 			event EventHandler NonPublicEvent;
@@ -212,9 +210,9 @@ namespace Mono.Linker.Tests.Cases.DynamicDependencies
 		class TypeWithNonPublicEvent
 		{
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			event EventHandler NonPublicEvent;
 
 			public event EventHandler PublicEven;

--- a/test/Mono.Linker.Tests.Cases/LinkXml/EmbeddedLinkXmlUnresolvedReferencesAreReported.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/EmbeddedLinkXmlUnresolvedReferencesAreReported.cs
@@ -21,11 +21,15 @@ namespace Mono.Linker.Tests.Cases.LinkXml
 	{
 		public static void Main ()
 		{
+			new TestType ();
 		}
 
 		[Kept]
 		class TestType
 		{
+			[Kept]
+			public TestType () { }
+
 			[Kept]
 			public int FieldWithSignature;
 

--- a/test/Mono.Linker.Tests.Cases/LinkXml/LinkXmlErrorCases.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/LinkXmlErrorCases.cs
@@ -61,6 +61,8 @@ namespace Mono.Linker.Tests.Cases.LinkXml
 		class TypeWithEverything
 		{
 			[Kept]
+			public TypeWithEverything () { }
+			[Kept]
 			public void Method () { }
 			[Kept]
 			[KeptBackingField]

--- a/test/Mono.Linker.Tests.Cases/LinkXml/LinkXmlErrorCases.xml
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/LinkXmlErrorCases.xml
@@ -27,6 +27,7 @@
     </type>
 
     <type fullname="Mono.Linker.Tests.Cases.LinkXml.LinkXmlErrorCases/TypeWithEverything">
+      <method name=".ctor"/>
       <method name="Method"/>
       <event name="Event"/>
       <field name="Field"/>
@@ -34,6 +35,7 @@
     </type>
 
     <type fullname="Mono.Linker.Tests.Cases.LinkXml.LinkXmlErrorCases/TypeWithEverything">
+      <method name=".ctor"/>
       <method name="Method"/>
       <event name="Event"/>
       <field name="Field"/>

--- a/test/Mono.Linker.Tests.Cases/LinkXml/PreserveIndividualMembersOfNonRequiredType.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/PreserveIndividualMembersOfNonRequiredType.cs
@@ -15,6 +15,9 @@ namespace Mono.Linker.Tests.Cases.LinkXml
 		class Required
 		{
 			[Kept]
+			public Required () { }
+
+			[Kept]
 			public int Field1;
 
 			public int Field2;

--- a/test/Mono.Linker.Tests.Cases/LinkXml/PreserveIndividualMembersOfNonRequiredType.xml
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/PreserveIndividualMembersOfNonRequiredType.xml
@@ -5,6 +5,7 @@
       <method name="Method1" />
       <property name="Property1" />
       <event name="Event1" />
+      <method name=".ctor" />
     </type>
   </assembly>
 </linker>

--- a/test/Mono.Linker.Tests.Cases/LinkXml/UsedNonRequiredTypeIsKeptWithSingleMethod.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/UsedNonRequiredTypeIsKeptWithSingleMethod.cs
@@ -5,6 +5,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.LinkXml
 {
 	[SetupLinkerDescriptorFile ("UsedNonRequiredTypeIsKeptWithSingleMethod.xml")]
+	[SetupLinkerArgument ("--disable-opt", "unreachablebodies")]
 	class UsedNonRequiredTypeIsKeptWithSingleMethod
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/Reflection/EventUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/EventUsedViaReflection.cs
@@ -190,9 +190,9 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			internal event EventHandler<EventArgs> InternalEvent;
 			static event EventHandler<EventArgs> Static;
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			private event EventHandler<EventArgs> PrivateEvent;
 			public event EventHandler<EventArgs> PublicEvent;
 		}
@@ -200,9 +200,9 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		class UnknownBindingFlags
 		{
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			internal event EventHandler<EventArgs> InternalEvent;
 			[Kept]
 			[KeptBackingField]
@@ -210,28 +210,28 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[KeptEventRemoveMethod]
 			static event EventHandler<EventArgs> Static;
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			private event EventHandler<EventArgs> PrivateEvent;
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			public event EventHandler<EventArgs> PublicEvent;
 		}
 
 		class IfClass
 		{
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			public event EventHandler<EventArgs> IfEvent;
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			public event EventHandler<EventArgs> ElseEvent;
 		}
 
@@ -243,9 +243,9 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[KeptEventRemoveMethod]
 			public static event EventHandler<EventArgs> ElseEvent;
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			public event EventHandler<EventArgs> IfEvent;
 		}
 
@@ -254,9 +254,9 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		{
 			protected static event EventHandler<EventArgs> ProtectedEventOnBase;
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			public event EventHandler<EventArgs> PublicEventOnBase;
 		}
 		[KeptBaseType (typeof (BaseClass))]
@@ -267,15 +267,15 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		class IgnoreCaseBindingFlagsClass
 		{
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			public event EventHandler<EventArgs> PublicEvent;
 
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			private event EventHandler<EventArgs> MarkedDueToIgnoreCaseEvent;
 		}
 
@@ -289,15 +289,15 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		class PutRefDispPropertyBindingFlagsClass
 		{
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			public event EventHandler<EventArgs> PublicEvent;
 
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			private event EventHandler<EventArgs> MarkedDueToPutRefDispPropertyEvent;
 		}
 	}

--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionPropertyString.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionPropertyString.cs
@@ -25,12 +25,13 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		}
 
 		[Kept]
-		[KeptBackingField]
 		private int Property {
 			[Kept]
+			[ExpectBodyModified]
 			get;
 
 			[Kept]
+			[ExpectBodyModified]
 			set;
 		}
 
@@ -62,9 +63,9 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			}
 
 			[Kept]
-			[KeptBackingField]
 			private int Property2 {
 				[Kept]
+				[ExpectBodyModified]
 				get;
 			}
 
@@ -94,9 +95,9 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			}
 
 			[Kept]
-			[KeptBackingField]
 			public int Property2 {
 				[Kept]
+				[ExpectBodyModified]
 				get;
 			}
 

--- a/test/Mono.Linker.Tests.Cases/Reflection/MethodUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/MethodUsedViaReflection.cs
@@ -7,6 +7,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 {
 
 	[SetupCSharpCompilerToUse ("csc")]
+	[SetupLinkerArgument ("--disable-opt", "unreachablebodies")]
 	public class MethodUsedViaReflection
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/Reflection/PropertyUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/PropertyUsedViaReflection.cs
@@ -6,6 +6,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.Reflection
 {
 	[SetupCSharpCompilerToUse ("csc")]
+	[SetupLinkerArgument ("--disable-opt", "unreachablebodies")]
 	public class PropertyUsedViaReflection
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/Reflection/RuntimeReflectionExtensionsCalls.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/RuntimeReflectionExtensionsCalls.cs
@@ -81,9 +81,9 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		class ClassWithKeptMembers
 		{
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			public event EventHandler<EventArgs> PublicEvent;
 
 			[Kept]
@@ -95,8 +95,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			}
 
 			[Kept]
-			[KeptBackingField]
-			public long PublicProperty { [Kept] get; [Kept] set; }
+			public long PublicProperty { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
 		}
 
 		[Kept]
@@ -157,9 +156,9 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		class Base
 		{
 			[Kept]
-			[KeptBackingField]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectBodyModified, ExpectLocalsModified]
 			public event EventHandler<EventArgs> Event;
 
 			[Kept]
@@ -171,8 +170,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			}
 
 			[Kept]
-			[KeptBackingField]
-			public long Property { [Kept] get; [Kept] set; }
+			public long Property { [Kept][ExpectBodyModified] get; [Kept][ExpectBodyModified] set; }
 		}
 
 		[Kept]


### PR DESCRIPTION
Whole runtime repo now passes with it and I could not repro xamarin issue
locally. If this will turn out problem again it can now temporary disabled
on per assembly basis.