### PR TITLE
Introduce test helpers and add DataFlowTypeExtensions

### DIFF
--- a/test/Mono.Linker.Tests.Cases.Expectations/Helpers/DataFlowTypeExtensions.cs
+++ b/test/Mono.Linker.Tests.Cases.Expectations/Helpers/DataFlowTypeExtensions.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Helpers
+{
+	public static class DataFlowTypeExtensions
+	{
+		public static void RequiresAll ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] this Type type) { }
+
+		public static void RequiresPublicConstructors ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)] this Type type) { }
+
+		public static void RequiresPublicEvents ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicEvents)] this Type type) { }
+
+		public static void RequiresPublicFields([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] this Type type) { }
+
+		public static void RequiresPublicMethods([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] this Type type) { }
+
+		public static void RequiresPublicNestedTypes([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicNestedTypes)] this Type type) { }
+
+		public static void RequiresPublicParameterlessConstructor([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] this Type type) { }
+
+		public static void RequiresPublicProperties([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] this Type type) { }
+
+		public static void RequiresNonPublicEvents ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicEvents)] this Type type) { }
+
+		public static void RequiresNonPublicFields ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicFields)] this Type type) { }
+
+		public static void RequiresNonPublicMethods ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicMethods)] this Type type) { }
+
+		public static void RequiresNonPublicNestedTypes ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicNestedTypes)] this Type type) { }
+
+		public static void RequiresNonPublicConstructors ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicConstructors)] this Type type) { }
+
+		public static void RequiresNonPublicProperties ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicProperties)] this Type type) { }
+
+		public static void RequiresNone (this Type type) { }
+	}
+}

--- a/test/Mono.Linker.Tests.Cases.Expectations/Helpers/DataFlowTypeExtensions.cs
+++ b/test/Mono.Linker.Tests.Cases.Expectations/Helpers/DataFlowTypeExtensions.cs
@@ -15,15 +15,15 @@ namespace Mono.Linker.Tests.Cases.Expectations.Helpers
 
 		public static void RequiresPublicEvents ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicEvents)] this Type type) { }
 
-		public static void RequiresPublicFields([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] this Type type) { }
+		public static void RequiresPublicFields ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] this Type type) { }
 
-		public static void RequiresPublicMethods([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] this Type type) { }
+		public static void RequiresPublicMethods ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] this Type type) { }
 
-		public static void RequiresPublicNestedTypes([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicNestedTypes)] this Type type) { }
+		public static void RequiresPublicNestedTypes ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicNestedTypes)] this Type type) { }
 
-		public static void RequiresPublicParameterlessConstructor([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] this Type type) { }
+		public static void RequiresPublicParameterlessConstructor ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] this Type type) { }
 
-		public static void RequiresPublicProperties([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] this Type type) { }
+		public static void RequiresPublicProperties ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicProperties)] this Type type) { }
 
 		public static void RequiresNonPublicEvents ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicEvents)] this Type type) { }
 

