### PR TITLE
Suppress dependencies for analyzer package

### DIFF
--- a/src/ILLink.CodeFix/ILLink.CodeFixProvider.csproj
+++ b/src/ILLink.CodeFix/ILLink.CodeFixProvider.csproj
@@ -13,6 +13,7 @@
     <Description>Analyzer utilities for ILLink attributes and single-file</Description>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes problem in https://github.com/dotnet/sdk/pull/16820

The build is automatically inserting a package dependency on "ILLink.RoslynAnalyzer" (the name of the dependent project) but both assemblies are included in the same package. Adding the `SuppressDependenciesWhenPacking` seems to do the trick.