### PR TITLE
Fixes a nullref and spurious warnings

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1671,7 +1671,7 @@ namespace Mono.Linker.Steps
 				// will call MarkType on the attribute type itself). 
 				// If for some reason we do keep the attribute type (could be because of previous reference which would cause IL2045
 				// or because of a copy assembly with a reference and so on) then we should not spam the warnings due to the type itself.
-				if (sourceLocationMember != null && sourceLocationMember.DeclaringType != type)
+				if (!(reason.Source is IMemberDefinition sourceMemberDefinition && sourceMemberDefinition.DeclaringType == type))
 					_context.LogWarning (
 						$"Attribute '{type.GetDisplayName ()}' is being referenced in code but the linker was " +
 						$"instructed to remove all instances of this attribute. If the attribute instances are necessary make sure to " +

--- a/src/linker/Linker/MessageContainer.cs
+++ b/src/linker/Linker/MessageContainer.cs
@@ -134,8 +134,9 @@ namespace Mono.Linker
 
 			if (subcategory == MessageSubCategory.TrimAnalysis) {
 				Debug.Assert (origin.MemberDefinition != null);
-				var assembly = origin.MemberDefinition?.DeclaringType.Module.Assembly;
-				var assemblyName = assembly?.Name.Name;
+				var declaringType = origin.MemberDefinition?.DeclaringType ?? (origin.MemberDefinition as TypeDefinition);
+				var assembly = declaringType?.Module?.Assembly;
+				var assemblyName = assembly?.Name?.Name;
 				if (assemblyName != null && context.IsSingleWarn (assemblyName)) {
 					if (context.AssembliesWithGeneratedSingleWarning.Add (assemblyName))
 						context.LogWarning ($"Assembly '{assemblyName}' produced trim warnings. For more information see https://aka.ms/dotnet-illink/libraries", 2104, context.GetAssemblyLocation (assembly));

--- a/src/linker/Linker/MessageContainer.cs
+++ b/src/linker/Linker/MessageContainer.cs
@@ -135,8 +135,8 @@ namespace Mono.Linker
 			if (subcategory == MessageSubCategory.TrimAnalysis) {
 				Debug.Assert (origin.MemberDefinition != null);
 				var declaringType = origin.MemberDefinition?.DeclaringType ?? (origin.MemberDefinition as TypeDefinition);
-				var assembly = declaringType?.Module?.Assembly;
-				var assemblyName = assembly?.Name?.Name;
+				var assembly = declaringType.Module.Assembly;
+				var assemblyName = assembly?.Name.Name;
 				if (assemblyName != null && context.IsSingleWarn (assemblyName)) {
 					if (context.AssembliesWithGeneratedSingleWarning.Add (assemblyName))
 						context.LogWarning ($"Assembly '{assemblyName}' produced trim warnings. For more information see https://aka.ms/dotnet-illink/libraries", 2104, context.GetAssemblyLocation (assembly));

--- a/test/Mono.Linker.Tests.Cases/LinkAttributes/Dependencies/LinkerAttributeRemovalAttributeFromCopyAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkAttributes/Dependencies/LinkerAttributeRemovalAttributeFromCopyAssembly.cs
@@ -6,5 +6,17 @@ namespace Mono.Linker.Tests.Cases.LinkAttributes.Dependencies
 {
 	public class AttributeFromCopyAssemblyAttribute : Attribute
 	{
+		// Add all kinds of members - as they cause the type to be marked again
+		// and we don't want these to generate more warnings.
+
+		private object _field;
+
+		private class NestedType
+		{
+		}
+
+		private int TestProperty { get; }
+
+		private event EventHandler _event;
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/LinkAttributes/LinkerAttributeRemoval.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkAttributes/LinkerAttributeRemoval.cs
@@ -6,6 +6,7 @@ using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.LinkAttributes.Dependencies;
 
@@ -77,6 +78,8 @@ namespace Mono.Linker.Tests.Cases.LinkAttributes
 			TestAttributeFromCopyAssembly ();
 
 			TestEmbeddedAttributeLazyLoadRemoved ();
+
+			TestMarkAllRemove ();
 		}
 
 #pragma warning disable CS0414
@@ -125,6 +128,13 @@ namespace Mono.Linker.Tests.Cases.LinkAttributes
 			// This needs the DynamicDependency above otherwise linker will not load the assembly at all
 			Activator.CreateInstance (Type.GetType ("Mono.Linker.Tests.Cases.LinkAttributes.Dependencies.TypeWithEmbeddedAttributeToBeRemoved, LinkerAttributeRemovalEmbeddedAndLazyLoad"));
 		}
+
+		[ExpectedWarning ("IL2045")]
+		[Kept]
+		static void TestMarkAllRemove ()
+		{
+			Type.GetType ("Mono.Linker.Tests.Cases.LinkAttributes.TestMarkAllRemoveAttribute").RequiresAll ();
+		}
 	}
 
 	[KeptBaseType (typeof (System.Attribute))]
@@ -141,5 +151,11 @@ namespace Mono.Linker.Tests.Cases.LinkAttributes
 		public TestRemoveAttribute ()
 		{
 		}
+	}
+
+	[KeptBaseType (typeof (System.Attribute))]
+	[KeptMember (".ctor()")]
+	class TestMarkAllRemoveAttribute : Attribute
+	{
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/LinkAttributes/LinkerAttributeRemoval.xml
+++ b/test/Mono.Linker.Tests.Cases/LinkAttributes/LinkerAttributeRemoval.xml
@@ -26,6 +26,9 @@
         <attribute internal="RemoveAttributeInstances"/>
       </method>
     </type>
+    <type fullname="Mono.Linker.Tests.Cases.LinkAttributes.TestMarkAllRemoveAttribute">
+      <attribute internal="RemoveAttributeInstances"/>
+    </type>
   </assembly>
   <assembly fullname="attribute, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
     <type fullname="Mono.Linker.Tests.Cases.LinkAttributes.Dependencies.TestAttributeUsedFromCopyAssemblyAttribute">


### PR DESCRIPTION
Both of these issues were found by the same test, so that's why fixing them together.

* Null ref in the recently added single-warning logic. If the origin of the warning is a top-level TypeDefinition, the code nullrefs.
* If there's an attribute type which should be removed (like NullableAttribute) in a copy assembly, we keep the type. Since all of its members are also marked the code will call MarkType many times on it - the current guard which prevents spurious 2045 warnings doesn't work in this case since the source location member is null (in theory it should be the "copy assembly", but currently we can't represent that). To prevent the warnings it's better to rely on reason.Source as that will be the member always.

Tweaked existing tests to cover this case and also added one more test case.