--- a/test/Mono.Linker.Tests.Cases.Expectations/Helpers/PlatformAssemblies.cs
+++ b/test/Mono.Linker.Tests.Cases.Expectations/Helpers/PlatformAssemblies.cs
@@ -1,4 +1,4 @@
-namespace Mono.Linker.Tests.Cases.Expectations.Metadata
+namespace Mono.Linker.Tests.Cases.Expectations.Helpers
 {
 	public static class PlatformAssemblies
 	{

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnAssemblyUsingTarget.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnAssemblyUsingTarget.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
 using Mono.Linker.Tests.Cases.Attributes.Debugger.KeepDebugMembers;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 [assembly: KeptAttributeAttribute (typeof (DebuggerDisplayAttribute))]

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnAssemblyUsingTargetOnUnusedType.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnAssemblyUsingTargetOnUnusedType.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
 using Mono.Linker.Tests.Cases.Attributes.Debugger.KeepDebugMembers;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 [assembly: DebuggerDisplay ("{Property}", Target = typeof (DebuggerDisplayAttributeOnAssemblyUsingTargetOnUnusedType.Foo))]

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInOtherAssembly.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using Mono.Linker.Tests.Cases.Attributes.Debugger.Dependencies;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 [assembly: KeptAttributeAttribute (typeof (DebuggerDisplayAttribute))]

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInSameAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameInSameAssembly.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 [assembly: KeptAttributeAttribute (typeof (DebuggerDisplayAttribute))]

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameOfGenericTypeInOtherAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameOfGenericTypeInOtherAssembly.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
 using Mono.Linker.Tests.Cases.Attributes.Debugger.Dependencies;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 [assembly: KeptAttributeAttribute (typeof (DebuggerDisplayAttribute))]

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameOfNestedTypeInOtherAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnAssemblyUsingTargetTypeNameOfNestedTypeInOtherAssembly.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
 using Mono.Linker.Tests.Cases.Attributes.Debugger.Dependencies;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 [assembly: KeptAttributeAttribute (typeof (DebuggerDisplayAttribute))]

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnType.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnType.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Attributes.Debugger.KeepDebugMembers

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerTypeProxyAttributeOnAssemblyUsingTarget.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerTypeProxyAttributeOnAssemblyUsingTarget.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
 using Mono.Linker.Tests.Cases.Attributes.Debugger.KeepDebugMembers;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 [assembly: KeptAttributeAttribute (typeof (DebuggerTypeProxyAttribute))]

--- a/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerTypeProxyAttributeOnType.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerTypeProxyAttributeOnType.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Attributes.Debugger.KeepDebugMembers

--- a/test/Mono.Linker.Tests.Cases/Attributes/CoreLibraryAssemblyAttributesAreKept.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes/CoreLibraryAssemblyAttributesAreKept.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Timers;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Attributes

--- a/test/Mono.Linker.Tests.Cases/Attributes/NoSecurity/CoreLibrarySecurityAttributeTypesAreRemoved.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes/NoSecurity/CoreLibrarySecurityAttributeTypesAreRemoved.cs
@@ -2,6 +2,7 @@
 using System.Security;
 using System.Security.Permissions;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Attributes.NoSecurity

--- a/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/CoreLibraryUnusedAssemblyAttributesAreRemoved.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/CoreLibraryUnusedAssemblyAttributesAreRemoved.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Timers;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed

--- a/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/CoreLibraryUsedAssemblyAttributesAreKept.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/CoreLibraryUsedAssemblyAttributesAreKept.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Timers;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed

--- a/test/Mono.Linker.Tests.Cases/CoreLink/CopyOfCoreLibrariesKeepsUnusedTypes.cs
+++ b/test/Mono.Linker.Tests.Cases/CoreLink/CopyOfCoreLibrariesKeepsUnusedTypes.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.CoreLink

--- a/test/Mono.Linker.Tests.Cases/CoreLink/DelegateAndMulticastDelegateKeepInstantiatedReqs.cs
+++ b/test/Mono.Linker.Tests.Cases/CoreLink/DelegateAndMulticastDelegateKeepInstantiatedReqs.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Runtime.Serialization;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.CoreLink

--- a/test/Mono.Linker.Tests.Cases/CoreLink/LinkingOfCoreLibrariesRemovesUnusedMethods.cs
+++ b/test/Mono.Linker.Tests.Cases/CoreLink/LinkingOfCoreLibrariesRemovesUnusedMethods.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.IO;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.CoreLink

--- a/test/Mono.Linker.Tests.Cases/CoreLink/LinkingOfCoreLibrariesRemovesUnusedTypes.cs
+++ b/test/Mono.Linker.Tests.Cases/CoreLink/LinkingOfCoreLibrariesRemovesUnusedTypes.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.CoreLink

--- a/test/Mono.Linker.Tests.Cases/CoreLink/NoSecurityPlusOnlyKeepUsedRemovesAllSecurityAttributesFromCoreLibraries.cs
+++ b/test/Mono.Linker.Tests.Cases/CoreLink/NoSecurityPlusOnlyKeepUsedRemovesAllSecurityAttributesFromCoreLibraries.cs
@@ -2,6 +2,7 @@
 using System.Security;
 using System.Security.Permissions;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.CoreLink

--- a/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
@@ -314,7 +314,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 						nameof(TRoot),
 						"Mono.Linker.Tests.Cases.DataFlow.GenericParameterDataFlow.RootTypeWithRequirements<TRoot>.InnerTypeWithNoAddedGenerics",
 						"type",
-						"Mono.Linker.Tests.Cases.DataFlow.GenericParameterDataFlow.RequiresPublicMethods(Type)" })]
+						"DataFlowTypeExtensions.RequiresPublicMethods(Type)" })]
 				public static void TestAccess ()
 				{
 					typeof (TRoot).RequiresPublicFields ();

--- a/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 using System.Security.Policy;
 using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using BindingFlags = System.Reflection.BindingFlags;
 
 namespace Mono.Linker.Tests.Cases.DataFlow
@@ -69,17 +69,17 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		class TypeRequiresPublicFields<
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T>
 		{
-			[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (RequiresPublicMethods), new Type[] { typeof (Type) },
+			[UnrecognizedReflectionAccessPattern (typeof (DataFlowTypeExtensions), nameof (DataFlowTypeExtensions.RequiresPublicMethods), new Type[] { typeof (Type) },
 				messageCode: "IL2087", message: new string[] {
 					nameof (T),
 					nameof (TypeRequiresPublicFields <T>),
-					nameof (RequiresPublicMethods)
+					nameof (DataFlowTypeExtensions.RequiresPublicMethods)
 				})]
 			public static void Test ()
 			{
-				RequiresPublicFields (typeof (T));
-				RequiresPublicMethods (typeof (T));
-				RequiresNothing (typeof (T));
+				typeof (T).RequiresPublicFields ();
+				typeof (T).RequiresPublicMethods ();
+				typeof (T).RequiresNone ();
 			}
 
 			[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (FieldRequiresPublicMethods),
@@ -125,24 +125,24 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		class TypeRequiresPublicMethods<
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] T>
 		{
-			[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (RequiresPublicFields), new Type[] { typeof (Type) }, messageCode: "IL2087")]
+			[UnrecognizedReflectionAccessPattern (typeof (DataFlowTypeExtensions), nameof (DataFlowTypeExtensions.RequiresPublicFields), new Type[] { typeof (Type) }, messageCode: "IL2087")]
 			public static void Test ()
 			{
-				RequiresPublicFields (typeof (T));
-				RequiresPublicMethods (typeof (T));
-				RequiresNothing (typeof (T));
+				typeof (T).RequiresPublicFields ();
+				typeof (T).RequiresPublicMethods ();
+				typeof (T).RequiresNone ();
 			}
 		}
 
 		class TypeRequiresNothing<T>
 		{
-			[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (RequiresPublicFields), new Type[] { typeof (Type) }, messageCode: "IL2087")]
-			[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (RequiresPublicMethods), new Type[] { typeof (Type) }, messageCode: "IL2087")]
+			[UnrecognizedReflectionAccessPattern (typeof (DataFlowTypeExtensions), nameof (DataFlowTypeExtensions.RequiresPublicFields), new Type[] { typeof (Type) }, messageCode: "IL2087")]
+			[UnrecognizedReflectionAccessPattern (typeof (DataFlowTypeExtensions), nameof (DataFlowTypeExtensions.RequiresPublicMethods), new Type[] { typeof (Type) }, messageCode: "IL2087")]
 			public static void Test ()
 			{
-				RequiresPublicFields (typeof (T));
-				RequiresPublicMethods (typeof (T));
-				RequiresNothing (typeof (T));
+				typeof (T).RequiresPublicFields ();
+				typeof (T).RequiresPublicMethods ();
+				typeof (T).RequiresNone ();
 			}
 		}
 
