### PR TITLE
Disable probing for assemblies by default

### DIFF
--- a/src/linker/Linker.Steps/RootAssemblyInputStep.cs
+++ b/src/linker/Linker.Steps/RootAssemblyInputStep.cs
@@ -92,8 +92,7 @@ namespace Mono.Linker.Steps
 			if (loaded != null)
 				return loaded;
 
-			Context.Resolver.CacheAssemblyWithPath (assembly);
-			Context.RegisterAssembly (assembly);
+			Context.Resolver.CacheAssembly (assembly);
 			return assembly;
 		}
 

--- a/src/linker/Linker/AssemblyResolver.cs
+++ b/src/linker/Linker/AssemblyResolver.cs
@@ -127,18 +127,11 @@ namespace Mono.Linker
 			return asm;
 		}
 
-		void CacheAssembly (AssemblyDefinition assembly)
+		public void CacheAssembly (AssemblyDefinition assembly)
 		{
 			_assemblies[assembly.Name.Name] = assembly;
 			if (assembly != null)
 				_context.RegisterAssembly (assembly);
-		}
-
-		public virtual AssemblyDefinition CacheAssemblyWithPath (AssemblyDefinition assembly)
-		{
-			CacheAssembly (assembly);
-			base.AddSearchDirectory (Path.GetDirectoryName (GetAssemblyFileName (assembly)));
-			return assembly;
 		}
 
 		public void AddReferenceAssembly (string referencePath)

--- a/src/linker/Linker/DirectoryAssemblyResolver.cs
+++ b/src/linker/Linker/DirectoryAssemblyResolver.cs
@@ -32,7 +32,7 @@ namespace Mono.Linker
 		{
 			defaultReaderParameters = new ReaderParameters ();
 			defaultReaderParameters.AssemblyResolver = this;
-			directories = new Collection<string> (2) { "." };
+			directories = new Collection<string> ();
 		}
 
 		public AssemblyDefinition GetAssembly (string file, ReaderParameters parameters)

