### PR TITLE
Allow illink pkg to be referenced directly

### DIFF
--- a/src/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/src/ILLink.Tasks/ILLink.Tasks.csproj
@@ -30,9 +30,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="Sdk/Sdk.props">
-      <PackagePath>Sdk</PackagePath>
-    </Content>
+    <Content Include="sdk/Sdk.props" PackagePath="sdk" />
+    <Content Include="build/$(PackageId).props" PackagePath="build" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ILLink.Tasks/build/Microsoft.NET.ILLink.Tasks.props
+++ b/src/ILLink.Tasks/build/Microsoft.NET.ILLink.Tasks.props
@@ -1,0 +1,19 @@
+<!--
+***********************************************************************************************
+Microsoft.NET.ILLink.Tasks.props
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project>
+
+  <PropertyGroup>
+    <ILLinkTasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\net5.0\ILLink.Tasks.dll</ILLinkTasksAssembly>
+    <ILLinkTasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\ILLink.Tasks.dll</ILLinkTasksAssembly>
+  </PropertyGroup>
+
+</Project>

--- a/src/ILLink.Tasks/sdk/Sdk.props
+++ b/src/ILLink.Tasks/sdk/Sdk.props
@@ -11,9 +11,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 <Project>
 
-  <PropertyGroup>
-    <ILLinkTasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\net5.0\ILLink.Tasks.dll</ILLinkTasksAssembly>
-    <ILLinkTasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\ILLink.Tasks.dll</ILLinkTasksAssembly>
-  </PropertyGroup>
+  <Import Project="..\build\Microsoft.NET.ILLink.Tasks.props" />
 
 </Project>


### PR DESCRIPTION
Having both a build and sdk folder allows the package not just be used as an SDK package but also used via a PackageReference with which the .props file gets honored then. This is needed for the linker tests in dotnet/runtime but is generally the recommended pattern when creating sdk packages.