@@ -193,47 +193,47 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[RecognizedReflectionAccessPattern]
 			public static void TestMultiple ()
 			{
-				RequiresPublicFields (typeof (TFields));
-				RequiresPublicMethods (typeof (TMethods));
-				RequiresPublicFields (typeof (TBoth));
-				RequiresPublicMethods (typeof (TBoth));
-				RequiresNothing (typeof (TFields));
-				RequiresNothing (typeof (TMethods));
-				RequiresNothing (typeof (TBoth));
-				RequiresNothing (typeof (TNothing));
+				typeof (TFields).RequiresPublicFields ();
+				typeof (TMethods).RequiresPublicMethods ();
+				typeof (TBoth).RequiresPublicFields ();
+				typeof (TBoth).RequiresPublicMethods ();
+				typeof (TFields).RequiresNone ();
+				typeof (TMethods).RequiresNone ();
+				typeof (TBoth).RequiresNone ();
+				typeof (TNothing).RequiresNone ();
 			}
 
-			[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (RequiresPublicMethods), new Type[] { typeof (Type) }, messageCode: "IL2087")]
+			[UnrecognizedReflectionAccessPattern (typeof (DataFlowTypeExtensions), nameof (DataFlowTypeExtensions.RequiresPublicMethods), new Type[] { typeof (Type) }, messageCode: "IL2087")]
 			public static void TestFields ()
 			{
-				RequiresPublicFields (typeof (TFields));
-				RequiresPublicMethods (typeof (TFields));
-				RequiresNothing (typeof (TFields));
+				typeof (TFields).RequiresPublicFields ();
+				typeof (TFields).RequiresPublicMethods ();
+				typeof (TFields).RequiresNone ();
 			}
 
