### PR TITLE
Change line endings to auto

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,4 @@
 # Autodetect text files
 * text=auto
 
-# Declare files that will always have LF line endings on checkout.
-*.cs text=auto diff=csharp
-*.csproj text=auto
-*.sln text=auto
-*.xml text=auto
+*.cs diff=csharp

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,7 @@
 * text=auto
 
 # Declare files that will always have LF line endings on checkout.
-*.cs text eol=lf
-*.csproj text eol=lf
-*.sln text eol=lf
-*.xml text eol=lf
+*.cs text=auto diff=csharp
+*.csproj text=auto
+*.sln text=auto
+*.xml text=auto


### PR DESCRIPTION
This fixes the problem on Windows where files are checked out as LF, but formatting/lint will enforce CRLF.

To apply to an existing clone of the repo run from the repo root. There should be no un-commited local changes, it should work find with locally commited changes.

```console
git rm -r :/
git checkout HEAD -- :/
```