### PR TITLE
Add a test to validate that using RequiresUnreferencedCode and DynamicallyAccessedMembers on the same method works

### DIFF
--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapabilityReflectionAnalysisEnabled.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapabilityReflectionAnalysisEnabled.cs
@@ -17,6 +17,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			TestRequiresUnreferencedCodeAttributeWithDynamicallyAccessedMembersEnabled ();
 			TestRequiresUnreferencedCodeAttributeWithReflectionPattern ();
 			TestRequiresUnreferencedCodeAttributeWithDynamicallyAccessedMembersOnGenericsEnabled ();
+			TestRequiresUnreferencedCodeAndDynamicallyAccessedMembers.Test ();
 		}
 
 		[Kept]
@@ -107,6 +108,55 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			public int _publicField;
 
 			private int _privateField;
+		}
+
+		[Kept]
+		[ExpectedNoWarnings]
+		class TestRequiresUnreferencedCodeAndDynamicallyAccessedMembers
+		{
+			[Kept]
+			[KeptAttributeAttribute(typeof(RequiresUnreferencedCodeAttribute))]
+			[RequiresUnreferencedCode("--- RequiresUnreferencedCodeAndPublicMethods ---")]
+			[RecognizedReflectionAccessPattern]
+			static void RequiresUnreferencedCodeAndPublicMethods (
+				[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+				[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+				Type type)
+			{
+				// This should not produce a warning since the method is annotated with RequiresUnreferencedCode
+				RequiresPublicFields (type);
+
+				// This will still "work" in that it will apply the PublicFields requirement onto the specified type
+				RequiresPublicFields (typeof (TestRequiresUnreferencedCodeAndDynamicallyAccessedMembers));
+			}
+
+			[Kept]
+			[RecognizedReflectionAccessPattern]
+			static void RequiresPublicFields (
+				[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+				[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
+				Type type)
+			{ }
+
+			[Kept]
+			public void PublicInstanceMethod () { }
+
+			[Kept]
+			public static void PublicStaticMethod () { }
+
+			static void PrivateInstanceMethod () { }
+
+			[Kept]
+			public static int PublicStaticField;
+
+			static int PrivateStaticField;
+
+			[Kept]
+			[ExpectedWarning("IL2026", "--- RequiresUnreferencedCodeAndPublicMethods ---")]
+			public static void Test()
+			{
+				RequiresUnreferencedCodeAndPublicMethods (typeof (TestRequiresUnreferencedCodeAndDynamicallyAccessedMembers));
+			}
 		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapabilityReflectionAnalysisEnabled.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapabilityReflectionAnalysisEnabled.cs
@@ -115,8 +115,8 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		class TestRequiresUnreferencedCodeAndDynamicallyAccessedMembers
 		{
 			[Kept]
-			[KeptAttributeAttribute(typeof(RequiresUnreferencedCodeAttribute))]
-			[RequiresUnreferencedCode("--- RequiresUnreferencedCodeAndPublicMethods ---")]
+			[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+			[RequiresUnreferencedCode ("--- RequiresUnreferencedCodeAndPublicMethods ---")]
 			[RecognizedReflectionAccessPattern]
 			static void RequiresUnreferencedCodeAndPublicMethods (
 				[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
@@ -152,8 +152,8 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			static int PrivateStaticField;
 
 			[Kept]
-			[ExpectedWarning("IL2026", "--- RequiresUnreferencedCodeAndPublicMethods ---")]
-			public static void Test()
+			[ExpectedWarning ("IL2026", "--- RequiresUnreferencedCodeAndPublicMethods ---")]
+			public static void Test ()
 			{
 				RequiresUnreferencedCodeAndPublicMethods (typeof (TestRequiresUnreferencedCodeAndDynamicallyAccessedMembers));
 			}


### PR DESCRIPTION
The intended behavior is:
* Callers will get a warning due to the `RequiresUnreferencedCode`
* Callers will apply the requirements of the `DynamicallyAccessedMembers` on the method parameters
* The method body will not produce data flow warnings
* The method body is still fully analyzed and if it adds requirements on something that will be applied

Test for https://github.com/mono/linker/issues/1815