-			[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (RequiresPublicFields), new Type[] { typeof (Type) }, messageCode: "IL2087")]
+			[UnrecognizedReflectionAccessPattern (typeof (DataFlowTypeExtensions), nameof (DataFlowTypeExtensions.RequiresPublicFields), new Type[] { typeof (Type) }, messageCode: "IL2087")]
 			public static void TestMethods ()
 			{
-				RequiresPublicFields (typeof (TMethods));
-				RequiresPublicMethods (typeof (TMethods));
-				RequiresNothing (typeof (TMethods));
+				typeof (TMethods).RequiresPublicFields ();
+				typeof (TMethods).RequiresPublicMethods ();
+				typeof (TMethods).RequiresNone ();
 			}
 
 			[RecognizedReflectionAccessPattern]
 			public static void TestBoth ()
 			{
-				RequiresPublicFields (typeof (TBoth));
-				RequiresPublicMethods (typeof (TBoth));
-				RequiresNothing (typeof (TBoth));
+				typeof (TBoth).RequiresPublicFields ();
+				typeof (TBoth).RequiresPublicMethods ();
+				typeof (TBoth).RequiresNone ();
 			}
 
-			[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (RequiresPublicFields), new Type[] { typeof (Type) }, messageCode: "IL2087")]
-			[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (RequiresPublicMethods), new Type[] { typeof (Type) }, messageCode: "IL2087")]
+			[UnrecognizedReflectionAccessPattern (typeof (DataFlowTypeExtensions), nameof (DataFlowTypeExtensions.RequiresPublicFields), new Type[] { typeof (Type) }, messageCode: "IL2087")]
+			[UnrecognizedReflectionAccessPattern (typeof (DataFlowTypeExtensions), nameof (DataFlowTypeExtensions.RequiresPublicMethods), new Type[] { typeof (Type) }, messageCode: "IL2087")]
 			public static void TestNothing ()
 			{
-				RequiresPublicFields (typeof (TNothing));
-				RequiresPublicMethods (typeof (TNothing));
-				RequiresNothing (typeof (TNothing));
+				typeof (TNothing).RequiresPublicFields ();
+				typeof (TNothing).RequiresPublicMethods ();
+				typeof (TNothing).RequiresNone ();
 			}
 		}
 
@@ -250,7 +250,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[RecognizedReflectionAccessPattern]
 			public GenericBaseTypeWithRequirements ()
 			{
-				RequiresPublicFields (typeof (T));
+				typeof (T).RequiresPublicFields ();
 			}
 		}
 
@@ -309,7 +309,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			{
 				// The message is not ideal since we report the TRoot to come from RootTypeWithRequirements/InnerTypeWIthNoAddedGenerics
 				// while it originates on RootTypeWithRequirements, but it's correct from IL's point of view.
-				[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (RequiresPublicMethods), new Type[] { typeof (Type) },
+				[UnrecognizedReflectionAccessPattern (typeof (DataFlowTypeExtensions), nameof (DataFlowTypeExtensions.RequiresPublicMethods), new Type[] { typeof (Type) },
 					messageCode: "IL2087", message: new string[] {
 						nameof(TRoot),
 						"Mono.Linker.Tests.Cases.DataFlow.GenericParameterDataFlow.RootTypeWithRequirements<TRoot>.InnerTypeWithNoAddedGenerics",
@@ -317,8 +317,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 						"Mono.Linker.Tests.Cases.DataFlow.GenericParameterDataFlow.RequiresPublicMethods(Type)" })]
 				public static void TestAccess ()
 				{
-					RequiresPublicFields (typeof (TRoot));
-					RequiresPublicMethods (typeof (TRoot));
+					typeof (TRoot).RequiresPublicFields ();
+					typeof (TRoot).RequiresPublicMethods ();
 				}
 			}
 		}
@@ -439,31 +439,31 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			MethodRequiresNothingPassThrough<TestType> ();
 		}
 
-		[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (RequiresPublicMethods), new Type[] { typeof (Type) }, messageCode: "IL2087")]
+		[UnrecognizedReflectionAccessPattern (typeof (DataFlowTypeExtensions), nameof (DataFlowTypeExtensions.RequiresPublicMethods), new Type[] { typeof (Type) }, messageCode: "IL2087")]
 		static void MethodRequiresPublicFields<
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T> ()
 		{
-			RequiresPublicFields (typeof (T));
-			RequiresPublicMethods (typeof (T));
-			RequiresNothing (typeof (T));
+			typeof (T).RequiresPublicFields ();
+			typeof (T).RequiresPublicMethods ();
+			typeof (T).RequiresNone ();
 		}
 
-		[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (RequiresPublicFields), new Type[] { typeof (Type) }, messageCode: "IL2087")]
+		[UnrecognizedReflectionAccessPattern (typeof (DataFlowTypeExtensions), nameof (DataFlowTypeExtensions.RequiresPublicFields), new Type[] { typeof (Type) }, messageCode: "IL2087")]
 		static void MethodRequiresPublicMethods<
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] T> ()
 		{
-			RequiresPublicFields (typeof (T));
-			RequiresPublicMethods (typeof (T));
-			RequiresNothing (typeof (T));
+			typeof (T).RequiresPublicFields ();
+			typeof (T).RequiresPublicMethods ();
+			typeof (T).RequiresNone ();
 		}
 