--- a/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeOnGenericParameterIsRemoved.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeOnGenericParameterIsRemoved.cs
@@ -3,6 +3,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed
 {
+	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[SetupLinkerArgument ("--used-attrs-only", "true")]
 	[Define ("IL_ASSEMBLY_AVAILABLE")]
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/AssemblyWithUnusedAttributeOnGenericParameter.il" })]

--- a/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeOnReturnTypeIsRemoved.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeOnReturnTypeIsRemoved.cs
@@ -3,6 +3,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed
 {
+	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[SetupLinkerArgument ("--used-attrs-only", "true")]
 	[Define ("IL_ASSEMBLY_AVAILABLE")]
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/AssemblyWithUnusedAttributeOnReturnParameterDefinition.il" })]

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/InterfaceWithAttributeOnImplementation.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/InterfaceWithAttributeOnImplementation.cs
@@ -6,6 +6,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 {
+	[SetupLinkerArgument ("--skip-unresolved", "true")]
 #if !NETCOREAPP
 	[IgnoreTestCase ("Only for .NET Core for some reason")]
 #endif

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndAssemblyPreserveAll.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndAssemblyPreserveAll.cs
@@ -3,6 +3,8 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor
 {
+	[SetupLinkerArgument ("--skip-unresolved", "true")]
+
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/NoInstanceCtorAndAssemblyPreserveAll_Lib.il" })]
 	[KeptInterfaceOnTypeInAssemblyAttribute ("library",
 		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A",

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveAll.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveAll.cs
@@ -3,6 +3,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor
 {
+	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/NoInstanceCtorAndAssemblyPreserveAll_Lib.il" })]
 	[KeptInterfaceOnTypeInAssembly ("library",
 		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A",

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveFields.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveFields.cs
@@ -3,6 +3,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor
 {
+	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/NoInstanceCtorAndAssemblyPreserveAll_Lib.il" })]
 
 	// The interfaces should be removed because the interface types are not marked

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveFieldsWithInterfacesMarked.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveFieldsWithInterfacesMarked.cs
@@ -3,6 +3,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor
 {
+	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Define ("IL_ASSEMBLY_COMPILED")]
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/NoInstanceCtorAndAssemblyPreserveAll_Lib.il" })]
 

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveMethods.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveMethods.cs
@@ -3,6 +3,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor
 {
+	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/NoInstanceCtorAndAssemblyPreserveAll_Lib.il" })]
 
 	// The interfaces should be removed because the interface types are not marked

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveMethodsWithInterfacesMarked.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveMethodsWithInterfacesMarked.cs
@@ -3,6 +3,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor
 {
+	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Define ("IL_ASSEMBLY_COMPILED")]
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/NoInstanceCtorAndAssemblyPreserveAll_Lib.il" })]
 

--- a/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveNone.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveNone.cs
@@ -3,6 +3,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor
 {
+	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/NoInstanceCtorAndAssemblyPreserveAll_Lib.il" })]
 	[RemovedInterfaceOnTypeInAssembly ("library",
 		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A",

--- a/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdb.cs
+++ b/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdb.cs
@@ -5,6 +5,7 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Symbols
 {
+	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Reference ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll")]
 	[ReferenceDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb")]
 	[SetupLinkerLinkSymbols ("false")]

--- a/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdbCopyAction.cs
+++ b/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdbCopyAction.cs
@@ -4,6 +4,7 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Symbols
 {
+	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Reference ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll")]
 	[ReferenceDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb")]
 	[SetupLinkerLinkSymbols ("false")]

--- a/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdbDeleteAction.cs
+++ b/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdbDeleteAction.cs
@@ -4,6 +4,7 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Symbols
 {
+	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Reference ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll")]
 	[ReferenceDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb")]
 	[SetupLinkerLinkSymbols ("false")]

--- a/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdbDeleteActionAndSymbolLinkingEnabled.cs
+++ b/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdbDeleteActionAndSymbolLinkingEnabled.cs
@@ -4,6 +4,7 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Symbols
 {
+	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Reference ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll")]
 	[ReferenceDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb")]
 	[SetupLinkerLinkSymbols ("true")]

--- a/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdb.cs
+++ b/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdb.cs
@@ -4,6 +4,7 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Symbols
 {
+	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Reference ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll")]
 	[ReferenceDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb")]
 	[SetupLinkerLinkSymbols ("false")]

--- a/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbAndSymbolLinkingEnabled.cs
+++ b/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbAndSymbolLinkingEnabled.cs
@@ -5,6 +5,7 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Symbols
 {
+	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Reference ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll")]
 	[ReferenceDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb")]
 	[SetupLinkerLinkSymbols ("true")]

--- a/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbAndSymbolLinkingEnabledAndDeterministicMvid.cs
+++ b/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbAndSymbolLinkingEnabledAndDeterministicMvid.cs
@@ -4,6 +4,7 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Symbols
 {
+	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Reference ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll")]
 	[ReferenceDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb")]
 	[SetupLinkerLinkSymbols ("true")]

--- a/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbAndSymbolLinkingEnabledAndNewMvid.cs
+++ b/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbAndSymbolLinkingEnabledAndNewMvid.cs
@@ -4,6 +4,7 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Symbols
 {
+	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Reference ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll")]
 	[ReferenceDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb")]
 	[SetupLinkerLinkSymbols ("true")]

--- a/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbCopyAction.cs
+++ b/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbCopyAction.cs
@@ -4,6 +4,7 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Symbols
 {
+	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Reference ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll")]
 	[ReferenceDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb")]
 	[SetupLinkerLinkSymbols ("false")]

--- a/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbDeleteAction.cs
+++ b/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbDeleteAction.cs
@@ -4,6 +4,7 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Symbols
 {
+	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Reference ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll")]
 	[ReferenceDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb")]
 	[SetupLinkerLinkSymbols ("false")]

--- a/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbDeleteActionAndSymbolLinkingEnabled.cs
+++ b/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbDeleteActionAndSymbolLinkingEnabled.cs
@@ -4,6 +4,7 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Symbols
 {
+	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Reference ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll")]
 	[ReferenceDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb")]
 	[SetupLinkerLinkSymbols ("true")]

--- a/test/Mono.Linker.Tests.Cases/Symbols/ReferencesWithMixedSymbolTypes.cs
+++ b/test/Mono.Linker.Tests.Cases/Symbols/ReferencesWithMixedSymbolTypes.cs
@@ -5,6 +5,7 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Symbols
 {
+	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Reference ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll")]
 	[ReferenceDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb")]
 

--- a/test/Mono.Linker.Tests.Cases/Symbols/ReferencesWithMixedSymbolTypesAndSymbolLinkingEnabled.cs
+++ b/test/Mono.Linker.Tests.Cases/Symbols/ReferencesWithMixedSymbolTypesAndSymbolLinkingEnabled.cs
@@ -5,6 +5,7 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Symbols
 {
+	[SetupLinkerArgument ("--skip-unresolved", "true")]
 #if !NETCOREAPP
 	[Reference ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll")]
 	[ReferenceDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb")]

--- a/test/Mono.Linker.Tests.Cases/TestFramework/CanCompileILAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/TestFramework/CanCompileILAssembly.cs
@@ -4,6 +4,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.TestFramework
 {
+	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Define ("IL_ASSEMBLY_AVAILABLE")]
 	[SetupCompileBefore ("ILAssembly.dll", new[] { "Dependencies/ILAssemblySample.il" })]
 	[KeptMemberInAssembly ("ILAssembly.dll", "Mono.Linker.Tests.Cases.TestFramework.Dependencies.ILAssemblySample", "GiveMeAValue()")]

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/SecurityAttributeScope.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/SecurityAttributeScope.cs
@@ -12,6 +12,7 @@ namespace Mono.Linker.Tests.Cases.TypeForwarding
 	///
 	/// In order words, until https://github.com/mono/linker/issues/1703 is addressed this test will pass with or without the fix to update the scope on security attributes
 	/// </summary>
+	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[SetupLinkerArgument ("--strip-security", "false")]
 	[Define ("IL_ASSEMBLY_AVAILABLE")]
 	[KeepTypeForwarderOnlyAssemblies ("false")]

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/TypeForwardersModifiers.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/TypeForwardersModifiers.cs
@@ -4,6 +4,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.TypeForwarding
 {
+	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	// Actions:
 	// link - This assembly, TypeForwarderModifiersLibDef.dll and TypeForwardersModifiersLib.dll
 	[SetupLinkerUserAction ("link")]

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/UninitializedLocals.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/UninitializedLocals.cs
@@ -3,6 +3,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.UnreachableBlock
 {
+	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Define ("IL_ASSEMBLY_AVAILABLE")]
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/LocalsWithoutStore.il" })]
 	[SetupLinkerArgument ("--enable-opt", "ipconstprop")]

--- a/test/Mono.Linker.Tests.Cases/UnreachableBody/DoesNotApplyToCopiedAssembly2.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBody/DoesNotApplyToCopiedAssembly2.cs
@@ -3,6 +3,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.UnreachableBody
 {
+	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Define ("OTHER_INCLUDED")]
 	[SetupLinkerAction ("copy", "other")]
 	[SetupCompileBefore ("other.dll", new[] { "Dependencies/OtherAssemblyNoInstanceCtor.il" })]

--- a/test/Mono.Linker.Tests.Cases/UnreachableBody/LinkedOtherIncludedLibraryNoInstanceCtor.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBody/LinkedOtherIncludedLibraryNoInstanceCtor.cs
@@ -3,6 +3,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.UnreachableBody
 {
+	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Define ("OTHER_INCLUDED")]
 #if NETCOREAPP
 	[SetupLinkerArgument ("-a", "other.dll", "visible")]


### PR DESCRIPTION
We used to probe for assemblies in:
- the working directory
- next to any root assembly
- in directories passed on the command-line

Now we will only probe for directories passed on the command-line, which
aren't used by the SDK.

Some of the testcases have references to mscorlib (either from .il, or from
checked-in dlls), which references System.Security.Permissions. This isn't
included with netcoreapp, but the tests used to resolve it from the
working directory of Mono.Linker.Tests.dll. We pass --skip-unresolved true
to keep these testcases from throwing resolution errors with the change.

Fixes https://github.com/mono/linker/issues/1539