### PR TITLE
Don't publish test results in official build

### DIFF
--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -40,8 +40,9 @@ stages:
       helixRepo: mono/linker
       enablePublishUsingPipelines: true
       enablePublishBuildArtifacts: true # publish build logs to pipeline storage
-      enablePublishTestResults: true
-      testResultsFormat: vstest
+      ${{ if eq(variables.officialBuild, 'false') }}:
+        enablePublishTestResults: true
+        testResultsFormat: vstest
       enablePublishBuildAssets: true # generate build manifests and publish to BAR in internal builds
       enableMicrobuild: true # only affects internal builds
 


### PR DESCRIPTION
We don't run tests there so we get a warning about missing test result files in the official build.