### PR TITLE
Basic tracking of MethodInfo and use it to improve Expression.Property and MakeGenericMethod

### DIFF
--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -880,7 +880,7 @@ This is technically possible if a custom assembly defines `DynamicDependencyAttr
   </linker>
   ```
 
-#### `IL2055`: Trim analysis: Call to 'System.Reflection.MethodInfo.MakeGenericType' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic type.
+#### `IL2055`: Trim analysis: Call to 'System.Type.MakeGenericType' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic type.
 
 - This can be either that the type on which the `MakeGenericType` is called can't be statically determined, or that the type parameters to be used for generic arguments can't be statically determined. If the open generic type has `DynamicallyAccessedMembersAttribute` on any of its generic parameters, ILLink currently can't validate that the requirements are fulfilled by the calling method.  
 
@@ -892,10 +892,10 @@ This is technically possible if a custom assembly defines `DynamicDependencyAttr
   
   void TestMethod(Type unknownType)
   {
-      // IL2055 Trim analysis: Call to `System.Reflection.MethodInfo.MakeGenericType(Type[])` can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic type.
+      // IL2055 Trim analysis: Call to `System.Type.MakeGenericType(Type[])` can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic type.
       typeof(Lazy<>).MakeGenericType(new Type[] { typeof(TestType) });
 
-      // IL2055 Trim analysis: Call to `System.Reflection.MethodInfo.MakeGenericType(Type[])` can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic type.
+      // IL2055 Trim analysis: Call to `System.Type.MakeGenericType(Type[])` can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic type.
       unknownType.MakeGenericType(new Type[] { typeof(TestType) });
   }
   ```
@@ -947,17 +947,27 @@ This is technically possible if a custom assembly defines `DynamicDependencyAttr
   }
   ```
 
-#### `IL2060`: Trim analysis: Call to `System.Reflection.MethodInfo.MakeGenericMethod` can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
+#### `IL2060`: Trim analysis: Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method
 
-- ILLink currently doesn't analyze `MethodInfo` values and thus can't statically determine the generic method the `MakeGenericMethod` operates on. If the actual method has generic parameters with `DynamicallyAccessedMembersAttribute` ILLink would be required to fulfill the requirements declared by those attributes, but since the ILLink doesn't know the method, it can't determine if such requirements exist.  
+- This can be either that the method on which the `MakeGenericMethod` is called can't be statically determined, or that the type parameters to be used for generic arguments can't be statically determined. If the open generic method has `DynamicallyAccessedMembersAttribute` on any of its generic parameters, ILLink currently can't validate that the requirements are fulfilled by the calling method.
 
-  ``` C#
-  void TestMethod()
+``` C#
+class Test
+{
+  public static void TestGenericMethod<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>()
   {
-      // IL2060 Trim analysis: Call to `System.Reflection.MethodInfo.MakeGenericMethod` can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
-      typeof(MyType).GetMethod("MyMethod").MakeGenericMethod(new Type[] { typeof(MyType) });
   }
-  ```
+  
+  void TestMethod(Type unknownType)
+  {
+    // IL2060 Trim analysis: Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method
+    typeof(Test).GetMethod("TestGenericMethod").MakeGenericMethod(new Type[] { typeof(TestType) });
+
+    // IL2060 Trim analysis: Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method
+    unknownMethod.MakeGenericMethod(new Type[] { typeof(TestType) });
+  }
+}
+```
 
 #### `IL2061`: Trim analysis: The assembly name 'assembly name' passed to method 'method' references assembly which is not available.
 
@@ -1522,6 +1532,18 @@ This is technically possible if a custom assembly defines `DynamicDependencyAttr
   // IL2102: Invalid AssemblyMetadata("IsTrimmable", "False") attribute in assembly 'assembly'. Value must be "True"
   [assembly: AssemblyMetadata("IsTrimmable", "False")] 
   ```
+
+#### `IL2103`: Trim analysis: Value passed to the 'propertyAccessor' parameter of method 'System.Linq.Expressions.Expression.Property(Expression, MethodInfo)' cannot be statically determined as a property accessor
+
+The value passed to the `propertyAccessor` parameter of `Expression.Property(expression, propertyAccessor)` was not recognized as a property accessor method. Trimmer can't guarantee the presence of the property.
+
+```C#
+void TestMethod(MethodInfo methodInfo)
+{
+  // IL2103: Value passed to the 'propertyAccessor' parameter of method 'System.Linq.Expressions.Expression.Property(Expression, MethodInfo)' cannot be statically determined as a property accessor.
+  Expression.Property(null, methodInfo);
+}
+```
 
 ## Single-File Warning Codes
 

--- a/src/linker/Linker.Dataflow/MethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/MethodBodyScanner.cs
@@ -715,6 +715,13 @@ namespace Mono.Linker.Dataflow
 					currentStack.Push (slot);
 					return;
 				}
+			} else if (operation.Operand is MethodReference methodReference) {
+				var resolvedMethod = methodReference.Resolve ();
+				if (resolvedMethod != null) {
+					StackSlot slot = new StackSlot (new RuntimeMethodHandleValue (resolvedMethod));
+					currentStack.Push (slot);
+					return;
+				}
 			}
 
 			PushUnknown (currentStack);

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -67,9 +67,6 @@ namespace Mono.Linker.Dataflow
 
 		public void ScanAndProcessReturnValue (MethodBody methodBody)
 		{
-			if (methodBody.Method.Name == "GetCSharpThunk")
-				Debug.WriteLine ("");
-
 			Scan (methodBody);
 
 			if (methodBody.Method.ReturnType.MetadataType != MetadataType.Void) {

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -1665,7 +1665,7 @@ namespace Mono.Linker.Dataflow
 			}
 		}
 
