### PR TITLE
Fix lint to avoid generating binlog file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,9 +1,7 @@
 # top-most EditorConfig file
 root = true
-end_of_line = lf
 
 [*.cs]
-end_of_line = lf
 indent_style = tab
 indent_size = 4
 csharp_new_line_before_open_brace = types,methods

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,9 @@
 # top-most EditorConfig file
 root = true
+end_of_line = lf
 
 [*.cs]
+end_of_line = lf
 indent_style = tab
 indent_size = 4
 csharp_new_line_before_open_brace = types,methods

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -141,7 +141,7 @@ stages:
       steps:
       - checkout: self
         submodules: true
-      - script: ./lint.sh --check
+      - script: ./lint.sh --check --verbosity diagnostic
 
 # Post-Build Arcade logic
 - ${{ if eq(variables.officialBuild, 'true') }}:

--- a/lint.cmd
+++ b/lint.cmd
@@ -1,3 +1,3 @@
 @echo off
 powershell -ExecutionPolicy ByPass -NoProfile -command "Set-Location %~dp0; & """%~dp0eng\dotnet.ps1""" ""tool restore"""
-powershell -ExecutionPolicy ByPass -NoProfile -command "Set-Location %~dp0; & """%~dp0eng\dotnet.ps1""" ""tool run dotnet-format -- illink.sln --verbosity diagnostic --fix-whitespace --exclude src/analyzer src/tuner external %*"""
+powershell -ExecutionPolicy ByPass -NoProfile -command "Set-Location %~dp0; & """%~dp0eng\dotnet.ps1""" ""tool run dotnet-format -- illink.sln --fix-whitespace --exclude src/analyzer src/tuner external %*"""

--- a/lint.sh
+++ b/lint.sh
@@ -14,4 +14,4 @@ done
 
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 "$scriptroot/eng/dotnet.sh" tool restore
-"$scriptroot/eng/dotnet.sh" tool run dotnet-format -- illink.sln --verbosity diagnostic --fix-whitespace --exclude src/analyzer src/tuner external $@
+"$scriptroot/eng/dotnet.sh" tool run dotnet-format -- illink.sln --fix-whitespace --exclude src/analyzer src/tuner external $@


### PR DESCRIPTION
Latest lint writes formatDiagnosticLog.binlong next to the solution file when running with --verbosity diagnostic. There's no way to redirect or disable this - https://github.com/dotnet/format/issues/1041.

So this change disables --verbosity diagnostic for local runs of lint and adds it only to the CI (where the machine will clean the enlistment anyway).