### PR TITLE
Compile roslyn analyzer tests using repo's assembly refs

### DIFF
--- a/test/ILLink.RoslynAnalyzer.Tests/RequiresAssemblyFilesAnalyzerTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/RequiresAssemblyFilesAnalyzerTests.cs
@@ -65,6 +65,7 @@ class C
 		public Task SimpleDiagnosticOnProperty ()
 		{
 			var TestRequiresAssemblyFilesOnProperty = @"
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 class C
@@ -75,14 +76,14 @@ class C
 	void M()
 	{
 		P = false;
-		bool b = P;
+		List<bool> b = new List<bool> { P };
 	}
 }";
 			return VerifyRequiresAssemblyFilesAnalyzer (TestRequiresAssemblyFilesOnProperty,
 				// (11,3): warning IL3002: Using member 'C.P' which has 'RequiresAssemblyFilesAttribute' can break functionality when embedded in a single-file app.
-				VerifyCS.Diagnostic ().WithSpan (11, 3, 11, 4).WithArguments ("C.P", "", ""),
-				// (26,12): warning IL3002: Using member 'C.P' which has 'RequiresAssemblyFilesAttribute' can break functionality when embedded in a single-file app.
-				VerifyCS.Diagnostic ().WithSpan (12, 12, 12, 13).WithArguments ("C.P", "", ""));
+				VerifyCS.Diagnostic ().WithSpan (12, 3, 12, 4).WithArguments ("C.P", "", ""),
+				// (13,12): warning IL3002: Using member 'C.P' which has 'RequiresAssemblyFilesAttribute' can break functionality when embedded in a single-file app.
+				VerifyCS.Diagnostic ().WithSpan (13, 35, 13, 36).WithArguments ("C.P", "", ""));
 		}
 
 		[Fact]

--- a/test/ILLink.RoslynAnalyzer.Tests/Verifiers/CSharpAnalyzerVerifier`1.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/Verifiers/CSharpAnalyzerVerifier`1.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.Loader;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;

--- a/test/ILLink.RoslynAnalyzer.Tests/Verifiers/CSharpAnalyzerVerifier`1.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/Verifiers/CSharpAnalyzerVerifier`1.cs
@@ -48,11 +48,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 			DirectoryInfo netCoreAppDirectory = new DirectoryInfo (fiSPCL.DirectoryName);
 			string[] assemblies = Directory.GetFiles (netCoreAppDirectory.FullName, "System.*.dll");
 
-			TestCaseUtils.GetDirectoryPaths (out _, out string testAssemblyPath);
-			var expectationsPath = Path.Combine (testAssemblyPath, "Mono.Linker.Tests.Cases.Expectations.dll");
-
-			List<MetadataReference> metadataReferences = new List<MetadataReference> {
-				MetadataReference.CreateFromFile (expectationsPath) };
+			List<MetadataReference> metadataReferences = new List<MetadataReference> ();
 			foreach (var assemblyLocation in assemblies) {
 				try {
 					var assemblyName = AssemblyName.GetAssemblyName (assemblyLocation);
@@ -70,7 +66,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 			SyntaxTree src,
 			(string, string)[]? globalAnalyzerOptions = null)
 		{
-			var metadataReferences = Task.Run (() => GetLatestNETCoreReferenceAssemblies());
+			var metadataReferences = Task.Run (() => GetLatestNETCoreReferenceAssemblies ());
 			var comp = CSharpCompilation.Create (
 				assemblyName: Guid.NewGuid ().ToString ("N"),
 				syntaxTrees: new SyntaxTree[] { src },

--- a/test/ILLink.RoslynAnalyzer.Tests/Verifiers/CSharpAnalyzerVerifier`1.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/Verifiers/CSharpAnalyzerVerifier`1.cs
@@ -39,25 +39,16 @@ namespace ILLink.RoslynAnalyzer.Tests
 			(string, string)[]? globalAnalyzerOptions = null)
 			=> CreateCompilation (CSharpSyntaxTree.ParseText (src), globalAnalyzerOptions);
 
-		static List<MetadataReference> GetSystemPrivateCoreLibMetadataReference ()
-		{
-			FileInfo fiSPCL = new FileInfo (typeof (int).Assembly.Location);
-			if (fiSPCL == null)
-				throw new FileNotFoundException ("Could not find System.Private.CoreLib.dll.");
-
-			List<MetadataReference> metadataReferences = new List<MetadataReference> { MetadataReference.CreateFromFile (fiSPCL.FullName) };
-			return metadataReferences;
-		}
-
 		public static async Task<CompilationWithAnalyzers> CreateCompilation (
 			SyntaxTree src,
 			(string, string)[]? globalAnalyzerOptions = null)
 		{
-			var metadataReferences = Task.Run (() => GetSystemPrivateCoreLibMetadataReference ());
 			var comp = CSharpCompilation.Create (
 				assemblyName: Guid.NewGuid ().ToString ("N"),
 				syntaxTrees: new SyntaxTree[] { src },
-				references: await metadataReferences,
+				references: await Task.Run (() => new List<MetadataReference> {
+					MetadataReference.CreateFromFile (typeof (int).Assembly.Location)
+				}),
 				new CSharpCompilationOptions (OutputKind.DynamicallyLinkedLibrary));
 
 			var analyzerOptions = new AnalyzerOptions (


### PR DESCRIPTION
This change will allow us to test our roslyn analyzers with the latest dotnet/runtime bits.