### PR TITLE
Check for namespace in GetDisplayName

### DIFF
--- a/src/linker/Linker/TypeReferenceExtensions.cs
+++ b/src/linker/Linker/TypeReferenceExtensions.cs
@@ -11,8 +11,11 @@ namespace Mono.Linker
 		public static string GetDisplayName (this TypeReference type)
 		{
 			var builder = GetDisplayNameWithoutNamespace (type);
-			builder.Insert (0, ".");
-			builder.Insert (0, type.GetNamespaceDisplayName ());
+			var namespaceDisplayName = type.GetNamespaceDisplayName ();
+			if (!string.IsNullOrEmpty (namespaceDisplayName)) {
+				builder.Insert (0, ".");
+				builder.Insert (0, namespaceDisplayName);
+			}
 
 			return builder.ToString ();
 		}

--- a/test/Mono.Linker.Tests/Tests/GetDisplayNameTests.cs
+++ b/test/Mono.Linker.Tests/Tests/GetDisplayNameTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Mono.Cecil;
+using Mono.Linker;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.TestCasesRunner;
 using NUnit.Framework;
@@ -197,6 +198,28 @@ namespace Mono.Linker.Tests
 			"(GetDisplayNameTests.GenericClassMultipleParameters<MethodT,String>.NestedGenericClassMultipleParameters<Int32,MethodV>)")]
 		public void MethodWithPartiallyInstantiatedNestedGenericTypeArguments<MethodT, MethodV> (
 			GenericClassMultipleParameters<MethodT, string>.NestedGenericClassMultipleParameters<int, MethodV> p)
+		{
+		}
+	}
+}
+
+[TestFixture]
+public class GetDisplayNameTestsGlobalScope
+{
+	[TestCaseSource (nameof (GetMemberAssertions), new object[] { typeof (global::GetDisplayNameTestsGlobalScope) })]
+	public void TestGetDisplayName (IMemberDefinition member, CustomAttribute customAttribute)
+	{
+		var expectedDisplayName = (string) customAttribute.ConstructorArguments[0].Value;
+		Assert.AreEqual (expectedDisplayName, (member as MemberReference).GetDisplayName ());
+	}
+
+	public static IEnumerable<TestCaseData> GetMemberAssertions (Type type) => MemberAssertionsCollector.GetMemberAssertionsData (type);
+
+	[DisplayName ("GetDisplayNameTestsGlobalScope.TypeInGlobalScope")]
+	public class TypeInGlobalScope
+	{
+		[DisplayName ("GetDisplayNameTestsGlobalScope.TypeInGlobalScope.Method()")]
+		public void Method ()
 		{
 		}
 	}


### PR DESCRIPTION
Fix #1967. If a type lives in the global namespace, `GetDisplayName` will prepend a period `<emptystring>.MyType.MyMember`.