### PR TITLE
Move analyzers into ILLink.Tasks package

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -22,8 +22,8 @@
     <MicrosoftBuildUtilitiesCoreVersion>16.10.0-preview-21112-04</MicrosoftBuildUtilitiesCoreVersion>
     <MicrosoftDotNetApiCompatVersion>6.0.0-beta.21176.2</MicrosoftDotNetApiCompatVersion>
     <MicrosoftDotNetCodeAnalysisVersion>6.0.0-beta.21105.12</MicrosoftDotNetCodeAnalysisVersion>
+    <MicrosoftCodeAnalysisVersion>3.9.0</MicrosoftCodeAnalysisVersion>
     <MicrosoftCodeAnalysisCSharpCodeStyleVersion>3.9.0</MicrosoftCodeAnalysisCSharpCodeStyleVersion>
-    <MicrosoftCodeAnalysisCSharpWorkspacesVersion>3.9.0</MicrosoftCodeAnalysisCSharpWorkspacesVersion>
     <MicrosoftCodeAnalysisCSharpAnalyzerTestingXunitVersion>1.0.1-beta1.*</MicrosoftCodeAnalysisCSharpAnalyzerTestingXunitVersion>
     <!-- This controls the version of the cecil package, or the version of cecil in the project graph
          when we build the cecil submodule. The reference assembly package will depend on this version of cecil.

--- a/src/ILLink.CodeFix/ILLink.CodeFixProvider.csproj
+++ b/src/ILLink.CodeFix/ILLink.CodeFixProvider.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisCSharpWorkspacesVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj
+++ b/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj
@@ -8,14 +8,6 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
   </PropertyGroup>
 
-  <!-- Analyzer package properties -->
-  <PropertyGroup>
-    <PackageId>Microsoft.NET.ILLink.Analyzers</PackageId>
-    <Authors>Microsoft</Authors>
-    <Description>Analyzer utilities for ILLink attributes and single-file</Description>
-    <NoPackageAnalysis>true</NoPackageAnalysis>
-  </PropertyGroup>
-
   <ItemGroup>
     <EmbeddedResource Include="Resources.resx" GenerateSource="true" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.7.0" PrivateAssets="all" />

--- a/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj
+++ b/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj
@@ -6,11 +6,13 @@
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <!-- There are currently no translations, so the satellite assemblies are a waste of space. -->
+    <EnableXlfLocalization>false</EnableXlfLocalization>
   </PropertyGroup>
 
   <ItemGroup>
     <EmbeddedResource Include="Resources.resx" GenerateSource="true" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.7.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion)" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj
+++ b/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj
@@ -10,7 +10,6 @@
 
   <!-- Analyzer package properties -->
   <PropertyGroup>
-    <IsPackable>true</IsPackable>
     <PackageId>Microsoft.NET.ILLink.Analyzers</PackageId>
     <Authors>Microsoft</Authors>
     <Description>Analyzer utilities for ILLink attributes and single-file</Description>
@@ -20,17 +19,6 @@
   <ItemGroup>
     <EmbeddedResource Include="Resources.resx" GenerateSource="true" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.7.0" PrivateAssets="all" />
-  </ItemGroup>
-
-  <Target Name="IncludeAnalyzerAssembliesInPkg"
-          DependsOnTargets="InitializeStandardNuspecProperties"
-          AfterTargets="AfterBuild">
-    <ItemGroup>
-      <None Include="$(OutputPath)\**\*.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
-    </ItemGroup>
-  </Target>
-  <ItemGroup>
-    <Content Include="Microsoft.NET.ILLink.Analyzers.props" Pack="true" PackagePath="build"/>
   </ItemGroup>
 
 </Project>

--- a/src/ILLink.RoslynAnalyzer/Microsoft.NET.ILLink.Analyzers.props
+++ b/src/ILLink.RoslynAnalyzer/Microsoft.NET.ILLink.Analyzers.props
@@ -1,2 +1,0 @@
-<Project>
-</Project>

