### PR TITLE
Resolving a type represented by a type name string should mimic Type.GetType behavior

### DIFF
--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -1573,6 +1573,23 @@ void TestMethod(MethodInfo methodInfo)
 
 The assembly 'assembly' produced trim analysis warnings in the context of the app. This means the assembly has not been fully annotated for trimming. Consider contacting the library author to request they add trim annotations to the library. To see detailed warnings for this assembly, turn off grouped warnings by passing either `--singlewarn-` to show detailed warnings for all assemblies, or `--singlewarn- "assembly"` to show detailed warnings for that assembly. https://aka.ms/dotnet-illink/libraries has more information on annotating libraries for trimming.
 
+#### `IL2105`: Type 'type' was not found in the caller assembly nor in the base library. Type name strings used for dynamically accessing a type should be assembly qualified.
+
+Type name strings representing dynamically accessed types must be assembly qualified, otherwise linker will first search for the type name in the caller's assembly and then in System.Private.CoreLib.
+If the linker fails to resolve the type name, null will be returned.
+
+```C#
+void TestInvalidTypeName()
+{
+    RequirePublicMethodOnAType("Foo.Unqualified.TypeName");
+}
+void RequirePublicMethodOnAType(
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+    string typeName)
+{
+}
+```
+
 ## Single-File Warning Codes
 
 #### `IL3000`: 'member' always returns an empty string for assemblies embedded in a single-file app. If the path to the app directory is needed, consider calling 'System.AppContext.BaseDirectory'

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -1006,7 +1006,7 @@ namespace Mono.Linker.Dataflow
 						}
 						foreach (var typeNameValue in methodParams[0].UniqueValues ()) {
 							if (typeNameValue is KnownStringValue knownStringValue) {
-								TypeReference foundTypeRef = _context.TypeNameResolver.ResolveTypeName (knownStringValue.Contents, out AssemblyDefinition typeAssembly);
+								TypeReference foundTypeRef = _context.TypeNameResolver.ResolveTypeName (knownStringValue.Contents, callingMethodDefinition, out AssemblyDefinition typeAssembly, false);
 								TypeDefinition foundType = foundTypeRef?.ResolveToMainTypeDefinition ();
 								if (foundType == null) {
 									// Intentionally ignore - it's not wrong for code to call Type.GetType on non-existing name, the code might expect null/exception back.
@@ -2005,7 +2005,7 @@ namespace Mono.Linker.Dataflow
 				} else if (uniqueValue is SystemTypeValue systemTypeValue) {
 					MarkTypeForDynamicallyAccessedMembers (ref reflectionContext, systemTypeValue.TypeRepresented, requiredMemberTypes);
 				} else if (uniqueValue is KnownStringValue knownStringValue) {
-					TypeReference typeRef = _context.TypeNameResolver.ResolveTypeName (knownStringValue.Contents, out AssemblyDefinition typeAssembly);
+					TypeReference typeRef = _context.TypeNameResolver.ResolveTypeName (knownStringValue.Contents, reflectionContext.Source, out AssemblyDefinition typeAssembly);
 					TypeDefinition foundType = typeRef?.ResolveToMainTypeDefinition ();
 					if (foundType == null) {
 						// Intentionally ignore - it's not wrong for code to call Type.GetType on non-existing name, the code might expect null/exception back.

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1893,7 +1893,7 @@ namespace Mono.Linker.Steps
 			TypeDefinition typeDefinition = null;
 			switch (attribute.ConstructorArguments[0].Value) {
 			case string s:
-				typeDefinition = _context.TypeNameResolver.ResolveTypeName (s, out AssemblyDefinition assemblyDefinition)?.Resolve ();
+				typeDefinition = _context.TypeNameResolver.ResolveTypeName (s, sourceLocationMember, out AssemblyDefinition assemblyDefinition)?.Resolve ();
 				if (typeDefinition != null)
 					MarkingHelpers.MarkMatchingExportedType (typeDefinition, assemblyDefinition, new DependencyInfo (DependencyKind.CustomAttribute, provider));
 

--- a/src/linker/Linker/TypeNameResolver.cs
+++ b/src/linker/Linker/TypeNameResolver.cs
@@ -58,7 +58,7 @@ namespace Mono.Linker
 			if (needsAssemblyName && origin != null) {
 				_context.LogWarning ($"Type '{typeNameString}' was not found in the caller assembly nor in the base library. " +
 					$"Type name strings used for dynamically accessing a type should be assembly qualified.",
-				2104, new MessageOrigin (origin));
+				2105, new MessageOrigin (origin));
 			}
 
 			typeAssembly = null;

--- a/src/linker/Linker/TypeNameResolver.cs
+++ b/src/linker/Linker/TypeNameResolver.cs
@@ -13,7 +13,7 @@ namespace Mono.Linker
 			_context = context;
 		}
 
-		public TypeReference ResolveTypeName (string typeNameString, out AssemblyDefinition typeAssembly)
+		public TypeReference ResolveTypeName (string typeNameString, IMemberDefinition origin, out AssemblyDefinition typeAssembly, bool needsAssemblyName = true)
 		{
 			typeAssembly = null;
 			if (string.IsNullOrEmpty (typeNameString))
@@ -36,15 +36,43 @@ namespace Mono.Linker
 				return ResolveTypeName (typeAssembly, assemblyQualifiedTypeName.TypeName);
 			}
 
-			foreach (var assemblyDefinition in _context.GetReferencedAssemblies ()) {
-				var foundType = ResolveTypeName (assemblyDefinition, parsedTypeName);
-				if (foundType != null) {
-					typeAssembly = assemblyDefinition;
-					return foundType;
-				}
+			// If parsedTypeName doesn't have an assembly name in it but it does have a namespace,
+			// search for the type in the calling object's assembly. If not found, look in the core
+			// assembly.
+			typeAssembly = origin switch {
+				TypeReference tr => tr.Module?.Assembly,
+				null => null,
+				_ => origin.DeclaringType.Module.Assembly
+			};
+
+			if (typeAssembly != null && TryResolveTypeName (typeAssembly, parsedTypeName, out var typeRef))
+				return typeRef;
+
+			// If type is not found in the caller's assembly, try in core assembly.
+			typeAssembly = _context.TryResolve (PlatformAssemblies.CoreLib);
+			if (typeAssembly != null && TryResolveTypeName (typeAssembly, parsedTypeName, out var typeRefFromSPCL))
+				return typeRefFromSPCL;
+
+			// It is common to use Type.GetType for looking if a type is available.
+			// If no type was found only warn and return null.
+			if (needsAssemblyName && origin != null) {
+				_context.LogWarning ($"Type '{typeNameString}' was not found in the caller assembly nor in the base library. " +
+					$"Type name strings used for dynamically accessing a type should be assembly qualified.",
+				2104, new MessageOrigin (origin));
 			}
 
+			typeAssembly = null;
 			return null;
+
+			bool TryResolveTypeName (AssemblyDefinition assemblyDefinition, TypeName typeName, out TypeReference typeReference)
+			{
+				typeReference = null;
+				if (assemblyDefinition == null)
+					return false;
+
+				typeReference = ResolveTypeName (assemblyDefinition, typeName);
+				return typeReference != null;
+			}
 		}
 
 		public TypeReference ResolveTypeName (AssemblyDefinition assembly, string typeNameString)

--- a/test/Mono.Linker.Tests.Cases/ComponentModel/TypeConverterOnMembers.cs
+++ b/test/Mono.Linker.Tests.Cases/ComponentModel/TypeConverterOnMembers.cs
@@ -15,6 +15,13 @@ namespace Mono.Linker.Tests.Cases.ComponentModel
 		{
 			var r1 = new OnProperty ().Foo;
 			var r2 = new OnField ().Field;
+			TestArgumentWithTypeNameReferencingANonExistentType ();
+		}
+
+		[Kept]
+		public static void TestArgumentWithTypeNameReferencingANonExistentType ()
+		{
+			_ = new OnProperty ().Bar;
 		}
 	}
 
@@ -32,6 +39,16 @@ namespace Mono.Linker.Tests.Cases.ComponentModel
 		[KeptAttributeAttribute (typeof (TypeConverterAttribute))]
 		[KeptBackingField]
 		public string Foo { [Kept] get; set; }
+
+		[TypeConverter ("NonExistentType")]
+
+		[Kept]
+		[KeptAttributeAttribute (typeof (TypeConverterAttribute))]
+		[KeptBackingField]
+		[ExpectedWarning ("IL2105",
+			"Type 'NonExistentType' was not found in the caller assembly nor in the base library. " +
+			"Type name strings used for dynamically accessing a type should be assembly qualified.")]
+		public string Bar { [Kept] get; set; }
 
 		[Kept]
 		[KeptBaseType (typeof (TypeConverter))]

--- a/test/Mono.Linker.Tests.Cases/DataFlow/AssemblyQualifiedNameDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/AssemblyQualifiedNameDataflow.cs
@@ -16,6 +16,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			TestPublicParameterlessConstructor ();
 			TestPublicConstructors ();
 			TestConstructors ();
+			TestUnqualifiedTypeNameWarns ();
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (AssemblyQualifiedNameDataflow), nameof (RequirePublicConstructors), new Type[] { typeof (string) }, messageCode: "IL2072")]
@@ -48,6 +49,14 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			RequirePublicConstructors (type);
 			RequireNonPublicConstructors (type);
 			RequireNothing (type);
+		}
+
+		[ExpectedWarning ("IL2105",
+			"Type 'System.Invalid.TypeName' was not found in the caller assembly nor in the base library. " +
+			"Type name strings used for dynamically accessing a type should be assembly qualified.")]
+		static void TestUnqualifiedTypeNameWarns ()
+		{
+			RequirePublicConstructors ("System.Invalid.TypeName");
 		}
 
 		private static void RequirePublicParameterlessConstructor (


### PR DESCRIPTION
See #1895. Mimic `Type.GetType` when resolving a type from a type name string. This is, if the type name is not assembly qualified, we will try to search for it in the caller's assembly, mscorlib and System.Private.CoreLib, in that same order. If the type is not found anywhere, linker will produce a warning.