### PR TITLE
Fix issue with forwarders in copyused assemblies

### DIFF
--- a/src/linker/Linker.Steps/SweepStep.cs
+++ b/src/linker/Linker.Steps/SweepStep.cs
@@ -66,6 +66,7 @@ namespace Mono.Linker.Steps
 			// Update scopes before removing any type forwarder.
 			foreach (var assembly in assemblies) {
 				switch (Annotations.GetAction (assembly)) {
+				case AssemblyAction.CopyUsed:
 				case AssemblyAction.Link:
 				case AssemblyAction.Save:
 					SweepAssemblyReferences (assembly);

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/AttributeEnumArgumentForwarded.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/AttributeEnumArgumentForwarded.cs
@@ -9,7 +9,7 @@ namespace Mono.Linker.Tests.Cases.TypeForwarding
 	// link - This assembly, Forwarder.dll and Implementation.dll
 	[SetupLinkerDefaultAction ("link")]
 
-	[SetupCompileBefore ("Forwarder.dll", new[] { "Dependencies/MyEnum.cs" }, defines: new[] { "INCLUDE_REFERENCE_IMPL" })]
+	[SetupCompileBefore ("Forwarder.dll", new[] { "Dependencies/MyEnum.cs" })]
 	[SetupCompileBefore ("Attribute.dll", new[] { "Dependencies/AttributeWithEnumArgument.cs" }, references: new[] { "Forwarder.dll" })]
 
 	// After compiling the test case we then replace the reference impl with implementation + type forwarder
@@ -18,6 +18,7 @@ namespace Mono.Linker.Tests.Cases.TypeForwarding
 
 	[KeptTypeInAssembly ("Forwarder.dll", typeof (UsedToReferenceForwarderAssembly))]
 	[KeptTypeInAssembly ("Implementation.dll", "Mono.Linker.Tests.Cases.TypeForwarding.Dependencies.MyEnum")]
+	[RemovedForwarder ("Forwarder.dll", "Mono.Linker.Tests.Cases.TypeForwarding.Dependencies.MyEnum")]
 	class AttributeEnumArgumentForwarded
 	{
 		static void Main ()

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/AttributeEnumArgumentForwardedCopyUsedWithSweptForwarder.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/AttributeEnumArgumentForwardedCopyUsedWithSweptForwarder.cs
@@ -1,0 +1,47 @@
+using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.TypeForwarding.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.TypeForwarding
+{
+	[SetupLinkerAction ("copyused", "Attribute")]
+	[SetupLinkerAction ("copyused", "Forwarder")]
+
+	[SetupCompileBefore ("Forwarder.dll", new[] { "Dependencies/MyEnum.cs" })]
+	[SetupCompileBefore ("Attribute.dll", new[] { "Dependencies/AttributeWithEnumArgument.cs" },
+		defines: new[] { "INCLUDE_FORWARDER" }, references: new[] { "Forwarder.dll" })]
+
+	// After compiling the test case we then replace the reference impl with implementation + type forwarder
+	[SetupCompileAfter ("Implementation.dll", new[] { "Dependencies/MyEnum.cs" })]
+	[SetupCompileAfter ("Forwarder.dll", new[] { "Dependencies/MyEnumForwarder.cs" }, references: new[] { "Implementation.dll" })]
+
+	[KeptTypeInAssembly ("Forwarder.dll", typeof (UsedToReferenceForwarderAssembly))]
+	[KeptTypeInAssembly ("Implementation.dll", "Mono.Linker.Tests.Cases.TypeForwarding.Dependencies.MyEnum")]
+	[RemovedForwarder ("Forwarder.dll", "Mono.Linker.Tests.Cases.TypeForwarding.Dependencies.MyEnum")]
+	class AttributeEnumArgumentForwardedCopyUsedWithSweptForwarder
+	{
+		static void Main ()
+		{
+			// attribute enum arg typeref -> forwarder -> enum def
+			// copyused                      copyused
+
+			// The forwarder is not referenced and will be removed. This is a regression test for a case where the copyused typeref
+			// scope is not updated, causing an exception to be thrown when the assembly is output.
+
+			// Mark the attribute enum argument, causing cecil to read the attribute blob and resolve the typeref through the forwarder.
+			var _ = typeof (AttributedType);
+
+			// The attribute assembly needs to be written back with cecil for this to cause problems.
+			// To prevent its action from being changed to "copy", it has an unused type forwarder which gets swept.
+
+			// Reference the forwarder assembly (but without marking the forwarder) to prevent it from being removed entirely.
+			// This ensures that:
+			// - The forwarder assembly is swept and the enum forwarder is removed (invalidating the attribute argument's typeref)
+			// - The attribute assembly doesn't reference a removed assembly.
+			//   Referencing a removed assembly would change its action to "save" and it would get typerefs updated (correctly), avoiding the bug
+			//   this is trying to reproduce.
+			var _2 = typeof (UsedToReferenceForwarderAssembly);
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/AttributeWithEnumArgument.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/AttributeWithEnumArgument.cs
@@ -1,4 +1,10 @@
 using System;
+using System.Runtime.CompilerServices;
+using Mono.Linker.Tests.Cases.TypeForwarding.Dependencies;
+
+#if INCLUDE_FORWARDER
+[assembly: TypeForwardedTo (typeof (UsedToReferenceForwarderAssembly))]
+#endif
 
 namespace Mono.Linker.Tests.Cases.TypeForwarding.Dependencies
 {


### PR DESCRIPTION
@vitek-karas noticed an issue where we stopped updating typerefs from copyused assemblies in some cases. This fixes the issue by always updating scopes in copyused assemblies.

This will be subtly different from the behavior before @mateoatr's changes in case the copyused assembly doesn't reference a removed assembly (we used to not rewrite references in that case, but now we will). I think this is the right thing to do since I believe the old behavior could have caused bugs similar to this one.
