### PR TITLE
Remove line ending config from editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,9 +1,7 @@
 # top-most EditorConfig file
 root = true
-end_of_line = lf
 
 [*.cs]
-end_of_line = lf
 indent_style = tab
 indent_size = 4
 csharp_new_line_before_open_brace = types,methods


### PR DESCRIPTION
Git usually handles this correctly, and there are a number of problems with using LF locally on Windows.

For instance, testing code fixes needs to have a baseline file, but the codefix APIs always insert
Environment.Newline when applying the refactoring, which makes it difficult to record the baseline in the file.