### PR TITLE
Fix stack overflow in MarkEntireType

### DIFF
--- a/test/Mono.Linker.Tests.Cases/DataFlow/AttributeConstructorDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/AttributeConstructorDataflow.cs
@@ -22,6 +22,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		{
 			typeof (AttributeConstructorDataflow).GetMethod ("Main").GetCustomAttribute (typeof (KeepsPublicConstructorAttribute));
 			typeof (AttributeConstructorDataflow).GetMethod ("Main").GetCustomAttribute (typeof (KeepsPublicMethodsAttribute));
+			AllOnSelf.Test ();
 		}
 
 		[Kept]
@@ -67,6 +68,43 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[Kept]
 			public static void KeptMethod () { }
 			static void Method () { }
+		}
+
+		[Kept]
+		class AllOnSelf
+		{
+			[Kept]
+			[RecognizedReflectionAccessPattern]
+			public static void Test ()
+			{
+				var t = typeof (KeepAllOnSelf);
+			}
+
+			[Kept]
+			[KeptBaseType (typeof (Attribute))]
+			class KeepsAllAttribute : Attribute
+			{
+				[Kept]
+				public KeepsAllAttribute (
+					[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+					[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+					Type type)
+				{
+				}
+			}
+
+			[KeepsAll(typeof(KeepAllOnSelf))]
+			[Kept]
+			[KeptAttributeAttribute(typeof(KeepsAllAttribute))]
+			[KeptMember(".ctor()")]
+			class KeepAllOnSelf
+			{
+				[Kept]
+				public void Method () { }
+
+				[Kept]
+				public int Field;
+			}
 		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/DataFlow/AttributeConstructorDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/AttributeConstructorDataflow.cs
@@ -93,10 +93,10 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				}
 			}
 
-			[KeepsAll(typeof(KeepAllOnSelf))]
+			[KeepsAll (typeof (KeepAllOnSelf))]
 			[Kept]
-			[KeptAttributeAttribute(typeof(KeepsAllAttribute))]
-			[KeptMember(".ctor()")]
+			[KeptAttributeAttribute (typeof (KeepsAllAttribute))]
+			[KeptMember (".ctor()")]
 			class KeepAllOnSelf
 			{
 				[Kept]


### PR DESCRIPTION
If the type has a custom attribute which will cause MarkEntireType on the type itself (for example through data flow annotation), we will end up recursively calling MarkEntireType with the same input - leading to stack overflow.

The existing protection against SO in MarkEntireType is not enough since it only works on immediate recursion, not through custom attribute marking.

So moved the hashset of entire types marked as global on MarkStep, which prevents the recursion no matter the codepath.
