### PR TITLE
Fix scopes not updated on SecurityAttributes

### DIFF
--- a/src/linker/Linker.Steps/SweepStep.cs
+++ b/src/linker/Linker.Steps/SweepStep.cs
@@ -574,6 +574,7 @@ namespace Mono.Linker.Steps
 				updated = new HashSet<TypeReference> ();
 
 				UpdateCustomAttributesTypesScopes (assembly);
+				UpdateSecurityAttributesTypesScopes (assembly);
 
 				foreach (var module in assembly.Modules)
 					UpdateCustomAttributesTypesScopes (module);
@@ -594,6 +595,7 @@ namespace Mono.Linker.Steps
 			void UpdateScopes (TypeDefinition typeDefinition)
 			{
 				UpdateCustomAttributesTypesScopes (typeDefinition);
+				UpdateSecurityAttributesTypesScopes (typeDefinition);
 
 				if (typeDefinition.BaseType != null)
 					UpdateScopeOfTypeReference (typeDefinition.BaseType);
@@ -626,6 +628,7 @@ namespace Mono.Linker.Steps
 				if (typeDefinition.HasMethods) {
 					foreach (var m in typeDefinition.Methods) {
 						UpdateCustomAttributesTypesScopes (m);
+						UpdateSecurityAttributesTypesScopes (m);
 						if (m.HasGenericParameters)
 							UpdateTypeScope (m.GenericParameters);
 
@@ -795,6 +798,20 @@ namespace Mono.Linker.Steps
 					UpdateForwardedTypesScope (ca);
 			}
 
+			void UpdateSecurityAttributesTypesScopes (ISecurityDeclarationProvider securityAttributeProvider)
+			{
+				if (!securityAttributeProvider.HasSecurityDeclarations)
+					return;
+
+				foreach (var ca in securityAttributeProvider.SecurityDeclarations) {
+					if (!ca.HasSecurityAttributes)
+						continue;
+
+					foreach (var securityAttribute in ca.SecurityAttributes)
+						UpdateForwardedTypesScope (securityAttribute);
+				}
+			}
+
 			void UpdateForwardedTypesScope (CustomAttribute attribute)
 			{
 				UpdateMethodReference (attribute.Constructor);
@@ -804,6 +821,19 @@ namespace Mono.Linker.Steps
 						UpdateForwardedTypesScope (ca);
 				}
 
+				if (attribute.HasFields) {
+					foreach (var field in attribute.Fields)
+						UpdateForwardedTypesScope (field.Argument);
+				}
+
+				if (attribute.HasProperties) {
+					foreach (var property in attribute.Properties)
+						UpdateForwardedTypesScope (property.Argument);
+				}
+			}
+
+			void UpdateForwardedTypesScope (SecurityAttribute attribute)
+			{
 				if (attribute.HasFields) {
 					foreach (var field in attribute.Fields)
 						UpdateForwardedTypesScope (field.Argument);

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/LibraryWithSecurityAttributes.il
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/LibraryWithSecurityAttributes.il
@@ -1,0 +1,73 @@
+﻿.assembly extern mscorlib
+{
+
+}
+.assembly Library
+{
+
+}
+.module Library.dll
+
+.class public auto ansi beforefieldinit LibraryWithSecurityAttributes
+       extends [mscorlib]System.Object
+{
+  .permissionset demand
+             = {[Forwarder]System.Security.Permissions.SecurityPermissionAttribute = {property enum [Forwarder]System.Security.Permissions.SecurityPermissionFlag 'Flags' = int32(16383)}}
+  .class auto ansi nested private beforefieldinit NestedType
+         extends [mscorlib]System.Object
+  {
+    .permissionset demand
+               = {[Forwarder]System.Security.Permissions.SecurityPermissionAttribute = {property enum [Forwarder]System.Security.Permissions.SecurityPermissionFlag 'Flags' = int32(16383)}}
+    .method public hidebysig instance void 
+            OnAMethodInNestedClass() cil managed
+    {
+      .permissionset demand
+                 = {[Forwarder]System.Security.Permissions.SecurityPermissionAttribute = {property enum [Forwarder]System.Security.Permissions.SecurityPermissionFlag 'Flags' = int32(16383)}}
+      // Code size       2 (0x2)
+      .maxstack  8
+      IL_0000:  nop
+      IL_0001:  ret
+    } // end of method NestedType::OnAMethodInNestedClass
+
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+      IL_0006:  nop
+      IL_0007:  ret
+    } // end of method NestedType::.ctor
+
+  } // end of class NestedType
+
+  .method public hidebysig instance void 
+          OnAMethod() cil managed
+  {
+    .permissionset demand
+               = {[Forwarder]System.Security.Permissions.SecurityPermissionAttribute = {property enum [Forwarder]System.Security.Permissions.SecurityPermissionFlag 'Flags' = int32(16383)}}
+    // Code size       15 (0xf)
+    .maxstack  1
+    .locals init ([0] class LibraryWithSecurityAttributes/NestedType 'nested')
+    IL_0000:  nop
+    IL_0001:  newobj     instance void LibraryWithSecurityAttributes/NestedType::.ctor()
+    IL_0006:  stloc.0
+    IL_0007:  ldloc.0
+    IL_0008:  callvirt   instance void LibraryWithSecurityAttributes/NestedType::OnAMethodInNestedClass()
+    IL_000d:  nop
+    IL_000e:  ret
+  } // end of method LibraryWithSecurityAttributes::OnAMethod
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  nop
+    IL_0007:  ret
+  } // end of method LibraryWithSecurityAttributes::.ctor
+
+} // end of class LibraryWithSecurityAttributes

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/SecurityAttributeForwarderLibrary.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/SecurityAttributeForwarderLibrary.cs
@@ -1,0 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo (typeof (System.Security.Permissions.SecurityPermissionFlag))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo (typeof (System.Security.Permissions.SecurityPermissionAttribute))]

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/SecurityAttributeScope.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/SecurityAttributeScope.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.TypeForwarding
+{
+	/// <summary>
+	/// This test depends on a functioning peverify / il verify in order to fail if the scope of type references on security attributes
+	/// were not correctly updated.
+	///
+	/// In order words, until https://github.com/mono/linker/issues/1703 is addressed this test will pass with or without the fix to update the scope on security attributes
+	/// </summary>
+	[SetupLinkerArgument ("--strip-security", "false")]
+	[Define ("IL_ASSEMBLY_AVAILABLE")]
+	[KeepTypeForwarderOnlyAssemblies ("false")]
+	[SetupLinkerAction ("copy", "Library.dll")]
+	[SetupCompileBefore ("Forwarder.dll", new[] { "Dependencies/SecurityAttributeForwarderLibrary.cs" })]
+	[SetupCompileBefore ("Library.dll", new[] { "Dependencies/LibraryWithSecurityAttributes.il" }, new[] { "Forwarder.dll" })]
+
+	// Sanity checks to verify the test was setup correctly
+	[KeptTypeInAssembly ("Library.dll", "LibraryWithSecurityAttributes")]
+	[RemovedAssembly ("Forwarder.dll")]
+	public class SecurityAttributeScope
+	{
+		public static void Main ()
+		{
+#if IL_ASSEMBLY_AVAILABLE
+			new LibraryWithSecurityAttributes().OnAMethod ();
+#endif
+		}
+	}
+}


### PR DESCRIPTION
This fixes a bug in the linker where it would not update the scope of TypeReferences on ISecurityAttributeProviders

This would result in references to `netstandard` surviving linking in situations where netstandard was linked away and SecurityAttribute's survived.  For us this would happen when facades were linked away and an assembly had the `AssemblyAction.Copy`.  There may have been other scenarios where it was possible to hit this.

I did not write a test for this.  It would be hard to write one.  I don't think it's worth the effort.