### PR TITLE
Warn on cctors annotated with RUC if a field triggers its marking

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1498,7 +1498,7 @@ namespace Mono.Linker.Steps
 			if (CheckProcessed (field))
 				return;
 
-			MarkType (field.DeclaringType, new DependencyInfo (DependencyKind.DeclaringType, field), field);
+			MarkType (field.DeclaringType, new DependencyInfo (DependencyKind.DeclaringType, field), reason.Source as IMemberDefinition ?? field);
 			MarkType (field.FieldType, new DependencyInfo (DependencyKind.FieldType, field), field);
 			MarkCustomAttributes (field, new DependencyInfo (DependencyKind.CustomAttribute, field), field);
 			MarkMarshalSpec (field, new DependencyInfo (DependencyKind.FieldMarshalSpec, field), field);
@@ -1709,7 +1709,7 @@ namespace Mono.Linker.Steps
 				// For virtuals that must be preserved, blame the declaring type.
 				MarkMethodsIf (type.Methods, IsVirtualNeededByTypeDueToPreservedScope, new DependencyInfo (DependencyKind.VirtualNeededDueToPreservedScope, type), type);
 				if (ShouldMarkTypeStaticConstructor (type) && reason.Kind != DependencyKind.TriggersCctorForCalledMethod)
-					MarkStaticConstructor (type, new DependencyInfo (DependencyKind.CctorForType, type), type);
+					MarkStaticConstructor (type, new DependencyInfo (DependencyKind.CctorForType, type), sourceLocationMember);
 
 				MarkMethodsIf (type.Methods, HasOnSerializeOrDeserializeAttribute, new DependencyInfo (DependencyKind.SerializationMethodForType, type), type);
 			}
@@ -2590,6 +2590,7 @@ namespace Mono.Linker.Steps
 		{
 			switch (dependencyKind) {
 			case DependencyKind.AccessedViaReflection:
+			case DependencyKind.CctorForType:
 			case DependencyKind.DynamicallyAccessedMember:
 			case DependencyKind.DynamicDependency:
 			case DependencyKind.ElementMethod:

--- a/test/ILLink.RoslynAnalyzer.Tests/LinkerTestCases.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/LinkerTestCases.cs
@@ -22,6 +22,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 			case "TestCovariantReturnCallOnDerived":
 			case "TestRequiresUnreferencedCodeOnlyThroughReflection":
 			case "TestStaticCctorRequiresUnreferencedCode":
+			case "TestStaticCtorMarkingIsTriggeredByFieldAccess":
 			case "TestTypeWhichOverridesMethodVirtualMethodRequiresUnreferencedCode":
 			case "TestRequiresInMethodFromCopiedAssembly":
 			case "TestRequiresThroughReflectionInMethodFromCopiedAssembly":

--- a/test/ILLink.RoslynAnalyzer.Tests/LinkerTestCases.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/LinkerTestCases.cs
@@ -26,7 +26,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 			case "TestTypeWhichOverridesMethodVirtualMethodRequiresUnreferencedCode":
 			case "TestRequiresInMethodFromCopiedAssembly":
 			case "TestRequiresThroughReflectionInMethodFromCopiedAssembly":
-			case "TestStaticCctorTriggeredByMethodCall":
+			case "TestStaticCtorTriggeredByMethodCall":
 			case "TestTypeIsBeforeFieldInit":
 				return;
 			}

--- a/test/ILLink.RoslynAnalyzer.Tests/LinkerTestCases.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/LinkerTestCases.cs
@@ -27,6 +27,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 			case "TestRequiresInMethodFromCopiedAssembly":
 			case "TestRequiresThroughReflectionInMethodFromCopiedAssembly":
 			case "TestStaticCctorTriggeredByMethodCall":
+			case "TestTypeIsBeforeFieldInit":
 				return;
 			}
 

--- a/test/ILLink.RoslynAnalyzer.Tests/LinkerTestCases.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/LinkerTestCases.cs
@@ -26,6 +26,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 			case "TestTypeWhichOverridesMethodVirtualMethodRequiresUnreferencedCode":
 			case "TestRequiresInMethodFromCopiedAssembly":
 			case "TestRequiresThroughReflectionInMethodFromCopiedAssembly":
+			case "TestStaticCctorTriggeredByMethodCall":
 				return;
 			}
 

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
@@ -46,6 +46,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			TestTypeWhichOverridesMethodVirtualMethodRequiresUnreferencedCode ();
 			TestTypeWhichOverridesMethodVirtualMethodRequiresUnreferencedCodeOnBase ();
 			TestStaticCctorRequiresUnreferencedCode ();