-		[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (RequiresPublicFields), new Type[] { typeof (Type) }, messageCode: "IL2087")]
-		[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (RequiresPublicMethods), new Type[] { typeof (Type) }, messageCode: "IL2087")]
+		[UnrecognizedReflectionAccessPattern (typeof (DataFlowTypeExtensions), nameof (DataFlowTypeExtensions.RequiresPublicFields), new Type[] { typeof (Type) }, messageCode: "IL2087")]
+		[UnrecognizedReflectionAccessPattern (typeof (DataFlowTypeExtensions), nameof (DataFlowTypeExtensions.RequiresPublicMethods), new Type[] { typeof (Type) }, messageCode: "IL2087")]
 		static void MethodRequiresNothing<T> ()
 		{
-			RequiresPublicFields (typeof (T));
-			RequiresPublicMethods (typeof (T));
-			RequiresNothing (typeof (T));
+			typeof (T).RequiresPublicFields ();
+			typeof (T).RequiresPublicMethods ();
+			typeof (T).RequiresNone ();
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (MethodRequiresPublicMethods) + "<T>()::T", messageCode: "IL2091")]
@@ -511,31 +511,31 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		{
 			[RecognizedReflectionAccessPattern]
 			public static void StaticRequiresPublicFields<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T> ()
-				=> RequiresPublicFields (typeof (T));
+				=> typeof (T).RequiresPublicFields ();
 			[RecognizedReflectionAccessPattern]
 			public void InstanceRequiresPublicFields<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T> ()
-				=> RequiresPublicFields (typeof (T));
+				=> typeof (T).RequiresPublicFields ();
 			[RecognizedReflectionAccessPattern]
 			public virtual void VirtualRequiresPublicFields<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T> ()
-				=> RequiresPublicFields (typeof (T));
+				=> typeof (T).RequiresPublicFields ();
 
 			[RecognizedReflectionAccessPattern]
 			public static void StaticRequiresPublicMethods<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] T> ()
-				=> RequiresPublicMethods (typeof (T));
+				=> typeof (T).RequiresPublicMethods ();
 			[RecognizedReflectionAccessPattern]
 			public void InstanceRequiresPublicMethods<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]T> ()
-				=> RequiresPublicMethods (typeof (T));
+				=> typeof (T).RequiresPublicMethods ();
 			[RecognizedReflectionAccessPattern]
 			public virtual void VirtualRequiresPublicMethods<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]T> ()
-				=> RequiresPublicMethods (typeof (T));
+				=> typeof (T).RequiresPublicMethods ();
 
 			[RecognizedReflectionAccessPattern]
 			public static void StaticRequiresMultipleGenericParams<
 				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] TFields,
 				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] TMethods> ()
 			{
-				RequiresPublicFields (typeof (TFields));
-				RequiresPublicMethods (typeof (TMethods));
+				typeof (TFields).RequiresPublicFields ();
+				typeof (TMethods).RequiresPublicMethods ();
 			}
 		}
 
@@ -616,25 +616,25 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[RecognizedReflectionAccessPattern]
 			public override void VirtualRequiresPublicFields<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T> ()
 			{
-				RequiresPublicFields (typeof (T));
+				typeof (T).RequiresPublicFields ();
 			}
 
 			[RecognizedReflectionAccessPattern]
 			public override void VirtualRequiresPublicMethods<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] T> ()
 			{
-				RequiresPublicMethods (typeof (T));
+				typeof (T).RequiresPublicMethods ();
 			}
 
 			[RecognizedReflectionAccessPattern]
 			public void InterfaceRequiresPublicFields<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T> ()
 			{
-				RequiresPublicFields (typeof (T));
+				typeof (T).RequiresPublicFields (); ;
 			}
 
 			[RecognizedReflectionAccessPattern]
 			public void InterfaceRequiresPublicMethods<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] T> ()
 			{
-				RequiresPublicMethods (typeof (T));
+				typeof (T).RequiresPublicMethods ();
 			}
 
 			[UnrecognizedReflectionAccessPattern (typeof (IInterfaceWithGenericMethod), nameof (IInterfaceWithGenericMethod.InterfaceRequiresPublicMethods) + "<T>()::T",
@@ -668,38 +668,38 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicMethods)] TBoth,
 			TNothing> ()
 		{
-			RequiresPublicFields (typeof (TFields));
-			RequiresPublicMethods (typeof (TMethods));
-			RequiresPublicFields (typeof (TBoth));
-			RequiresPublicMethods (typeof (TBoth));
-			RequiresNothing (typeof (TFields));
-			RequiresNothing (typeof (TMethods));
-			RequiresNothing (typeof (TBoth));
-			RequiresNothing (typeof (TNothing));
+			typeof (TFields).RequiresPublicFields (); ;
+			typeof (TMethods).RequiresPublicMethods ();
+			typeof (TBoth).RequiresPublicFields (); ;
+			typeof (TBoth).RequiresPublicMethods ();
+			typeof (TFields).RequiresNone ();
+			typeof (TMethods).RequiresNone ();
+			typeof (TBoth).RequiresNone ();
+			typeof (TNothing).RequiresNone ();
 		}
 