-		void ProcessGetMethodByName(
+		void ProcessGetMethodByName (
 			ref ReflectionPatternContext reflectionContext,
 			TypeDefinition typeDefinition,
 			string methodName,

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -67,6 +67,9 @@ namespace Mono.Linker.Dataflow
 
 		public void ScanAndProcessReturnValue (MethodBody methodBody)
 		{
+			if (methodBody.Method.Name == "GetCSharpThunk")
+				Debug.WriteLine ("");
+
 			Scan (methodBody);
 
 			if (methodBody.Method.ReturnType.MetadataType != MetadataType.Void) {
@@ -224,6 +227,7 @@ namespace Mono.Linker.Dataflow
 			TypeDelegator_Ctor,
 			Array_Empty,
 			TypeInfo_AsType,
+			MethodBase_GetMethodFromHandle,
 
 			// Anything above this marker will require the method to be run through
 			// the reflection body scanner.
@@ -282,6 +286,13 @@ namespace Mono.Linker.Dataflow
 				// System.Type.GetTypeHandle (Type type)
 				"get_TypeHandle" when calledMethod.IsDeclaredOnType ("System", "Type") => IntrinsicId.Type_get_TypeHandle,
 
+				// System.Reflection.MethodBase.GetMethodFromHandle (RuntimeMethodHandle handle)
+				// System.Reflection.MethodBase.GetMethodFromHandle (RuntimeMethodHandle handle, RuntimeTypeHandle declaringType)
+				"GetMethodFromHandle" when calledMethod.IsDeclaredOnType ("System.Reflection", "MethodBase")
+					&& calledMethod.HasParameterOfType (0, "System", "RuntimeMethodHandle")
+					&& (calledMethod.Parameters.Count == 1 || calledMethod.Parameters.Count == 2)
+					=> IntrinsicId.MethodBase_GetMethodFromHandle,
+
 				// static System.Type.MakeGenericType (Type [] typeArguments)
 				"MakeGenericType" when calledMethod.IsDeclaredOnType ("System", "Type") => IntrinsicId.Type_MakeGenericType,
 
@@ -322,9 +333,10 @@ namespace Mono.Linker.Dataflow
 					=> IntrinsicId.Expression_Field,
 
 				// static System.Linq.Expressions.Expression.Property (Expression, Type, String)
+				// static System.Linq.Expressions.Expression.Property (Expression, MethodInfo)
 				"Property" when calledMethod.IsDeclaredOnType ("System.Linq.Expressions", "Expression")
-					&& calledMethod.HasParameterOfType (1, "System", "Type")
-					&& calledMethod.Parameters.Count == 3
+					&& ((calledMethod.HasParameterOfType (1, "System", "Type") && calledMethod.Parameters.Count == 3)
+					|| (calledMethod.HasParameterOfType (1, "System.Reflection", "MethodInfo") && calledMethod.Parameters.Count == 2))
 					=> IntrinsicId.Expression_Property,
 
 				// static System.Linq.Expressions.Expression.New (Type)
@@ -652,12 +664,27 @@ namespace Mono.Linker.Dataflow
 					}
 					break;
 
+				// System.Reflection.MethodBase.GetMethodFromHandle (RuntimeMethodHandle handle)
+				// System.Reflection.MethodBase.GetMethodFromHandle (RuntimeMethodHandle handle, RuntimeTypeHandle declaringType)
+				case IntrinsicId.MethodBase_GetMethodFromHandle: {
+						// Infrastructure piece to support "ldtoken method -> GetMethodFromHandle"
+						if (methodParams[0] is RuntimeMethodHandleValue methodHandle)
+							methodReturnValue = new SystemReflectionMethodBaseValue (methodHandle.MethodRepresented);
+					}
+					break;
+
+				//
+				// System.Type
+				//
+				// Type MakeGenericType (params Type[] typeArguments)
+				//
 				case IntrinsicId.Type_MakeGenericType: {
 						reflectionContext.AnalyzingPattern ();
 						foreach (var value in methodParams[0].UniqueValues ()) {
 							if (value is SystemTypeValue typeValue) {
 								foreach (var genericParameter in typeValue.TypeRepresented.GenericParameters) {
-									if (_context.Annotations.FlowAnnotations.GetGenericParameterAnnotation (genericParameter) != DynamicallyAccessedMemberTypes.None) {
+									if (_context.Annotations.FlowAnnotations.GetGenericParameterAnnotation (genericParameter) != DynamicallyAccessedMemberTypes.None ||
+										genericParameter.HasDefaultConstructorConstraint) {
 										// There is a generic parameter which has some requirements on the input types.
 										// For now we don't support tracking actual array elements, so we can't validate that the requirements are fulfilled.
 										reflectionContext.RecordUnrecognizedPattern (
@@ -782,6 +809,39 @@ namespace Mono.Linker.Dataflow
 				//
 				// System.Linq.Expressions.Expression
 				// 
+				// static Property (Expression, MethodInfo)
+				//
+				case IntrinsicId.Expression_Property when calledMethod.HasParameterOfType (1, "System.Reflection", "MethodInfo"): {
+						reflectionContext.AnalyzingPattern ();
+
+						foreach (var value in methodParams[1].UniqueValues ()) {
+							if (value is SystemReflectionMethodBaseValue methodBaseValue) {
+								// We have one of the accessor for the property. The Expression.Property will in this case search
+								// for the matching PropertyInfo and store that. So to be perfectly correct we need to mark the
+								// respective PropertyInfo as "accessed via reflection".
+								var propertyDefinition = methodBaseValue.MethodRepresented.GetProperty ();
+								if (propertyDefinition != null) {
+									MarkProperty (ref reflectionContext, propertyDefinition);
+									continue;
+								}
+							} else if (value == NullValue.Instance) {
+								reflectionContext.RecordHandledPattern ();
+								continue;
+							}
+
+							// In all other cases we may not even know which type this is about, so there's nothing we can do
+							// report it as a warning.
+							reflectionContext.RecordUnrecognizedPattern (
+								2103, string.Format (Resources.Strings.IL2103,
+									DiagnosticUtilities.GetParameterNameForErrorMessage (calledMethod.Parameters[1]),
+									DiagnosticUtilities.GetMethodSignatureDisplayName (calledMethod)));
+						}
+					}
+					break;
+
+				//
+				// System.Linq.Expressions.Expression
+				// 
 				// static Field (Expression, Type, String)
 				// static Property (Expression, Type, String)
 				//
@@ -796,8 +856,6 @@ namespace Mono.Linker.Dataflow
 								foreach (var stringParam in methodParams[2].UniqueValues ()) {
 									if (stringParam is KnownStringValue stringValue) {
 										BindingFlags bindingFlags = methodParams[0].Kind == ValueNodeKind.Null ? BindingFlags.Static : BindingFlags.Default;
-										// TODO: Change this as needed after deciding if we are to keep all fields/properties on a type
-										// that is accessed via reflection. For now, let's only keep the field/property that is retrieved.
 										if (fieldOrPropertyInstrinsic == IntrinsicId.Expression_Property) {
 											MarkPropertiesOnTypeHierarchy (ref reflectionContext, systemTypeValue.TypeRepresented, filter: p => p.Name == stringValue.Contents, bindingFlags);
 										} else {
@@ -993,10 +1051,24 @@ namespace Mono.Linker.Dataflow
 							if (value is SystemTypeValue systemTypeValue) {
 								foreach (var stringParam in methodParams[1].UniqueValues ()) {
 									if (stringParam is KnownStringValue stringValue) {
-										if (BindingFlagsAreUnsupported (bindingFlags))
+										if (BindingFlagsAreUnsupported (bindingFlags)) {
 											RequireDynamicallyAccessedMembers (ref reflectionContext, DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods, value, calledMethodDefinition);
-										else
-											MarkMethodsOnTypeHierarchy (ref reflectionContext, systemTypeValue.TypeRepresented, m => m.Name == stringValue.Contents, bindingFlags);
+										} else {
+											bool foundAny = false;
+											foreach (var method in systemTypeValue.TypeRepresented.GetMethodsOnTypeHierarchy (m => m.Name == stringValue.Contents, bindingFlags)) {
+												MarkMethod (ref reflectionContext, method);
+												methodReturnValue = MergePointValue.MergeValues (methodReturnValue, new SystemReflectionMethodBaseValue (method));
+												foundAny = true;
+											}
+
+											// If there were no methods found the API will return null at runtime, so we should
+											// track the null as a return value as well.
+											// This also prevents warnings in such case, since if we don't set the return value it will be
+											// "unknown" and consumers may warn.
+											if (!foundAny)
+												methodReturnValue = MergePointValue.MergeValues (methodReturnValue, NullValue.Instance);
+										}
+
 										reflectionContext.RecordHandledPattern ();
 									} else {
 										// Otherwise fall back to the bitfield requirements
@@ -1463,9 +1535,34 @@ namespace Mono.Linker.Dataflow
 				case IntrinsicId.MethodInfo_MakeGenericMethod: {
 						reflectionContext.AnalyzingPattern ();
 
-						// We don't track MethodInfo values, so we can't determine if the MakeGenericMethod is problematic or not.
-						// Since some of the generic parameters may have annotations, all calls are potentially dangerous.
-						reflectionContext.RecordUnrecognizedPattern (2060, $"Call to `{calledMethod.GetDisplayName ()}` can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.");
+						foreach (var methodValue in methodParams[0].UniqueValues ()) {
+							if (methodValue is SystemReflectionMethodBaseValue methodBaseValue) {
+								foreach (var genericParameter in methodBaseValue.MethodRepresented.GenericParameters) {
+									if (_context.Annotations.FlowAnnotations.GetGenericParameterAnnotation (genericParameter) != DynamicallyAccessedMemberTypes.None ||
+										genericParameter.HasDefaultConstructorConstraint) {
+										// There is a generic parameter which has some requirements on input types.
+										// For now we don't support tracking actual array elements, so we can't validate that the requirements are fulfilled.
+										reflectionContext.RecordUnrecognizedPattern (
+											2060, string.Format (Resources.Strings.IL2060,
+												DiagnosticUtilities.GetMethodSignatureDisplayName (calledMethod)));
+									}
+								}
+
+								// We haven't found any generic parameters with annotations, so there's nothing to validate
+								reflectionContext.RecordHandledPattern ();
+							} else if (methodValue == NullValue.Instance) {
+								reflectionContext.RecordHandledPattern ();
+							} else {
+								// There is a generic parameter which has some requirements on input types.
+								// For now we don't support tracking actual array elements, so we can't validate that the requirements are fulfilled.
+								reflectionContext.RecordUnrecognizedPattern (
+									2060, string.Format (Resources.Strings.IL2060,
+										DiagnosticUtilities.GetMethodSignatureDisplayName (calledMethod)));
+							}
+						}
+
+						// MakeGenericMethod doesn't change the identity of the MethodBase we're tracking so propagate to the return value
+						methodReturnValue = methodParams[0];
 					}
 					break;
 

--- a/src/linker/Linker.Dataflow/ValueNode.cs
+++ b/src/linker/Linker.Dataflow/ValueNode.cs
@@ -30,6 +30,9 @@ namespace Mono.Linker.Dataflow
 		MethodParameter,                // symbolic placeholder
 		MethodReturn,                   // symbolic placeholder
 
+		RuntimeMethodHandle,            // known value - MethodRepresented
+		SystemReflectionMethodBase,     // known value - MethodRepresented
+
 		RuntimeTypeHandleForGenericParameter, // symbolic placeholder for generic parameter
 		SystemTypeForGenericParameter,        // symbolic placeholder for generic parameter
 
@@ -77,7 +80,7 @@ namespace Mono.Linker.Dataflow
 		/// applied so that each 'unique value' can be considered on its own without regard to the structure that led to
 		/// it.
 		/// </summary>
-		public UniqueValueCollection UniqueValues {
+		public UniqueValueCollection UniqueValuesInternal {
 			get {
 				return new UniqueValueCollection (this);
 			}
@@ -415,7 +418,7 @@ namespace Mono.Linker.Dataflow
 			if (node == null)
 				return new ValueNode.UniqueValueCollection (UnknownValue.Instance);
 
-			return node.UniqueValues;
+			return node.UniqueValuesInternal;
 		}
 
 		public static int? AsConstInt (this ValueNode node)
@@ -541,7 +544,7 @@ namespace Mono.Linker.Dataflow
 	}
 
 	/// <summary>
-	/// This is a known System.Type value.  TypeRepresented is the 'value' of the System.Type..
+	/// This is a known System.Type value.  TypeRepresented is the 'value' of the System.Type.
 	/// </summary>
 	class SystemTypeValue : LeafValueNode
 	{
@@ -677,6 +680,74 @@ namespace Mono.Linker.Dataflow
 		protected override string NodeToString ()
 		{
 			return ValueNodeDump.ValueNodeToString (this, GenericParameter);
+		}
+	}
+
+	/// <summary>
+	/// This is the System.RuntimeMethodHandle equivalent to a <see cref="SystemReflectionMethodBaseValue"/> node.
+	/// </summary>
+	class RuntimeMethodHandleValue : LeafValueNode
+	{
+		public RuntimeMethodHandleValue (MethodDefinition methodRepresented)
+		{
+			Kind = ValueNodeKind.RuntimeMethodHandle;
+			MethodRepresented = methodRepresented;
+		}
+
+		public MethodDefinition MethodRepresented { get; }
+
+		public override bool Equals (ValueNode other)
+		{
+			if (other == null)
+				return false;
+			if (this.Kind != other.Kind)
+				return false;
+
+			return Equals (this.MethodRepresented, ((RuntimeMethodHandleValue) other).MethodRepresented);
+		}
+
+		public override int GetHashCode ()
+		{
+			return HashCode.Combine (Kind, MethodRepresented);
+		}
+
+		protected override string NodeToString ()
+		{
+			return ValueNodeDump.ValueNodeToString (this, MethodRepresented);
+		}
+	}
+
+	/// <summary>
+	/// This is a known System.Reflection.MethodBase value.  MethodRepresented is the 'value' of the MethodBase.
+	/// </summary>
+	class SystemReflectionMethodBaseValue : LeafValueNode
+	{
+		public SystemReflectionMethodBaseValue (MethodDefinition methodRepresented)
+		{
+			Kind = ValueNodeKind.SystemReflectionMethodBase;
+			MethodRepresented = methodRepresented;
+		}
+
+		public MethodDefinition MethodRepresented { get; private set; }
+
+		public override bool Equals (ValueNode other)
+		{
+			if (other == null)
+				return false;
+			if (this.Kind != other.Kind)
+				return false;
+
+			return Equals (this.MethodRepresented, ((SystemReflectionMethodBaseValue) other).MethodRepresented);
+		}
+
+		public override int GetHashCode ()
+		{
+			return HashCode.Combine (Kind, MethodRepresented);
+		}
+
+		protected override string NodeToString ()
+		{
+			return ValueNodeDump.ValueNodeToString (this, MethodRepresented);
 		}
 	}
 
@@ -912,7 +983,7 @@ namespace Mono.Linker.Dataflow
 		protected override IEnumerable<ValueNode> EvaluateUniqueValues ()
 		{
 			foreach (ValueNode value in Values) {
-				foreach (ValueNode uniqueValue in value.UniqueValues) {
+				foreach (ValueNode uniqueValue in value.UniqueValuesInternal) {
 					yield return uniqueValue;
 				}
 			}
@@ -983,7 +1054,7 @@ namespace Mono.Linker.Dataflow
 		{
 			HashSet<string> names = null;
 
-			foreach (ValueNode nameStringValue in NameString.UniqueValues) {
+			foreach (ValueNode nameStringValue in NameString.UniqueValuesInternal) {
 				if (nameStringValue.Kind == ValueNodeKind.KnownString) {
 					if (names == null) {
 						names = new HashSet<string> ();
@@ -997,7 +1068,7 @@ namespace Mono.Linker.Dataflow
 			bool foundAtLeastOne = false;
 
 			if (names != null) {
-				foreach (ValueNode assemblyValue in AssemblyIdentity.UniqueValues) {
+				foreach (ValueNode assemblyValue in AssemblyIdentity.UniqueValuesInternal) {
 					if (assemblyValue.Kind == ValueNodeKind.KnownString) {
 						string assemblyName = ((KnownStringValue) assemblyValue).Contents;
 
@@ -1154,7 +1225,7 @@ namespace Mono.Linker.Dataflow
 
 		protected override IEnumerable<ValueNode> EvaluateUniqueValues ()
 		{
-			foreach (var sizeConst in Size.UniqueValues)
+			foreach (var sizeConst in Size.UniqueValuesInternal)
 				yield return new ArrayValue (sizeConst);
 		}
 

--- a/src/linker/Linker.Dataflow/ValueNode.cs
+++ b/src/linker/Linker.Dataflow/ValueNode.cs
@@ -380,6 +380,8 @@ namespace Mono.Linker.Dataflow
 			case ValueNodeKind.MethodReturn:
 			case ValueNodeKind.SystemTypeForGenericParameter:
 			case ValueNodeKind.RuntimeTypeHandleForGenericParameter:
+			case ValueNodeKind.SystemReflectionMethodBase:
+			case ValueNodeKind.RuntimeMethodHandle:
 			case ValueNodeKind.LoadField:
 				break;
 

--- a/src/linker/Resources/Strings.Designer.cs
+++ b/src/linker/Resources/Strings.Designer.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace Mono.Resources {
+namespace Mono.Linker.Resources {
     using System;
     
     
@@ -61,7 +61,16 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in call to &apos;{1}&apos;. The parameter &apos;{2}&apos; of method &apos;{3}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to Call to &apos;{0}&apos; can not be statically analyzed. It&apos;s not possible to guarantee the availability of requirements of the generic method..
+        /// </summary>
+        internal static string IL2060 {
+            get {
+                return ResourceManager.GetString("IL2060", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; argument does not satisfy {4} in call to &apos;{1}&apos;. The parameter &apos;{2}&apos; of method &apos;{3}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2067 {
             get {
@@ -70,7 +79,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; method return value does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; requirements. The parameter &apos;{1}&apos; of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; method return value does not satisfy {3} requirements. The parameter &apos;{1}&apos; of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2068 {
             get {
@@ -79,7 +88,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; field does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; requirements. The parameter &apos;{1}&apos; of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to value stored in field &apos;{0}&apos; does not satisfy {3} requirements. The parameter &apos;{1}&apos; of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2069 {
             get {
@@ -88,7 +97,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;this&apos; argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in call to &apos;{0}&apos;. The parameter &apos;{1}&apos; of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;this&apos; argument does not satisfy {3} in call to &apos;{0}&apos;. The parameter &apos;{1}&apos; of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2070 {
             get {
@@ -97,7 +106,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; generic argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in &apos;{1}&apos;. The parameter &apos;{2}&apos; of method &apos;{3}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; generic argument does not satisfy {4} in &apos;{1}&apos;. The parameter &apos;{2}&apos; of method &apos;{3}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2071 {
             get {
@@ -106,7 +115,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in call to &apos;{1}&apos;. The return value of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; argument does not satisfy {3} in call to &apos;{1}&apos;. The return value of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2072 {
             get {
@@ -115,7 +124,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; method return value does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; requirements. The return value of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; method return value does not satisfy {2} requirements. The return value of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2073 {
             get {
@@ -124,7 +133,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; field does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; requirements. The return value of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to value stored in field &apos;{0}&apos; does not satisfy {2} requirements. The return value of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2074 {
             get {
@@ -133,7 +142,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;this&apos; argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in call to &apos;{0}&apos;. The return value of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;this&apos; argument does not satisfy {2} in call to &apos;{0}&apos;. The return value of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2075 {
             get {
@@ -142,7 +151,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; generic argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in &apos;{1}&apos;. The return value of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; generic argument does not satisfy {3} in &apos;{1}&apos;. The return value of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2076 {
             get {
@@ -151,7 +160,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in call to &apos;{1}&apos;. The field &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; argument does not satisfy {3} in call to &apos;{1}&apos;. The field &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2077 {
             get {
@@ -160,7 +169,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; method return value does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; requirements. The field &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; method return value does not satisfy {2} requirements. The field &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2078 {
             get {
@@ -169,7 +178,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; field does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; requirements. The field &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to value stored in field &apos;{0}&apos; does not satisfy {2} requirements. The field &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2079 {
             get {
@@ -178,7 +187,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;this&apos; argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in call to &apos;{0}&apos;. The field &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;this&apos; argument does not satisfy {2} in call to &apos;{0}&apos;. The field &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2080 {
             get {
@@ -187,7 +196,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; generic argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in &apos;{1}&apos;. The field &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; generic argument does not satisfy {3} in &apos;{1}&apos;. The field &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2081 {
             get {
@@ -196,7 +205,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in call to &apos;{1}&apos;. The implicit &apos;this&apos; argument of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; argument does not satisfy {3} in call to &apos;{1}&apos;. The implicit &apos;this&apos; argument of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2082 {
             get {
@@ -205,7 +214,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; method return value does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; requirements. The implicit &apos;this&apos; argument of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; method return value does not satisfy {2} requirements. The implicit &apos;this&apos; argument of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2083 {
             get {
@@ -214,7 +223,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; field does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; requirements. The implicit &apos;this&apos; argument of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to value stored in field &apos;{0}&apos; does not satisfy {2} requirements. The implicit &apos;this&apos; argument of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2084 {
             get {
@@ -223,7 +232,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;this&apos; argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in call to &apos;{0}&apos;. The implicit &apos;this&apos; argument of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;this&apos; argument does not satisfy {2} in call to &apos;{0}&apos;. The implicit &apos;this&apos; argument of method &apos;{1}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2085 {
             get {
@@ -232,7 +241,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; generic argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in &apos;{1}&apos;. The implicit &apos;this&apos; argument of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; generic argument does not satisfy {3} in &apos;{1}&apos;. The implicit &apos;this&apos; argument of method &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2086 {
             get {
@@ -241,7 +250,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in call to &apos;{1}&apos;. The generic parameter &apos;{2}&apos; of &apos;{3}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; argument does not satisfy {4} in call to &apos;{1}&apos;. The generic parameter &apos;{2}&apos; of &apos;{3}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2087 {
             get {
@@ -250,7 +259,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; method return value does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; requirements. The generic parameter &apos;{1}&apos; of &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; method return value does not satisfy {3} requirements. The generic parameter &apos;{1}&apos; of &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2088 {
             get {
@@ -259,7 +268,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; field does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; requirements. The generic parameter &apos;{1}&apos; of &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to value stored in field &apos;{0}&apos; does not satisfy {3} requirements. The generic parameter &apos;{1}&apos; of &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2089 {
             get {
@@ -268,7 +277,7 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;this&apos; argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in call to &apos;{0}&apos;. The generic parameter &apos;{1}&apos; of &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;this&apos; argument does not satisfy {3} in call to &apos;{0}&apos;. The generic parameter &apos;{1}&apos; of &apos;{2}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2090 {
             get {
@@ -277,11 +286,20 @@ namespace Mono.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; generic argument does not satisfy &apos;DynamicallyAccessedMembersAttribute&apos; in &apos;{1}&apos;. The generic parameter &apos;{2}&apos; of &apos;{3}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
+        ///   Looks up a localized string similar to &apos;{0}&apos; generic argument does not satisfy {4} in &apos;{1}&apos;. The generic parameter &apos;{2}&apos; of &apos;{3}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2091 {
             get {
                 return ResourceManager.GetString("IL2091", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Value passed to the &apos;{0}&apos; parameter of method &apos;{1}&apos; cannot be statically determined as a property accessor..
+        /// </summary>
+        internal static string IL2103 {
+            get {
+                return ResourceManager.GetString("IL2103", resourceCulture);
             }
         }
     }

--- a/src/linker/Resources/Strings.resx
+++ b/src/linker/Resources/Strings.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="IL2060" xml:space="preserve">
+    <value>Call to '{0}' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.</value>
+  </data>
   <data name="IL2067" xml:space="preserve">
     <value>'{0}' argument does not satisfy {4} in call to '{1}'. The parameter '{2}' of method '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</value>
   </data>
@@ -191,5 +194,8 @@
   </data>
   <data name="IL2091" xml:space="preserve">
     <value>'{0}' generic argument does not satisfy {4} in '{1}'. The generic parameter '{2}' of '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</value>
+  </data>
+  <data name="IL2103" xml:space="preserve">
+    <value>Value passed to the '{0}' parameter of method '{1}' cannot be statically determined as a property accessor.</value>
   </data>
 </root>

--- a/src/linker/Resources/xlf/Strings.cs.xlf
+++ b/src/linker/Resources/xlf/Strings.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Strings.resx">
     <body>
+      <trans-unit id="IL2060">
+        <source>Call to '{0}' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.</source>
+        <target state="new">Call to '{0}' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IL2067">
         <source>'{0}' argument does not satisfy {4} in call to '{1}'. The parameter '{2}' of method '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</source>
         <target state="new">'{0}' argument does not satisfy {4} in call to '{1}'. The parameter '{2}' of method '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</target>
@@ -125,6 +130,11 @@
       <trans-unit id="IL2091">
         <source>'{0}' generic argument does not satisfy {4} in '{1}'. The generic parameter '{2}' of '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</source>
         <target state="new">'{0}' generic argument does not satisfy {4} in '{1}'. The generic parameter '{2}' of '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IL2103">
+        <source>Value passed to the '{0}' parameter of method '{1}' cannot be statically determined as a property accessor.</source>
+        <target state="new">Value passed to the '{0}' parameter of method '{1}' cannot be statically determined as a property accessor.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/linker/Resources/xlf/Strings.de.xlf
+++ b/src/linker/Resources/xlf/Strings.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Strings.resx">
     <body>
+      <trans-unit id="IL2060">
+        <source>Call to '{0}' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.</source>
+        <target state="new">Call to '{0}' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IL2067">
         <source>'{0}' argument does not satisfy {4} in call to '{1}'. The parameter '{2}' of method '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</source>
         <target state="new">'{0}' argument does not satisfy {4} in call to '{1}'. The parameter '{2}' of method '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</target>
@@ -125,6 +130,11 @@
       <trans-unit id="IL2091">
         <source>'{0}' generic argument does not satisfy {4} in '{1}'. The generic parameter '{2}' of '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</source>
         <target state="new">'{0}' generic argument does not satisfy {4} in '{1}'. The generic parameter '{2}' of '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IL2103">
+        <source>Value passed to the '{0}' parameter of method '{1}' cannot be statically determined as a property accessor.</source>
+        <target state="new">Value passed to the '{0}' parameter of method '{1}' cannot be statically determined as a property accessor.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/linker/Resources/xlf/Strings.es.xlf
+++ b/src/linker/Resources/xlf/Strings.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Strings.resx">
     <body>
+      <trans-unit id="IL2060">
+        <source>Call to '{0}' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.</source>
+        <target state="new">Call to '{0}' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IL2067">
         <source>'{0}' argument does not satisfy {4} in call to '{1}'. The parameter '{2}' of method '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</source>
         <target state="new">'{0}' argument does not satisfy {4} in call to '{1}'. The parameter '{2}' of method '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</target>
@@ -125,6 +130,11 @@
       <trans-unit id="IL2091">
         <source>'{0}' generic argument does not satisfy {4} in '{1}'. The generic parameter '{2}' of '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</source>
         <target state="new">'{0}' generic argument does not satisfy {4} in '{1}'. The generic parameter '{2}' of '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IL2103">
+        <source>Value passed to the '{0}' parameter of method '{1}' cannot be statically determined as a property accessor.</source>
+        <target state="new">Value passed to the '{0}' parameter of method '{1}' cannot be statically determined as a property accessor.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/linker/Resources/xlf/Strings.fr.xlf
+++ b/src/linker/Resources/xlf/Strings.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Strings.resx">
     <body>
+      <trans-unit id="IL2060">
+        <source>Call to '{0}' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.</source>
+        <target state="new">Call to '{0}' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IL2067">
         <source>'{0}' argument does not satisfy {4} in call to '{1}'. The parameter '{2}' of method '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</source>
         <target state="new">'{0}' argument does not satisfy {4} in call to '{1}'. The parameter '{2}' of method '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</target>
@@ -125,6 +130,11 @@
       <trans-unit id="IL2091">
         <source>'{0}' generic argument does not satisfy {4} in '{1}'. The generic parameter '{2}' of '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</source>
         <target state="new">'{0}' generic argument does not satisfy {4} in '{1}'. The generic parameter '{2}' of '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IL2103">
+        <source>Value passed to the '{0}' parameter of method '{1}' cannot be statically determined as a property accessor.</source>
+        <target state="new">Value passed to the '{0}' parameter of method '{1}' cannot be statically determined as a property accessor.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/linker/Resources/xlf/Strings.it.xlf
+++ b/src/linker/Resources/xlf/Strings.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Strings.resx">
     <body>
+      <trans-unit id="IL2060">
+        <source>Call to '{0}' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.</source>
+        <target state="new">Call to '{0}' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IL2067">
         <source>'{0}' argument does not satisfy {4} in call to '{1}'. The parameter '{2}' of method '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</source>
         <target state="new">'{0}' argument does not satisfy {4} in call to '{1}'. The parameter '{2}' of method '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</target>
@@ -125,6 +130,11 @@
       <trans-unit id="IL2091">
         <source>'{0}' generic argument does not satisfy {4} in '{1}'. The generic parameter '{2}' of '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</source>
         <target state="new">'{0}' generic argument does not satisfy {4} in '{1}'. The generic parameter '{2}' of '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IL2103">
+        <source>Value passed to the '{0}' parameter of method '{1}' cannot be statically determined as a property accessor.</source>
+        <target state="new">Value passed to the '{0}' parameter of method '{1}' cannot be statically determined as a property accessor.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/linker/Resources/xlf/Strings.ja.xlf
+++ b/src/linker/Resources/xlf/Strings.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Strings.resx">
     <body>
+      <trans-unit id="IL2060">
+        <source>Call to '{0}' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.</source>
+        <target state="new">Call to '{0}' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IL2067">
         <source>'{0}' argument does not satisfy {4} in call to '{1}'. The parameter '{2}' of method '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</source>
         <target state="new">'{0}' argument does not satisfy {4} in call to '{1}'. The parameter '{2}' of method '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</target>
@@ -125,6 +130,11 @@
       <trans-unit id="IL2091">
         <source>'{0}' generic argument does not satisfy {4} in '{1}'. The generic parameter '{2}' of '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</source>
         <target state="new">'{0}' generic argument does not satisfy {4} in '{1}'. The generic parameter '{2}' of '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IL2103">
+        <source>Value passed to the '{0}' parameter of method '{1}' cannot be statically determined as a property accessor.</source>
+        <target state="new">Value passed to the '{0}' parameter of method '{1}' cannot be statically determined as a property accessor.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/linker/Resources/xlf/Strings.ko.xlf
+++ b/src/linker/Resources/xlf/Strings.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Strings.resx">
     <body>
+      <trans-unit id="IL2060">
+        <source>Call to '{0}' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.</source>
+        <target state="new">Call to '{0}' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IL2067">
         <source>'{0}' argument does not satisfy {4} in call to '{1}'. The parameter '{2}' of method '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</source>
         <target state="new">'{0}' argument does not satisfy {4} in call to '{1}'. The parameter '{2}' of method '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</target>
@@ -125,6 +130,11 @@
       <trans-unit id="IL2091">
         <source>'{0}' generic argument does not satisfy {4} in '{1}'. The generic parameter '{2}' of '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</source>
         <target state="new">'{0}' generic argument does not satisfy {4} in '{1}'. The generic parameter '{2}' of '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IL2103">
+        <source>Value passed to the '{0}' parameter of method '{1}' cannot be statically determined as a property accessor.</source>
+        <target state="new">Value passed to the '{0}' parameter of method '{1}' cannot be statically determined as a property accessor.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/linker/Resources/xlf/Strings.pl.xlf
+++ b/src/linker/Resources/xlf/Strings.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Strings.resx">
     <body>
+      <trans-unit id="IL2060">
+        <source>Call to '{0}' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.</source>
+        <target state="new">Call to '{0}' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IL2067">
         <source>'{0}' argument does not satisfy {4} in call to '{1}'. The parameter '{2}' of method '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</source>
         <target state="new">'{0}' argument does not satisfy {4} in call to '{1}'. The parameter '{2}' of method '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</target>
@@ -125,6 +130,11 @@
       <trans-unit id="IL2091">
         <source>'{0}' generic argument does not satisfy {4} in '{1}'. The generic parameter '{2}' of '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</source>
         <target state="new">'{0}' generic argument does not satisfy {4} in '{1}'. The generic parameter '{2}' of '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IL2103">
+        <source>Value passed to the '{0}' parameter of method '{1}' cannot be statically determined as a property accessor.</source>
+        <target state="new">Value passed to the '{0}' parameter of method '{1}' cannot be statically determined as a property accessor.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/linker/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/linker/Resources/xlf/Strings.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Strings.resx">
     <body>
+      <trans-unit id="IL2060">
+        <source>Call to '{0}' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.</source>
+        <target state="new">Call to '{0}' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IL2067">
         <source>'{0}' argument does not satisfy {4} in call to '{1}'. The parameter '{2}' of method '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</source>
         <target state="new">'{0}' argument does not satisfy {4} in call to '{1}'. The parameter '{2}' of method '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</target>
@@ -125,6 +130,11 @@
       <trans-unit id="IL2091">
         <source>'{0}' generic argument does not satisfy {4} in '{1}'. The generic parameter '{2}' of '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</source>
         <target state="new">'{0}' generic argument does not satisfy {4} in '{1}'. The generic parameter '{2}' of '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IL2103">
+        <source>Value passed to the '{0}' parameter of method '{1}' cannot be statically determined as a property accessor.</source>
+        <target state="new">Value passed to the '{0}' parameter of method '{1}' cannot be statically determined as a property accessor.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/linker/Resources/xlf/Strings.ru.xlf
+++ b/src/linker/Resources/xlf/Strings.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Strings.resx">
     <body>
+      <trans-unit id="IL2060">
+        <source>Call to '{0}' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.</source>
+        <target state="new">Call to '{0}' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IL2067">
         <source>'{0}' argument does not satisfy {4} in call to '{1}'. The parameter '{2}' of method '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</source>
         <target state="new">'{0}' argument does not satisfy {4} in call to '{1}'. The parameter '{2}' of method '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</target>
@@ -125,6 +130,11 @@
       <trans-unit id="IL2091">
         <source>'{0}' generic argument does not satisfy {4} in '{1}'. The generic parameter '{2}' of '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</source>
         <target state="new">'{0}' generic argument does not satisfy {4} in '{1}'. The generic parameter '{2}' of '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IL2103">
+        <source>Value passed to the '{0}' parameter of method '{1}' cannot be statically determined as a property accessor.</source>
+        <target state="new">Value passed to the '{0}' parameter of method '{1}' cannot be statically determined as a property accessor.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/linker/Resources/xlf/Strings.tr.xlf
+++ b/src/linker/Resources/xlf/Strings.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Strings.resx">
     <body>
+      <trans-unit id="IL2060">
+        <source>Call to '{0}' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.</source>
+        <target state="new">Call to '{0}' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IL2067">
         <source>'{0}' argument does not satisfy {4} in call to '{1}'. The parameter '{2}' of method '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</source>
         <target state="new">'{0}' argument does not satisfy {4} in call to '{1}'. The parameter '{2}' of method '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</target>
@@ -125,6 +130,11 @@
       <trans-unit id="IL2091">
         <source>'{0}' generic argument does not satisfy {4} in '{1}'. The generic parameter '{2}' of '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</source>
         <target state="new">'{0}' generic argument does not satisfy {4} in '{1}'. The generic parameter '{2}' of '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IL2103">
+        <source>Value passed to the '{0}' parameter of method '{1}' cannot be statically determined as a property accessor.</source>
+        <target state="new">Value passed to the '{0}' parameter of method '{1}' cannot be statically determined as a property accessor.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/linker/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/linker/Resources/xlf/Strings.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Strings.resx">
     <body>
+      <trans-unit id="IL2060">
+        <source>Call to '{0}' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.</source>
+        <target state="new">Call to '{0}' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IL2067">
         <source>'{0}' argument does not satisfy {4} in call to '{1}'. The parameter '{2}' of method '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</source>
         <target state="new">'{0}' argument does not satisfy {4} in call to '{1}'. The parameter '{2}' of method '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</target>
@@ -125,6 +130,11 @@
       <trans-unit id="IL2091">
         <source>'{0}' generic argument does not satisfy {4} in '{1}'. The generic parameter '{2}' of '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</source>
         <target state="new">'{0}' generic argument does not satisfy {4} in '{1}'. The generic parameter '{2}' of '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IL2103">
+        <source>Value passed to the '{0}' parameter of method '{1}' cannot be statically determined as a property accessor.</source>
+        <target state="new">Value passed to the '{0}' parameter of method '{1}' cannot be statically determined as a property accessor.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/linker/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/linker/Resources/xlf/Strings.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Strings.resx">
     <body>
+      <trans-unit id="IL2060">
+        <source>Call to '{0}' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.</source>
+        <target state="new">Call to '{0}' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IL2067">
         <source>'{0}' argument does not satisfy {4} in call to '{1}'. The parameter '{2}' of method '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</source>
         <target state="new">'{0}' argument does not satisfy {4} in call to '{1}'. The parameter '{2}' of method '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</target>
@@ -125,6 +130,11 @@
       <trans-unit id="IL2091">
         <source>'{0}' generic argument does not satisfy {4} in '{1}'. The generic parameter '{2}' of '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</source>
         <target state="new">'{0}' generic argument does not satisfy {4} in '{1}'. The generic parameter '{2}' of '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IL2103">
+        <source>Value passed to the '{0}' parameter of method '{1}' cannot be statically determined as a property accessor.</source>
+        <target state="new">Value passed to the '{0}' parameter of method '{1}' cannot be statically determined as a property accessor.</target>
         <note />
       </trans-unit>
     </body>

--- a/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
@@ -868,9 +868,11 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				TestWithRequirements ();
 				TestWithRequirementsFromParam (null);
 				TestWithRequirementsFromGenericParam<TestType> ();
+				TestWithRequirementsViaRuntimeMethod ();
 
 				TestWithNoRequirements ();
 				TestWithNoRequirementsFromParam (null);
+				TestWithNoRequirementsViaRuntimeMethod ();
 
 				TestWithMultipleArgumentsWithRequirements ();
 
@@ -906,7 +908,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				messageCode: "IL2060")]
 			static void TestWithRequirements ()
 			{
-				typeof (MakeGenericMethod).GetMethod (nameof (GenericWithRequirements), BindingFlags.Static | BindingFlags.NonPublic)
+				typeof (MakeGenericMethod).GetMethod (nameof (GenericWithRequirements), BindingFlags.Static)
 					.MakeGenericMethod (typeof (TestType));
 			}
 
@@ -915,36 +917,51 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			static void TestWithRequirementsFromParam (
 				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] Type type)
 			{
-				typeof (MakeGenericMethod).GetMethod (nameof (GenericWithRequirements), BindingFlags.Static | BindingFlags.NonPublic)
+				typeof (MakeGenericMethod).GetMethod (nameof (GenericWithRequirements), BindingFlags.Static)
 					.MakeGenericMethod (type);
 			}
 
 			static void TestWithRequirementsFromGenericParam<
 				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T> ()
 			{
-				typeof (MakeGenericMethod).GetMethod (nameof (GenericWithRequirements), BindingFlags.Static | BindingFlags.NonPublic)
+				typeof (MakeGenericMethod).GetMethod (nameof (GenericWithRequirements), BindingFlags.Static)
 					.MakeGenericMethod (typeof (T));
 			}
 
-			static void GenericWithRequirements<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T> ()
+			[UnrecognizedReflectionAccessPattern (typeof (MethodInfo), nameof (MethodInfo.MakeGenericMethod), new Type[] { typeof (Type[]) },
+				messageCode: "IL2060")]
+			static void TestWithRequirementsViaRuntimeMethod ()
+			{
+				typeof (MakeGenericMethod).GetRuntimeMethod (nameof (GenericWithRequirements), Type.EmptyTypes)
+					.MakeGenericMethod (typeof (TestType));
+			}
+
+			public static void GenericWithRequirements<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T> ()
 			{
 			}
 
 			[RecognizedReflectionAccessPattern]
 			static void TestWithNoRequirements ()
 			{
-				typeof (MakeGenericMethod).GetMethod (nameof (GenericWithNoRequirements), BindingFlags.Static | BindingFlags.NonPublic)
+				typeof (MakeGenericMethod).GetMethod (nameof (GenericWithNoRequirements), BindingFlags.Static)
 					.MakeGenericMethod (typeof (TestType));
 			}
 
 			[RecognizedReflectionAccessPattern]
 			static void TestWithNoRequirementsFromParam (Type type)
 			{
-				typeof (MakeGenericMethod).GetMethod (nameof (GenericWithNoRequirements), BindingFlags.Static | BindingFlags.NonPublic)
+				typeof (MakeGenericMethod).GetMethod (nameof (GenericWithNoRequirements), BindingFlags.Static)
 					.MakeGenericMethod (type);
 			}
 
-			static void GenericWithNoRequirements<T> ()
+			[RecognizedReflectionAccessPattern]
+			static void TestWithNoRequirementsViaRuntimeMethod ()
+			{
+				typeof (MakeGenericMethod).GetRuntimeMethod (nameof (GenericWithNoRequirements), Type.EmptyTypes)
+					.MakeGenericMethod (typeof (TestType));
+			}
+
+			public static void GenericWithNoRequirements<T> ()
 			{
 			}
 

--- a/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Security.Policy;
 using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
@@ -27,8 +28,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			TestMultipleGenericParametersOnMethod ();
 			TestMethodGenericParametersViaInheritance ();
 
-			TestMakeGenericType ();
-			TestMakeGenericMethod ();
+			MakeGenericType.Test ();
+			MakeGenericMethod.Test ();
 
 			TestNewConstraintSatisfiesParameterlessConstructor<object> ();
 
@@ -740,131 +741,239 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		{
 		}
 
-		static void TestMakeGenericType ()
+		class MakeGenericType
 		{
-			TestMakeGenericTypeNullType ();
-			TestMakeGenericTypeUnknownInput (null);
-			TestMakeGenericTypeNoArguments ();
+			public static void Test ()
+			{
+				TestNullType ();
+				TestUnknownInput (null);
+				TestNoArguments ();
 
-			TestMakeGenericWithRequirements ();
-			TestMakeGenericWithRequirementsFromParam (null);
-			TestMakeGenericWithRequirementsFromGenericParam<TestType> ();
+				TestWithRequirements ();
+				TestWithRequirementsFromParam (null);
+				TestWithRequirementsFromGenericParam<TestType> ();
 
-			TestMakeGenericWithNoRequirements ();
-			TestMakeGenericWithNoRequirementsFromParam (null);
+				TestWithNoRequirements ();
+				TestWithNoRequirementsFromParam (null);
 
-			TestMakeGenericWithMultipleArgumentsWithRequirements ();
+				TestWithMultipleArgumentsWithRequirements ();
+
+				TestWithNewConstraint ();
+			}
+
+			// This is OK since we know it's null, so MakeGenericType is effectively a no-op (will throw)
+			// so no validation necessary.
+			[RecognizedReflectionAccessPattern]
+			static void TestNullType ()
+			{
+				Type nullType = null;
+				nullType.MakeGenericType (typeof (TestType));
+			}
+
+			[UnrecognizedReflectionAccessPattern (typeof (Type), nameof (Type.MakeGenericType), new Type[] { typeof (Type[]) },
+				messageCode: "IL2055")]
+			static void TestUnknownInput (Type inputType)
+			{
+				inputType.MakeGenericType (typeof (TestType));
+			}
+
+			[RecognizedReflectionAccessPattern]
+			static void TestNoArguments ()
+			{
+				typeof (TypeMakeGenericNoArguments).MakeGenericType ();
+			}
+
+			class TypeMakeGenericNoArguments
+			{
+			}
+
+			[UnrecognizedReflectionAccessPattern (typeof (Type), nameof (Type.MakeGenericType), new Type[] { typeof (Type[]) },
+				messageCode: "IL2055")]
+			static void TestWithRequirements ()
+			{
+				// Currently this is not analyzable since we don't track array elements.
+				// Would be really nice to support this kind of code in the future though.
+				typeof (GenericWithPublicFieldsArgument<>).MakeGenericType (typeof (TestType));
+			}
+
+			[UnrecognizedReflectionAccessPattern (typeof (Type), nameof (Type.MakeGenericType), new Type[] { typeof (Type[]) },
+				messageCode: "IL2055")]
+			static void TestWithRequirementsFromParam (
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] Type type)
+			{
+				typeof (GenericWithPublicFieldsArgument<>).MakeGenericType (type);
+			}
+
+			[UnrecognizedReflectionAccessPattern (typeof (Type), nameof (Type.MakeGenericType), new Type[] { typeof (Type[]) },
+				messageCode: "IL2055")]
+			static void TestWithRequirementsFromGenericParam<
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T> ()
+			{
+				typeof (GenericWithPublicFieldsArgument<>).MakeGenericType (typeof (T));
+			}
+
+			class GenericWithPublicFieldsArgument<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T>
+			{
+			}
+
+			[RecognizedReflectionAccessPattern]
+			static void TestWithNoRequirements ()
+			{
+				typeof (GenericWithNoRequirements<>).MakeGenericType (typeof (TestType));
+			}
+
+			[RecognizedReflectionAccessPattern]
+			static void TestWithNoRequirementsFromParam (Type type)
+			{
+				typeof (GenericWithNoRequirements<>).MakeGenericType (type);
+			}
+
+			class GenericWithNoRequirements<T>
+			{
+			}
+
+			[UnrecognizedReflectionAccessPattern (typeof (Type), nameof (Type.MakeGenericType), new Type[] { typeof (Type[]) },
+				messageCode: "IL2055")]
+			static void TestWithMultipleArgumentsWithRequirements ()
+			{
+				typeof (GenericWithMultipleArgumentsWithRequirements<,>).MakeGenericType (typeof (TestType), typeof (TestType));
+			}
+
+			class GenericWithMultipleArgumentsWithRequirements<
+				TOne,
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] TTwo>
+			{
+			}
+
+			[UnrecognizedReflectionAccessPattern (typeof (Type), nameof (Type.MakeGenericType), new Type[] { typeof (Type[]) },
+				messageCode: "IL2055")]
+			static void TestWithNewConstraint ()
+			{
+				typeof (GenericWithNewConstraint<>).MakeGenericType (typeof (TestType));
+			}
+
+			class GenericWithNewConstraint<T> where T : new()
+			{
+			}
 		}
 
-		// This is OK since we know it's null, so MakeGenericType is effectively a no-op (will throw)
-		// so no validation necessary.
-		[RecognizedReflectionAccessPattern]
-		static void TestMakeGenericTypeNullType ()
+		class MakeGenericMethod
 		{
-			Type nullType = null;
-			nullType.MakeGenericType (typeof (TestType));
-		}
+			public static void Test ()
+			{
+				TestNullMethod ();
+				TestUnknownInput (null);
+				TestWithNoArguments ();
 
-		[UnrecognizedReflectionAccessPattern (typeof (Type), nameof (Type.MakeGenericType), new Type[] { typeof (Type[]) }, messageCode: "IL2055")]
-		static void TestMakeGenericTypeUnknownInput (Type inputType)
-		{
-			inputType.MakeGenericType (typeof (TestType));
-		}
+				TestWithRequirements ();
+				TestWithRequirementsFromParam (null);
+				TestWithRequirementsFromGenericParam<TestType> ();
 
-		[RecognizedReflectionAccessPattern]
-		static void TestMakeGenericTypeNoArguments ()
-		{
-			typeof (TypeMakeGenericNoArguments).MakeGenericType ();
-		}
+				TestWithNoRequirements ();
+				TestWithNoRequirementsFromParam (null);
 
-		class TypeMakeGenericNoArguments
-		{
-		}
+				TestWithMultipleArgumentsWithRequirements ();
 
-		[UnrecognizedReflectionAccessPattern (typeof (Type), nameof (Type.MakeGenericType), new Type[] { typeof (Type[]) }, messageCode: "IL2055")]
-		static void TestMakeGenericWithRequirements ()
-		{
-			// Currently this is not analyzable since we don't track array elements.
-			// Would be really nice to support this kind of code in the future though.
-			typeof (TypeMakeGenericWithPublicFieldsArgument<>).MakeGenericType (typeof (TestType));
-		}
+				TestWithNewConstraint ();
+			}
 
-		[UnrecognizedReflectionAccessPattern (typeof (Type), nameof (Type.MakeGenericType), new Type[] { typeof (Type[]) }, messageCode: "IL2055")]
-		static void TestMakeGenericWithRequirementsFromParam (
-			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] Type type)
-		{
-			typeof (TypeMakeGenericWithPublicFieldsArgument<>).MakeGenericType (type);
-		}
+			[RecognizedReflectionAccessPattern]
+			static void TestNullMethod ()
+			{
+				MethodInfo mi = null;
+				mi.MakeGenericMethod (typeof (TestType));
+			}
 
-		[UnrecognizedReflectionAccessPattern (typeof (Type), nameof (Type.MakeGenericType), new Type[] { typeof (Type[]) }, messageCode: "IL2055")]
-		static void TestMakeGenericWithRequirementsFromGenericParam<
-			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T> ()
-		{
-			typeof (TypeMakeGenericWithPublicFieldsArgument<>).MakeGenericType (typeof (T));
-		}
+			[UnrecognizedReflectionAccessPattern (typeof (MethodInfo), nameof (MethodInfo.MakeGenericMethod), new Type[] { typeof (Type[]) },
+				messageCode: "IL2060")]
+			static void TestUnknownInput (MethodInfo mi)
+			{
+				mi.MakeGenericMethod (typeof (TestType));
+			}
 
-		class TypeMakeGenericWithPublicFieldsArgument<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T>
-		{
-		}
+			[RecognizedReflectionAccessPattern]
+			static void TestWithNoArguments ()
+			{
+				typeof (MakeGenericMethod).GetMethod (nameof (NonGenericMethod), BindingFlags.Static | BindingFlags.NonPublic)
+					.MakeGenericMethod ();
+			}
 
-		[RecognizedReflectionAccessPattern]
-		static void TestMakeGenericWithNoRequirements ()
-		{
-			typeof (TypeMakeGenericWithNoRequirements<>).MakeGenericType (typeof (TestType));
-		}
+			static void NonGenericMethod ()
+			{
+			}
 
-		[RecognizedReflectionAccessPattern]
-		static void TestMakeGenericWithNoRequirementsFromParam (Type type)
-		{
-			typeof (TypeMakeGenericWithNoRequirements<>).MakeGenericType (type);
-		}
+			[UnrecognizedReflectionAccessPattern (typeof (MethodInfo), nameof (MethodInfo.MakeGenericMethod), new Type[] { typeof (Type[]) },
+				messageCode: "IL2060")]
+			static void TestWithRequirements ()
+			{
+				typeof (MakeGenericMethod).GetMethod (nameof (GenericWithRequirements), BindingFlags.Static | BindingFlags.NonPublic)
+					.MakeGenericMethod (typeof (TestType));
+			}
 
-		class TypeMakeGenericWithNoRequirements<T>
-		{
-		}
+			[UnrecognizedReflectionAccessPattern (typeof (MethodInfo), nameof (MethodInfo.MakeGenericMethod), new Type[] { typeof (Type[]) },
+				messageCode: "IL2060")]
+			static void TestWithRequirementsFromParam (
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] Type type)
+			{
+				typeof (MakeGenericMethod).GetMethod (nameof (GenericWithRequirements), BindingFlags.Static | BindingFlags.NonPublic)
+					.MakeGenericMethod (type);
+			}
 
-		[UnrecognizedReflectionAccessPattern (typeof (Type), nameof (Type.MakeGenericType), new Type[] { typeof (Type[]) }, messageCode: "IL2055")]
-		static void TestMakeGenericWithMultipleArgumentsWithRequirements ()
-		{
-			typeof (TypeMakeGenericWithMultipleArgumentsWithRequirements<,>).MakeGenericType (typeof (TestType), typeof (TestType));
-		}
+			static void TestWithRequirementsFromGenericParam<
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T> ()
+			{
+				typeof (MakeGenericMethod).GetMethod (nameof (GenericWithRequirements), BindingFlags.Static | BindingFlags.NonPublic)
+					.MakeGenericMethod (typeof (T));
+			}
 
-		class TypeMakeGenericWithMultipleArgumentsWithRequirements<
-			TOne,
-			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] TTwo>
-		{
-		}
+			static void GenericWithRequirements<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T> ()
+			{
+			}
 
-		static void TestMakeGenericMethod ()
-		{
-			TestMakeGenericMethodWithRequirements ();
-			TestMakeGenericMethodWithNoRequirements ();
-		}
+			[RecognizedReflectionAccessPattern]
+			static void TestWithNoRequirements ()
+			{
+				typeof (MakeGenericMethod).GetMethod (nameof (GenericWithNoRequirements), BindingFlags.Static | BindingFlags.NonPublic)
+					.MakeGenericMethod (typeof (TestType));
+			}
 
-		[UnrecognizedReflectionAccessPattern (typeof (System.Reflection.MethodInfo), nameof (System.Reflection.MethodInfo.MakeGenericMethod), new Type[] { typeof (Type[]) }, messageCode: "IL2060")]
-		static void TestMakeGenericMethodWithRequirements ()
-		{
-			typeof (GenericParameterDataFlow).GetMethod (nameof (MethodMakeGenericWithRequirements), BindingFlags.Static | BindingFlags.NonPublic)
-				.MakeGenericMethod (typeof (TestType));
-		}
+			[RecognizedReflectionAccessPattern]
+			static void TestWithNoRequirementsFromParam (Type type)
+			{
+				typeof (MakeGenericMethod).GetMethod (nameof (GenericWithNoRequirements), BindingFlags.Static | BindingFlags.NonPublic)
+					.MakeGenericMethod (type);
+			}
 
-		static void MethodMakeGenericWithRequirements<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T> ()
-		{
-		}
+			static void GenericWithNoRequirements<T> ()
+			{
+			}
 
-		[UnrecognizedReflectionAccessPattern (typeof (System.Reflection.MethodInfo), nameof (System.Reflection.MethodInfo.MakeGenericMethod), new Type[] { typeof (Type[]) }, messageCode: "IL2060")]
-		static void TestMakeGenericMethodWithNoRequirements ()
-		{
-			typeof (GenericParameterDataFlow).GetMethod (nameof (MethodMakeGenericWithNoRequirements), BindingFlags.Static | BindingFlags.NonPublic)
-				.MakeGenericMethod (typeof (TestType));
-		}
+			[UnrecognizedReflectionAccessPattern (typeof (MethodInfo), nameof (MethodInfo.MakeGenericMethod), new Type[] { typeof (Type[]) },
+				messageCode: "IL2060")]
+			static void TestWithMultipleArgumentsWithRequirements ()
+			{
+				typeof (MakeGenericMethod).GetMethod (nameof (GenericWithMultipleArgumentsWithRequirements), BindingFlags.Static | BindingFlags.NonPublic)
+					.MakeGenericMethod (typeof (TestType), typeof (TestType));
+			}
 
-		static void MethodMakeGenericWithNoRequirements<T> ()
-		{
-		}
+			static void GenericWithMultipleArgumentsWithRequirements<
+				TOne,
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] TTwo> ()
+			{
+			}
 
-		public class TestType
-		{
+			[UnrecognizedReflectionAccessPattern (typeof (MethodInfo), nameof (MethodInfo.MakeGenericMethod), new Type[] { typeof (Type[]) },
+				messageCode: "IL2060")]
+			static void TestWithNewConstraint ()
+			{
+				typeof (MakeGenericMethod).GetMethod (nameof (GenericWithNewConstraint), BindingFlags.Static | BindingFlags.NonPublic)
+					.MakeGenericMethod (typeof (TestType));
+			}
+
+			static void GenericWithNewConstraint<T> () where T : new()
+			{
+				var t = new T ();
+			}
 		}
 
 		[RecognizedReflectionAccessPattern]
@@ -874,6 +983,10 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		static void RequiresParameterlessConstructor<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T> ()
+		{
+		}
+
+		public class TestType
 		{
 		}
 	}

--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionPropertyMethodInfo.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionPropertyMethodInfo.cs
@@ -1,0 +1,192 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Reflection
+{
+	[ExpectedNoWarnings]
+	public class ExpressionPropertyMethodInfo
+	{
+		public static void Main ()
+		{
+			PropertyGetter.Test ();
+			PropertySetter.Test ();
+			TestNull ();
+			TestNonPropertyMethod ();
+			TestNonExistentMethod ();
+			MultipleMethods.Test (0);
+			TestUnknownMethod (null);
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		class PropertyGetter
+		{
+			[Kept]
+			[KeptBackingField]
+			public static int StaticProperty {
+				[Kept]
+				get;
+				[Kept]
+				set;
+			}
+
+			[Kept]
+			[KeptBackingField]
+			public static int StaticPropertyViaReflection {
+				[Kept]
+				get;
+				[Kept]
+				set;
+			}
+
+			[Kept]
+			[KeptBackingField]
+			public int InstanceProperty {
+				[Kept]
+				get;
+				[Kept]
+				set;
+			}
+
+			[Kept]
+			[KeptBackingField]
+			public int InstancePropertyViaReflection {
+				[Kept]
+				get;
+				[Kept]
+				set;
+			}
+
+			[Kept]
+			[RecognizedReflectionAccessPattern]
+			public static void Test ()
+			{
+				Expression<Func<int>> staticGetter = () => StaticProperty;
+
+				Expression.Property (null, typeof (PropertyGetter).GetMethod ("get_StaticPropertyViaReflection"));
+
+				PropertyGetter instance = new PropertyGetter ();
+				Expression<Func<PropertyGetter, int>> instanceGetter = i => i.InstanceProperty;
+
+				Expression.Property (Expression.New (typeof (PropertyGetter)), typeof (PropertyGetter).GetMethod ("get_InstancePropertyViaReflection"));
+			}
+		}
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		class PropertySetter
+		{
+			[Kept]
+			[KeptBackingField]
+			public static int StaticProperty {
+				[Kept]
+				get;
+				[Kept]
+				set;
+			}
+
+			[Kept]
+			[KeptBackingField]
+			public int InstanceProperty {
+				[Kept]
+				get;
+				[Kept]
+				set;
+			}
+
+			[Kept]
+			[RecognizedReflectionAccessPattern]
+			public static void Test ()
+			{
+				Expression.Property (null, typeof (PropertySetter).GetMethod ("set_StaticProperty"));
+
+				Expression.Property (Expression.New (typeof (PropertySetter)), typeof (PropertySetter).GetMethod ("set_InstanceProperty"));
+			}
+		}
+
+		[Kept]
+		[RecognizedReflectionAccessPattern]
+		static void TestNull ()
+		{
+			MethodInfo mi = null;
+			Expression.Property (null, mi);
+		}
+
+		[Kept]
+		[UnrecognizedReflectionAccessPattern (
+			typeof (Expression), nameof (Expression.Property), new Type[] { typeof (Expression), typeof (MethodInfo) },
+			messageCode: "IL2103")]
+		static void TestNonPropertyMethod ()
+		{
+			Expression.Property (null, typeof (ExpressionPropertyMethodInfo).GetMethod (nameof (TestNonPropertyMethod), BindingFlags.NonPublic | BindingFlags.Static));
+		}
+
+		[Kept]
+		[RecognizedReflectionAccessPattern]
+		static void TestNonExistentMethod ()
+		{
+			Expression.Property (null, typeof (ExpressionPropertyMethodInfo).GetMethod ("NonExistent"));
+		}
+
+		[Kept]
+		class MultipleMethods
+		{
+			[Kept]
+			[KeptBackingField]
+			public static int StaticProperty {
+				[Kept]
+				get;
+				[Kept]
+				set;
+			}
+
+			[Kept]
+			[KeptBackingField]
+			public static int SecondStaticProperty {
+				[Kept]
+				get;
+				[Kept]
+				set;
+			}
+
+			[Kept]
+			[RecognizedReflectionAccessPattern]
+			public static void Test (int p)
+			{
+				MethodInfo mi;
+				switch (p) {
+				case 0:
+					mi = typeof (MultipleMethods).GetMethod ("get_StaticProperty");
+					break;
+				case 1:
+					mi = typeof (MultipleMethods).GetMethod ("get_SecondStaticProperty");
+					break;
+				default:
+					mi = null;
+					break;
+				}
+
+				Expression.Property (null, mi);
+			}
+		}
+
+		[Kept]
+		[UnrecognizedReflectionAccessPattern (
+			typeof (Expression), nameof (Expression.Property), new Type[] { typeof (Expression), typeof (MethodInfo) },
+			messageCode: "IL2103")]
+		static void TestUnknownMethod (MethodInfo mi)
+		{
+			Expression.Property (null, mi);
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionPropertyMethodInfo.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionPropertyMethodInfo.cs
@@ -51,6 +51,15 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
 			[Kept]
 			[KeptBackingField]
+			public static int StaticPropertyViaRuntimeMethod {
+				[Kept]
+				get;
+				[Kept]
+				set;
+			}
+
+			[Kept]
+			[KeptBackingField]
 			public int InstanceProperty {
 				[Kept]
 				get;
@@ -79,6 +88,8 @@ namespace Mono.Linker.Tests.Cases.Reflection
 				Expression<Func<PropertyGetter, int>> instanceGetter = i => i.InstanceProperty;
 
 				Expression.Property (Expression.New (typeof (PropertyGetter)), typeof (PropertyGetter).GetMethod ("get_InstancePropertyViaReflection"));
+
+				Expression.Property (null, typeof (PropertyGetter).GetRuntimeMethod ("get_StaticPropertyViaRuntimeMethod", Type.EmptyTypes));
 			}
 		}
 
@@ -89,6 +100,15 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[Kept]
 			[KeptBackingField]
 			public static int StaticProperty {
+				[Kept]
+				get;
+				[Kept]
+				set;
+			}
+
+			[Kept]
+			[KeptBackingField]
+			public static int StaticPropertyViaRuntimeMethod {
 				[Kept]
 				get;
 				[Kept]
@@ -109,6 +129,8 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			public static void Test ()
 			{
 				Expression.Property (null, typeof (PropertySetter).GetMethod ("set_StaticProperty"));
+
+				Expression.Property (null, typeof (PropertySetter).GetRuntimeMethod ("set_StaticPropertyViaRuntimeMethod", Type.EmptyTypes));
 
 				Expression.Property (Expression.New (typeof (PropertySetter)), typeof (PropertySetter).GetMethod ("set_InstanceProperty"));
 			}


### PR DESCRIPTION
Adds the ability to track some basic patterns around `MethodBase`/`MethodInfo`. Linker now recognizes `ldtoken` for a method as well as tracks return value of `Type.GetMethod`.

With this, the change implements two improvements:

#1814 - Mark property as accessed via reflection when using Expression.Property(Expression,MethodInfo)

Added a new warning to report cases where the intrinsic handling of the Property call doesn't work.

#1727 - Ability to handle simple MakeGenericMethod calls without generating a warning

If the generic method has no annotations on the generic arguments, linker will no longer warn.

Added tests for all the new behaviors.
Improved tests for MakeGenericMethod and MakeGenericType.
Implement checking for new constraint in MakeGenericType - it now behaves the same as if the generic argument is annotated.