--- a/src/ILLink.RoslynAnalyzer/Microsoft.NET.ILLink.Analyzers.props
+++ b/src/ILLink.RoslynAnalyzer/Microsoft.NET.ILLink.Analyzers.props
@@ -1,7 +1,2 @@
 <Project>
-  <ItemGroup>
-    <CompilerVisibleProperty Include="EnableSingleFileAnalyzer"/>
-    <CompilerVisibleProperty Include="EnableTrimAnalyzer"/>
-    <CompilerVisibleProperty Include="IncludeAllContentForSelfExtract"/>
-  </ItemGroup>
 </Project>

--- a/src/ILLink.RoslynAnalyzer/OperationExtensions.cs
+++ b/src/ILLink.RoslynAnalyzer/OperationExtensions.cs
@@ -124,7 +124,7 @@ namespace ILLink.RoslynAnalyzer
 					   operation.Parent is ISizeOfOperation) {
 				return ValueUsageInfo.Name;
 			} else if (operation.Parent is IArgumentOperation argumentOperation) {
-				switch (argumentOperation.Parameter.RefKind) {
+				switch (argumentOperation.Parameter?.RefKind) {
 				case RefKind.RefReadOnly:
 					return ValueUsageInfo.ReadableReference;
 
@@ -203,19 +203,19 @@ namespace ILLink.RoslynAnalyzer
 			deconstructionAssignment = null;
 
 			var previousOperation = operation;
-			operation = operation.Parent;
+			var current = operation.Parent;
 
-			while (operation != null) {
-				switch (operation.Kind) {
+			while (current != null) {
+				switch (current.Kind) {
 				case OperationKind.DeconstructionAssignment:
-					deconstructionAssignment = (IDeconstructionAssignmentOperation) operation;
+					deconstructionAssignment = (IDeconstructionAssignmentOperation) current;
 					return deconstructionAssignment.Target == previousOperation;
 
 				case OperationKind.Tuple:
 				case OperationKind.Conversion:
 				case OperationKind.Parenthesized:
-					previousOperation = operation;
-					operation = operation.Parent;
+					previousOperation = current;
+					current = current.Parent;
 					continue;
 
 				default:

--- a/src/ILLink.RoslynAnalyzer/RequiresAssemblyFilesAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresAssemblyFilesAnalyzer.cs
@@ -53,7 +53,11 @@ namespace ILLink.RoslynAnalyzer
 
 				context.RegisterOperationAction (operationContext => {
 					var objectCreation = (IObjectCreationOperation) operationContext.Operation;
-					CheckCalledMember (operationContext, objectCreation.Constructor);
+					var ctor = objectCreation.Constructor;
+					if (ctor is not null)
+					{
+						CheckCalledMember (operationContext, ctor);
+					}
 				}, OperationKind.ObjectCreation);
 
 				context.RegisterOperationAction (operationContext => {

--- a/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
@@ -50,7 +50,11 @@ namespace ILLink.RoslynAnalyzer
 
 				context.RegisterOperationAction (operationContext => {
 					var call = (IObjectCreationOperation) operationContext.Operation;
-					CheckMethodOrCtorCall (operationContext, call.Constructor);
+					var ctor = call.Constructor;
+					if (ctor is not null)
+					{
+						CheckMethodOrCtorCall (operationContext, ctor);
+					}
 				}, OperationKind.ObjectCreation);
 
 				context.RegisterOperationAction (operationContext => {

--- a/src/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/src/ILLink.Tasks/ILLink.Tasks.csproj
@@ -42,7 +42,22 @@
       <SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>
     </ProjectReference>
     <ProjectReference Condition="('$(UseCecilPackage)' != 'true') And ('$(TargetFramework)' != 'net472')" Include="../../external/cecil/symbols/pdb/Mono.Cecil.Pdb.csproj" PrivateAssets="All" />
+    <ProjectReference Include="../ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj">
+      <PrivateAssets>all</PrivateAssets>
+      <DestinationSubDirectory>analyzers/dotnet/cs/</DestinationSubDirectory>
+    </ProjectReference>
+    <ProjectReference Include="../ILLink.CodeFix/ILLink.CodeFixProvider.csproj">
+      <PrivateAssets>all</PrivateAssets>
+      <DestinationSubDirectory>analyzers/dotnet/cs/</DestinationSubDirectory>
+    </ProjectReference>
   </ItemGroup>
+
+  <Target Name="IncludeAnalyzerAssembliesInPkg"
+          AfterTargets="AfterBuild">
+    <ItemGroup>
+      <None Include="$(OutputPath)/analyzers/dotnet/cs/*" Pack="true" PackagePath="analyzers/dotnet/cs/" />
+    </ItemGroup>
+  </Target>
 
   <ItemGroup>
     <!-- We use private assets for the Microsoft.Build packages to

--- a/src/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/src/ILLink.Tasks/ILLink.Tasks.csproj
@@ -42,11 +42,11 @@
       <SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>
     </ProjectReference>
     <ProjectReference Condition="('$(UseCecilPackage)' != 'true') And ('$(TargetFramework)' != 'net472')" Include="../../external/cecil/symbols/pdb/Mono.Cecil.Pdb.csproj" PrivateAssets="All" />
-    <ProjectReference Include="../ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj">
+    <ProjectReference Condition="'$(TargetFramework)' != 'net472'" Include="../ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj">
       <PrivateAssets>all</PrivateAssets>
       <DestinationSubDirectory>analyzers/dotnet/cs/</DestinationSubDirectory>
     </ProjectReference>
-    <ProjectReference Include="../ILLink.CodeFix/ILLink.CodeFixProvider.csproj">
+    <ProjectReference Condition="'$(TargetFramework)' != 'net472'" Include="../ILLink.CodeFix/ILLink.CodeFixProvider.csproj">
       <PrivateAssets>all</PrivateAssets>
       <DestinationSubDirectory>analyzers/dotnet/cs/</DestinationSubDirectory>
     </ProjectReference>

--- a/src/ILLink.Tasks/build/Microsoft.NET.ILLink.Tasks.props
+++ b/src/ILLink.Tasks/build/Microsoft.NET.ILLink.Tasks.props
@@ -17,4 +17,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ILLinkTasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\ILLink.Tasks.dll</ILLinkTasksAssembly>
   </PropertyGroup>
 
+  <ItemGroup>
+    <CompilerVisibleProperty Include="EnableSingleFileAnalyzer"/>
+    <CompilerVisibleProperty Include="EnableTrimAnalyzer"/>
+    <CompilerVisibleProperty Include="IncludeAllContentForSelfExtract"/>
+  </ItemGroup>
+
 </Project>

--- a/test/ILLink.RoslynAnalyzer.Tests/ILLink.RoslynAnalyzer.Tests.csproj
+++ b/test/ILLink.RoslynAnalyzer.Tests/ILLink.RoslynAnalyzer.Tests.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="$(MicrosoftCodeAnalysisCSharpAnalyzerTestingXunitVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="$(MicrosoftCodeAnalysisCSharpAnalyzerTestingXunitVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisCSharpWorkspacesVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" />
     <ProjectReference Include="..\..\src\ILLink.CodeFix\ILLink.CodeFixProvider.csproj" />
     <ProjectReference Include="..\..\src\ILLink.RoslynAnalyzer\ILLink.RoslynAnalyzer.csproj" />
     <ProjectReference Include="../Mono.Linker.Tests.Cases\Mono.Linker.Tests.Cases.csproj" />


### PR DESCRIPTION
Since the analyzers and linker should generally stay in-sync, it makes
sense to ship them all in one package. This change also includes the
codefix provider.