### PR TITLE
Update SDK to latest version

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "6.0.100-preview.2.21155.3",
+    "dotnet": "6.0.100-preview.4.21179.4",
     "runtimes": {
       "dotnet": [
         "5.0.0"

--- a/test/Mono.Linker.Tests.Cases/ComponentModel/CustomTypeConvertor.cs
+++ b/test/Mono.Linker.Tests.Cases/ComponentModel/CustomTypeConvertor.cs
@@ -10,7 +10,7 @@ namespace Mono.Linker.Tests.Cases.ComponentModel
 
 	[Kept]
 	[KeptAttributeAttribute (typeof (TypeConverterAttribute))]
-	[KeptMember(".ctor()")]
+	[KeptMember (".ctor()")]
 	class CustomDataType
 	{
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/ComponentModel/CustomTypeConvertor.cs
+++ b/test/Mono.Linker.Tests.Cases/ComponentModel/CustomTypeConvertor.cs
@@ -10,6 +10,7 @@ namespace Mono.Linker.Tests.Cases.ComponentModel
 
 	[Kept]
 	[KeptAttributeAttribute (typeof (TypeConverterAttribute))]
+	[KeptMember(".ctor()")]
 	class CustomDataType
 	{
 		[Kept]
@@ -33,6 +34,7 @@ namespace Mono.Linker.Tests.Cases.ComponentModel
 
 	[Kept]
 	[KeptAttributeAttribute (typeof (TypeConverterAttribute))]
+	[KeptMember (".ctor()")]
 	class CustomDataType_2
 	{
 		[Kept]
@@ -53,6 +55,9 @@ namespace Mono.Linker.Tests.Cases.ComponentModel
 	}
 
 	[Reference ("System.dll")]
+	// System.dll referenced by a dynamically (for example in TypeConverterAttribute on IComponent)
+	// has unresolved references.
+	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	public class CustomTypeConvertor
 	{
 		public static void Main ()


### PR DESCRIPTION
Runtime in this SDK has the `DynamicallyAccessedMembersAttribute` allowed on types.