-		[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (RequiresPublicMethods), new Type[] { typeof (Type) }, messageCode: "IL2087")]
+		[UnrecognizedReflectionAccessPattern (typeof (DataFlowTypeExtensions), nameof (DataFlowTypeExtensions.RequiresPublicMethods), new Type[] { typeof (Type) }, messageCode: "IL2087")]
 		static void MethodMultipleWithDifferentRequirements_TestFields<
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] TFields,
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] TMethods,
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicMethods)] TBoth,
 			TNothing> ()
 		{
-			RequiresPublicFields (typeof (TFields));
-			RequiresPublicMethods (typeof (TFields));
-			RequiresNothing (typeof (TFields));
+			typeof (TFields).RequiresPublicFields (); ;
+			typeof (TFields).RequiresPublicMethods ();
+			typeof (TFields).RequiresNone ();
 		}
 
-		[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (RequiresPublicFields), new Type[] { typeof (Type) }, messageCode: "IL2087")]
+		[UnrecognizedReflectionAccessPattern (typeof (DataFlowTypeExtensions), nameof (DataFlowTypeExtensions.RequiresPublicFields), new Type[] { typeof (Type) }, messageCode: "IL2087")]
 		static void MethodMultipleWithDifferentRequirements_TestMethods<
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] TFields,
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] TMethods,
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicMethods)] TBoth,
 			TNothing> ()
 		{
-			RequiresPublicFields (typeof (TMethods));
-			RequiresPublicMethods (typeof (TMethods));
-			RequiresNothing (typeof (TMethods));
+			typeof (TMethods).RequiresPublicFields ();
+			typeof (TMethods).RequiresPublicMethods ();
+			typeof (TMethods).RequiresNone ();
 		}
 
 		static void MethodMultipleWithDifferentRequirements_TestBoth<
@@ -708,38 +708,24 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicMethods)] TBoth,
 			TNothing> ()
 		{
-			RequiresPublicFields (typeof (TBoth));
-			RequiresPublicMethods (typeof (TBoth));
-			RequiresNothing (typeof (TBoth));
+			typeof (TBoth).RequiresPublicFields ();
+			typeof (TBoth).RequiresPublicMethods ();
+			typeof (TBoth).RequiresNone ();
 		}
 
-		[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (RequiresPublicFields), new Type[] { typeof (Type) }, messageCode: "IL2087")]
-		[UnrecognizedReflectionAccessPattern (typeof (GenericParameterDataFlow), nameof (RequiresPublicMethods), new Type[] { typeof (Type) }, messageCode: "IL2087")]
+		[UnrecognizedReflectionAccessPattern (typeof (DataFlowTypeExtensions), nameof (DataFlowTypeExtensions.RequiresPublicFields), new Type[] { typeof (Type) }, messageCode: "IL2087")]
+		[UnrecognizedReflectionAccessPattern (typeof (DataFlowTypeExtensions), nameof (DataFlowTypeExtensions.RequiresPublicMethods), new Type[] { typeof (Type) }, messageCode: "IL2087")]
 		static void MethodMultipleWithDifferentRequirements_TestNothing<
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] TFields,
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] TMethods,
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicMethods)] TBoth,
 			TNothing> ()
 		{
-			RequiresPublicFields (typeof (TNothing));
-			RequiresPublicMethods (typeof (TNothing));
-			RequiresNothing (typeof (TNothing));
+			typeof (TNothing).RequiresPublicFields ();
+			typeof (TNothing).RequiresPublicMethods ();
+			typeof (TNothing).RequiresNone ();
 		}
 
-
-		static void RequiresPublicFields (
-		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] Type type)
-		{
-		}
-
-		static void RequiresPublicMethods (
-			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] Type type)
-		{
-		}
-
-		static void RequiresNothing (Type type)
-		{
-		}
 
 		class MakeGenericType
 		{

--- a/test/Mono.Linker.Tests.Cases/DataFlow/GetNestedTypeOnAllAnnotatedType.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/GetNestedTypeOnAllAnnotatedType.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
 
 namespace Mono.Linker.Tests.Cases.DataFlow
 {
@@ -35,35 +36,35 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		static void TestOnAllAnnotatedParameter ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] Type parentType)
 		{
 			var nestedType = parentType.GetNestedType (nameof (NestedType));
-			RequiresAll (nestedType);
+			nestedType.RequiresAll ();
 		}
 
