### PR TITLE
Don't override the ILLinkTaskAssembly in the SDK

### DIFF
--- a/src/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/src/ILLink.Tasks/ILLink.Tasks.csproj
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <Content Include="sdk/Sdk.props" PackagePath="Sdk/" />
-    <Content Include="build/$(PackageId).props" PackagePath="build/" />
+    <Content Include="build/$(PackageId).props;build/$(PackageId).targets" PackagePath="build/" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/src/ILLink.Tasks/ILLink.Tasks.csproj
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <Content Include="sdk/Sdk.props" PackagePath="Sdk/" />
-    <Content Include="build/$(PackageId).props;build/$(PackageId).targets" PackagePath="build/" />
+    <Content Include="build/$(PackageId).*" PackagePath="build/" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ILLink.Tasks/build/Microsoft.NET.ILLink.Tasks.props
+++ b/src/ILLink.Tasks/build/Microsoft.NET.ILLink.Tasks.props
@@ -12,6 +12,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 <Project>
 
   <PropertyGroup>
+    <UsingILLinkTasksSdk>true</UsingILLinkTasksSdk>
     <ILLinkTasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\net5.0\ILLink.Tasks.dll</ILLinkTasksAssembly>
     <ILLinkTasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\ILLink.Tasks.dll</ILLinkTasksAssembly>
   </PropertyGroup>

--- a/src/ILLink.Tasks/build/Microsoft.NET.ILLink.Tasks.targets
+++ b/src/ILLink.Tasks/build/Microsoft.NET.ILLink.Tasks.targets
@@ -1,0 +1,9 @@
+<!-- TODO: Remove this file after the SDK consumes a new ILLink.Tasks package and dotnet/runtime consumes that newer SDK. -->
+<Project>
+
+  <PropertyGroup>
+    <ILLinkTasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\net5.0\ILLink.Tasks.dll</ILLinkTasksAssembly>
+    <ILLinkTasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\ILLink.Tasks.dll</ILLinkTasksAssembly>
+  </PropertyGroup>
+
+</Project>

--- a/src/ILLink.Tasks/sdk/Sdk.props
+++ b/src/ILLink.Tasks/sdk/Sdk.props
@@ -11,6 +11,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 <Project>
 
-  <Import Project="$(MSBuildThisFileDirectory)..\build\Microsoft.NET.ILLink.Tasks.props" />
+  <!-- Only import the build props if the ILLink.Tasks package isn't referenced via NuGet. -->
+  <Import Project="$(MSBuildThisFileDirectory)..\build\Microsoft.NET.ILLink.Tasks.props" Condition="'$(UsingILLinkTasksSdk)' != 'true'" />
 
 </Project>

--- a/src/ILLink.Tasks/sdk/Sdk.targets
+++ b/src/ILLink.Tasks/sdk/Sdk.targets
@@ -1,9 +1,0 @@
-<!-- TODO: Remove this file after the SDK consumes a new ILLink.Tasks package and dotnet/runtime consumes that newer SDK. -->
-<Project>
-
-  <PropertyGroup>
-    <ILLinkTasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\net5.0\ILLink.Tasks.dll</ILLinkTasksAssembly>
-    <ILLinkTasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\ILLink.Tasks.dll</ILLinkTasksAssembly>
-  </PropertyGroup>
-
-</Project>

--- a/src/ILLink.Tasks/sdk/Sdk.targets
+++ b/src/ILLink.Tasks/sdk/Sdk.targets
@@ -1,0 +1,9 @@
+<!-- TODO: Remove this file after the SDK consumes a new ILLink.Tasks package and dotnet/runtime consumes that newer SDK. -->
+<Project>
+
+  <PropertyGroup>
+    <ILLinkTasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\net5.0\ILLink.Tasks.dll</ILLinkTasksAssembly>
+    <ILLinkTasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\ILLink.Tasks.dll</ILLinkTasksAssembly>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
NuGet generated props and targets are imported before the SDK's props and targets. To avoid the SDK overriding the nuget path, add an additional property which is being checked on.