### PR TITLE
Unified handling of Resolve calls

### DIFF
--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -17,41 +17,34 @@ namespace Mono.Linker.Dataflow
 {
 	class ReflectionMethodBodyScanner : MethodBodyScanner
 	{
-		readonly LinkContext _context;
 		readonly MarkStep _markStep;
 
 		public static bool RequiresReflectionMethodBodyScannerForCallSite (LinkContext context, MethodReference calledMethod)
 		{
-			MethodDefinition methodDefinition = calledMethod.Resolve ();
-			if (methodDefinition != null) {
-				return
-					GetIntrinsicIdForMethod (methodDefinition) > IntrinsicId.RequiresReflectionBodyScanner_Sentinel ||
-					context.Annotations.FlowAnnotations.RequiresDataFlowAnalysis (methodDefinition) ||
-					context.Annotations.HasLinkerAttribute<RequiresUnreferencedCodeAttribute> (methodDefinition);
-			}
+			MethodDefinition methodDefinition = context.TryResolveMethodDefinition (calledMethod);
+			if (methodDefinition == null)
+				return false;
 
-			return false;
+			return
+				GetIntrinsicIdForMethod (methodDefinition) > IntrinsicId.RequiresReflectionBodyScanner_Sentinel ||
+				context.Annotations.FlowAnnotations.RequiresDataFlowAnalysis (methodDefinition) ||
+				context.Annotations.HasLinkerAttribute<RequiresUnreferencedCodeAttribute> (methodDefinition);
 		}
 
-		public static bool RequiresReflectionMethodBodyScannerForMethodBody (FlowAnnotations flowAnnotations, MethodReference method)
+		public static bool RequiresReflectionMethodBodyScannerForMethodBody (FlowAnnotations flowAnnotations, MethodDefinition methodDefinition)
 		{
-			MethodDefinition methodDefinition = method.Resolve ();
-			if (methodDefinition != null) {
-				return
-					GetIntrinsicIdForMethod (methodDefinition) > IntrinsicId.RequiresReflectionBodyScanner_Sentinel ||
-					flowAnnotations.RequiresDataFlowAnalysis (methodDefinition);
-			}
-
-			return false;
+			return
+				GetIntrinsicIdForMethod (methodDefinition) > IntrinsicId.RequiresReflectionBodyScanner_Sentinel ||
+				flowAnnotations.RequiresDataFlowAnalysis (methodDefinition);
 		}
 
-		public static bool RequiresReflectionMethodBodyScannerForAccess (FlowAnnotations flowAnnotations, FieldReference field)
+		public static bool RequiresReflectionMethodBodyScannerForAccess (LinkContext context, FieldReference field)
 		{
-			FieldDefinition fieldDefinition = field.Resolve ();
-			if (fieldDefinition != null)
-				return flowAnnotations.RequiresDataFlowAnalysis (fieldDefinition);
+			FieldDefinition fieldDefinition = context.TryResolveFieldDefinition (field);
+			if (fieldDefinition == null)
+				return false;
 
-			return false;
+			return context.Annotations.FlowAnnotations.RequiresDataFlowAnalysis (fieldDefinition);
 		}
 
 		bool ShouldEnableReflectionPatternReporting (MethodDefinition method)
@@ -60,8 +53,8 @@ namespace Mono.Linker.Dataflow
 		}
 
 		public ReflectionMethodBodyScanner (LinkContext context, MarkStep parent)
+			: base (context)
 		{
-			_context = context;
 			_markStep = parent;
 		}
 
@@ -118,11 +111,11 @@ namespace Mono.Linker.Dataflow
 			MarkTypeForDynamicallyAccessedMembers (ref reflectionPatternContext, type, annotation);
 		}
 