-		[UnrecognizedReflectionAccessPattern (typeof (GetNestedTypeOnAllAnnotatedType), nameof (RequiresAll), new Type[] { typeof (Type) }, messageCode: "IL2072")]
+		[UnrecognizedReflectionAccessPattern (typeof (DataFlowTypeExtensions), nameof (DataFlowTypeExtensions.RequiresAll), new Type[] { typeof (Type) }, messageCode: "IL2072")]
 		static void TestOnNonAllAnnotatedParameter ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicNestedTypes)] Type parentType)
 		{
 			var nestedType = parentType.GetNestedType (nameof (NestedType));
-			RequiresAll (nestedType);
+			nestedType.RequiresAll ();
 		}
 
 		[RecognizedReflectionAccessPattern]
 		static void TestWithBindingFlags ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] Type parentType)
 		{
 			var nestedType = parentType.GetNestedType (nameof (NestedType), BindingFlags.Public);
-			RequiresAll (nestedType);
+			nestedType.RequiresAll ();
 		}
 
 		[RecognizedReflectionAccessPattern]
 		static void TestWithUnknownBindingFlags (BindingFlags bindingFlags, [DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] Type parentType)
 		{
 			var nestedType = parentType.GetNestedType (nameof (NestedType), bindingFlags);
-			RequiresAll (nestedType);
+			nestedType.RequiresAll ();
 		}
 
 		[RecognizedReflectionAccessPattern]
 		static void TestUnsupportedBindingFlags ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] Type parentType)
 		{
 			var nestedType = parentType.GetNestedType (nameof (NestedType), BindingFlags.IgnoreCase);
-			RequiresAll (nestedType);
+			nestedType.RequiresAll ();
 		}
 
 		[RecognizedReflectionAccessPattern]
@@ -71,10 +72,10 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		{
 			Type parentType = null;
 			var nestedType = parentType.GetNestedType (nameof (NestedType));
-			RequiresAll (nestedType);
+			nestedType.RequiresAll ();
 		}
 
-		[UnrecognizedReflectionAccessPattern (typeof (GetNestedTypeOnAllAnnotatedType), nameof (RequiresAll), new Type[] { typeof (Type) }, messageCode: "IL2072")]
+		[UnrecognizedReflectionAccessPattern (typeof (DataFlowTypeExtensions), nameof (DataFlowTypeExtensions.RequiresAll), new Type[] { typeof (Type) }, messageCode: "IL2072")]
 		static void TestIfElse (int number, [DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] Type parentWithAll, [DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicNestedTypes)] Type parentWithoutAll)
 		{
 			Type typeOfParent;
@@ -84,7 +85,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				typeOfParent = parentWithoutAll;
 			}
 			var nestedType = typeOfParent.GetNestedType (nameof (NestedType));
-			RequiresAll (nestedType);
+			nestedType.RequiresAll ();
 		}
 
 		[RecognizedReflectionAccessPattern]
@@ -97,17 +98,13 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			};
 
 			var nestedType = typeOfParent.GetNestedType (nameof (NestedType));
-			RequiresAll (nestedType);
+			nestedType.RequiresAll ();
 		}
 
 		[RecognizedReflectionAccessPattern]
 		static void TestOnKnownTypeOnly ()
 		{
-			RequiresAll (typeof (GetNestedTypeOnAllAnnotatedType).GetNestedType (nameof (NestedType)));
-		}
-
-		static void RequiresAll ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] Type type)
-		{
+			typeof (GetNestedTypeOnAllAnnotatedType).GetNestedType (nameof (NestedType)).RequiresAll ();
 		}
 
 		private class NestedType

--- a/test/Mono.Linker.Tests.Cases/LinkAttributes/EmbeddedLinkAttributesInCorelib.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkAttributes/EmbeddedLinkAttributesInCorelib.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 using System;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace System