+			TestStaticCtorMarkingIsTriggeredByFieldAccess ();
 			TestDynamicallyAccessedMembersWithRequiresUnreferencedCode (typeof (DynamicallyAccessedTypeWithRequiresUnreferencedCode));
 			TestDynamicallyAccessedMembersWithRequiresUnreferencedCode (typeof (TypeWhichOverridesMethod));
 			TestInterfaceMethodWithRequiresUnreferencedCode ();
@@ -232,6 +233,22 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		static void TestStaticCctorRequiresUnreferencedCode ()
 		{
 			_ = new StaticCtor ();
+		}
+
+		class StaticCtorTriggeredByFieldAccess
+		{
+			[RequiresUnreferencedCode ("Message for --StaticCtorTriggeredByFieldAccess.Cctor--")]
+			static StaticCtorTriggeredByFieldAccess ()
+			{
+			}
+
+			public static int field = 0;
+		}
+
+		[ExpectedWarning ("IL2026", "--StaticCtorTriggeredByFieldAccess.Cctor--")]
+		static void TestStaticCtorMarkingIsTriggeredByFieldAccess ()
+		{
+			var x = StaticCtorTriggeredByFieldAccess.field + 1;
 		}
 
 		public class DynamicallyAccessedTypeWithRequiresUnreferencedCode

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
@@ -47,6 +47,8 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			TestTypeWhichOverridesMethodVirtualMethodRequiresUnreferencedCodeOnBase ();
 			TestStaticCctorRequiresUnreferencedCode ();
 			TestStaticCtorMarkingIsTriggeredByFieldAccess ();
+			TestStaticCtorTriggeredByMethodCall ();
+			TestTypeIsBeforeFieldInit ();
 			TestDynamicallyAccessedMembersWithRequiresUnreferencedCode (typeof (DynamicallyAccessedTypeWithRequiresUnreferencedCode));
 			TestDynamicallyAccessedMembersWithRequiresUnreferencedCode (typeof (TypeWhichOverridesMethod));
 			TestInterfaceMethodWithRequiresUnreferencedCode ();
@@ -240,15 +242,53 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			[RequiresUnreferencedCode ("Message for --StaticCtorTriggeredByFieldAccess.Cctor--")]
 			static StaticCtorTriggeredByFieldAccess ()
 			{
+				field = 0;
 			}
 
-			public static int field = 0;
+			public static int field;
 		}
 
 		[ExpectedWarning ("IL2026", "--StaticCtorTriggeredByFieldAccess.Cctor--")]
 		static void TestStaticCtorMarkingIsTriggeredByFieldAccess ()
 		{
 			var x = StaticCtorTriggeredByFieldAccess.field + 1;
+		}
+
+		class TypeIsBeforeFieldInit
+		{
+			public static int field = AnnotatedMethod ();
+
+			[RequiresUnreferencedCode ("Message from --TypeIsBeforeFieldInit.AnnotatedMethod--")]
+			public static int AnnotatedMethod () => 42;
+		}
+
+		[LogContains ("IL2026: Mono.Linker.Tests.Cases.RequiresCapability.RequiresUnreferencedCodeCapability.TypeIsBeforeFieldInit..cctor():" +
+			" Using method 'Mono.Linker.Tests.Cases.RequiresCapability.RequiresUnreferencedCodeCapability.TypeIsBeforeFieldInit.AnnotatedMethod()'" +
+			" which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code." +
+			" Message from --TypeIsBeforeFieldInit.AnnotatedMethod--.")]
+		static void TestTypeIsBeforeFieldInit ()
+		{
+			var x = TypeIsBeforeFieldInit.field + 42;
+		}
+
+		class StaticCtorTriggeredByMethodCall
+		{
+			[RequiresUnreferencedCode ("Message for --StaticCtorTriggeredByMethodCall.Cctor--")]
+			static StaticCtorTriggeredByMethodCall ()
+			{
+			}
+
+			[RequiresUnreferencedCode ("Message for --StaticCtorTriggeredByMethodCall.TriggerStaticCtorMarking--")]
+			public void TriggerStaticCtorMarking ()
+			{
+			}
+		}
+
+		[ExpectedWarning ("IL2026", "--StaticCtorTriggeredByMethodCall.Cctor--")]
+		[ExpectedWarning ("IL2026", "--StaticCtorTriggeredByMethodCall.TriggerStaticCtorMarking--")]
+		static void TestStaticCtorTriggeredByMethodCall ()
+		{
+			new StaticCtorTriggeredByMethodCall ().TriggerStaticCtorMarking ();
 		}
 
 		public class DynamicallyAccessedTypeWithRequiresUnreferencedCode


### PR DESCRIPTION
Whenever a static member is referenced, static constructors on the declared type are called. If the cctor is annotated with `RequiresUnreferencedCode`, this should warn.