### PR TITLE
Expression.Call can act as MakeGenericMethod so make it perform same validation

### DIFF
--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -797,7 +797,7 @@ namespace Mono.Linker.Dataflow
 								foreach (var stringParam in methodParams[1].UniqueValues ()) {
 									if (stringParam is KnownStringValue stringValue) {
 										foreach (var method in systemTypeValue.TypeRepresented.GetMethodsOnTypeHierarchy (m => m.Name == stringValue.Contents, bindingFlags)) {
-											ValidateGenericMethodInstantiation (ref reflectionContext, method, methodParams[2], calledMethod);
+											ValidateGenericMethodInstantiation (ref reflectionContext, method, calledMethod);
 											MarkMethod (ref reflectionContext, method);
 										}
 
@@ -1611,7 +1611,7 @@ namespace Mono.Linker.Dataflow
 
 						foreach (var methodValue in methodParams[0].UniqueValues ()) {
 							if (methodValue is SystemReflectionMethodBaseValue methodBaseValue) {
-								ValidateGenericMethodInstantiation (ref reflectionContext, methodBaseValue.MethodRepresented, methodParams[1], calledMethod);
+								ValidateGenericMethodInstantiation (ref reflectionContext, methodBaseValue.MethodRepresented, calledMethod);
 								reflectionContext.RecordHandledPattern ();
 							} else if (methodValue == NullValue.Instance) {
 								reflectionContext.RecordHandledPattern ();
@@ -2157,18 +2157,9 @@ namespace Mono.Linker.Dataflow
 		void ValidateGenericMethodInstantiation (
 			ref ReflectionPatternContext reflectionContext,
 			MethodDefinition genericMethod,
-			ValueNode typeArgumentsValue,
 			MethodReference reflectionMethod)
 		{
 			if (!genericMethod.HasGenericParameters)
-				return;
-
-			// If there are no type arguments there's nothing to validate.
-			// This case will typically fail at runtime
-			// since the call requires that all generic parameters have arguments to them.
-			// But it's not the job of the linker to detect possible runtime error cases
-			// the code may well expect to get an exception in this case.
-			if ((typeArgumentsValue as ArrayValue)?.Size.AsConstInt () == 0)
 				return;
 
 			foreach (var genericParameter in genericMethod.GenericParameters) {

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -781,6 +781,7 @@ namespace Mono.Linker.Dataflow
 						}
 					}
 					break;
+
 				//
 				// System.Linq.Expressions.Expression
 				// 
@@ -790,15 +791,26 @@ namespace Mono.Linker.Dataflow
 						reflectionContext.AnalyzingPattern ();
 						BindingFlags bindingFlags = BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy;
 
+						bool hasTypeArguments = (methodParams[2] as ArrayValue)?.Size.AsConstInt () != 0;
 						foreach (var value in methodParams[0].UniqueValues ()) {
 							if (value is SystemTypeValue systemTypeValue) {
 								foreach (var stringParam in methodParams[1].UniqueValues ()) {
-									// TODO: Change this as needed after deciding whether or not we are to keep
-									// all methods on a type that was accessed via reflection.
 									if (stringParam is KnownStringValue stringValue) {
-										MarkMethodsOnTypeHierarchy (ref reflectionContext, systemTypeValue.TypeRepresented, m => m.Name == stringValue.Contents, bindingFlags);
+										foreach (var method in systemTypeValue.TypeRepresented.GetMethodsOnTypeHierarchy (m => m.Name == stringValue.Contents, bindingFlags)) {
+											ValidateGenericMethodInstantiation (ref reflectionContext, method, methodParams[2], calledMethod);
+											MarkMethod (ref reflectionContext, method);
+										}
+
 										reflectionContext.RecordHandledPattern ();
 									} else {
+										if (hasTypeArguments) {
+											// We don't know what method the `MakeGenericMethod` was called on, so we have to assume
+											// that the method may have requirements which we can't fullfil -> warn.
+											reflectionContext.RecordUnrecognizedPattern (
+												2060, string.Format (Resources.Strings.IL2060,
+													DiagnosticUtilities.GetMethodSignatureDisplayName (calledMethod)));
+										}
+
 										RequireDynamicallyAccessedMembers (
 											ref reflectionContext,
 											GetDynamicallyAccessedMemberTypesFromBindingFlagsForMethods (bindingFlags),
@@ -807,6 +819,14 @@ namespace Mono.Linker.Dataflow
 									}
 								}
 							} else {
+								if (hasTypeArguments) {
+									// We don't know what method the `MakeGenericMethod` was called on, so we have to assume
+									// that the method may have requirements which we can't fullfil -> warn.
+									reflectionContext.RecordUnrecognizedPattern (
+										2060, string.Format (Resources.Strings.IL2060,
+											DiagnosticUtilities.GetMethodSignatureDisplayName (calledMethod)));
+								}
+
 								RequireDynamicallyAccessedMembers (
 									ref reflectionContext,
 									GetDynamicallyAccessedMemberTypesFromBindingFlagsForMethods (bindingFlags),
@@ -1588,30 +1608,31 @@ namespace Mono.Linker.Dataflow
 				//
 				case IntrinsicId.MethodInfo_MakeGenericMethod: {
 						reflectionContext.AnalyzingPattern ();
+						if (callingMethodDefinition.Name == "TestWithRequirementsButNoTypeArguments")
+							Debug.WriteLine ("");
 
+						bool hasTypeArguments = (methodParams[1] as ArrayValue)?.Size.AsConstInt () != 0;
 						foreach (var methodValue in methodParams[0].UniqueValues ()) {
 							if (methodValue is SystemReflectionMethodBaseValue methodBaseValue) {
-								foreach (var genericParameter in methodBaseValue.MethodRepresented.GenericParameters) {
-									if (_context.Annotations.FlowAnnotations.GetGenericParameterAnnotation (genericParameter) != DynamicallyAccessedMemberTypes.None ||
-										genericParameter.HasDefaultConstructorConstraint) {
-										// There is a generic parameter which has some requirements on input types.
-										// For now we don't support tracking actual array elements, so we can't validate that the requirements are fulfilled.
-										reflectionContext.RecordUnrecognizedPattern (
-											2060, string.Format (Resources.Strings.IL2060,
-												DiagnosticUtilities.GetMethodSignatureDisplayName (calledMethod)));
-									}
-								}
-
-								// We haven't found any generic parameters with annotations, so there's nothing to validate
+								ValidateGenericMethodInstantiation (ref reflectionContext, methodBaseValue.MethodRepresented, methodParams[1], calledMethod);
 								reflectionContext.RecordHandledPattern ();
 							} else if (methodValue == NullValue.Instance) {
 								reflectionContext.RecordHandledPattern ();
 							} else {
-								// There is a generic parameter which has some requirements on input types.
-								// For now we don't support tracking actual array elements, so we can't validate that the requirements are fulfilled.
-								reflectionContext.RecordUnrecognizedPattern (
-									2060, string.Format (Resources.Strings.IL2060,
-										DiagnosticUtilities.GetMethodSignatureDisplayName (calledMethod)));
+								if (hasTypeArguments) {
+									// We don't know what method the `MakeGenericMethod` was called on, so we have to assume
+									// that the method may have requirements which we can't fullfil -> warn.
+									reflectionContext.RecordUnrecognizedPattern (
+										2060, string.Format (Resources.Strings.IL2060,
+											DiagnosticUtilities.GetMethodSignatureDisplayName (calledMethod)));
+								} else {
+									// Even if we can't figure out which method, if there are no type arguments
+									// there's nothing to validate. This case will typically fail at runtime
+									// since the call requires that all generic parameters have arguments to them.
+									// But it's not the job of the linker to detect possible runtime error cases
+									// the code may well expect to get an exception in this case.
+									reflectionContext.RecordHandledPattern ();
+								}
 							}
 						}
 
@@ -2115,12 +2136,6 @@ namespace Mono.Linker.Dataflow
 				MarkMethod (ref reflectionContext, ctor);
 		}
 
-		void MarkMethodsOnTypeHierarchy (ref ReflectionPatternContext reflectionContext, TypeDefinition type, Func<MethodDefinition, bool> filter, BindingFlags? bindingFlags = null)
-		{
-			foreach (var method in type.GetMethodsOnTypeHierarchy (filter, bindingFlags))
-				MarkMethod (ref reflectionContext, method);
-		}
-
 		void MarkFieldsOnTypeHierarchy (ref ReflectionPatternContext reflectionContext, TypeDefinition type, Func<FieldDefinition, bool> filter, BindingFlags? bindingFlags = BindingFlags.Default)
 		{
 			foreach (var field in type.GetFieldsOnTypeHierarchy (filter, bindingFlags))
@@ -2149,6 +2164,35 @@ namespace Mono.Linker.Dataflow
 		{
 			foreach (var @event in type.GetEventsOnTypeHierarchy (filter, bindingFlags))
 				MarkEvent (ref reflectionContext, @event);
+		}
+
+		void ValidateGenericMethodInstantiation (
+			ref ReflectionPatternContext reflectionContext,
+			MethodDefinition genericMethod,
+			ValueNode typeArgumentsValue,
+			MethodReference reflectionMethod)
+		{
+			if (!genericMethod.HasGenericParameters)
+				return;
+
+			// If there are no type arguments there's nothing to validate.
+			// This case will typically fail at runtime
+			// since the call requires that all generic parameters have arguments to them.
+			// But it's not the job of the linker to detect possible runtime error cases
+			// the code may well expect to get an exception in this case.
+			if ((typeArgumentsValue as ArrayValue)?.Size.AsConstInt () == 0)
+				return;
+
+			foreach (var genericParameter in genericMethod.GenericParameters) {
+				if (_context.Annotations.FlowAnnotations.GetGenericParameterAnnotation (genericParameter) != DynamicallyAccessedMemberTypes.None ||
+					genericParameter.HasDefaultConstructorConstraint) {
+					// There is a generic parameter which has some requirements on input types.
+					// For now we don't support tracking actual array elements, so we can't validate that the requirements are fulfilled.
+					reflectionContext.RecordUnrecognizedPattern (
+						2060, string.Format (Resources.Strings.IL2060,
+							DiagnosticUtilities.GetMethodSignatureDisplayName (reflectionMethod)));
+				}
+			}
 		}
 
 		static DynamicallyAccessedMemberTypes GetDynamicallyAccessedMemberTypesFromBindingFlagsForNestedTypes (BindingFlags? bindingFlags) =>

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -1608,10 +1608,7 @@ namespace Mono.Linker.Dataflow
 				//
 				case IntrinsicId.MethodInfo_MakeGenericMethod: {
 						reflectionContext.AnalyzingPattern ();
-						if (callingMethodDefinition.Name == "TestWithRequirementsButNoTypeArguments")
-							Debug.WriteLine ("");
 
-						bool hasTypeArguments = (methodParams[1] as ArrayValue)?.Size.AsConstInt () != 0;
 						foreach (var methodValue in methodParams[0].UniqueValues ()) {
 							if (methodValue is SystemReflectionMethodBaseValue methodBaseValue) {
 								ValidateGenericMethodInstantiation (ref reflectionContext, methodBaseValue.MethodRepresented, methodParams[1], calledMethod);
@@ -1619,20 +1616,11 @@ namespace Mono.Linker.Dataflow
 							} else if (methodValue == NullValue.Instance) {
 								reflectionContext.RecordHandledPattern ();
 							} else {
-								if (hasTypeArguments) {
-									// We don't know what method the `MakeGenericMethod` was called on, so we have to assume
-									// that the method may have requirements which we can't fullfil -> warn.
-									reflectionContext.RecordUnrecognizedPattern (
-										2060, string.Format (Resources.Strings.IL2060,
-											DiagnosticUtilities.GetMethodSignatureDisplayName (calledMethod)));
-								} else {
-									// Even if we can't figure out which method, if there are no type arguments
-									// there's nothing to validate. This case will typically fail at runtime
-									// since the call requires that all generic parameters have arguments to them.
-									// But it's not the job of the linker to detect possible runtime error cases
-									// the code may well expect to get an exception in this case.
-									reflectionContext.RecordHandledPattern ();
-								}
+								// We don't know what method the `MakeGenericMethod` was called on, so we have to assume
+								// that the method may have requirements which we can't fullfil -> warn.
+								reflectionContext.RecordUnrecognizedPattern (
+									2060, string.Format (Resources.Strings.IL2060,
+										DiagnosticUtilities.GetMethodSignatureDisplayName (calledMethod)));
 							}
 						}
 

--- a/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
@@ -882,7 +882,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			{
 				TestNullMethod ();
 				TestUnknownInput (null);
-				TestUnknownMethodByNoTypeArguments (null);
+				TestUnknownMethodButNoTypeArguments (null);
 				TestWithNoArguments ();
 
 				TestWithRequirements ();
@@ -916,9 +916,11 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				mi.MakeGenericMethod (typeof (TestType));
 			}
 
-			[RecognizedReflectionAccessPattern]
-			static void TestUnknownMethodByNoTypeArguments (MethodInfo mi)
+			[UnrecognizedReflectionAccessPattern (typeof (MethodInfo), nameof (MethodInfo.MakeGenericMethod), new Type[] { typeof (Type[]) },
+				messageCode: "IL2060")]
+			static void TestUnknownMethodButNoTypeArguments (MethodInfo mi)
 			{
+				// Thechnically linker could figure this out, but it's not worth the complexity - such call will always fail at runtime.
 				mi.MakeGenericMethod (Type.EmptyTypes);
 			}
 

--- a/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
@@ -882,12 +882,14 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			{
 				TestNullMethod ();
 				TestUnknownInput (null);
+				TestUnknownMethodByNoTypeArguments (null);
 				TestWithNoArguments ();
 
 				TestWithRequirements ();
 				TestWithRequirementsFromParam (null);
 				TestWithRequirementsFromGenericParam<TestType> ();
 				TestWithRequirementsViaRuntimeMethod ();
+				TestWithRequirementsButNoTypeArguments ();
 
 				TestWithNoRequirements ();
 				TestWithNoRequirementsFromParam (null);
@@ -912,6 +914,12 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			static void TestUnknownInput (MethodInfo mi)
 			{
 				mi.MakeGenericMethod (typeof (TestType));
+			}
+
+			[RecognizedReflectionAccessPattern]
+			static void TestUnknownMethodByNoTypeArguments (MethodInfo mi)
+			{
+				mi.MakeGenericMethod (Type.EmptyTypes);
 			}
 
 			[RecognizedReflectionAccessPattern]
@@ -955,6 +963,13 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			{
 				typeof (MakeGenericMethod).GetRuntimeMethod (nameof (GenericWithRequirements), Type.EmptyTypes)
 					.MakeGenericMethod (typeof (TestType));
+			}
+
+			[RecognizedReflectionAccessPattern]
+			static void TestWithRequirementsButNoTypeArguments ()
+			{
+				typeof (MakeGenericMethod).GetMethod (nameof (GenericWithRequirements), BindingFlags.Static)
+					.MakeGenericMethod (Type.EmptyTypes);
 			}
 
 			public static void GenericWithRequirements<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T> ()

--- a/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
@@ -967,9 +967,11 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 					.MakeGenericMethod (typeof (TestType));
 			}
 
-			[RecognizedReflectionAccessPattern]
+			[UnrecognizedReflectionAccessPattern (typeof (MethodInfo), nameof (MethodInfo.MakeGenericMethod), new Type[] { typeof (Type[]) },
+				messageCode: "IL2060")]
 			static void TestWithRequirementsButNoTypeArguments ()
 			{
+				// Linker could figure out that this is not a problem, but it's not worth the complexity, since this will always throw at runtime
 				typeof (MakeGenericMethod).GetMethod (nameof (GenericWithRequirements), BindingFlags.Static)
 					.MakeGenericMethod (Type.EmptyTypes);
 			}

--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallString.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallString.cs
@@ -9,6 +9,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 {
 	[SetupCSharpCompilerToUse ("csc")]
 	[Reference ("System.Core.dll")]
+	[ExpectedNoWarnings]
 	public class ExpressionCallString
 	{
 		public static void Main ()
@@ -231,19 +232,111 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			{ }
 
 			[Kept]
-			// BUG:https://github.com/mono/linker/issues/1819
-			// [ExpectedWarning("IL9999", nameof(GenericMethodWithRequirements))]
-			public static void Test ()
+			public static void GenericMethodWithRequirementsNoArguments<
+				[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicProperties)] T> ()
+			{ }
+
+			[Kept]
+			static void TestWithNoTypeParameters ()
 			{
 				// Linker doesn't check if it's valid to call a generic method without generic parameters, it looks like a non-generic call
 				// so it will preserve the target method.
 				Expression.Call (typeof (TestGenericMethods), nameof (GenericMethodCalledAsNonGeneric), Type.EmptyTypes);
+			}
 
+			[Kept]
+			static void TestMethodWithoutRequirements ()
+			{
 				// This may not warn - as it's safe
 				Expression.Call (typeof (TestGenericMethods), nameof (GenericMethodWithNoRequirements), new Type[] { GetUnknownType () });
+			}
 
+			[Kept]
+			[ExpectedWarning ("IL2060", "Expression::Call")]
+			static void TestMethodWithRequirements ()
+			{
 				// This must warn - as this is dangerous
 				Expression.Call (typeof (TestGenericMethods), nameof (GenericMethodWithRequirements), new Type[] { GetUnknownType () });
+			}
+
+			[Kept]
+			static void TestMethodWithRequirementsButNoTypeArguments ()
+			{
+				// This will not warn - no type arguments -> nothing to validate
+				Expression.Call (typeof (TestGenericMethods), nameof (GenericMethodWithRequirementsNoArguments), Type.EmptyTypes);
+			}
+
+			[Kept]
+			[KeptMember (".cctor()")]
+			class UnknownMethodWithRequirements
+			{
+				[Kept]
+				public static void GenericMethodWithRequirements<
+					[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicProperties)] T> ()
+				{ }
+
+				[Kept]
+				static string _unknownMethodName = "NoMethod";
+
+				[Kept]
+				[ExpectedWarning ("IL2060")]
+				public static void TestWithTypeParameters ()
+				{
+					// Linker has no idea which method to mark - so it should warn if there are type parameters
+					Expression.Call (typeof (UnknownMethodWithRequirements), _unknownMethodName, new Type[] { GetUnknownType () });
+				}
+
+				[Kept]
+				public static void TestWithoutTypeParameters ()
+				{
+					// Linker has no idea which method to mark - so it should warn if there are type parameters
+					Expression.Call (typeof (UnknownMethodWithRequirements), _unknownMethodName, Type.EmptyTypes);
+				}
+			}
+
+			[Kept]
+			[KeptMember (".cctor()")]
+			class UnknownTypeWithRequirements
+			{
+				public static void GenericMethodWithRequirements<
+					[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicProperties)] T> ()
+				{ }
+
+				[Kept]
+				[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]
+				static Type _unknownType = null;
+
+				[Kept]
+				[ExpectedWarning ("IL2060")]
+				public static void TestWithTypeParameters ()
+				{
+					// Linker has no idea which method to mark - so it should warn if there are type parameters
+					Expression.Call (_unknownType, "NoMethod", new Type[] { GetUnknownType () });
+				}
+
+				[Kept]
+				public static void TestWithoutTypeParameters ()
+				{
+					// Linker has no idea which method to mark - so it should warn if there are type parameters
+					Expression.Call (_unknownType, "NoMethod", Type.EmptyTypes);
+				}
+			}
+
+			[Kept]
+			public static void Test ()
+			{
+				TestWithNoTypeParameters ();
+				TestMethodWithoutRequirements ();
+				TestMethodWithRequirements ();
+				TestMethodWithRequirementsButNoTypeArguments ();
+				UnknownMethodWithRequirements.TestWithTypeParameters ();
+				UnknownMethodWithRequirements.TestWithoutTypeParameters ();
+				UnknownTypeWithRequirements.TestWithTypeParameters ();
+				UnknownTypeWithRequirements.TestWithoutTypeParameters ();
 			}
 
 			[Kept]

--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallString.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallString.cs
@@ -261,9 +261,10 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			}
 
 			[Kept]
+			[ExpectedWarning ("IL2060", "Expression::Call")]
 			static void TestMethodWithRequirementsButNoTypeArguments ()
 			{
-				// This will not warn - no type arguments -> nothing to validate
+				// Linker could figure out that this is not a problem, but it's not worth the complexity, since this will always throw at runtime
 				Expression.Call (typeof (TestGenericMethods), nameof (GenericMethodWithRequirementsNoArguments), Type.EmptyTypes);
 			}
 


### PR DESCRIPTION
Also improved validation done by MakeGenericMethod to avoid warning if no type arguments are passed in.
Added tests.

Fixes #1819 