--- a/test/Mono.Linker.Tests.Cases/References/ReferencesAreRemovedWhenAllUsagesAreRemoved.cs
+++ b/test/Mono.Linker.Tests.Cases/References/ReferencesAreRemovedWhenAllUsagesAreRemoved.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.References

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
@@ -9,6 +9,8 @@ using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.RequiresCapability.Dependencies;
+using Mono.Linker.Tests.Cases.DataFlow;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
 
 namespace Mono.Linker.Tests.Cases.RequiresCapability
 {
@@ -123,7 +125,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			RequiresUnreferencedCodeMethod ();
 
 			// Normally this would warn due to incompatible annotations, but with the attribute on this method it should be auto-suppressed
-			RequiresPublicFields (GetTypeWithPublicMethods ());
+			GetTypeWithPublicMethods ().RequiresPublicFields ();
 
 			TypeRequiresPublicFields<TPublicMethods>.Method ();
 
@@ -132,10 +134,6 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 		[RequiresUnreferencedCode ("Message for --RequiresUnreferencedCodeMethod--")]
 		static void RequiresUnreferencedCodeMethod ()
-		{
-		}
-
-		static void RequiresPublicFields ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] Type type)
 		{
 		}
 

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
@@ -6,11 +6,11 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
+using Mono.Linker.Tests.Cases.DataFlow;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.RequiresCapability.Dependencies;
-using Mono.Linker.Tests.Cases.DataFlow;
-using Mono.Linker.Tests.Cases.Expectations.Helpers;
 
 namespace Mono.Linker.Tests.Cases.RequiresCapability
 {

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
-using Mono.Linker.Tests.Cases.DataFlow;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapabilityReflectionAnalysisEnabled.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapabilityReflectionAnalysisEnabled.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
-using Mono.Linker.Tests.Cases.DataFlow;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
@@ -71,8 +70,8 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		[Kept]
 		class TypeRequiresPublicFields<
 			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
-		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)]
-		T>
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)]
+			T>
 		{
 			[Kept]
 			public static void Method () { }

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapabilityReflectionAnalysisEnabled.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapabilityReflectionAnalysisEnabled.cs
@@ -4,6 +4,8 @@ using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.DataFlow;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
 
 namespace Mono.Linker.Tests.Cases.RequiresCapability
 {
@@ -26,15 +28,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		[RecognizedReflectionAccessPattern]
 		static void TestRequiresUnreferencedCodeAttributeWithDynamicallyAccessedMembersEnabled ()
 		{
-			RequiresPublicFields (typeof (TypeWithPublicFieldsAccessed));
-		}
-
-		[Kept]
-		static void RequiresPublicFields (
-			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
-			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)]
-			Type type)
-		{
+			typeof (TypeWithPublicFieldsAccessed).RequiresPublicFields ();
 		}
 
 		[Kept]
@@ -124,19 +118,11 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				Type type)
 			{
 				// This should not produce a warning since the method is annotated with RequiresUnreferencedCode
-				RequiresPublicFields (type);
+				type.RequiresPublicFields ();
 
 				// This will still "work" in that it will apply the PublicFields requirement onto the specified type
-				RequiresPublicFields (typeof (TestRequiresUnreferencedCodeAndDynamicallyAccessedMembers));
+				typeof (TestRequiresUnreferencedCodeAndDynamicallyAccessedMembers).RequiresPublicFields ();
 			}
-
-			[Kept]
-			[RecognizedReflectionAccessPattern]
-			static void RequiresPublicFields (
-				[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
-				[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
-				Type type)
-			{ }
 
 			[Kept]
 			public void PublicInstanceMethod () { }

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapabilityReflectionAnalysisEnabled.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapabilityReflectionAnalysisEnabled.cs
@@ -2,10 +2,10 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.DataFlow;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.RequiresCapability
 {

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapabilityReflectionAnalysisEnabled.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapabilityReflectionAnalysisEnabled.cs
@@ -70,8 +70,8 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		[Kept]
 		class TypeRequiresPublicFields<
 			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
-			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)]
-			T>
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)]
+		T>
 		{
 			[Kept]
 			public static void Method () { }

--- a/test/Mono.Linker.Tests/Tests/TestFrameworkRulesAndConventions.cs
+++ b/test/Mono.Linker.Tests/Tests/TestFrameworkRulesAndConventions.cs
@@ -63,8 +63,8 @@ namespace Mono.Linker.Tests.Tests
 			if (type.Name == "<Module>")
 				return true;
 
-			// A static class with a const string field helper. This file is OK.
-			if (type.Name == "PlatformAssemblies")
+			// Helpers - these should few and very simple
+			if (type.Namespace == "Mono.Linker.Tests.Cases.Expectations.Helpers")
 				return true;
 
 			// Simple types like enums are OK and needed for certain attributes


### PR DESCRIPTION
Several of the DataFlow tests use the `RequirePublicMethods` or similar methods to perform validation. These methods are always the same, so there no reason to duplicate them across tests.

In the infra I added an exception that the Expectation assembly can contain non-attribute classes if they're in the Helper namespace.

It's cumbersome to add these helpers into the TestCases because each test case would have to add an explicit compilation attribute to include the source file in the test compilation.

If there are too many helpers, we might consider creating a new assembly for them instead.