### PR TITLE
Fix Sdk folder path in linker.tasks pkg

### DIFF
--- a/src/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/src/ILLink.Tasks/ILLink.Tasks.csproj
@@ -19,7 +19,6 @@
     <!-- Place linker and cecil alongside ILLink.Tasks in the output, for integration tests. -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <Nullable>disable</Nullable>
-    <PackageType>MSBuildSdk</PackageType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/src/ILLink.Tasks/ILLink.Tasks.csproj
@@ -19,6 +19,7 @@
     <!-- Place linker and cecil alongside ILLink.Tasks in the output, for integration tests. -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <Nullable>disable</Nullable>
+    <PackageType>MSBuildSdk</PackageType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -30,8 +31,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="sdk/Sdk.props" PackagePath="sdk" />
-    <Content Include="build/$(PackageId).props" PackagePath="build" />
+    <Content Include="sdk/Sdk.props" PackagePath="Sdk/" />
+    <Content Include="build/$(PackageId).props" PackagePath="build/" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ILLink.Tasks/sdk/Sdk.props
+++ b/src/ILLink.Tasks/sdk/Sdk.props
@@ -11,6 +11,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 <Project>
 
-  <Import Project="..\build\Microsoft.NET.ILLink.Tasks.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\build\Microsoft.NET.ILLink.Tasks.props" />
 
 </Project>


### PR DESCRIPTION
The PackageType was missing to indicate that the package is an msbuild sdk package, and the `Sdk` folder should start with a capital S. Hopefully that fixes the issue that we observed.