### PR TITLE
Overwrite ILLinkTasksAssembly

### DIFF
--- a/src/ILLink.Tasks/Sdk/Sdk.props
+++ b/src/ILLink.Tasks/Sdk/Sdk.props
@@ -9,14 +9,11 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
-<Project ToolsVersion="14.0">
+<Project>
 
   <PropertyGroup>
-    <_ILLinkTasksDirectoryRoot Condition=" '$(_ILLinkTasksDirectoryRoot)' == '' ">$(MSBuildThisFileDirectory)../tools/</_ILLinkTasksDirectoryRoot>
-    <_ILLinkTasksTFM Condition=" '$(MSBuildRuntimeType)' == 'Core' ">net5.0</_ILLinkTasksTFM>
-    <_ILLinkTasksTFM Condition=" '$(_ILLinkTasksTFM)' == '' ">net472</_ILLinkTasksTFM>
-    <_ILLinkTasksDirectory>$(_ILLinkTasksDirectoryRoot)$(_ILLinkTasksTFM)/</_ILLinkTasksDirectory>
-    <ILLinkTasksAssembly Condition=" '$(ILLinkTasksAssembly)' == '' ">$(_ILLinkTasksDirectory)ILLink.Tasks.dll</ILLinkTasksAssembly>
+    <ILLinkTasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\net5.0\ILLink.Tasks.dll</ILLinkTasksAssembly>
+    <ILLinkTasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\ILLink.Tasks.dll</ILLinkTasksAssembly>
   </PropertyGroup>
 
   <UsingTask TaskName="ILLink.Tasks.ILLink" AssemblyFile="$(ILLinkTasksAssembly)" />


### PR DESCRIPTION
If the Microsoft.NET.ILLink.Tasks package is package referenced directly, overwriting `ILLinkTasksAssembly` guarantees that the SDK uses the right ILLink assembly. Github org searches didn't show any consumer of the private properties, hence removing them for simplification.

https://github.com/dotnet/arcade/pull/6936 benefits from this change.