### PR TITLE
Relax validtion of MakeGeneric* on struct and unmanaged constraint

### DIFF
--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -681,7 +681,7 @@ namespace Mono.Linker.Dataflow
 							if (value is SystemTypeValue typeValue) {
 								foreach (var genericParameter in typeValue.TypeRepresented.GenericParameters) {
 									if (_context.Annotations.FlowAnnotations.GetGenericParameterAnnotation (genericParameter) != DynamicallyAccessedMemberTypes.None ||
-										genericParameter.HasDefaultConstructorConstraint) {
+										(genericParameter.HasDefaultConstructorConstraint && !genericParameter.HasNotNullableValueTypeConstraint)) {
 										// There is a generic parameter which has some requirements on the input types.
 										// For now we don't support tracking actual array elements, so we can't validate that the requirements are fulfilled.
 										reflectionContext.RecordUnrecognizedPattern (
@@ -1524,7 +1524,7 @@ namespace Mono.Linker.Dataflow
 							if (methodValue is SystemReflectionMethodBaseValue methodBaseValue) {
 								foreach (var genericParameter in methodBaseValue.MethodRepresented.GenericParameters) {
 									if (_context.Annotations.FlowAnnotations.GetGenericParameterAnnotation (genericParameter) != DynamicallyAccessedMemberTypes.None ||
-										genericParameter.HasDefaultConstructorConstraint) {
+										(genericParameter.HasDefaultConstructorConstraint && !genericParameter.HasNotNullableValueTypeConstraint)) {
 										// There is a generic parameter which has some requirements on input types.
 										// For now we don't support tracking actual array elements, so we can't validate that the requirements are fulfilled.
 										reflectionContext.RecordUnrecognizedPattern (

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -681,9 +681,14 @@ namespace Mono.Linker.Dataflow
 							if (value is SystemTypeValue typeValue) {
 								foreach (var genericParameter in typeValue.TypeRepresented.GenericParameters) {
 									if (_context.Annotations.FlowAnnotations.GetGenericParameterAnnotation (genericParameter) != DynamicallyAccessedMemberTypes.None ||
-										(genericParameter.HasDefaultConstructorConstraint && !genericParameter.HasNotNullableValueTypeConstraint)) {
+										(genericParameter.HasDefaultConstructorConstraint && !typeValue.TypeRepresented.IsTypeOf ("System", "Nullable"))) {
 										// There is a generic parameter which has some requirements on the input types.
 										// For now we don't support tracking actual array elements, so we can't validate that the requirements are fulfilled.
+
+										// Special case: Nullable<T> where T : struct
+										//  The struct constraint in C# implies new() constraints, but Nullable doesn't make a use of that part.
+										//  There are several places even in the framework where typeof(Nullable<>).MakeGenericType would warn
+										//  without any good reason to do so.
 										reflectionContext.RecordUnrecognizedPattern (
 											2055,
 											$"Call to '{calledMethodDefinition.GetDisplayName ()}' can not be statically analyzed. " +
@@ -1524,7 +1529,7 @@ namespace Mono.Linker.Dataflow
 							if (methodValue is SystemReflectionMethodBaseValue methodBaseValue) {
 								foreach (var genericParameter in methodBaseValue.MethodRepresented.GenericParameters) {
 									if (_context.Annotations.FlowAnnotations.GetGenericParameterAnnotation (genericParameter) != DynamicallyAccessedMemberTypes.None ||
-										(genericParameter.HasDefaultConstructorConstraint && !genericParameter.HasNotNullableValueTypeConstraint)) {
+										genericParameter.HasDefaultConstructorConstraint) {
 										// There is a generic parameter which has some requirements on input types.
 										// For now we don't support tracking actual array elements, so we can't validate that the requirements are fulfilled.
 										reflectionContext.RecordUnrecognizedPattern (

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -681,7 +681,7 @@ namespace Mono.Linker.Dataflow
 							if (value is SystemTypeValue typeValue) {
 								foreach (var genericParameter in typeValue.TypeRepresented.GenericParameters) {
 									if (_context.Annotations.FlowAnnotations.GetGenericParameterAnnotation (genericParameter) != DynamicallyAccessedMemberTypes.None ||
-										(genericParameter.HasDefaultConstructorConstraint && !typeValue.TypeRepresented.IsTypeOf ("System", "Nullable"))) {
+										(genericParameter.HasDefaultConstructorConstraint && !typeValue.TypeRepresented.IsTypeOf ("System", "Nullable`1"))) {
 										// There is a generic parameter which has some requirements on the input types.
 										// For now we don't support tracking actual array elements, so we can't validate that the requirements are fulfilled.
 

--- a/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
@@ -763,6 +763,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				TestWithNewConstraint ();
 				TestWithStructConstraint ();
 				TestWithUnmanagedConstraint ();
+				TestWithNullable ();
 			}
 
 			// This is OK since we know it's null, so MakeGenericType is effectively a no-op (will throw)

--- a/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
@@ -32,6 +32,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			MakeGenericMethod.Test ();
 
 			TestNewConstraintSatisfiesParameterlessConstructor<object> ();
+			TestStructConstraintSatisfiesParameterlessConstructor<TestStruct> ();
+			TestUnmanagedConstraintSatisfiesParameterlessConstructor<byte> ();
 
 			TestGenericParameterFlowsToField ();
 			TestGenericParameterFlowsToReturnValue ();
@@ -759,6 +761,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				TestWithMultipleArgumentsWithRequirements ();
 
 				TestWithNewConstraint ();
+				TestWithStructConstraint ();
+				TestWithUnmanagedConstraint ();
 			}
 
 			// This is OK since we know it's null, so MakeGenericType is effectively a no-op (will throw)
@@ -855,6 +859,26 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			class GenericWithNewConstraint<T> where T : new()
 			{
 			}
+
+			[RecognizedReflectionAccessPattern]
+			static void TestWithStructConstraint ()
+			{
+				typeof (GenericWithStructConstraint<>).MakeGenericType (typeof (TestType));
+			}
+
+			class GenericWithStructConstraint<T> where T : struct
+			{
+			}
+
+			[RecognizedReflectionAccessPattern]
+			static void TestWithUnmanagedConstraint ()
+			{
+				typeof (GenericWithUnmanagedConstraint<>).MakeGenericType (typeof (TestType));
+			}
+
+			class GenericWithUnmanagedConstraint<T> where T : unmanaged
+			{
+			}
 		}
 
 		class MakeGenericMethod
@@ -877,6 +901,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				TestWithMultipleArgumentsWithRequirements ();
 
 				TestWithNewConstraint ();
+				TestWithStructConstraint ();
+				TestWithUnmanagedConstraint ();
 			}
 
 			[RecognizedReflectionAccessPattern]
@@ -991,10 +1017,46 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			{
 				var t = new T ();
 			}
+
+			[RecognizedReflectionAccessPattern]
+			static void TestWithStructConstraint ()
+			{
+				typeof (MakeGenericMethod).GetMethod (nameof (GenericWithStructConstraint), BindingFlags.Static | BindingFlags.NonPublic)
+					.MakeGenericMethod (typeof (TestType));
+			}
+
+			static void GenericWithStructConstraint<T> () where T : struct
+			{
+				var t = new T ();
+			}
+
+			[RecognizedReflectionAccessPattern]
+			static void TestWithUnmanagedConstraint ()
+			{
+				typeof (MakeGenericMethod).GetMethod (nameof (GenericWithUnmanagedConstraint), BindingFlags.Static | BindingFlags.NonPublic)
+					.MakeGenericMethod (typeof (TestType));
+			}
+
+			static void GenericWithUnmanagedConstraint<T> () where T : unmanaged
+			{
+				var t = new T ();
+			}
 		}
 
 		[RecognizedReflectionAccessPattern]
 		static void TestNewConstraintSatisfiesParameterlessConstructor<T> () where T : new()
+		{
+			RequiresParameterlessConstructor<T> ();
+		}
+
+		[RecognizedReflectionAccessPattern]
+		static void TestStructConstraintSatisfiesParameterlessConstructor<T> () where T : struct
+		{
+			RequiresParameterlessConstructor<T> ();
+		}
+
+		[RecognizedReflectionAccessPattern]
+		static void TestUnmanagedConstraintSatisfiesParameterlessConstructor<T> () where T : unmanaged
 		{
 			RequiresParameterlessConstructor<T> ();
 		}
@@ -1004,6 +1066,10 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		public class TestType
+		{
+		}
+
+		public struct TestStruct
 		{
 		}
 	}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
@@ -860,7 +860,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			{
 			}
 
-			[RecognizedReflectionAccessPattern]
+			[UnrecognizedReflectionAccessPattern (typeof (Type), nameof (Type.MakeGenericType), new Type[] { typeof (Type[]) },
+				messageCode: "IL2055")]
 			static void TestWithStructConstraint ()
 			{
 				typeof (GenericWithStructConstraint<>).MakeGenericType (typeof (TestType));
@@ -870,7 +871,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			{
 			}
 
-			[RecognizedReflectionAccessPattern]
+			[UnrecognizedReflectionAccessPattern (typeof (Type), nameof (Type.MakeGenericType), new Type[] { typeof (Type[]) },
+				messageCode: "IL2055")]
 			static void TestWithUnmanagedConstraint ()
 			{
 				typeof (GenericWithUnmanagedConstraint<>).MakeGenericType (typeof (TestType));
@@ -878,6 +880,12 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 			class GenericWithUnmanagedConstraint<T> where T : unmanaged
 			{
+			}
+
+			[RecognizedReflectionAccessPattern]
+			static void TestWithNullable ()
+			{
+				typeof (Nullable<>).MakeGenericType (typeof (TestType));
 			}
 		}
 
@@ -1018,7 +1026,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				var t = new T ();
 			}
 
-			[RecognizedReflectionAccessPattern]
+			[UnrecognizedReflectionAccessPattern (typeof (MethodInfo), nameof (MethodInfo.MakeGenericMethod), new Type[] { typeof (Type[]) },
+				messageCode: "IL2060")]
 			static void TestWithStructConstraint ()
 			{
 				typeof (MakeGenericMethod).GetMethod (nameof (GenericWithStructConstraint), BindingFlags.Static | BindingFlags.NonPublic)
@@ -1030,7 +1039,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				var t = new T ();
 			}
 
-			[RecognizedReflectionAccessPattern]
+			[UnrecognizedReflectionAccessPattern (typeof (MethodInfo), nameof (MethodInfo.MakeGenericMethod), new Type[] { typeof (Type[]) },
+				messageCode: "IL2060")]
 			static void TestWithUnmanagedConstraint ()
 			{
 				typeof (MakeGenericMethod).GetMethod (nameof (GenericWithUnmanagedConstraint), BindingFlags.Static | BindingFlags.NonPublic)


### PR DESCRIPTION
`struct` and `unmanaged` constraint also imply `new()` constraint, but any type allowable for `struct` or `unmanaged` constraints always has public parameterless constructor. Or rather the type can be constructed without parameters (the `.ctor` itself is actually not accessible through reflection).

Since `MakeGenericType` and `MakeGenericMethod` both enforce that only types compatible with `struct` or `unmanaged` constraints can be passed as type arguments to such generic parameters, there's no need for linker to validate this as well. At runtime it will always work - and on top of that, there's nothing for linker to mark - struct and unmanaged don't have a parameterless `.ctor` in IL - it's just that at runtime they behave as if they do.

So enforcing the `new()` constraint in `MakeGenericMethod` or `MakeGenericType` makes sense only when it's just `new()` constraint, not if it's implied from `struct` or `unmanaged` constraints.

Fixes #1887 