-		static ValueNode GetValueNodeForCustomAttributeArgument (CustomAttributeArgument argument)
+		ValueNode GetValueNodeForCustomAttributeArgument (CustomAttributeArgument argument)
 		{
 			ValueNode valueNode;
 			if (argument.Type.Name == "Type") {
-				TypeDefinition referencedType = ((TypeReference) argument.Value).ResolveToMainTypeDefinition ();
+				TypeDefinition referencedType = ResolveToTypeDefinition ((TypeReference) argument.Value);
 				if (referencedType == null)
 					valueNode = UnknownValue.Instance;
 				else
@@ -159,7 +152,7 @@ namespace Mono.Linker.Dataflow
 				// That said we only use it to perform the dynamically accessed members checks and for that purpose treating it as System.Type is perfectly valid.
 				return new SystemTypeForGenericParameterValue (inputGenericParameter, _context.Annotations.FlowAnnotations.GetGenericParameterAnnotation (inputGenericParameter));
 			} else {
-				TypeDefinition genericArgumentTypeDef = genericArgument.ResolveToMainTypeDefinition ();
+				TypeDefinition genericArgumentTypeDef = ResolveToTypeDefinition (genericArgument);
 				if (genericArgumentTypeDef != null) {
 					return new SystemTypeValue (genericArgumentTypeDef);
 				} else {
@@ -185,7 +178,7 @@ namespace Mono.Linker.Dataflow
 		protected override ValueNode GetMethodParameterValue (MethodDefinition method, int parameterIndex)
 		{
 			DynamicallyAccessedMemberTypes memberTypes = _context.Annotations.FlowAnnotations.GetParameterAnnotation (method, parameterIndex);
-			return new MethodParameterValue (method, parameterIndex, memberTypes, DiagnosticUtilities.GetMethodParameterFromIndex (method, parameterIndex));
+			return new MethodParameterValue (this, method, parameterIndex, memberTypes, DiagnosticUtilities.GetMethodParameterFromIndex (method, parameterIndex));
 		}
 
 		protected override ValueNode GetFieldValue (MethodDefinition method, FieldDefinition field)
@@ -200,7 +193,7 @@ namespace Mono.Linker.Dataflow
 
 			default: {
 					DynamicallyAccessedMemberTypes memberTypes = _context.Annotations.FlowAnnotations.GetFieldAnnotation (field);
-					return new LoadFieldValue (field, memberTypes);
+					return new LoadFieldValue (this, field, memberTypes);
 				}
 			}
 		}
@@ -612,18 +605,18 @@ namespace Mono.Linker.Dataflow
 				return false;
 
 			var callingMethodDefinition = callingMethodBody.Method;
+			var calledMethodDefinition = _context.TryResolveMethodDefinition (calledMethod);
+			if (calledMethodDefinition == null)
+				return false;
+
 			var reflectionContext = new ReflectionPatternContext (
 				_context,
 				ShouldEnableReflectionPatternReporting (callingMethodDefinition),
 				callingMethodDefinition,
-				calledMethod.Resolve (),
+				calledMethodDefinition,
 				operation);
 
 			DynamicallyAccessedMemberTypes returnValueDynamicallyAccessedMemberTypes = 0;
-
-			var calledMethodDefinition = calledMethod.Resolve ();
-			if (calledMethodDefinition == null)
-				return false;
 
 			try {
 
@@ -818,7 +811,7 @@ namespace Mono.Linker.Dataflow
 							if (value is SystemTypeValue systemTypeValue) {
 								foreach (var stringParam in methodParams[1].UniqueValues ()) {
 									if (stringParam is KnownStringValue stringValue) {
-										foreach (var method in systemTypeValue.TypeRepresented.GetMethodsOnTypeHierarchy (m => m.Name == stringValue.Contents, bindingFlags)) {
+										foreach (var method in systemTypeValue.TypeRepresented.GetMethodsOnTypeHierarchy (_context, m => m.Name == stringValue.Contents, bindingFlags)) {
 											ValidateGenericMethodInstantiation (ref reflectionContext, method, methodParams[2], calledMethod);
 											MarkMethod (ref reflectionContext, method);
 										}
@@ -955,8 +948,8 @@ namespace Mono.Linker.Dataflow
 						foreach (var valueNode in methodParams[0].UniqueValues ()) {
 							TypeDefinition staticType = valueNode.StaticType;
 							if (staticType is null) {
-								// We don’t know anything about the type GetType was called on. Track this as a usual “result of a method call without any annotations”
-								methodReturnValue = MergePointValue.MergeValues (methodReturnValue, new MethodReturnValue (calledMethod.MethodReturnType, DynamicallyAccessedMemberTypes.None));
+								// We donï¿½t know anything about the type GetType was called on. Track this as a usual ï¿½result of a method call without any annotationsï¿½
+								methodReturnValue = MergePointValue.MergeValues (methodReturnValue, new MethodReturnValue (this, calledMethod.MethodReturnType, DynamicallyAccessedMemberTypes.None));
 							} else if (staticType.IsSealed || staticType.IsTypeOf ("System", "Delegate")) {
 								// We can treat this one the same as if it was a typeof() expression
 
@@ -987,7 +980,7 @@ namespace Mono.Linker.Dataflow
 								// Return a value which is "unknown type" with annotation. For now we'll use the return value node
 								// for the method, which means we're loosing the information about which staticType this
 								// started with. For now we don't need it, but we can add it later on.
-								methodReturnValue = MergePointValue.MergeValues (methodReturnValue, new MethodReturnValue (calledMethod.MethodReturnType, annotation));
+								methodReturnValue = MergePointValue.MergeValues (methodReturnValue, new MethodReturnValue (this, calledMethod.MethodReturnType, annotation));
 							}
 						}
 					}
@@ -1015,12 +1008,12 @@ namespace Mono.Linker.Dataflow
 						foreach (var typeNameValue in methodParams[0].UniqueValues ()) {
 							if (typeNameValue is KnownStringValue knownStringValue) {
 								TypeReference foundTypeRef = _context.TypeNameResolver.ResolveTypeName (knownStringValue.Contents, callingMethodDefinition, out AssemblyDefinition typeAssembly, false);
-								TypeDefinition foundType = foundTypeRef?.ResolveToMainTypeDefinition ();
+								TypeDefinition foundType = ResolveToTypeDefinition (foundTypeRef);
 								if (foundType == null) {
 									// Intentionally ignore - it's not wrong for code to call Type.GetType on non-existing name, the code might expect null/exception back.
 									reflectionContext.RecordHandledPattern ();
 								} else {
-									reflectionContext.RecordRecognizedPattern (foundType, () => _markStep.MarkTypeVisibleToReflection (foundTypeRef, new DependencyInfo (DependencyKind.AccessedViaReflection, callingMethodDefinition), callingMethodDefinition));
+									reflectionContext.RecordRecognizedPattern (foundType, () => _markStep.MarkTypeVisibleToReflection (foundTypeRef, foundType, new DependencyInfo (DependencyKind.AccessedViaReflection, callingMethodDefinition), callingMethodDefinition));
 									methodReturnValue = MergePointValue.MergeValues (methodReturnValue, new SystemTypeValue (foundType));
 									_context.MarkingHelpers.MarkMatchingExportedType (foundType, typeAssembly, new DependencyInfo (DependencyKind.AccessedViaReflection, foundType));
 								}
@@ -1030,7 +1023,7 @@ namespace Mono.Linker.Dataflow
 								// Propagate the annotation from the type name to the return value. Annotation on a string value will be fullfilled whenever a value is assigned to the string with annotation.
 								// So while we don't know which type it is, we can guarantee that it will fulfill the annotation.
 								reflectionContext.RecordHandledPattern ();
-								methodReturnValue = MergePointValue.MergeValues (methodReturnValue, new MethodReturnValue (calledMethodDefinition.MethodReturnType, valueWithDynamicallyAccessedMember.DynamicallyAccessedMemberTypes));
+								methodReturnValue = MergePointValue.MergeValues (methodReturnValue, new MethodReturnValue (this, calledMethodDefinition.MethodReturnType, valueWithDynamicallyAccessedMember.DynamicallyAccessedMemberTypes));
 							} else {
 								reflectionContext.RecordUnrecognizedPattern (2057, $"Unrecognized value passed to the parameter 'typeName' of method '{calledMethod.GetDisplayName ()}'. It's not possible to guarantee the availability of the target type.");
 							}
@@ -1201,7 +1194,7 @@ namespace Mono.Linker.Dataflow
 						// Note it's OK to blindly overwrite any potential annotation on the return value from the method definition
 						// since DynamicallyAccessedMemberTypes.All is a superset of any other annotation.
 						if (everyParentTypeHasAll && methodReturnValue == null)
-							methodReturnValue = new MethodReturnValue (calledMethodDefinition.MethodReturnType, DynamicallyAccessedMemberTypes.All);
+							methodReturnValue = new MethodReturnValue (this, calledMethodDefinition.MethodReturnType, DynamicallyAccessedMemberTypes.All);
 					}
 					break;
 
@@ -1264,19 +1257,19 @@ namespace Mono.Linker.Dataflow
 										propagatedMemberTypes |= DynamicallyAccessedMemberTypes.PublicProperties;
 								}
 
-								methodReturnValue = MergePointValue.MergeValues (methodReturnValue, new MethodReturnValue (calledMethod.MethodReturnType, propagatedMemberTypes));
+								methodReturnValue = MergePointValue.MergeValues (methodReturnValue, new MethodReturnValue (this, calledMethod.MethodReturnType, propagatedMemberTypes));
 							} else if (value is SystemTypeValue systemTypeValue) {
-								TypeDefinition baseTypeDefinition = systemTypeValue.TypeRepresented.BaseType.Resolve ();
+								TypeDefinition baseTypeDefinition = _context.TryResolveTypeDefinition (systemTypeValue.TypeRepresented.BaseType);
 								if (baseTypeDefinition != null)
 									methodReturnValue = MergePointValue.MergeValues (methodReturnValue, new SystemTypeValue (baseTypeDefinition));
 								else
-									methodReturnValue = MergePointValue.MergeValues (methodReturnValue, new MethodReturnValue (calledMethod.MethodReturnType, DynamicallyAccessedMemberTypes.None));
+									methodReturnValue = MergePointValue.MergeValues (methodReturnValue, new MethodReturnValue (this, calledMethod.MethodReturnType, DynamicallyAccessedMemberTypes.None));
 							} else if (value == NullValue.Instance) {
 								// Ignore nulls - null.BaseType will fail at runtime, but it has no effect on static analysis
 								continue;
 							} else {
 								// Unknown input - propagate a return value without any annotation - we know it's a Type but we know nothing about it
-								methodReturnValue = MergePointValue.MergeValues (methodReturnValue, new MethodReturnValue (calledMethod.MethodReturnType, DynamicallyAccessedMemberTypes.None));
+								methodReturnValue = MergePointValue.MergeValues (methodReturnValue, new MethodReturnValue (this, calledMethod.MethodReturnType, DynamicallyAccessedMemberTypes.None));
 							}
 						}
 					}
@@ -1683,7 +1676,7 @@ namespace Mono.Linker.Dataflow
 					// To get good reporting of errors we need to track the origin of the value for all method calls
 					// but except Newobj as those are special.
 					if (calledMethodDefinition.ReturnType.MetadataType != MetadataType.Void) {
-						methodReturnValue = new MethodReturnValue (calledMethodDefinition.MethodReturnType, returnValueDynamicallyAccessedMemberTypes);
+						methodReturnValue = new MethodReturnValue (this, calledMethodDefinition.MethodReturnType, returnValueDynamicallyAccessedMemberTypes);
 
 						return true;
 					}
@@ -1699,7 +1692,7 @@ namespace Mono.Linker.Dataflow
 			// unknown value with the return type of the method.
 			if (methodReturnValue == null) {
 				if (calledMethod.ReturnType.MetadataType != MetadataType.Void) {
-					methodReturnValue = new MethodReturnValue (calledMethodDefinition.MethodReturnType, returnValueDynamicallyAccessedMemberTypes);
+					methodReturnValue = new MethodReturnValue (this, calledMethodDefinition.MethodReturnType, returnValueDynamicallyAccessedMemberTypes);
 				}
 			}
 
@@ -1784,7 +1777,7 @@ namespace Mono.Linker.Dataflow
 							}
 
 							var typeRef = _context.TypeNameResolver.ResolveTypeName (resolvedAssembly, typeNameStringValue.Contents);
