### PR TITLE
Add Recognized pattern to PropertyIndexers test

### DIFF
--- a/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
@@ -269,6 +269,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				set { PropertyWithExistingAttributes_Field = value; }
 			}
 
+			[RecognizedReflectionAccessPattern]
 			public void TestPropertyWithIndexerWithMatchingAnnotations ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)] Type myType)
 			{
 				var propclass = new PropertyWithIndexer ();


### PR DESCRIPTION
Add Recognized Reflection Access Pattern to PropertyIndexers test otherwise linker will not test for errors