### PR TITLE
Continue updating forwarder scopes even if a non resolvable forwarder is found

### DIFF
--- a/src/linker/Linker.Steps/SweepStep.cs
+++ b/src/linker/Linker.Steps/SweepStep.cs
@@ -68,7 +68,7 @@ namespace Mono.Linker.Steps
 				switch (Annotations.GetAction (assembly)) {
 				case AssemblyAction.Link:
 				case AssemblyAction.Save:
-					SweepAssemblyReferences (assembly, Annotations);
+					SweepAssemblyReferences (assembly);
 					break;
 				}
 			}
@@ -246,7 +246,7 @@ namespace Mono.Linker.Steps
 				SweepAssemblyReferences (assembly);
 		}
 
-		static void SweepAssemblyReferences (AssemblyDefinition assembly, AnnotationStore annotations = null)
+		static void SweepAssemblyReferences (AssemblyDefinition assembly)
 		{
 			//
 			// We used to run over list returned by GetTypeReferences but
@@ -256,7 +256,7 @@ namespace Mono.Linker.Steps
 			//
 			assembly.MainModule.AssemblyReferences.Clear ();
 
-			var ars = new AssemblyReferencesCorrector (assembly, annotations);
+			var ars = new AssemblyReferencesCorrector (assembly);
 			ars.Process ();
 		}
 
@@ -546,14 +546,12 @@ namespace Mono.Linker.Steps
 		{
 			readonly AssemblyDefinition assembly;
 			readonly DefaultMetadataImporter importer;
-			readonly AnnotationStore annotations;
 
 			HashSet<TypeReference> updated;
 
-			public AssemblyReferencesCorrector (AssemblyDefinition assembly, AnnotationStore annotations = null)
+			public AssemblyReferencesCorrector (AssemblyDefinition assembly)
 			{
 				this.assembly = assembly;
-				this.annotations = annotations;
 				this.importer = new DefaultMetadataImporter (assembly.MainModule);
 
 				updated = null;
@@ -682,15 +680,11 @@ namespace Mono.Linker.Steps
 			{
 				foreach (var f in forwarders) {
 					TypeDefinition td = f.Resolve ();
-
-					// Forwarded type cannot be resolved but it was marked
-					// linker is running in --skip-unresolved true mode
-					if (td == null)
-						return;
-
-					// Do not update the scope of kept forwarders.
-					if (annotations != null && annotations.IsMarked (td))
+					if (td == null) {
+						// Forwarded type cannot be resolved but it was marked
+						// linker is running in --skip-unresolved true mode
 						continue;
+					}
 
 					var tr = assembly.MainModule.ImportReference (td);
 					if (f.Scope != tr.Scope)

--- a/src/linker/Linker.Steps/SweepStep.cs
+++ b/src/linker/Linker.Steps/SweepStep.cs
@@ -682,13 +682,15 @@ namespace Mono.Linker.Steps
 			{
 				foreach (var f in forwarders) {
 					TypeDefinition td = f.Resolve ();
-					if (td == null ||
-						// Do not update the scope of kept forwarders.
-						(annotations != null && !annotations.IsMarked (td))) {
-						// Forwarded type cannot be resolved but it was marked
-						// linker is running in --skip-unresolved true mode
+
+					// Forwarded type cannot be resolved but it was marked
+					// linker is running in --skip-unresolved true mode
+					if (td == null)
 						return;
-					}
+
+					// Do not update the scope of kept forwarders.
+					if (annotations != null && annotations.IsMarked (td))
+						continue;
 
 					var tr = assembly.MainModule.ImportReference (td);
 					if (f.Scope != tr.Scope)


### PR DESCRIPTION
Should fix https://github.com/dotnet/runtime/pull/50846

We mark all type forwarders for copy assemblies during MarkStep; this may end up marking forwarders that are not resolvable (i.e., `td = forwarder.Resolve()` will be null) -- which is fine. During SweepStep we update scopes of forwarders so that we point to the correct assembly ref, although, we might end up returning early if there was a forwarder which could not be resolved:

https://github.com/mono/linker/blob/eded7e5b8aaa09d0d4c9564b5419ab35a057507c/src/linker/Linker.Steps/SweepStep.cs#L681-L687

If we return early, some forwarders that are actually used, might have assembly refs pointing to nowhere.