-							var resolvedType = typeRef?.Resolve ();
+							var resolvedType = _context.TryResolveTypeDefinition (typeRef);
 							if (resolvedType == null || typeRef is ArrayType) {
 								// It's not wrong to have a reference to non-existing type - the code may well expect to get an exception in this case
 								// Note that we did find the assembly, so it's not a linker config problem, it's either intentional, or wrong versions of assemblies
@@ -1813,7 +1806,7 @@ namespace Mono.Linker.Dataflow
 			ref ValueNode methodReturnValue)
 		{
 			bool foundAny = false;
-			foreach (var method in typeDefinition.GetMethodsOnTypeHierarchy (m => m.Name == methodName, bindingFlags)) {
+			foreach (var method in typeDefinition.GetMethodsOnTypeHierarchy (_context, m => m.Name == methodName, bindingFlags)) {
 				MarkMethod (ref reflectionContext, method);
 				methodReturnValue = MergePointValue.MergeValues (methodReturnValue, new SystemReflectionMethodBaseValue (method));
 				foundAny = true;
@@ -2049,7 +2042,7 @@ namespace Mono.Linker.Dataflow
 					MarkTypeForDynamicallyAccessedMembers (ref reflectionContext, systemTypeValue.TypeRepresented, requiredMemberTypes);
 				} else if (uniqueValue is KnownStringValue knownStringValue) {
 					TypeReference typeRef = _context.TypeNameResolver.ResolveTypeName (knownStringValue.Contents, reflectionContext.Source, out AssemblyDefinition typeAssembly);
-					TypeDefinition foundType = typeRef?.ResolveToMainTypeDefinition ();
+					TypeDefinition foundType = ResolveToTypeDefinition (typeRef);
 					if (foundType == null) {
 						// Intentionally ignore - it's not wrong for code to call Type.GetType on non-existing name, the code might expect null/exception back.
 						reflectionContext.RecordHandledPattern ();
@@ -2083,7 +2076,7 @@ namespace Mono.Linker.Dataflow
 							$"Value passed to implicit 'this' parameter of method '{methodDefinition.GetDisplayName ()}' can not be statically determined and may not meet 'DynamicallyAccessedMembersAttribute' requirements.");
 						break;
 					case GenericParameter genericParameter:
-						// Unknown value to generic parameter - this is possible if the generic argumnet fails to resolve
+						// Unknown value to generic parameter - this is possible if the generic argument fails to resolve
 						reflectionContext.RecordUnrecognizedPattern (
 							2066,
 							$"Type passed to generic parameter '{genericParameter.Name}' of '{DiagnosticUtilities.GetGenericParameterDeclaringMemberDisplayName (genericParameter)}' can not be statically determined and may not meet 'DynamicallyAccessedMembersAttribute' requirements.");
@@ -2104,7 +2097,7 @@ namespace Mono.Linker.Dataflow
 
 		void MarkTypeForDynamicallyAccessedMembers (ref ReflectionPatternContext reflectionContext, TypeDefinition typeDefinition, DynamicallyAccessedMemberTypes requiredMemberTypes)
 		{
-			foreach (var member in typeDefinition.GetDynamicallyAccessedMembers (requiredMemberTypes)) {
+			foreach (var member in typeDefinition.GetDynamicallyAccessedMembers (_context, requiredMemberTypes)) {
 				switch (member) {
 				case MethodDefinition method:
 					MarkMethod (ref reflectionContext, method, DependencyKind.DynamicallyAccessedMember);
@@ -2132,7 +2125,8 @@ namespace Mono.Linker.Dataflow
 		void MarkType (ref ReflectionPatternContext reflectionContext, TypeReference typeReference)
 		{
 			var source = reflectionContext.Source;
-			reflectionContext.RecordRecognizedPattern (typeReference?.Resolve (), () => _markStep.MarkTypeVisibleToReflection (typeReference, new DependencyInfo (DependencyKind.AccessedViaReflection, source), source));
+			TypeDefinition type = _context.TryResolveTypeDefinition (typeReference);
+			reflectionContext.RecordRecognizedPattern (type, () => _markStep.MarkTypeVisibleToReflection (typeReference, type, new DependencyInfo (DependencyKind.AccessedViaReflection, source), source));
 		}
 
 		void MarkMethod (ref ReflectionPatternContext reflectionContext, MethodDefinition method, DependencyKind dependencyKind = DependencyKind.AccessedViaReflection)
@@ -2145,7 +2139,8 @@ namespace Mono.Linker.Dataflow
 		void MarkNestedType (ref ReflectionPatternContext reflectionContext, TypeDefinition nestedType, DependencyKind dependencyKind = DependencyKind.AccessedViaReflection)
 		{
 			var source = reflectionContext.Source;
-			reflectionContext.RecordRecognizedPattern (nestedType, () => _markStep.MarkTypeVisibleToReflection (nestedType, new DependencyInfo (dependencyKind, source), source));
+			TypeDefinition type = _context.TryResolveTypeDefinition (nestedType);
+			reflectionContext.RecordRecognizedPattern (nestedType, () => _markStep.MarkTypeVisibleToReflection (nestedType, type, new DependencyInfo (dependencyKind, source), source));
 		}
 
 		void MarkField (ref ReflectionPatternContext reflectionContext, FieldDefinition field, DependencyKind dependencyKind = DependencyKind.AccessedViaReflection)
@@ -2188,7 +2183,7 @@ namespace Mono.Linker.Dataflow
 
 		void MarkFieldsOnTypeHierarchy (ref ReflectionPatternContext reflectionContext, TypeDefinition type, Func<FieldDefinition, bool> filter, BindingFlags? bindingFlags = BindingFlags.Default)
 		{
-			foreach (var field in type.GetFieldsOnTypeHierarchy (filter, bindingFlags))
+			foreach (var field in type.GetFieldsOnTypeHierarchy (_context, filter, bindingFlags))
 				MarkField (ref reflectionContext, field);
 		}
 
@@ -2206,13 +2201,13 @@ namespace Mono.Linker.Dataflow
 
 		void MarkPropertiesOnTypeHierarchy (ref ReflectionPatternContext reflectionContext, TypeDefinition type, Func<PropertyDefinition, bool> filter, BindingFlags? bindingFlags = BindingFlags.Default)
 		{
-			foreach (var property in type.GetPropertiesOnTypeHierarchy (filter, bindingFlags))
+			foreach (var property in type.GetPropertiesOnTypeHierarchy (_context, filter, bindingFlags))
 				MarkProperty (ref reflectionContext, property);
 		}
 
 		void MarkEventsOnTypeHierarchy (ref ReflectionPatternContext reflectionContext, TypeDefinition type, Func<EventDefinition, bool> filter, BindingFlags? bindingFlags = BindingFlags.Default)
 		{
-			foreach (var @event in type.GetEventsOnTypeHierarchy (filter, bindingFlags))
+			foreach (var @event in type.GetEventsOnTypeHierarchy (_context, filter, bindingFlags))
 				MarkEvent (ref reflectionContext, @event);
 		}
 

--- a/src/linker/Linker.Dataflow/ValueNode.cs
+++ b/src/linker/Linker.Dataflow/ValueNode.cs
@@ -901,12 +901,12 @@ namespace Mono.Linker.Dataflow
 	/// </summary>
 	class MethodReturnValue : LeafValueWithDynamicallyAccessedMemberNode
 	{
-		public MethodReturnValue (MethodBodyScanner scanner, MethodReturnType methodReturnType, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
+		public MethodReturnValue (TypeDefinition staticType, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes, IMetadataTokenProvider sourceContext)
 		{
 			Kind = ValueNodeKind.MethodReturn;
-			StaticType = scanner.ResolveToTypeDefinition (methodReturnType.ReturnType);
+			StaticType = staticType;
 			DynamicallyAccessedMemberTypes = dynamicallyAccessedMemberTypes;
-			SourceContext = methodReturnType;
+			SourceContext = sourceContext;
 		}
 
 		public override bool Equals (ValueNode other)

--- a/src/linker/Linker.Dataflow/ValueNode.cs
+++ b/src/linker/Linker.Dataflow/ValueNode.cs
@@ -833,14 +833,14 @@ namespace Mono.Linker.Dataflow
 	/// </summary>
 	class MethodParameterValue : LeafValueWithDynamicallyAccessedMemberNode
 	{
-		public MethodParameterValue (MethodDefinition method, int parameterIndex, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes, IMetadataTokenProvider sourceContext)
+		public MethodParameterValue (MethodBodyScanner scanner, MethodDefinition method, int parameterIndex, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes, IMetadataTokenProvider sourceContext)
 		{
 			Kind = ValueNodeKind.MethodParameter;
 			StaticType = method.HasImplicitThis ()
 				? (parameterIndex == 0
 					? method.DeclaringType
-					: method.Parameters[parameterIndex - 1].ParameterType.ResolveToMainTypeDefinition ())
-				: method.Parameters[parameterIndex].ParameterType.ResolveToMainTypeDefinition ();
+					: scanner.ResolveToTypeDefinition (method.Parameters[parameterIndex - 1].ParameterType))
+				: scanner.ResolveToTypeDefinition (method.Parameters[parameterIndex].ParameterType);
 			ParameterIndex = parameterIndex;
 			DynamicallyAccessedMemberTypes = dynamicallyAccessedMemberTypes;
 			SourceContext = sourceContext;
@@ -905,10 +905,10 @@ namespace Mono.Linker.Dataflow
 	/// </summary>
 	class MethodReturnValue : LeafValueWithDynamicallyAccessedMemberNode
 	{
-		public MethodReturnValue (MethodReturnType methodReturnType, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
+		public MethodReturnValue (MethodBodyScanner scanner, MethodReturnType methodReturnType, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
 		{
 			Kind = ValueNodeKind.MethodReturn;
-			StaticType = methodReturnType.ReturnType.ResolveToMainTypeDefinition ();
+			StaticType = scanner.ResolveToTypeDefinition (methodReturnType.ReturnType);
 			DynamicallyAccessedMemberTypes = dynamicallyAccessedMemberTypes;
 			SourceContext = methodReturnType;
 		}
@@ -1144,10 +1144,10 @@ namespace Mono.Linker.Dataflow
 	/// </summary>
 	class LoadFieldValue : LeafValueWithDynamicallyAccessedMemberNode
 	{
-		public LoadFieldValue (FieldDefinition fieldToLoad, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
+		public LoadFieldValue (MethodBodyScanner scanner, FieldDefinition fieldToLoad, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
 		{
 			Kind = ValueNodeKind.LoadField;
-			StaticType = fieldToLoad.FieldType.ResolveToMainTypeDefinition ();
+			StaticType = scanner.ResolveToTypeDefinition (fieldToLoad.FieldType);
 			Field = fieldToLoad;
 			DynamicallyAccessedMemberTypes = dynamicallyAccessedMemberTypes;
 			SourceContext = fieldToLoad;
@@ -1227,7 +1227,7 @@ namespace Mono.Linker.Dataflow
 			StaticType = null;
 
 			Size = size ?? UnknownValue.Instance;
-			ElementType = elementType.ResolveToMainTypeDefinition ();
+			ElementType = elementType;
 			IndexValues = new Dictionary<int, ValueBasicBlockPair> ();
 		}
 

--- a/src/linker/Linker.Dataflow/ValueNode.cs
+++ b/src/linker/Linker.Dataflow/ValueNode.cs
@@ -833,14 +833,10 @@ namespace Mono.Linker.Dataflow
 	/// </summary>
 	class MethodParameterValue : LeafValueWithDynamicallyAccessedMemberNode
 	{
-		public MethodParameterValue (MethodBodyScanner scanner, MethodDefinition method, int parameterIndex, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes, IMetadataTokenProvider sourceContext)
+		public MethodParameterValue (TypeDefinition staticType, int parameterIndex, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes, IMetadataTokenProvider sourceContext)
 		{
 			Kind = ValueNodeKind.MethodParameter;
-			StaticType = method.HasImplicitThis ()
-				? (parameterIndex == 0
-					? method.DeclaringType
-					: scanner.ResolveToTypeDefinition (method.Parameters[parameterIndex - 1].ParameterType))
-				: scanner.ResolveToTypeDefinition (method.Parameters[parameterIndex].ParameterType);
+			StaticType = staticType;
 			ParameterIndex = parameterIndex;
 			DynamicallyAccessedMemberTypes = dynamicallyAccessedMemberTypes;
 			SourceContext = sourceContext;
@@ -1144,10 +1140,10 @@ namespace Mono.Linker.Dataflow
 	/// </summary>
 	class LoadFieldValue : LeafValueWithDynamicallyAccessedMemberNode
 	{
-		public LoadFieldValue (MethodBodyScanner scanner, FieldDefinition fieldToLoad, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
+		public LoadFieldValue (TypeDefinition staticType, FieldDefinition fieldToLoad, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
 		{
 			Kind = ValueNodeKind.LoadField;
-			StaticType = scanner.ResolveToTypeDefinition (fieldToLoad.FieldType);
+			StaticType = staticType;
 			Field = fieldToLoad;
 			DynamicallyAccessedMemberTypes = dynamicallyAccessedMemberTypes;
 			SourceContext = fieldToLoad;

--- a/src/linker/Linker.Steps/LinkAttributesParser.cs
+++ b/src/linker/Linker.Steps/LinkAttributesParser.cs
@@ -258,7 +258,7 @@ namespace Mono.Linker.Steps
 				return new CustomAttributeArgument (typeref, ConvertStringValue (svalue, typeref));
 
 			case MetadataType.ValueType:
-				var enumType = typeref.Resolve ();
+				var enumType = _context.ResolveTypeDefinition (typeref);
 				if (enumType?.IsEnum != true)
 					goto default;
 
@@ -376,7 +376,7 @@ namespace Mono.Linker.Steps
 					return false;
 				}
 
-				attributeType = _context.TypeNameResolver.ResolveTypeName (assembly, attributeFullName)?.Resolve ();
+				attributeType = _context.TryResolveTypeDefinition (assembly, attributeFullName);
 			}
 
 			if (attributeType == null) {

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -279,8 +279,7 @@ namespace Mono.Linker.Steps
 				return false;
 
 			foreach (var ca in type.CustomAttributes) {
-				TypeDefinition caType = ca.AttributeType.Resolve ();
-				if (caType?.Name == "DynamicInterfaceCastableImplementationAttribute" && caType.Namespace == "System.Runtime.InteropServices")
+				if (ca.AttributeType.IsTypeOf ("System.Runtime.InteropServices", "DynamicInterfaceCastableImplementationAttribute"))
 					return true;
 			}
 			return false;
@@ -324,7 +323,7 @@ namespace Mono.Linker.Steps
 			}
 
 			Annotations.Mark (type, reason);
-			var baseTypeDefinition = type.BaseType?.Resolve ();
+			var baseTypeDefinition = _context.ResolveTypeDefinition (type.BaseType);
 			if (includeBaseTypes && baseTypeDefinition != null) {
 				MarkEntireTypeInternal (baseTypeDefinition, includeBaseTypes: true, includeInterfaceTypes, new DependencyInfo (DependencyKind.BaseType, type), type);
 			}
@@ -333,7 +332,7 @@ namespace Mono.Linker.Steps
 
 			if (type.HasInterfaces) {
 				foreach (InterfaceImplementation iface in type.Interfaces) {
-					var interfaceTypeDefinition = iface.InterfaceType.Resolve ();
+					var interfaceTypeDefinition = _context.ResolveTypeDefinition (iface.InterfaceType);
 					if (includeInterfaceTypes && interfaceTypeDefinition != null)
 						MarkEntireTypeInternal (interfaceTypeDefinition, includeBaseTypes, includeInterfaceTypes: true, new DependencyInfo (reason.Kind, type), type);
 
@@ -699,7 +698,7 @@ namespace Mono.Linker.Steps
 		{
 			if (type.HasInterfaces) {
 				foreach (var intf in type.Interfaces) {
-					TypeDefinition resolvedInterface = intf.InterfaceType.Resolve ();
+					TypeDefinition resolvedInterface = _context.ResolveTypeDefinition (intf.InterfaceType);
 					if (resolvedInterface == null)
 						continue;
 
@@ -718,7 +717,7 @@ namespace Mono.Linker.Steps
 
 			if (typeToExamine.HasInterfaces) {
 				foreach (var iface in typeToExamine.Interfaces) {
-					var resolved = iface.InterfaceType.Resolve ();
+					var resolved = _context.TryResolveTypeDefinition (iface.InterfaceType);
 					if (resolved == null)
 						continue;
 
@@ -745,12 +744,10 @@ namespace Mono.Linker.Steps
 
 			if (spec.MarshalInfo is CustomMarshalInfo marshaler) {
 				MarkType (marshaler.ManagedType, reason, sourceLocationMember);
-				TypeDefinition type = marshaler.ManagedType.Resolve ();
+				TypeDefinition type = _context.ResolveTypeDefinition (marshaler.ManagedType);
 				if (type != null) {
 					MarkICustomMarshalerMethods (type, in reason, sourceLocationMember);
 					MarkCustomMarshalerGetInstance (type, in reason, sourceLocationMember);
-				} else {
-					HandleUnresolvedType (marshaler.ManagedType);
 				}
 			}
 		}
@@ -773,9 +770,8 @@ namespace Mono.Linker.Steps
 					if (UnconditionalSuppressMessageAttributeState.TypeRefHasUnconditionalSuppressions (ca.Constructor.DeclaringType))
 						_context.Suppressions.AddSuppression (ca, provider);
 
-					var resolvedAttributeType = ca.AttributeType.Resolve ();
+					var resolvedAttributeType = _context.ResolveTypeDefinition (ca.AttributeType);
 					if (resolvedAttributeType == null) {
-						HandleUnresolvedType (ca.AttributeType);
 						continue;
 					}
 
@@ -875,13 +871,13 @@ namespace Mono.Linker.Steps
 
 				MarkingHelpers.MarkMatchingExportedType (type, assembly, new DependencyInfo (DependencyKind.DynamicDependency, type));
 			} else if (dynamicDependency.Type is TypeReference typeReference) {
-				type = typeReference.Resolve ();
+				type = _context.TryResolveTypeDefinition (typeReference);
 				if (type == null) {
 					_context.LogWarning ($"Unresolved type '{typeReference}' in DynamicDependencyAtribute", 2036, context);
 					return;
 				}
 			} else {
-				type = context.DeclaringType.Resolve ();
+				type = _context.TryResolveTypeDefinition (context.DeclaringType);
 				if (type == null) {
 					_context.LogWarning ($"Unresolved type '{context.DeclaringType}' in DynamicDependencyAttribute", 2036, context);
 					return;
@@ -897,7 +893,7 @@ namespace Mono.Linker.Steps
 				}
 			} else {
 				var memberTypes = dynamicDependency.MemberTypes;
-				members = DynamicallyAccessedMembersBinder.GetDynamicallyAccessedMembers (type, memberTypes);
+				members = type.GetDynamicallyAccessedMembers (_context, memberTypes);
 				if (!members.Any ()) {
 					_context.LogWarning ($"No members were resolved for '{memberTypes}'.", 2037, context);
 					return;
@@ -963,12 +959,10 @@ namespace Mono.Linker.Steps
 				assembly = null;
 			}
 
-			TypeDefinition td = null;
+			TypeDefinition td;
 			if (args.Count >= 2 && args[1].Value is string typeName) {
 				AssemblyDefinition assemblyDef = assembly ?? (context as MemberReference).Module.Assembly;
-				TypeReference tr = _context.TypeNameResolver.ResolveTypeName (assemblyDef, typeName);
-				if (tr != null)
-					td = tr.Resolve ();
+				td = _context.TryResolveTypeDefinition (assemblyDef, typeName);
 
 				if (td == null) {
 					_context.LogWarning (
@@ -978,7 +972,7 @@ namespace Mono.Linker.Steps
 
 				MarkingHelpers.MarkMatchingExportedType (td, assemblyDef, new DependencyInfo (DependencyKind.PreservedDependency, ca));
 			} else {
-				td = context.DeclaringType.Resolve ();
+				td = _context.TryResolveTypeDefinition (context.DeclaringType);
 			}
 
 			string member = null;
@@ -1075,10 +1069,9 @@ namespace Mono.Linker.Steps
 			MarkCustomAttributeArguments (source, ca);
 
 			TypeReference constructor_type = ca.Constructor.DeclaringType;
-			TypeDefinition type = constructor_type.Resolve ();
+			TypeDefinition type = _context.ResolveTypeDefinition (constructor_type);
 
 			if (type == null) {
-				HandleUnresolvedType (constructor_type);
 				return;
 			}
 
@@ -1105,7 +1098,8 @@ namespace Mono.Linker.Steps
 					return true;
 				}
 
-				if (!Annotations.IsMarked (attr_type.Resolve ()))
+				TypeDefinition type = _context.ResolveTypeDefinition (attr_type);
+				if (type is null || !Annotations.IsMarked (type))
 					return false;
 			}
 
@@ -1178,9 +1172,8 @@ namespace Mono.Linker.Steps
 		protected virtual void MarkSecurityAttribute (SecurityAttribute sa, in DependencyInfo reason, IMemberDefinition sourceLocationMember)
 		{
 			TypeReference security_type = sa.AttributeType;
-			TypeDefinition type = security_type.Resolve ();
+			TypeDefinition type = _context.ResolveTypeDefinition (security_type);
 			if (type == null) {
-				HandleUnresolvedType (security_type);
 				return;
 			}
 
@@ -1214,14 +1207,14 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		static PropertyDefinition GetProperty (TypeDefinition type, string propertyname)
+		PropertyDefinition GetProperty (TypeDefinition type, string propertyname)
 		{
 			while (type != null) {
 				PropertyDefinition property = type.Properties.FirstOrDefault (p => p.Name == propertyname);
 				if (property != null)
 					return property;
 
-				type = type.BaseType?.Resolve ();
+				type = _context.TryResolveTypeDefinition (type.BaseType);
 			}
 
 			return null;
@@ -1250,27 +1243,27 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		static FieldDefinition GetField (TypeDefinition type, string fieldname)
+		FieldDefinition GetField (TypeDefinition type, string fieldname)
 		{
 			while (type != null) {
 				FieldDefinition field = type.Fields.FirstOrDefault (f => f.Name == fieldname);
 				if (field != null)
 					return field;
 
-				type = type.BaseType?.Resolve ();
+				type = _context.TryResolveTypeDefinition (type.BaseType);
 			}
 
 			return null;
 		}
 
-		static MethodDefinition GetMethodWithNoParameters (TypeDefinition type, string methodname)
+		MethodDefinition GetMethodWithNoParameters (TypeDefinition type, string methodname)
 		{
 			while (type != null) {
 				MethodDefinition method = type.Methods.FirstOrDefault (m => m.Name == methodname && !m.HasParameters);
 				if (method != null)
 					return method;
 
-				type = type.BaseType?.Resolve ();
+				type = _context.TryResolveTypeDefinition (type.BaseType);
 			}
 
 			return null;
@@ -1284,7 +1277,7 @@ namespace Mono.Linker.Steps
 			foreach (var argument in ca.ConstructorArguments)
 				MarkCustomAttributeArgument (argument, ca, source);
 
-			var resolvedConstructor = ca.Constructor.Resolve ();
+			var resolvedConstructor = _context.TryResolveMethodDefinition (ca.Constructor);
 			if (resolvedConstructor != null && _context.Annotations.FlowAnnotations.RequiresDataFlowAnalysis (resolvedConstructor)) {
 				var scanner = new ReflectionMethodBodyScanner (_context, this);
 				scanner.ProcessAttributeDataflow (source, resolvedConstructor, ca.ConstructorArguments);
@@ -1408,9 +1401,8 @@ namespace Mono.Linker.Steps
 				var assemblyLevelAttribute = _assemblyLevelAttributes.Dequeue ();
 				var customAttribute = assemblyLevelAttribute.Attribute;
 
-				var resolved = customAttribute.Constructor.Resolve ();
+				var resolved = _context.ResolveMethodDefinition (customAttribute.Constructor);
 				if (resolved == null) {
-					HandleUnresolvedMethod (customAttribute.Constructor);
 					continue;
 				}
 
@@ -1460,9 +1452,8 @@ namespace Mono.Linker.Steps
 				var customAttribute = attributeProviderPair.Attribute;
 				var provider = attributeProviderPair.Provider;
 
-				var resolved = customAttribute.Constructor.Resolve ();
+				var resolved = _context.ResolveMethodDefinition (customAttribute.Constructor);
 				if (resolved == null) {
-					HandleUnresolvedMethod (customAttribute.Constructor);
 					continue;
 				}
 
@@ -1495,10 +1486,9 @@ namespace Mono.Linker.Steps
 				reason = new DependencyInfo (DependencyKind.FieldOnGenericInstance, reference);
 			}
 
-			FieldDefinition field = reference.Resolve ();
+			FieldDefinition field = _context.ResolveFieldDefinition (reference);
 
 			if (field == null) {
-				HandleUnresolvedField (reference);
 				return;
 			}
 
@@ -1541,7 +1531,7 @@ namespace Mono.Linker.Steps
 				TypeDefinition typeWithFields = field.DeclaringType;
 				while (typeWithFields != null) {
 					MarkImplicitlyUsedFields (typeWithFields);
-					typeWithFields = typeWithFields.BaseType?.Resolve ();
+					typeWithFields = _context.TryResolveTypeDefinition (typeWithFields.BaseType);
 				}
 			}
 
@@ -1595,16 +1585,16 @@ namespace Mono.Linker.Steps
 			MarkMethodsIf (type.Methods, HasOnSerializeOrDeserializeAttribute, new DependencyInfo (DependencyKind.SerializationMethodForType, type), type);
 		}
 
-		protected internal virtual TypeDefinition MarkTypeVisibleToReflection (TypeReference reference, DependencyInfo reason, IMemberDefinition sourceLocationMember)
+		protected internal virtual TypeDefinition MarkTypeVisibleToReflection (TypeReference type, TypeDefinition definition, DependencyInfo reason, IMemberDefinition sourceLocationMember)
 		{
 			// If a type is visible to reflection, we need to stop doing optimization that could cause observable difference
 			// in reflection APIs. This includes APIs like MakeGenericType (where variant castability of the produced type
 			// could be incorrect) or IsAssignableFrom (where assignability of unconstructed types might change).
-			Annotations.MarkRelevantToVariantCasting (reference.Resolve ());
+			Annotations.MarkRelevantToVariantCasting (definition);
 
-			MarkImplicitlyUsedFields (reference.Resolve ());
+			MarkImplicitlyUsedFields (definition);
 
-			return MarkType (reference, reason, sourceLocationMember);
+			return MarkType (type, reason, sourceLocationMember);
 		}
 
 		/// <summary>
@@ -1614,8 +1604,7 @@ namespace Mono.Linker.Steps
 		/// <param name="reason">The reason why the marking is occuring</param>
 		/// <param name="sourceLocationMember">The member which is the "source location" for the marking.
 		/// For example if the type is marked due to an instruction in a method's body, this should be the method which body it is.</param>
-		/// <returns>The resolved type definition if the reference can be resolved and if the call ended up actually marking.
-		/// If the type definition was already marked, the method returns null.</returns>
+		/// <returns>The resolved type definition if the reference can be resolved</returns>
 		protected internal virtual TypeDefinition MarkType (TypeReference reference, DependencyInfo reason, IMemberDefinition sourceLocationMember)
 		{
 #if DEBUG
@@ -1633,12 +1622,10 @@ namespace Mono.Linker.Steps
 			if (reference is GenericParameter)
 				return null;
 
-			TypeDefinition type = reference.Resolve ();
+			TypeDefinition type = _context.ResolveTypeDefinition (reference);
 
-			if (type == null) {
-				HandleUnresolvedType (reference);
+			if (type == null)
 				return null;
-			}
 
 			// Track a mark reason for each call to MarkType.
 			switch (reason.Kind) {
@@ -1670,7 +1657,7 @@ namespace Mono.Linker.Steps
 			}
 
 			if (CheckProcessed (type))
-				return null;
+				return type;
 
 			MarkModule (type.Scope as ModuleDefinition, new DependencyInfo (DependencyKind.ScopeOfType, type));
 
@@ -1790,17 +1777,17 @@ namespace Mono.Linker.Steps
 		{
 			foreach (var property in ca.Properties) {
 				if (property.Name == "Target")
-					return ((TypeReference) property.Argument.Value)?.Resolve ();
+					return _context.ResolveTypeDefinition ((TypeReference) property.Argument.Value);
 
 				if (property.Name == "TargetTypeName") {
 					string targetTypeName = (string) property.Argument.Value;
 					TypeName typeName = TypeParser.ParseTypeName (targetTypeName);
 					if (typeName is AssemblyQualifiedTypeName assemblyQualifiedTypeName) {
 						AssemblyDefinition assembly = _context.TryResolve (assemblyQualifiedTypeName.AssemblyName.Name);
-						return _context.TypeNameResolver.ResolveTypeName (assembly, targetTypeName)?.Resolve ();
+						return _context.TryResolveTypeDefinition (assembly, targetTypeName);
 					}
 
-					return _context.TypeNameResolver.ResolveTypeName (asm, targetTypeName)?.Resolve ();
+					return _context.TryResolveTypeDefinition (asm, targetTypeName);
 				}
 			}
 
@@ -1814,9 +1801,8 @@ namespace Mono.Linker.Steps
 
 			foreach (CustomAttribute attribute in type.CustomAttributes) {
 				var attrType = attribute.Constructor.DeclaringType;
-				var resolvedAttributeType = attrType.Resolve ();
+				var resolvedAttributeType = _context.ResolveTypeDefinition (attrType);
 				if (resolvedAttributeType == null) {
-					HandleUnresolvedType (attrType);
 					continue;
 				}
 
@@ -1899,7 +1885,7 @@ namespace Mono.Linker.Steps
 
 				break;
 			case TypeReference type:
-				typeDefinition = type.Resolve ();
+				typeDefinition = _context.ResolveTypeDefinition (type);
 				break;
 			}
 
@@ -1973,7 +1959,7 @@ namespace Mono.Linker.Steps
 						// This can be improved: mono/linker/issues/1873
 						MarkMethods (type, new DependencyInfo (DependencyKind.KeptForSpecialAttribute, attribute), type);
 						MarkFields (type, includeStatic: true, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute));
-						type = type.BaseType?.Resolve ();
+						type = _context.TryResolveTypeDefinition (type.BaseType);
 					}
 					return;
 				}
@@ -1998,7 +1984,7 @@ namespace Mono.Linker.Steps
 				Tracer.AddDirectDependency (attribute, new DependencyInfo (DependencyKind.CustomAttribute, type), marked: false);
 				MarkType (proxyTypeReference, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute), type);
 
-				TypeDefinition proxyType = proxyTypeReference.Resolve ();
+				TypeDefinition proxyType = _context.TryResolveTypeDefinition (proxyTypeReference);
 				if (proxyType != null) {
 					MarkMethods (proxyType, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute), type);
 					MarkFields (proxyType, includeStatic: true, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute));
@@ -2083,9 +2069,8 @@ namespace Mono.Linker.Steps
 			foreach (var iface in type.Interfaces) {
 				// Only mark interface implementations of interface types that have been marked.
 				// This enables stripping of interfaces that are never used
-				var resolvedInterfaceType = iface.InterfaceType.Resolve ();
+				var resolvedInterfaceType = _context.ResolveTypeDefinition (iface.InterfaceType);
 				if (resolvedInterfaceType == null) {
-					HandleUnresolvedType (iface.InterfaceType);
 					continue;
 				}
 
@@ -2235,9 +2220,8 @@ namespace Mono.Linker.Steps
 					// Instead of trying to guess where to find the interface declaration linker walks
 					// the list of implemented interfaces and resolve the declaration from there
 					//
-					var tdef = iface_type.Resolve ();
+					var tdef = _context.ResolveTypeDefinition (iface_type);
 					if (tdef == null) {
-						HandleUnresolvedType (iface_type);
 						return;
 					}
 
@@ -2246,7 +2230,7 @@ namespace Mono.Linker.Steps
 					MarkInterfaceImplementation (iface, type);
 					return;
 				}
-			} while ((type = type.BaseType?.Resolve ()) != null);
+			} while ((type = _context.TryResolveTypeDefinition (type.BaseType)) != null);
 		}
 
 		static bool IsNonEmptyStaticConstructor (MethodDefinition method)
@@ -2369,7 +2353,7 @@ namespace Mono.Linker.Steps
 				var argument = arguments[i];
 				var parameter = parameters[i];
 
-				MarkType (argument, new DependencyInfo (DependencyKind.GenericArgumentType, instance), sourceLocationMember);
+				TypeDefinition argumentTypeDef = MarkType (argument, new DependencyInfo (DependencyKind.GenericArgumentType, instance), sourceLocationMember);
 
 				if (_context.Annotations.FlowAnnotations.RequiresDataFlowAnalysis (parameter)) {
 					// The only two implementations of IGenericInstance both derive from MemberReference
@@ -2379,21 +2363,23 @@ namespace Mono.Linker.Steps
 					scanner.ProcessGenericArgumentDataFlow (parameter, argument, sourceLocationMember ?? (instance as MemberReference).Resolve ());
 				}
 
-				var argument_definition = argument.Resolve ();
-				Annotations.MarkRelevantToVariantCasting (argument_definition);
+				if (argumentTypeDef == null)
+					continue;
+
+				Annotations.MarkRelevantToVariantCasting (argumentTypeDef);
 
 				if (parameter.HasDefaultConstructorConstraint)
-					MarkDefaultConstructor (argument_definition, new DependencyInfo (DependencyKind.DefaultCtorForNewConstrainedGenericArgument, instance), sourceLocationMember);
+					MarkDefaultConstructor (argumentTypeDef, new DependencyInfo (DependencyKind.DefaultCtorForNewConstrainedGenericArgument, instance), sourceLocationMember);
 			}
 		}
 
-		static IGenericParameterProvider GetGenericProviderFromInstance (IGenericInstance instance)
+		IGenericParameterProvider GetGenericProviderFromInstance (IGenericInstance instance)
 		{
 			if (instance is GenericInstanceMethod method)
-				return method.ElementMethod.Resolve ();
+				return _context.TryResolveMethodDefinition (method.ElementMethod);
 
 			if (instance is GenericInstanceType type)
-				return type.ElementType.Resolve ();
+				return _context.TryResolveTypeDefinition (type.ElementType);
 
 			return null;
 		}
@@ -2587,7 +2573,7 @@ namespace Mono.Linker.Steps
 				MarkType (reference.DeclaringType, new DependencyInfo (DependencyKind.DeclaringType, reference), origin?.MemberDefinition);
 
 				if (reference.Name == ".ctor") {
-					Annotations.MarkRelevantToVariantCasting (arrayType.Resolve ());
+					Annotations.MarkRelevantToVariantCasting (_context.TryResolveTypeDefinition (arrayType));
 				}
 				return null;
 			}
@@ -2600,12 +2586,9 @@ namespace Mono.Linker.Steps
 				reason = new DependencyInfo (DependencyKind.MethodOnGenericInstance, reference);
 			}
 
-			MethodDefinition method = reference.Resolve ();
-
-			if (method == null) {
-				HandleUnresolvedMethod (reference);
+			MethodDefinition method = _context.ResolveMethodDefinition (reference);
+			if (method == null)
 				return null;
-			}
 
 			if (Annotations.GetAction (method) == MethodAction.Nothing)
 				Annotations.SetAction (method, MethodAction.Parse);
@@ -2840,18 +2823,15 @@ namespace Mono.Linker.Steps
 
 		void MarkExplicitInterfaceImplementation (MethodDefinition method, MethodReference ov)
 		{
-			var resolvedOverride = ov.Resolve ();
+			MethodDefinition resolvedOverride = _context.ResolveMethodDefinition (ov);
 
-			if (resolvedOverride == null) {
-				HandleUnresolvedMethod (ov);
+			if (resolvedOverride == null)
 				return;
-			}
 
 			if (resolvedOverride.DeclaringType.IsInterface) {
 				foreach (var ifaceImpl in method.DeclaringType.Interfaces) {
-					var resolvedInterfaceType = ifaceImpl.InterfaceType.Resolve ();
+					var resolvedInterfaceType = _context.ResolveTypeDefinition (ifaceImpl.InterfaceType);
 					if (resolvedInterfaceType == null) {
-						HandleUnresolvedType (ifaceImpl.InterfaceType);
 						continue;
 					}
 
@@ -2870,7 +2850,7 @@ namespace Mono.Linker.Steps
 				if (!method.IsInstanceConstructor ())
 					return;
 
-				var baseType = method.DeclaringType.BaseType.Resolve ();
+				var baseType = _context.ResolveTypeDefinition (method.DeclaringType.BaseType);
 				if (!MarkDefaultConstructor (baseType, new DependencyInfo (DependencyKind.BaseDefaultCtorForStubbedMethod, method), method))
 					throw new LinkerFatalErrorException (MessageContainer.CreateErrorMessage ($"Cannot stub constructor on '{method.DeclaringType}' when base type does not have default constructor",
 						1006, origin: new MessageOrigin (method)));
@@ -2957,7 +2937,7 @@ namespace Mono.Linker.Steps
 				}
 			}
 
-			TypeDefinition returnTypeDefinition = method.ReturnType.Resolve ();
+			TypeDefinition returnTypeDefinition = _context.TryResolveTypeDefinition (method.ReturnType);
 
 			bool didWarnAboutCom = false;
 
@@ -2993,7 +2973,7 @@ namespace Mono.Linker.Steps
 				if (paramTypeReference is TypeSpecification) {
 					paramTypeReference = (paramTypeReference as TypeSpecification).ElementType;
 				}
-				TypeDefinition paramTypeDefinition = paramTypeReference?.Resolve ();
+				TypeDefinition paramTypeDefinition = _context.TryResolveTypeDefinition (paramTypeReference);
 				if (paramTypeDefinition != null) {
 					if (!paramTypeDefinition.IsImport) {
 						// What we keep here is correct most of the time, but not every time. Fine for now.
@@ -3017,7 +2997,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		private static bool IsComInterop (IMarshalInfoProvider marshalInfoProvider, TypeReference parameterType)
+		bool IsComInterop (IMarshalInfoProvider marshalInfoProvider, TypeReference parameterType)
 		{
 			// This is best effort. One can likely find ways how to get COM without triggering these alarms.
 			// AsAny marshalling of a struct with an object-typed field would be one, for example.
@@ -3046,7 +3026,7 @@ namespace Mono.Linker.Steps
 					return false;
 				}
 
-				var parameterTypeDef = parameterType.Resolve ();
+				var parameterTypeDef = _context.TryResolveTypeDefinition (parameterType);
 				if (parameterTypeDef != null) {
 					if (parameterTypeDef.IsValueType) {
 						// Value types don't marshal as COM
@@ -3167,7 +3147,7 @@ namespace Mono.Linker.Steps
 			// If a type could be on the stack in the body and an interface it implements could be on the stack on the body
 			// then we need to mark that interface implementation.  When this occurs it is not safe to remove the interface implementation from the type
 			// even if the type is never instantiated
-			var implementations = MethodBodyScanner.GetReferencedInterfaces (body);
+			var implementations = new InterfacesOnStackScanner (_context).GetReferencedInterfaces (body);
 			if (implementations == null)
 				return;
 
@@ -3185,7 +3165,7 @@ namespace Mono.Linker.Steps
 				case Code.Ldflda: // Field address loads (as those can be used to store values to annotated field and thus must be checked)
 				case Code.Ldsflda:
 					requiresReflectionMethodBodyScanner |=
-						ReflectionMethodBodyScanner.RequiresReflectionMethodBodyScannerForAccess (_context.Annotations.FlowAnnotations, (FieldReference) instruction.Operand);
+						ReflectionMethodBodyScanner.RequiresReflectionMethodBodyScannerForAccess (_context, (FieldReference) instruction.Operand);
 					break;
 
 				default: // Other field operations are not interesting as they don't need to be checked
@@ -3204,6 +3184,7 @@ namespace Mono.Linker.Steps
 						Code.Ldftn => DependencyKind.Ldftn,
 						_ => throw new InvalidOperationException ($"unexpected opcode {instruction.OpCode}")
 					};
+
 					requiresReflectionMethodBodyScanner |=
 						ReflectionMethodBodyScanner.RequiresReflectionMethodBodyScannerForCallSite (_context, (MethodReference) instruction.Operand);
 					MarkMethod ((MethodReference) instruction.Operand, new DependencyInfo (dependencyKind, method), new MessageOrigin (method, instruction.Offset));
@@ -3215,7 +3196,9 @@ namespace Mono.Linker.Steps
 					Debug.Assert (instruction.OpCode.Code == Code.Ldtoken);
 					var reason = new DependencyInfo (DependencyKind.Ldtoken, method);
 					if (token is TypeReference typeReference) {
-						MarkTypeVisibleToReflection (typeReference, reason, method);
+						// Error will be reported as part of MarkType
+						TypeDefinition type = _context.TryResolveTypeDefinition (typeReference);
+						MarkTypeVisibleToReflection (typeReference, type, reason, method);
 					} else if (token is MethodReference methodReference) {
 						MarkMethod (methodReference, reason, new MessageOrigin (method, instruction.Offset));
 					} else {
@@ -3228,7 +3211,7 @@ namespace Mono.Linker.Steps
 				var operand = (TypeReference) instruction.Operand;
 				switch (instruction.OpCode.Code) {
 				case Code.Newarr:
-					Annotations.MarkRelevantToVariantCasting (operand.Resolve ());
+					Annotations.MarkRelevantToVariantCasting (_context.TryResolveTypeDefinition (operand));
 					break;
 				case Code.Isinst:
 					if (operand is TypeSpecification || operand is GenericParameter)
@@ -3237,11 +3220,9 @@ namespace Mono.Linker.Steps
 					if (!_context.CanApplyOptimization (CodeOptimizations.UnusedTypeChecks, method.DeclaringType.Module.Assembly))
 						break;
 
-					TypeDefinition type = operand.Resolve ();
-					if (type == null) {
-						HandleUnresolvedType (operand);
+					TypeDefinition type = _context.ResolveTypeDefinition (operand);
+					if (type == null)
 						return;
-					}
 
 					if (type.IsInterface)
 						break;
@@ -3256,27 +3237,6 @@ namespace Mono.Linker.Steps
 
 				MarkType (operand, new DependencyInfo (DependencyKind.InstructionTypeRef, method), method);
 				break;
-			}
-		}
-
-		protected virtual void HandleUnresolvedType (TypeReference reference)
-		{
-			if (!_context.IgnoreUnresolved) {
-				throw new ResolutionException (reference);
-			}
-		}
-
-		protected virtual void HandleUnresolvedMethod (MethodReference reference)
-		{
-			if (!_context.IgnoreUnresolved) {
-				throw new ResolutionException (reference);
-			}
-		}
-
-		protected virtual void HandleUnresolvedField (FieldReference reference)
-		{
-			if (!_context.IgnoreUnresolved) {
-				throw new ResolutionException (reference);
 			}
 		}
 

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1777,7 +1777,7 @@ namespace Mono.Linker.Steps
 		{
 			foreach (var property in ca.Properties) {
 				if (property.Name == "Target")
-					return _context.ResolveTypeDefinition ((TypeReference) property.Argument.Value);
+					return _context.TryResolveTypeDefinition ((TypeReference) property.Argument.Value);
 
 				if (property.Name == "TargetTypeName") {
 					string targetTypeName = (string) property.Argument.Value;

--- a/src/linker/Linker.Steps/SealerStep.cs
+++ b/src/linker/Linker.Steps/SealerStep.cs
@@ -44,7 +44,7 @@ namespace Mono.Linker.Steps
 					void PopulateCache (Collection<TypeDefinition> types)
 					{
 						foreach (var t in types) {
-							var btd = t.BaseType?.Resolve ();
+							var btd = Context.TryResolveTypeDefinition (t.BaseType);
 							if (btd != null)
 								referencedBaseTypeCache.Add (btd);
 
@@ -56,7 +56,7 @@ namespace Mono.Linker.Steps
 				}
 			}
 
-			var bt = type.Resolve ();
+			var bt = Context.TryResolveTypeDefinition (type);
 			return referencedBaseTypeCache.Contains (bt);
 		}
 

--- a/src/linker/Linker.Steps/UnreachableBlocksOptimizer.cs
+++ b/src/linker/Linker.Steps/UnreachableBlocksOptimizer.cs
@@ -283,7 +283,7 @@ namespace Mono.Linker.Steps
 			if (!_context.IsOptimizationEnabled (CodeOptimizations.IPConstantPropagation, method))
 				return null;
 
-			var analyzer = new ConstantExpressionMethodAnalyzer (method, instructions ?? method.Body.Instructions);
+			var analyzer = new ConstantExpressionMethodAnalyzer (_context, method, instructions ?? method.Body.Instructions);
 			if (analyzer.Analyze ()) {
 				return analyzer.Result;
 			}
@@ -355,8 +355,7 @@ namespace Mono.Linker.Steps
 
 				case Code.Call:
 				case Code.Callvirt:
-					var target = (MethodReference) instr.Operand;
-					var md = target.Resolve ();
+					var md = _context.TryResolveMethodDefinition ((MethodReference) instr.Operand);
 					if (md == null)
 						break;
 
@@ -415,12 +414,12 @@ namespace Mono.Linker.Steps
 
 				case Code.Ldsfld:
 					var ftarget = (FieldReference) instr.Operand;
-					var field = ftarget.Resolve ();
+					var field = _context.TryResolveFieldDefinition (ftarget);
 					if (field == null)
 						break;
 
 					if (_context.Annotations.TryGetFieldUserValue (field, out object value)) {
-						targetResult = CodeRewriterStep.CreateConstantResultInstruction (field.FieldType, value);
+						targetResult = CodeRewriterStep.CreateConstantResultInstruction (_context, field.FieldType, value);
 						if (targetResult == null)
 							break;
 						reducer.Rewrite (i, targetResult);
@@ -438,11 +437,9 @@ namespace Mono.Linker.Steps
 
 					var operand = (TypeReference) instr.Operand;
 					if (operand.MetadataType == MetadataType.UIntPtr) {
-						sizeOfImpl = (UIntPtrSize ??= FindSizeMethod (operand.Resolve ()));
-					}
-
-					if (operand.MetadataType == MetadataType.IntPtr) {
-						sizeOfImpl = (IntPtrSize ??= FindSizeMethod (operand.Resolve ()));
+						sizeOfImpl = (UIntPtrSize ??= FindSizeMethod (_context.TryResolveTypeDefinition (operand)));
+					} else if (operand.MetadataType == MetadataType.IntPtr) {
+						sizeOfImpl = (IntPtrSize ??= FindSizeMethod (_context.TryResolveTypeDefinition (operand)));
 					}
 
 					if (sizeOfImpl != null) {
@@ -1253,12 +1250,14 @@ namespace Mono.Linker.Steps
 		{
 			readonly MethodDefinition method;
 			readonly Collection<Instruction> instructions;
+			readonly LinkContext context;
 
 			Stack<Instruction> stack_instr;
 			Dictionary<int, Instruction> locals;
 
-			public ConstantExpressionMethodAnalyzer (MethodDefinition method)
+			public ConstantExpressionMethodAnalyzer (LinkContext context, MethodDefinition method)
 			{
+				this.context = context;
 				this.method = method;
 				instructions = method.Body.Instructions;
 				stack_instr = null;
@@ -1266,8 +1265,8 @@ namespace Mono.Linker.Steps
 				Result = null;
 			}
 
-			public ConstantExpressionMethodAnalyzer (MethodDefinition method, Collection<Instruction> instructions)
-				: this (method)
+			public ConstantExpressionMethodAnalyzer (LinkContext context, MethodDefinition method, Collection<Instruction> instructions)
+				: this (context, method)
 			{
 				this.instructions = instructions;
 			}
@@ -1436,7 +1435,7 @@ namespace Mono.Linker.Steps
 					return null;
 
 				// local variables don't need to be explicitly initialized
-				return CodeRewriterStep.CreateConstantResultInstruction (body.Variables[index].VariableType);
+				return CodeRewriterStep.CreateConstantResultInstruction (context, body.Variables[index].VariableType);
 			}
 
 			void PushOnStack (Instruction instruction)

--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -72,7 +72,7 @@ namespace Mono.Linker
 			this.context = context;
 			FlowAnnotations = new FlowAnnotations (context);
 			VirtualMethodsWithAnnotationsToValidate = new HashSet<MethodDefinition> ();
-			TypeMapInfo = new TypeMapInfo ();
+			TypeMapInfo = new TypeMapInfo (context);
 			MemberActions = new MemberActionStore (context);
 		}
 

--- a/src/linker/Linker/BCL.cs
+++ b/src/linker/Linker/BCL.cs
@@ -6,20 +6,16 @@ namespace Mono.Linker
 	{
 		public static class EventTracingForWindows
 		{
-			public static bool IsEventSourceImplementation (TypeDefinition type, LinkContext context = null)
+			public static bool IsEventSourceImplementation (TypeDefinition type, LinkContext context)
 			{
 				if (!type.IsClass)
 					return false;
 
 				while (type.BaseType != null) {
-					var bt = type.BaseType.Resolve ();
+					var bt = context.ResolveTypeDefinition (type.BaseType);
 
-					if (bt == null) {
-						if (context != null && !context.IgnoreUnresolved)
-							throw new ResolutionException (type.BaseType);
-
-						break;
-					}
+					if (bt == null)
+						return false;
 
 					if (IsEventSourceType (bt))
 						return true;

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -812,19 +812,24 @@ namespace Mono.Linker
 			return TryResolveTypeDefinition (_typeNameResolver.ResolveTypeName (assembly, typeNameString));
 		}
 
+		readonly HashSet<MemberReference> unresolved_reported = new ();
+
 		protected virtual void ReportUnresolved (FieldReference fieldReference)
 		{
-			LogError ($"Field '{fieldReference.FullName}' reference could not be resolved", 1040);
+			if (unresolved_reported.Add (fieldReference))
+				LogError ($"Field '{fieldReference.FullName}' reference could not be resolved", 1040);
 		}
 
 		protected virtual void ReportUnresolved (MethodReference methodReference)
 		{
-			LogError ($"Method '{methodReference.GetDisplayName ()}' reference could not be resolved", 1040);
+			if (unresolved_reported.Add (methodReference))
+				LogError ($"Method '{methodReference.GetDisplayName ()}' reference could not be resolved", 1040);
 		}
 
 		protected virtual void ReportUnresolved (TypeReference typeReference)
 		{
-			LogError ($"Type '{typeReference.GetDisplayName ()}' reference could not be resolved", 1040);
+			if (unresolved_reported.Add (typeReference))
+				LogError ($"Type '{typeReference.GetDisplayName ()}' reference could not be resolved", 1040);
 		}
 	}
 

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -663,6 +663,169 @@ namespace Mono.Linker
 
 			return _targetRuntime.Value;
 		}
+
+		readonly Dictionary<MethodReference, MethodDefinition> methodresolveCache = new ();
+		readonly Dictionary<FieldReference, FieldDefinition> fieldresolveCache = new ();
+		readonly Dictionary<TypeReference, TypeDefinition> typeresolveCache = new ();
+
+		public MethodDefinition ResolveMethodDefinition (MethodReference methodReference)
+		{
+			if (methodReference is MethodDefinition md)
+				return md;
+
+			if (methodReference is null)
+				return null;
+
+			if (methodresolveCache.TryGetValue (methodReference, out md)) {
+				if (md == null && !IgnoreUnresolved)
+					ReportUnresolved (methodReference);
+
+				return md;
+			}
+
+			md = methodReference.Resolve ();
+			if (md == null && !IgnoreUnresolved) {
+				ReportUnresolved (methodReference);
+			}
+
+			methodresolveCache.Add (methodReference, md);
+			return md;
+		}
+
+		public MethodDefinition TryResolveMethodDefinition (MethodReference methodReference)
+		{
+			if (methodReference is MethodDefinition md)
+				return md;
+
+			if (methodReference is null)
+				return null;
+
+			if (methodresolveCache.TryGetValue (methodReference, out md))
+				return md;
+
+			md = methodReference.Resolve ();
+			methodresolveCache.Add (methodReference, md);
+			return md;
+		}
+
+		public FieldDefinition ResolveFieldDefinition (FieldReference fieldReference)
+		{
+			if (fieldReference is FieldDefinition fd)
+				return fd;
+
+			if (fieldReference is null)
+				return null;
+
+			if (fieldresolveCache.TryGetValue (fieldReference, out fd)) {
+				if (fd == null && !IgnoreUnresolved)
+					ReportUnresolved (fieldReference);
+
+				return fd;
+			}
+
+			fd = fieldReference.Resolve ();
+			if (fd == null && !IgnoreUnresolved) {
+				ReportUnresolved (fieldReference);
+			}
+
+			fieldresolveCache.Add (fieldReference, fd);
+			return fd;
+		}
+
+		public FieldDefinition TryResolveFieldDefinition (FieldReference fieldReference)
+		{
+			if (fieldReference is FieldDefinition fd)
+				return fd;
+
+			if (fieldReference is null)
+				return null;
+
+			if (fieldresolveCache.TryGetValue (fieldReference, out fd))
+				return fd;
+
+			fd = fieldReference.Resolve ();
+			fieldresolveCache.Add (fieldReference, fd);
+			return fd;
+		}
+
+		public TypeDefinition ResolveTypeDefinition (TypeReference typeReference)
+		{
+			if (typeReference is TypeDefinition td)
+				return td;
+
+			if (typeReference is null)
+				return null;
+
+			if (typeresolveCache.TryGetValue (typeReference, out td)) {
+				if (td == null && !IgnoreUnresolved)
+					ReportUnresolved (typeReference);
+
+				return td;
+			}
+
+			//
+			// Types which never have TypeDefinition or can have ambiguous definition should not be passed in
+			//
+			if (typeReference is GenericParameter || (typeReference is TypeSpecification && typeReference is not GenericInstanceType))
+				throw new NotSupportedException ($"TypeDefinition cannot be resolved from '{typeReference.GetType ()}' type");
+
+			td = typeReference.Resolve ();
+			if (td == null && !IgnoreUnresolved) {
+				ReportUnresolved (typeReference);
+			}
+
+			typeresolveCache.Add (typeReference, td);
+			return td;
+		}
+
+		public TypeDefinition TryResolveTypeDefinition (TypeReference typeReference)
+		{
+			if (typeReference is TypeDefinition td)
+				return td;
+
+			if (typeReference is null || typeReference is GenericParameter)
+				return null;
+
+			if (typeresolveCache.TryGetValue (typeReference, out td))
+				return td;
+
+			if (typeReference is TypeSpecification ts) {
+				if (typeReference is FunctionPointerType) {
+					td = null;
+				} else {
+					//
+					// It returns element-type for arrays and also element type for wrapping types like ByReference, PinnedType, etc
+					//
+					td = TryResolveTypeDefinition (ts.GetElementType ());
+				}
+			} else {
+				td = typeReference.Resolve ();
+			}
+
+			typeresolveCache.Add (typeReference, td);
+			return td;
+		}
+
+		public TypeDefinition TryResolveTypeDefinition (AssemblyDefinition assembly, string typeNameString)
+		{
+			// It could be cached if shows up on fast path
+			return TryResolveTypeDefinition (_typeNameResolver.ResolveTypeName (assembly, typeNameString));
+		}
+
+		protected virtual void ReportUnresolved (FieldReference fieldReference)
+		{
+			LogError ($"Field '{fieldReference.FullName}' reference could not be resolved", 1040);
+		}
+
+		protected virtual void ReportUnresolved (MethodReference methodReference)
+		{
+			LogError ($"Method '{methodReference.GetDisplayName ()}' reference could not be resolved", 1040);
+		}
+
+		protected virtual void ReportUnresolved (TypeReference typeReference)
+		{
+			LogError ($"Type '{typeReference.GetDisplayName ()}' reference could not be resolved", 1040);
+		}
 	}
 
 	public class CodeOptimizationsSettings

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -808,7 +808,7 @@ namespace Mono.Linker
 
 		public TypeDefinition TryResolveTypeDefinition (AssemblyDefinition assembly, string typeNameString)
 		{
-			// It could be cached if shows up on fast path
+			// It could be cached if it shows up on fast path
 			return TryResolveTypeDefinition (_typeNameResolver.ResolveTypeName (assembly, typeNameString));
 		}
 

--- a/src/linker/Linker/MarkingHelpers.cs
+++ b/src/linker/Linker/MarkingHelpers.cs
@@ -35,7 +35,7 @@ namespace Mono.Linker
 
 			if (typeReference.Scope is AssemblyNameReference) {
 				var assembly = _context.Resolve (typeReference.Scope);
-				if (assembly != null && assembly.MainModule.GetMatchingExportedType (typeReference.Resolve (), out var exportedType))
+				if (assembly != null && assembly.MainModule.GetMatchingExportedType (_context.TryResolveTypeDefinition (typeReference), out var exportedType))
 					MarkExportedType (exportedType, assembly.MainModule, new DependencyInfo (DependencyKind.ExportedType, typeReference));
 			}
 		}

--- a/src/linker/Linker/TypeDefinitionExtensions.cs
+++ b/src/linker/Linker/TypeDefinitionExtensions.cs
@@ -5,22 +5,6 @@ namespace Mono.Linker
 {
 	public static class TypeDefinitionExtensions
 	{
-		public static bool HasInterface (this TypeDefinition type, TypeDefinition interfaceType, out InterfaceImplementation implementation)
-		{
-			implementation = null;
-			if (!type.HasInterfaces)
-				return false;
-
-			foreach (var iface in type.Interfaces) {
-				if (iface.InterfaceType.Resolve () == interfaceType) {
-					implementation = iface;
-					return true;
-				}
-			}
-
-			return false;
-		}
-
 		public static TypeReference GetEnumUnderlyingType (this TypeDefinition enumType)
 		{
 			foreach (var field in enumType.Fields) {

--- a/src/linker/Linker/TypeHierarchyCache.cs
+++ b/src/linker/Linker/TypeHierarchyCache.cs
@@ -14,13 +14,15 @@ namespace Mono.Linker
 		}
 
 		readonly Dictionary<TypeDefinition, HierarchyFlags> _cache = new Dictionary<TypeDefinition, HierarchyFlags> ();
+		readonly LinkContext context;
 
-		private HierarchyFlags GetFlags (TypeReference type)
+		public TypeHierarchyCache (LinkContext context)
 		{
-			TypeDefinition resolvedType = type.Resolve ();
-			if (resolvedType == null)
-				return 0;
+			this.context = context;
+		}
 
+		private HierarchyFlags GetFlags (TypeDefinition resolvedType)
+		{
 			if (_cache.TryGetValue (resolvedType, out var flags)) {
 				return flags;
 			}
@@ -43,20 +45,21 @@ namespace Mono.Linker
 					}
 				}
 
-				baseType = baseType.BaseType?.Resolve ();
+				baseType = context.TryResolveTypeDefinition (baseType.BaseType);
 			}
 
-			_cache.Add (resolvedType, flags);
+			if (resolvedType != null)
+				_cache.Add (resolvedType, flags);
 
 			return flags;
 		}
 
-		public bool IsSystemType (TypeReference type)
+		public bool IsSystemType (TypeDefinition type)
 		{
 			return (GetFlags (type) & HierarchyFlags.IsSystemType) != 0;
 		}
 
-		public bool IsSystemReflectionIReflect (TypeReference type)
+		public bool IsSystemReflectionIReflect (TypeDefinition type)
 		{
 			return (GetFlags (type) & HierarchyFlags.IsSystemReflectionIReflect) != 0;
 		}

--- a/src/linker/ref/Linker/LinkContext.cs
+++ b/src/linker/ref/Linker/LinkContext.cs
@@ -20,5 +20,13 @@ namespace Mono.Linker
 
 		public bool HasCustomData (string key) { throw null; }
 		public bool TryGetCustomData (string key, out string value) { throw null; }
+
+		public MethodDefinition ResolveMethodDefinition (MethodReference methodReference) { throw null; }
+		public FieldDefinition ResolveFieldDefinition (FieldReference fieldReference) { throw null; }
+		public TypeDefinition ResolveTypeDefinition (TypeReference typeReference) { throw null; }
+
+		public MethodDefinition TryResolveMethodDefinition (MethodReference methodReference) { throw null; }
+		public FieldDefinition TryResolveFieldDefinition (FieldReference fieldReference) { throw null; }
+		public TypeDefinition TryResolveTypeDefinition (TypeReference typeReference) { throw null; }
 	}
 }


### PR DESCRIPTION
This change introduces a commonplace for resolving definition for types,
methods and fields. This is useful for following reasons

- Speeds up linker by 20% for default Blazor app (more for large apps)
- Any custom step can avoid building local mapping cache
- Custom steps could support `--skip-unresolved` linker option
- Consistent error handling for unresolved references

Most of the changes are just mechanical method replacement and
Link context passing.

Contributes to #918
Fixes #1953