### PR TITLE
Implement support for ifdefs in header file parsing

### DIFF
--- a/src/ILLink.Tasks/CreateRuntimeRootDescriptorFile.cs
+++ b/src/ILLink.Tasks/CreateRuntimeRootDescriptorFile.cs
@@ -57,7 +57,7 @@ namespace ILLink.Tasks
 		readonly Dictionary<string, string> namespaceDictionary = new Dictionary<string, string> ();
 		readonly Dictionary<string, string> classIdsToClassNames = new Dictionary<string, string> ();
 		readonly Dictionary<string, ClassMembers> classNamesToClassMembers = new Dictionary<string, ClassMembers> ();
-		readonly HashSet<string> defineConstants = new HashSet<string> ();
+		readonly HashSet<string> defineConstants = new HashSet<string> (StringComparer.Ordinal);
 
 		public override bool Execute ()
 		{
@@ -85,7 +85,7 @@ namespace ILLink.Tasks
 				return false;
 			}
 
-			ParseDefineConstants ();
+			InitializeDefineConstants ();
 
 			var iLLinkTrimXmlFilePath = ILLinkTrimXmlFilePath.ItemSpec;
 			if (!File.Exists (iLLinkTrimXmlFilePath)) {
@@ -137,62 +137,11 @@ namespace ILLink.Tasks
 		void ProcessMscorlib (string typeFile)
 		{
 			string[] types = File.ReadAllLines (typeFile);
-			int linenum = 0;
+			DefineTracker defineTracker = new DefineTracker (defineConstants, Log, typeFile);
 			string classId;
 
-			Stack<bool?> activeSections = new Stack<bool?> ();
 			foreach (string def in types) {
-				linenum++;
-				{
-					int ifdefLength = 0;
-					bool negativeIfDef = false;
-					if (def.StartsWith ("#ifdef ")) {
-						ifdefLength = 7;
-					} else if (def.StartsWith ("#ifndef ")) {
-						ifdefLength = 8;
-						negativeIfDef = true;
-					} else if (def.StartsWith ("#if ")) {
-						ifdefLength = 4;
-					}
-
-					if (ifdefLength > 0) {
-						if (activeSections.Count > 0 && activeSections.Peek () != true) {
-							activeSections.Push (null);
-						} else {
-							string defineName = def.Substring (ifdefLength);
-							int commentIndex = defineName.IndexOf ('/');
-							if (commentIndex >= 0)
-								defineName = defineName.Substring (0, commentIndex);
-
-							defineName = defineName.Trim ();
-							if (defineConstants.Contains (defineName))
-								activeSections.Push (!negativeIfDef);
-							else
-								activeSections.Push (negativeIfDef);
-						}
-					}
-				}
-
-				if (def.StartsWith ("#else")) {
-					if (activeSections.Count == 0) {
-						Log.LogError ($"Could not figure out ifdefs in '{typeFile}' around line {linenum}");
-					} else {
-						bool? activeSection = activeSections.Pop ();
-						if (activeSection == null)
-							activeSections.Push (null);
-						else
-							activeSections.Push (!activeSection.Value);
-					}
-				}
-
-				if (def.StartsWith ("#endif")) {
-					if (activeSections.Count == 0)
-						Log.LogError ($"Could not figure out ifdefs in '{typeFile}' around line {linenum}");
-					else
-						activeSections.Pop ();
-				}
-
-				if (activeSections.Count > 0 && activeSections.Peek () != true)
+				if (defineTracker.ProcessLine (def) || !defineTracker.IsActiveSection)
 					continue;
 
 				string[] defElements = null;
@@ -245,8 +194,12 @@ namespace ILLink.Tasks
 		public void ProcessCoreTypes (string corTypeFile)
 		{
 			string[] corTypes = File.ReadAllLines (corTypeFile);
+			DefineTracker defineTracker = new DefineTracker (defineConstants, Log, corTypeFile);
 
 			foreach (string def in corTypes) {
+				if (defineTracker.ProcessLine (def) || !defineTracker.IsActiveSection)
+					continue;
+
 				// E.g., TYPEINFO(ELEMENT_TYPE_VOID,         "System", "Void",          0,              TYPE_GC_NONE,   false,  true,   false,  false,  false) // 0x01
 				if (def.StartsWith ("TYPEINFO(")) {
 					char[] separators = { ',', '(', ')', '"', ' ', '\t' };
@@ -262,8 +215,12 @@ namespace ILLink.Tasks
 		public void ProcessExceptionTypes (string excTypeFile)
 		{
 			string[] excTypes = File.ReadAllLines (excTypeFile);
+			DefineTracker defineTracker = new DefineTracker (defineConstants, Log, excTypeFile);
 
 			foreach (string def in excTypes) {
+				if (defineTracker.ProcessLine (def) || !defineTracker.IsActiveSection)
+					continue;
+
 				// E.g., DEFINE_EXCEPTION(g_InteropNS,          MarshalDirectiveException,      false,  COR_E_MARSHALDIRECTIVE)
 				if (def.StartsWith ("DEFINE_EXCEPTION(")) {
 					char[] separators = { ',', '(', ')', ' ', '\t' };
@@ -397,14 +354,93 @@ namespace ILLink.Tasks
 			return namespaceDictionary[classNamespace] + "." + className;
 		}
 
-		void ParseDefineConstants ()
+		void InitializeDefineConstants ()
 		{
-			if (DefineConstants is not null) {
-				foreach (var item in DefineConstants)
-					defineConstants.Add (item.ItemSpec.Trim ());
+			if (DefineConstants is null)
+				return;
+
+			foreach (var item in DefineConstants)
+				defineConstants.Add (item.ItemSpec.Trim ());
+		}
+
+		class DefineTracker
+		{
+			readonly HashSet<string> defineConstants;
+			readonly TaskLoggingHelper log;
+			readonly string filePath;
+			readonly Stack<bool?> activeSections = new Stack<bool?> ();
+			int linenum;
+
+			public DefineTracker (HashSet<string> defineConstants, TaskLoggingHelper log, string filePath)
+			{
+				this.defineConstants = defineConstants;
+				this.log = log;
+				this.filePath = filePath;
 			}
 
-			defineConstants.Add ("FOR_ILLINK");
+			public bool ProcessLine (string line)
+			{
+				linenum++;
+
+				int ifdefLength = 0;
+				bool negativeIfDef = false;
+				if (line.StartsWith ("#ifdef ")) {
+					ifdefLength = 7;
+				} else if (line.StartsWith ("#ifndef ")) {
+					ifdefLength = 8;
+					negativeIfDef = true;
+				} else if (line.StartsWith ("#if ")) {
+					ifdefLength = 4;
+				}
+
+				if (ifdefLength > 0) {
+					if (activeSections.Count > 0 && activeSections.Peek () != true) {
+						activeSections.Push (null);
+					} else {
+						string defineName = line.Substring (ifdefLength);
+						int commentIndex = defineName.IndexOf ('/');
+						if (commentIndex >= 0)
+							defineName = defineName.Substring (0, commentIndex);
+
+						defineName = defineName.Trim ();
+						if (defineConstants.Contains (defineName))
+							activeSections.Push (!negativeIfDef);
+						else
+							activeSections.Push (negativeIfDef);
+					}
+
+					return true;
+				}
+
+				if (line.StartsWith ("#else")) {
+					if (activeSections.Count == 0) {
+						log.LogError ($"Could not figure out ifdefs in '{filePath}' around line {linenum}");
+					} else {
+						bool? activeSection = activeSections.Pop ();
+						if (activeSection == null)
+							activeSections.Push (null);
+						else
+							activeSections.Push (!activeSection.Value);
+					}
+
+					return true;
+				}
+
+				if (line.StartsWith ("#endif")) {
+					if (activeSections.Count == 0)
+						log.LogError ($"Could not figure out ifdefs in '{filePath}' around line {linenum}");
+					else
+						activeSections.Pop ();
+
+					return true;
+				}
+
+				return false;
+			}
+
+			public bool IsActiveSection {
+				get => activeSections.Count == 0 || activeSections.Peek () == true;
+			}
 		}
 	}
 }

--- a/test/ILLink.Tasks.Tests/CombineLinkerXmlFilesTests.cs
+++ b/test/ILLink.Tasks.Tests/CombineLinkerXmlFilesTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Xml.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/test/ILLink.Tasks.Tests/CreateRuntimeRootDescriptorFileTests.cs
+++ b/test/ILLink.Tasks.Tests/CreateRuntimeRootDescriptorFileTests.cs
@@ -1,0 +1,91 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Xunit;
+
+namespace ILLink.Tasks.Tests
+{
+	public class CreateRuntimeRootDescriptorFileTests
+	{
+		[Fact]
+		public void TestCoreLibClassGen ()
+		{
+			File.WriteAllLines ("corelib.h", new string[] {
+				"#ifndef TESTDEF",
+				"#define TESTDEF",
+				"#endif",
+				"DEFINE_CLASS(TESTCLASS, TestNS, TestClass)",
+				"DEFINE_METHOD(TESTCLASS, TESTMETHOD, TestMethod, 0)",
+				"#ifdef FEATURE_ON",
+				"DEFINE_METHOD(TESTCLASS, TESTMETHODIFON, TestMethodIfOn, 1)",
+				"#endif",
+				"#ifdef FEATURE_OFF",
+				"DEFINE_METHOD(TESTCLASS, TESTMETHODIFOFF, TestMethodIfOff, 2)",
+				"#endif",
+				"#ifndef FEATURE_BOTH // Comment",
+				"DEFINE_METHOD(TESTCLASS, TESTMETHODIFBOTH, TestMethodIfBoth, 3)",
+				"#if FOR_ILLINK",
+				"DEFINE_METHOD(TESTCLASS, TESTMETHODIFBOTH, TestMethodIfBothForILLink, 3)",
+				"#endif",
+				"#else",
+				"DEFINE_METHOD(TESTCLASS, TESTMETHODIFNOTBOTH, TestMethodIfNotBoth, 4)",
+				"#if FOR_ILLINK",
+				"DEFINE_METHOD(TESTCLASS, TESTMETHODIFNOTBOTH, TestMethodIfNotBothForILLink, 4)",
+				"#endif",
+				"#endif // FEATURE_BOTH",
+				"#if FOR_ILLINK",
+				"DEFINE_METHOD(TESTCLASS, TESTMETHODFORILLINK, TestMethodForILLink, 5)",
+				"#endif"
+				});
+
+			File.WriteAllText ("namespace.h",
+				"#define g_TestNS \"TestNS\"" + Environment.NewLine);
+
+			File.WriteAllText ("cortypeinfo.h", "");
+
+			File.WriteAllText ("rexcep.h", "");
+
+			XElement existingAssembly = new XElement ("assembly", new XAttribute ("fullname", "testassembly"),
+					new XComment ("Existing content"));
+			XElement existingContent = new XElement ("linker", existingAssembly);
+			(new XDocument (existingContent)).Save ("Test.ILLink.Descriptors.Combined.xml");
+
+			var task = new CreateRuntimeRootILLinkDescriptorFile () {
+				NamespaceFilePath = new TaskItem ("namespace.h"),
+				MscorlibFilePath = new TaskItem ("corelib.h"),
+				CortypeFilePath = new TaskItem ("cortypeinfo.h"),
+				RexcepFilePath = new TaskItem ("rexcep.h"),
+				ILLinkTrimXmlFilePath = new TaskItem ("Test.ILLink.Descriptors.Combined.xml"),
+				DefineConstants = new TaskItem[] {
+					new TaskItem("_TEST"),
+					new TaskItem("FEATURE_ON"),
+					new TaskItem("FEATURE_BOTH")
+				},
+				RuntimeRootDescriptorFilePath = new TaskItem ("Test.ILLink.Descriptors.xml")
+			};
+
+			Assert.True (task.Execute ());
+
+			XDocument output = XDocument.Load ("Test.ILLink.Descriptors.xml");
+			string expectedXml = new XElement ("linker",
+				new XElement ("assembly",
+					existingAssembly.Attributes (),
+					existingAssembly.Nodes (),
+					new XElement ("type", new XAttribute ("fullname", "TestNS.TestClass"),
+						new XElement ("method", new XAttribute ("name", "TestMethod")),
+						new XElement ("method", new XAttribute ("name", "TestMethodIfOn")),
+						new XElement ("method", new XAttribute ("name", "TestMethodIfNotBoth")),
+						new XElement ("method", new XAttribute ("name", "TestMethodIfNotBothForILLink")),
+						new XElement ("method", new XAttribute ("name", "TestMethodForILLink")))
+					)).ToString ();
+			Assert.Equal (expectedXml, output.Root.ToString ());
+		}
+	}
+}

--- a/test/ILLink.Tasks.Tests/CreateRuntimeRootDescriptorFileTests.cs
+++ b/test/ILLink.Tasks.Tests/CreateRuntimeRootDescriptorFileTests.cs
@@ -48,9 +48,17 @@ namespace ILLink.Tasks.Tests
 			File.WriteAllText ("namespace.h",
 				"#define g_TestNS \"TestNS\"" + Environment.NewLine);
 
-			File.WriteAllText ("cortypeinfo.h", "");
+			File.WriteAllLines ("cortypeinfo.h", new string[] { });
 
-			File.WriteAllText ("rexcep.h", "");
+			File.WriteAllLines ("rexcep.h", new string[] {
+				"DEFINE_EXCEPTION(g_TestNS, TestAlwaysException, false, C)",
+				"#ifdef FEATURE_ON",
+				"DEFINE_EXCEPTION(g_TestNS, TestFeatureOnException, false, C)",
+				"#endif",
+				"#ifdef FEATURE_OFF",
+				"DEFINE_EXCEPTION(g_TestNS, TestFeatureOffException, false, C)",
+				"#endif"
+				});
 
 			XElement existingAssembly = new XElement ("assembly", new XAttribute ("fullname", "testassembly"),
 					new XComment ("Existing content"));
@@ -84,7 +92,11 @@ namespace ILLink.Tasks.Tests
 						new XElement ("method", new XAttribute ("name", "TestMethodIfOn")),
 						new XElement ("method", new XAttribute ("name", "TestMethodIfNotBoth")),
 						new XElement ("method", new XAttribute ("name", "TestMethodIfNotBothForILLink")),
-						new XElement ("method", new XAttribute ("name", "TestMethodForILLink")))
+						new XElement ("method", new XAttribute ("name", "TestMethodForILLink"))),
+					new XElement ("type", new XAttribute ("fullname", "TestNS.TestAlwaysException"),
+						new XElement ("method", new XAttribute ("name", ".ctor"))),
+					new XElement ("type", new XAttribute ("fullname", "TestNS.TestFeatureOnException"),
+						new XElement ("method", new XAttribute ("name", ".ctor")))
 					)).ToString ();
 			Assert.Equal (expectedXml, output.Root.ToString ());
 		}

--- a/test/ILLink.Tasks.Tests/CreateRuntimeRootDescriptorFileTests.cs
+++ b/test/ILLink.Tasks.Tests/CreateRuntimeRootDescriptorFileTests.cs
@@ -64,6 +64,7 @@ namespace ILLink.Tasks.Tests
 				RexcepFilePath = new TaskItem ("rexcep.h"),
 				ILLinkTrimXmlFilePath = new TaskItem ("Test.ILLink.Descriptors.Combined.xml"),
 				DefineConstants = new TaskItem[] {
+					new TaskItem("FOR_ILLINK"),
 					new TaskItem("_TEST"),
 					new TaskItem("FEATURE_ON"),
 					new TaskItem("FEATURE_BOTH")

--- a/test/ILLink.Tasks.Tests/ILLink.Tasks.Tests.cs
+++ b/test/ILLink.Tasks.Tests/ILLink.Tasks.Tests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/test/ILLink.Tasks.Tests/Mock.cs
+++ b/test/ILLink.Tasks.Tests/Mock.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections;
 using System.Collections.Generic;


### PR DESCRIPTION
The CreateRuntimeRootDescriptorFile task parses some header files from the CoreCLR and produces an XML descriptor. This change adds support for understanding simple ifdefs.

Also added tests.

This is the mono/linker part of fix for #1973 