### PR TITLE
Run primary queue processing after IVT attributes are checked.

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -237,7 +237,10 @@ namespace Mono.Linker.Steps
 			foreach (var body in _unreachableBodies) {
 				Annotations.SetAction (body.Method, MethodAction.ConvertToThrow);
 			}
+		}
 
+		void ProcessInternalsVisibleAttributes ()
+		{
 			foreach (var attr in _ivt_attributes) {
 				if (IsInternalsVisibleAttributeAssemblyMarked (attr.Attribute))
 					MarkCustomAttribute (attr.Attribute, new DependencyInfo (DependencyKind.AssemblyOrModuleAttribute, attr.Provider), null);
@@ -393,6 +396,11 @@ namespace Mono.Linker.Steps
 					}
 				}
 			}
+
+			// Process IVT attribute after all queues are empty. The process can
+			// repopulate the method queue if the IVT attribute is marked for the first time
+			ProcessInternalsVisibleAttributes ();
+			ProcessPrimaryQueue ();
 
 			ProcessPendingTypeChecks ();
 		}

--- a/test/Mono.Linker.Tests.Cases/Attributes/IVTUsed.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes/IVTUsed.cs
@@ -2,6 +2,7 @@ using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.Attributes.Dependencies;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
 
 namespace Mono.Linker.Tests.Cases.Attributes
 {
@@ -9,6 +10,11 @@ namespace Mono.Linker.Tests.Cases.Attributes
 	[KeptAssembly ("lib.dll")]
 	[KeptMemberInAssembly ("lib.dll", typeof (External), "InternalMethod()")]
 	[KeptAttributeInAssembly ("lib.dll", typeof (InternalsVisibleToAttribute))]
+
+	// This is a bit fragile but it's used to test that ITV attribute is marked correctly
+	[SetupLinkerTrimMode ("link")]
+	[SetupLinkerArgument ("--skip-unresolved", "true")]
+	[KeptTypeInAssembly (PlatformAssemblies.CoreLib, typeof (InternalsVisibleToAttribute))]
 	class IVTUsed
 	{
 		static void Main ()

--- a/test/Mono.Linker.Tests.Cases/Attributes/IVTUsed.cs
+++ b/test/Mono.Linker.Tests.Cases/Attributes/IVTUsed.cs
@@ -1,8 +1,8 @@
 using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.Attributes.Dependencies;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Attributes
 {


### PR DESCRIPTION
This can be the only place where IVT attribute is marked

Fixes #1913