### PR TITLE
Mark facades containing forwarders referenced via type name strings

### DIFF
--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -897,7 +897,7 @@ namespace Mono.Linker.Dataflow
 						}
 						foreach (var typeNameValue in methodParams[0].UniqueValues ()) {
 							if (typeNameValue is KnownStringValue knownStringValue) {
-								TypeReference foundTypeRef = _context.TypeNameResolver.ResolveTypeName (knownStringValue.Contents).Type;
+								TypeReference foundTypeRef = _context.TypeNameResolver.ResolveTypeName (knownStringValue.Contents, out _);
 								TypeDefinition foundType = foundTypeRef?.ResolveToMainTypeDefinition ();
 								if (foundType == null) {
 									// Intentionally ignore - it's not wrong for code to call Type.GetType on non-existing name, the code might expect null/exception back.
@@ -1804,7 +1804,7 @@ namespace Mono.Linker.Dataflow
 				} else if (uniqueValue is SystemTypeValue systemTypeValue) {
 					MarkTypeForDynamicallyAccessedMembers (ref reflectionContext, systemTypeValue.TypeRepresented, requiredMemberTypes);
 				} else if (uniqueValue is KnownStringValue knownStringValue) {
-					(AssemblyDefinition assembly, TypeReference typeRef) = _context.TypeNameResolver.ResolveTypeName (knownStringValue.Contents);
+					TypeReference typeRef = _context.TypeNameResolver.ResolveTypeName (knownStringValue.Contents, out AssemblyDefinition typeAssembly);
 					TypeDefinition foundType = typeRef?.ResolveToMainTypeDefinition ();
 					if (foundType == null) {
 						// Intentionally ignore - it's not wrong for code to call Type.GetType on non-existing name, the code might expect null/exception back.
@@ -1812,8 +1812,8 @@ namespace Mono.Linker.Dataflow
 					} else {
 						MarkType (ref reflectionContext, typeRef);
 						MarkTypeForDynamicallyAccessedMembers (ref reflectionContext, foundType, requiredMemberTypes);
-						if (assembly.MainModule.GetMatchingExportedType (foundType, out var exportedType))
-							_context.MarkingHelpers.MarkExportedType (exportedType, typeRef.Module, new DependencyInfo (DependencyKind.DynamicallyAccessedMember, foundType));
+						if (typeAssembly.MainModule.GetMatchingExportedType (foundType, out var exportedType))
+							_context.MarkingHelpers.MarkExportedType (exportedType, typeAssembly.MainModule, new DependencyInfo (DependencyKind.DynamicallyAccessedMember, foundType));
 					}
 				} else if (uniqueValue == NullValue.Instance) {
 					// Ignore - probably unreachable path as it would fail at runtime anyway.

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -897,7 +897,7 @@ namespace Mono.Linker.Dataflow
 						}
 						foreach (var typeNameValue in methodParams[0].UniqueValues ()) {
 							if (typeNameValue is KnownStringValue knownStringValue) {
-								TypeReference foundTypeRef = _context.TypeNameResolver.ResolveTypeName (knownStringValue.Contents);
+								TypeReference foundTypeRef = _context.TypeNameResolver.ResolveTypeName (knownStringValue.Contents).Type;
 								TypeDefinition foundType = foundTypeRef?.ResolveToMainTypeDefinition ();
 								if (foundType == null) {
 									// Intentionally ignore - it's not wrong for code to call Type.GetType on non-existing name, the code might expect null/exception back.
@@ -1804,7 +1804,7 @@ namespace Mono.Linker.Dataflow
 				} else if (uniqueValue is SystemTypeValue systemTypeValue) {
 					MarkTypeForDynamicallyAccessedMembers (ref reflectionContext, systemTypeValue.TypeRepresented, requiredMemberTypes);
 				} else if (uniqueValue is KnownStringValue knownStringValue) {
-					TypeReference typeRef = _context.TypeNameResolver.ResolveTypeName (knownStringValue.Contents);
+					(AssemblyDefinition assembly, TypeReference typeRef) = _context.TypeNameResolver.ResolveTypeName (knownStringValue.Contents);
 					TypeDefinition foundType = typeRef?.ResolveToMainTypeDefinition ();
 					if (foundType == null) {
 						// Intentionally ignore - it's not wrong for code to call Type.GetType on non-existing name, the code might expect null/exception back.
@@ -1812,6 +1812,8 @@ namespace Mono.Linker.Dataflow
 					} else {
 						MarkType (ref reflectionContext, typeRef);
 						MarkTypeForDynamicallyAccessedMembers (ref reflectionContext, foundType, requiredMemberTypes);
+						if (assembly.MainModule.GetMatchingExportedType (foundType, out var exportedType))
+							_context.MarkingHelpers.MarkExportedType (exportedType, typeRef.Module, new DependencyInfo (DependencyKind.DynamicallyAccessedMember, foundType));
 					}
 				} else if (uniqueValue == NullValue.Instance) {
 					// Ignore - probably unreachable path as it would fail at runtime anyway.

--- a/src/linker/Linker.Steps/DescriptorMarker.cs
+++ b/src/linker/Linker.Steps/DescriptorMarker.cs
@@ -45,6 +45,9 @@ namespace Mono.Linker.Steps
 			if (GetTypePreserve (nav) == TypePreserve.All) {
 				foreach (var type in assembly.MainModule.Types)
 					MarkAndPreserveAll (type);
+
+				foreach (var exportedType in assembly.MainModule.ExportedTypes)
+					_context.MarkingHelpers.MarkExportedType (exportedType, assembly.MainModule, new DependencyInfo (DependencyKind.ModuleOfExportedType, assembly.MainModule));
 			} else {
 				ProcessTypes (assembly, nav, warnOnUnresolvedTypes);
 				ProcessNamespaces (assembly, nav);

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -807,8 +807,10 @@ namespace Mono.Linker.Steps
 			ModuleDefinition module = assembly.MainModule;
 			if (module.HasExportedTypes) {
 				foreach (var exportedType in module.ExportedTypes)
-					if (exportedType.FullName == type.FullName)
+					if (exportedType.Resolve() == type) {
 						_context.MarkingHelpers.MarkExportedType (exportedType, module, new DependencyInfo (DependencyKind.DynamicDependency, type));
+						break;
+					}
 			}
 
 			IEnumerable<IMemberDefinition> members;
@@ -1804,7 +1806,7 @@ namespace Mono.Linker.Steps
 			TypeDefinition tdef = null;
 			switch (attribute.ConstructorArguments[0].Value) {
 			case string s:
-				tdef = _context.TypeNameResolver.ResolveTypeName (s).Type?.Resolve ();
+				tdef = _context.TypeNameResolver.ResolveTypeName (s, out _)?.Resolve ();
 				break;
 			case TypeReference type:
 				tdef = type.Resolve ();

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -807,7 +807,7 @@ namespace Mono.Linker.Steps
 			ModuleDefinition module = assembly.MainModule;
 			if (module.HasExportedTypes) {
 				foreach (var exportedType in module.ExportedTypes)
-					if (exportedType.Resolve() == type) {
+					if (exportedType.Resolve () == type) {
 						_context.MarkingHelpers.MarkExportedType (exportedType, module, new DependencyInfo (DependencyKind.DynamicDependency, type));
 						break;
 					}

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -824,6 +824,11 @@ namespace Mono.Linker.Steps
 					_context.LogWarning ($"Unresolved type '{typeName}' in DynamicDependencyAttribute", 2036, context);
 					return;
 				}
+
+				var module = assembly.MainModule;
+				if (module.GetMatchingExportedType (type, out var exportedType)) {
+					_context.MarkingHelpers.MarkExportedType (exportedType, module, new DependencyInfo (DependencyKind.ModuleOfExportedType, module));
+				}
 			} else if (dynamicDependency.Type is TypeReference typeReference) {
 				type = typeReference.Resolve ();
 				if (type == null) {

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -331,41 +331,7 @@ namespace Mono.Linker.Steps
 
 		void Process ()
 		{
-			while (ProcessPrimaryQueue () || ProcessMarkedPending () || ProcessLazyAttributes () || ProcessLateMarkedAttributes () || MarkFullyPreservedAssemblies ()) {
-
-				// deal with [TypeForwardedTo] pseudo-attributes
-
-				// This marks all exported types that resolve to a marked type. Note that it
-				// may mark unused exported types that happen to resolve to a type which was
-				// marked from a different reference. This seems incorrect.
-				// Note also that we may still remove type forwarder assemblies with marked exports in SweepStep,
-				// if they don't contain other used code.
-				// https://github.com/mono/linker/issues/1740
-				foreach (AssemblyDefinition assembly in _context.GetAssemblies ()) {
-					if (!assembly.MainModule.HasExportedTypes)
-						continue;
-
-					foreach (var exported in assembly.MainModule.ExportedTypes) {
-						bool isForwarder = exported.IsForwarder;
-						var declaringType = exported.DeclaringType;
-						while (!isForwarder && (declaringType != null)) {
-							isForwarder = declaringType.IsForwarder;
-							declaringType = declaringType.DeclaringType;
-						}
-
-						if (!isForwarder)
-							continue;
-						TypeDefinition type = exported.Resolve ();
-						if (type == null)
-							continue;
-						if (!Annotations.IsMarked (type))
-							continue;
-						var di = new DependencyInfo (DependencyKind.ExportedType, type);
-						_context.MarkingHelpers.MarkExportedType (exported, assembly.MainModule, di);
-					}
-				}
-			}
-
+			while (ProcessPrimaryQueue () || ProcessMarkedPending () || ProcessLazyAttributes () || ProcessLateMarkedAttributes () || MarkFullyPreservedAssemblies ()) ;
 			ProcessPendingTypeChecks ();
 		}
 
@@ -824,11 +790,6 @@ namespace Mono.Linker.Steps
 					_context.LogWarning ($"Unresolved type '{typeName}' in DynamicDependencyAttribute", 2036, context);
 					return;
 				}
-
-				var module = assembly.MainModule;
-				if (module.GetMatchingExportedType (type, out var exportedType)) {
-					_context.MarkingHelpers.MarkExportedType (exportedType, module, new DependencyInfo (DependencyKind.ModuleOfExportedType, module));
-				}
 			} else if (dynamicDependency.Type is TypeReference typeReference) {
 				type = typeReference.Resolve ();
 				if (type == null) {
@@ -841,6 +802,13 @@ namespace Mono.Linker.Steps
 					_context.LogWarning ($"Unresolved type '{context.DeclaringType}' in DynamicDependencyAttribute", 2036, context);
 					return;
 				}
+			}
+
+			ModuleDefinition module = assembly.MainModule;
+			if (module.HasExportedTypes) {
+				foreach (var exportedType in module.ExportedTypes)
+					if (exportedType.FullName == type.FullName)
+						_context.MarkingHelpers.MarkExportedType (exportedType, module, new DependencyInfo (DependencyKind.DynamicDependency, type));
 			}
 
 			IEnumerable<IMemberDefinition> members;
@@ -1330,7 +1298,8 @@ namespace Mono.Linker.Steps
 			MarkCustomAttributes (assembly.MainModule, new DependencyInfo (DependencyKind.AssemblyOrModuleAttribute, assembly.MainModule), null);
 
 			if (assembly.MainModule.HasExportedTypes) {
-				// TODO: This needs more work accross all steps
+				foreach (var exportedType in assembly.MainModule.ExportedTypes)
+					_context.MarkingHelpers.MarkExportedType (exportedType, assembly.MainModule, new DependencyInfo (DependencyKind.ModuleOfExportedType, assembly.MainModule));
 			}
 
 			foreach (TypeDefinition type in assembly.MainModule.Types)
@@ -1835,7 +1804,7 @@ namespace Mono.Linker.Steps
 			TypeDefinition tdef = null;
 			switch (attribute.ConstructorArguments[0].Value) {
 			case string s:
-				tdef = _context.TypeNameResolver.ResolveTypeName (s)?.Resolve ();
+				tdef = _context.TypeNameResolver.ResolveTypeName (s).Type?.Resolve ();
 				break;
 			case TypeReference type:
 				tdef = type.Resolve ();

--- a/src/linker/Linker.Steps/SweepStep.cs
+++ b/src/linker/Linker.Steps/SweepStep.cs
@@ -531,6 +531,14 @@ namespace Mono.Linker.Steps
 
 		protected virtual bool ShouldRemove<T> (T element) where T : IMetadataTokenProvider
 		{
+			if (typeof (T) == typeof (ExportedType)) {
+				var typeDef = (element as ExportedType).Resolve ();
+				if (Context.KeepTypeForwarderOnlyAssemblies)
+					return !Annotations.IsMarked (typeDef);
+
+				return !Annotations.IsMarked (typeDef) || !Annotations.IsMarked (element);
+			}
+
 			return !Annotations.IsMarked (element);
 		}
 

--- a/src/linker/Linker/MarkingHelpers.cs
+++ b/src/linker/Linker/MarkingHelpers.cs
@@ -16,25 +16,7 @@ namespace Mono.Linker
 			if (!_context.Annotations.MarkProcessed (exportedType, reason))
 				return;
 
-			if (reason.Kind == DependencyKind.ModuleOfExportedType) {
-				var facadeAssembly = (reason.Source as ModuleDefinition).Assembly;
-				TypeDefinition resolvedType = exportedType.Resolve ();
-				while (facadeAssembly.FullName != resolvedType.Module.Assembly.FullName) {
-					_context.Annotations.Mark (module, new DependencyInfo (DependencyKind.ModuleOfExportedType, exportedType));
-					foreach (var assemblyReference in module.AssemblyReferences) {
-						if (assemblyReference.MetadataToken == exportedType.Scope.MetadataToken) {
-							facadeAssembly = module.AssemblyResolver.Resolve (assemblyReference);
-							module = facadeAssembly.MainModule;
-							break;
-						}
-					}
-				}
-
-				return;
-			}
-
-			if (_context.KeepTypeForwarderOnlyAssemblies)
-				_context.Annotations.Mark (module, new DependencyInfo (DependencyKind.ModuleOfExportedType, exportedType));
+			_context.Annotations.Mark (module, new DependencyInfo (DependencyKind.ModuleOfExportedType, exportedType));
 		}
 	}
 }

--- a/src/linker/Linker/ModuleDefinitionExtensions.cs
+++ b/src/linker/Linker/ModuleDefinitionExtensions.cs
@@ -18,7 +18,7 @@ namespace Mono.Linker
 				return false;
 
 			foreach (var et in module.ExportedTypes)
-				if (et.FullName == typeDefinition.FullName) {
+				if (et.Resolve () == typeDefinition) {
 					exportedType = et;
 					return true;
 				}

--- a/src/linker/Linker/ModuleDefinitionExtensions.cs
+++ b/src/linker/Linker/ModuleDefinitionExtensions.cs
@@ -11,6 +11,21 @@ namespace Mono.Linker
 				(module.Attributes & ModuleAttributes.ILLibrary) != 0;
 		}
 
+		public static bool GetMatchingExportedType (this ModuleDefinition module, TypeDefinition typeDefinition, out ExportedType exportedType)
+		{
+			exportedType = null;
+			if (!module.HasExportedTypes || typeDefinition == null)
+				return false;
+
+			foreach (var et in module.ExportedTypes)
+				if (et.FullName == typeDefinition.FullName) {
+					exportedType = et;
+					return true;
+				}
+
+			return false;
+		}
+
 		public static TypeDefinition ResolveType (this ModuleDefinition module, string typeFullName)
 		{
 			if (typeFullName == null)

--- a/src/linker/Linker/TypeNameResolver.cs
+++ b/src/linker/Linker/TypeNameResolver.cs
@@ -86,7 +86,13 @@ namespace Mono.Linker
 				};
 			}
 
-			return assembly.MainModule.ResolveType (typeName.ToString ());
+			ModuleDefinition module = assembly.MainModule;
+			TypeDefinition typeDefinition = module.ResolveType (typeName.ToString ());
+			if (module.GetMatchingExportedType (typeDefinition, out var exportedType)) {
+				_context.MarkingHelpers.MarkExportedType (exportedType, module, new DependencyInfo (DependencyKind.ModuleOfExportedType, module));
+			}
+
+			return typeDefinition;
 		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/LinkXml/CanPreserveAnExportedType.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/CanPreserveAnExportedType.cs
@@ -10,7 +10,6 @@ namespace Mono.Linker.Tests.Cases.LinkXml
 	// Add another assembly in that uses the forwarder just to make things a little more complex
 	[SetupCompileBefore ("Forwarder.dll", new[] { "Dependencies/CanPreserveAnExportedType_Forwarder.cs" }, references: new[] { "Library.dll" })]
 
-	[RemovedAssembly ("Forwarder.dll")]
 	[KeptMemberInAssembly ("Library.dll", typeof (CanPreserveAnExportedType_Library), "Field1", "Method()", ".ctor()")]
 	[SetupLinkerDescriptorFile ("CanPreserveAnExportedType.xml")]
 	class CanPreserveAnExportedType

--- a/test/Mono.Linker.Tests.Cases/LinkXml/CanPreserveAnExportedType.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/CanPreserveAnExportedType.cs
@@ -12,6 +12,8 @@ namespace Mono.Linker.Tests.Cases.LinkXml
 
 	[KeptMemberInAssembly ("Library.dll", typeof (CanPreserveAnExportedType_Library), "Field1", "Method()", ".ctor()")]
 	[SetupLinkerDescriptorFile ("CanPreserveAnExportedType.xml")]
+
+	[KeptTypeInAssembly ("Forwarder.dll", typeof (CanPreserveAnExportedType_Library))]
 	class CanPreserveAnExportedType
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/LinkXml/CanPreserveExportedTypesUsingRegex.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/CanPreserveExportedTypesUsingRegex.cs
@@ -12,6 +12,8 @@ namespace Mono.Linker.Tests.Cases.LinkXml
 
 	[KeptMemberInAssembly ("Library.dll", typeof (CanPreserveAnExportedType_Library), "Field1", "Method()", ".ctor()")]
 	[SetupLinkerDescriptorFile ("CanPreserveExportedTypesUsingRegex.xml")]
+
+	[KeptTypeInAssembly ("Forwarder.dll", typeof (CanPreserveAnExportedType_Library))]
 	class CanPreserveExportedTypesUsingRegex
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/LinkXml/CanPreserveExportedTypesUsingRegex.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/CanPreserveExportedTypesUsingRegex.cs
@@ -10,7 +10,6 @@ namespace Mono.Linker.Tests.Cases.LinkXml
 	// Add another assembly in that uses the forwarder just to make things a little more complex
 	[SetupCompileBefore ("Forwarder.dll", new[] { "Dependencies/CanPreserveAnExportedType_Forwarder.cs" }, references: new[] { "Library.dll" })]
 
-	[RemovedAssembly ("Forwarder.dll")]
 	[KeptMemberInAssembly ("Library.dll", typeof (CanPreserveAnExportedType_Library), "Field1", "Method()", ".ctor()")]
 	[SetupLinkerDescriptorFile ("CanPreserveExportedTypesUsingRegex.xml")]
 	class CanPreserveExportedTypesUsingRegex

--- a/test/Mono.Linker.Tests.Cases/LinkXml/UsedNonRequiredExportedTypeIsKept.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/UsedNonRequiredExportedTypeIsKept.cs
@@ -5,14 +5,17 @@ namespace Mono.Linker.Tests.Cases.LinkXml
 {
 	[SetupLinkerDescriptorFile ("UsedNonRequiredExportedTypeIsKept.xml")]
 
-	[SetupCompileBefore ("lib.dll", new[] { "Dependencies/UsedNonRequiredExportedTypeIsKept_lib.cs" })]
-	[SetupCompileAfter ("libfwd.dll", new[] { "Dependencies/UsedNonRequiredExportedTypeIsKept_lib.cs" })]
-	[SetupCompileAfter ("lib.dll", new[] { "Dependencies/UsedNonRequiredExportedTypeIsKept_fwd.cs" }, references: new[] { "libfwd.dll" })]
+	[SetupCompileBefore ("libfwd.dll", new[] { "Dependencies/UsedNonRequiredExportedTypeIsKept_lib.cs" })]
+	[SetupCompileAfter ("lib.dll", new[] { "Dependencies/UsedNonRequiredExportedTypeIsKept_lib.cs" })]
+	[SetupCompileAfter ("libfwd.dll", new[] { "Dependencies/UsedNonRequiredExportedTypeIsKept_fwd.cs" }, references: new[] { "lib.dll" })]
+	[SetupLinkerAction ("copy", "libfwd")]
 
-	[KeptAssembly ("libfwd.dll")]
-	[KeptMemberInAssembly ("libfwd.dll", typeof (UsedNonRequiredExportedTypeIsKept_Used1), "field", ExpectationAssemblyName = "lib.dll")]
-	[KeptMemberInAssembly ("libfwd.dll", typeof (UsedNonRequiredExportedTypeIsKept_Used2), "Method()", ExpectationAssemblyName = "lib.dll")]
-	[KeptMemberInAssembly ("libfwd.dll", typeof (UsedNonRequiredExportedTypeIsKept_Used3), "Method()", ExpectationAssemblyName = "lib.dll")]
+	[KeptMemberInAssembly ("lib.dll", typeof (UsedNonRequiredExportedTypeIsKept_Used1), "field", ExpectationAssemblyName = "libfwd.dll")]
+	[KeptMemberInAssembly ("lib.dll", typeof (UsedNonRequiredExportedTypeIsKept_Used2), "Method()", ExpectationAssemblyName = "libfwd.dll")]
+	[KeptMemberInAssembly ("lib.dll", typeof (UsedNonRequiredExportedTypeIsKept_Used3), "Method()", ExpectationAssemblyName = "libfwd.dll")]
+	[KeptTypeInAssembly ("libfwd.dll", typeof (UsedNonRequiredExportedTypeIsKept_Used1))]
+	[KeptTypeInAssembly ("libfwd.dll", typeof (UsedNonRequiredExportedTypeIsKept_Used2))]
+	[KeptTypeInAssembly ("libfwd.dll", typeof (UsedNonRequiredExportedTypeIsKept_Used3))]
 	public class UsedNonRequiredExportedTypeIsKept
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/LinkXml/UsedNonRequiredExportedTypeIsKept.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/UsedNonRequiredExportedTypeIsKept.cs
@@ -13,7 +13,6 @@ namespace Mono.Linker.Tests.Cases.LinkXml
 	[KeptMemberInAssembly ("libfwd.dll", typeof (UsedNonRequiredExportedTypeIsKept_Used1), "field", ExpectationAssemblyName = "lib.dll")]
 	[KeptMemberInAssembly ("libfwd.dll", typeof (UsedNonRequiredExportedTypeIsKept_Used2), "Method()", ExpectationAssemblyName = "lib.dll")]
 	[KeptMemberInAssembly ("libfwd.dll", typeof (UsedNonRequiredExportedTypeIsKept_Used3), "Method()", ExpectationAssemblyName = "lib.dll")]
-	[RemovedAssembly ("lib.dll")]
 	public class UsedNonRequiredExportedTypeIsKept
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/UnusedForwarderWithAssemblyCopy.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/UnusedForwarderWithAssemblyCopy.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.TypeForwarding.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.TypeForwarding
+{
+	[SetupLinkerDefaultAction ("link")]
+	[SetupCompileBefore ("Forwarder.dll", new[] { "Dependencies/ReferenceImplementationLibrary.cs" }, defines: new[] { "INCLUDE_REFERENCE_IMPL" })]
+
+	[SetupCompileAfter ("Implementation.dll", new[] { "Dependencies/ImplementationLibrary.cs" })]
+	[SetupCompileAfter ("Forwarder.dll", new[] { "Dependencies/ForwarderLibrary.cs" }, references: new[] { "Implementation.dll" })]
+	
+	[SetupLinkerAction ("copy", "Forwarder")]
+
+	[RemovedAssembly ("Forwarder.dll")]
+	[RemovedAssembly ("Implementation.dll")]
+	
+	public class UnusedForwarderWithAssemblyCopy
+	{
+		static void Main ()
+		{
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/UsedForwarderIsDynamicallyAccessedWithAssemblyCopyUsed.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/UsedForwarderIsDynamicallyAccessedWithAssemblyCopyUsed.cs
@@ -11,7 +11,7 @@ namespace Mono.Linker.Tests.Cases.TypeForwarding
 {
 
 	[SetupLinkerAction ("link", "test")]
-	[SetupLinkerUserAction ("copyused")]
+	[SetupLinkerDefaultAction ("copyused")]
 	[KeepTypeForwarderOnlyAssemblies ("false")]
 
 	[SetupCompileBefore ("Forwarder.dll", new[] { "Dependencies/ReferenceImplementationLibrary.cs" }, defines: new[] { "INCLUDE_REFERENCE_IMPL" })]

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/UsedForwarderIsDynamicallyAccessedWithAssemblyCopyUsed.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/UsedForwarderIsDynamicallyAccessedWithAssemblyCopyUsed.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.CodeAnalysis;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.TypeForwarding.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.TypeForwarding
+{
+
+	[SetupLinkerAction ("link", "test")]
+	[SetupLinkerUserAction ("copyused")]
+	[KeepTypeForwarderOnlyAssemblies ("false")]
+
+	[SetupCompileBefore ("Forwarder.dll", new[] { "Dependencies/ReferenceImplementationLibrary.cs" }, defines: new[] { "INCLUDE_REFERENCE_IMPL" })]
+
+	// After compiling the test case we then replace the reference impl with implementation + type forwarder
+	[SetupCompileAfter ("Implementation.dll", new[] { "Dependencies/ImplementationLibrary.cs" })]
+	[SetupCompileAfter ("Forwarder.dll", new[] { "Dependencies/ForwarderLibrary.cs" }, references: new[] { "Implementation.dll" })]
+
+	[KeptAssembly ("Forwarder.dll")]
+	[KeptMemberInAssembly ("Implementation.dll", typeof (ImplementationLibrary), "GetSomeValue()")]
+	[RemovedForwarder ("Forwarder.dll", nameof (ImplementationStruct))]
+	class UsedForwarderIsDynamicallyAccessedWithAssemblyCopyUsed
+	{
+		static void Main ()
+		{
+			PointToTypeInFacade ("Mono.Linker.Tests.Cases.TypeForwarding.Dependencies.ImplementationLibrary, Forwarder");
+		}
+
+		[Kept]
+		static void PointToTypeInFacade (
+			[KeptAttributeAttribute (typeof(DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] string typeName)
+		{
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/UsedTransitiveForwarderIsDynamicallyAccessed.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/UsedTransitiveForwarderIsDynamicallyAccessed.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.CodeAnalysis;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.TypeForwarding.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.TypeForwarding
+{
+	[SetupLinkerAction ("link", "test")]
+	[SetupLinkerUserAction ("copyused")]
+	[KeepTypeForwarderOnlyAssemblies ("false")]
+
+	[SetupCompileBefore ("SecondForwarder.dll", new[] { "Dependencies/ReferenceImplementationLibrary.cs" }, defines: new[] { "INCLUDE_REFERENCE_IMPL" })]
+	[SetupCompileBefore ("FirstForwarder.dll", new[] { "Dependencies/ForwarderLibrary.cs" }, references: new[] { "SecondForwarder.dll" })]
+
+	// After compiling the test case we then replace the reference impl with implementation + type forwarder
+	[SetupCompileAfter ("Implementation.dll", new[] { "Dependencies/ImplementationLibrary.cs" })]
+	[SetupCompileAfter ("SecondForwarder.dll", new[] { "Dependencies/ForwarderLibrary.cs" }, references: new[] { "Implementation.dll" })]
+
+	[KeptAssembly ("FirstForwarder.dll")]
+	[KeptAssembly ("SecondForwarder.dll")]
+	[KeptMemberInAssembly ("Implementation.dll", typeof (ImplementationLibrary), "GetSomeValue()")]
+	[RemovedForwarder ("FirstForwarder.dll", nameof (ImplementationStruct))]
+	[RemovedForwarder ("SecondForwarder.dll", nameof (ImplementationStruct))]
+	class UsedTransitiveForwarderIsDynamicallyAccessed
+	{
+		static void Main ()
+		{
+			// FirstForwarder -> SecondForwarder -> Implementation
+			PointToTypeInFacade ("Mono.Linker.Tests.Cases.TypeForwarding.Dependencies.ImplementationLibrary, FirstForwarder");
+		}
+
+		[Kept]
+		static void PointToTypeInFacade (
+			[KeptAttributeAttribute (typeof(DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] string typeName)
+		{
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/UsedTransitiveForwarderIsDynamicallyAccessed.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/UsedTransitiveForwarderIsDynamicallyAccessed.cs
@@ -10,7 +10,7 @@ using Mono.Linker.Tests.Cases.TypeForwarding.Dependencies;
 namespace Mono.Linker.Tests.Cases.TypeForwarding
 {
 	[SetupLinkerAction ("link", "test")]
-	[SetupLinkerUserAction ("copyused")]
+	[SetupLinkerDefaultAction ("copyused")]
 	[KeepTypeForwarderOnlyAssemblies ("false")]
 
 	[SetupCompileBefore ("SecondForwarder.dll", new[] { "Dependencies/ReferenceImplementationLibrary.cs" }, defines: new[] { "INCLUDE_REFERENCE_IMPL" })]

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/UsedTransitiveForwarderIsDynamicallyAccessed.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/UsedTransitiveForwarderIsDynamicallyAccessed.cs
@@ -21,10 +21,9 @@ namespace Mono.Linker.Tests.Cases.TypeForwarding
 	[SetupCompileAfter ("SecondForwarder.dll", new[] { "Dependencies/ForwarderLibrary.cs" }, references: new[] { "Implementation.dll" })]
 
 	[KeptAssembly ("FirstForwarder.dll")]
-	[KeptAssembly ("SecondForwarder.dll")]
 	[KeptMemberInAssembly ("Implementation.dll", typeof (ImplementationLibrary), "GetSomeValue()")]
+	[RemovedAssembly ("SecondForwarder.dll")]
 	[RemovedForwarder ("FirstForwarder.dll", nameof (ImplementationStruct))]
-	[RemovedForwarder ("SecondForwarder.dll", nameof (ImplementationStruct))]
 	class UsedTransitiveForwarderIsDynamicallyAccessed
 	{
 		static void Main ()


### PR DESCRIPTION
Reachable facade assemblies are currently dropped by the linker even if its forwarders are explicitly referenced in user annotations (note however that the user can work around this by rooting the facades).

This PR changes linker behavior so that type name strings pointing to a forwarded type cause the linker to mark the facade containing the forwarder as well as all other forwarders in the transitive chain pointing to the resolved type.

Fixes #1542

@eerhardt 