### PR TITLE
Fix generic parameter validation in MakeGenericMethod and similar

### DIFF
--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -1723,8 +1723,10 @@ namespace Mono.Linker.Dataflow
 		{
 			bool hasRequirements = false;
 			foreach (var genericParameter in genericParameters) {
-				if (_context.Annotations.FlowAnnotations.GetGenericParameterAnnotation (genericParameter) != DynamicallyAccessedMemberTypes.None)
+				if (_context.Annotations.FlowAnnotations.GetGenericParameterAnnotation (genericParameter) != DynamicallyAccessedMemberTypes.None) {
 					hasRequirements = true;
+					break;
+				}
 			}
 
 			// If there are no requirements, then there's no point in warning

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -1721,6 +1721,16 @@ namespace Mono.Linker.Dataflow
 
 		private bool AnalyzeGenericInstatiationTypeArray (ValueNode arrayParam, ref ReflectionPatternContext reflectionContext, MethodReference calledMethod, IList<GenericParameter> genericParameters)
 		{
+			bool hasRequirements = false;
+			foreach (var genericParameter in genericParameters) {
+				if (_context.Annotations.FlowAnnotations.GetGenericParameterAnnotation (genericParameter) != DynamicallyAccessedMemberTypes.None)
+					hasRequirements = true;
+			}
+
+			// If there are no requirements, then there's no point in warning
+			if (!hasRequirements)
+				return true;
+
 			foreach (var typesValue in arrayParam.UniqueValues ()) {
 				if (typesValue.Kind != ValueNodeKind.Array) {
 					return false;
@@ -2224,6 +2234,7 @@ namespace Mono.Linker.Dataflow
 		{
 			if (!genericMethod.HasGenericParameters) {
 				reflectionContext.RecordHandledPattern ();
+				return;
 			}
 
 			if (!AnalyzeGenericInstatiationTypeArray (genericParametersArray, ref reflectionContext, reflectionMethod, genericMethod.GenericParameters)) {

--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallString.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallString.cs
@@ -238,11 +238,10 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			{ }
 
 			[Kept]
-			[ExpectedWarning ("IL2060", "Expression::Call")]
 			static void TestWithNoTypeParameters ()
 			{
-				// Linker warns since this is a call to a generic method with a mismatching number of generic parameters
-				// and provided type values for the generic instantiation.
+				// Linker should not warn even if the type parameters don't match since the target method has no requirements
+				// the fact that the reflection API may fail in this case is not something linker should worry about.
 				Expression.Call (typeof (TestGenericMethods), nameof (GenericMethodCalledAsNonGeneric), Type.EmptyTypes);
 			}
 


### PR DESCRIPTION
The validator must ignore methods which don't have any requirements. So even if the passed in array doesn't match the method, it needs to not warn in such cases. This is because we can't guarantee we always find the exact method info to work on, instead we compensate by considering potentially multiple candidates. Some of which may not even be generic, or may not have any requirements and so on. In such cases the validator should only warn if there's potentially a real problem - not if the reflection API will fail (that's a non-failure for the validator).

This should fix the problem in https://github.com/dotnet/runtime/pull/51558#issuecomment-823430400.