### PR TITLE
Upgrade linker TFM to net6.0

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <RunAnalyzers>true</RunAnalyzers>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 </Project>

--- a/src/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/src/ILLink.Tasks/ILLink.Tasks.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Keep these in sync with _ILLinkTasksTFM in Sdk.props. -->
-    <!-- Keep the netcoreapp TFM in sync with the Mono.Linker.csproj condition below. -->
-    <TargetFrameworks>net5.0;net472</TargetFrameworks>
+    <!-- Keep these in sync with ILLinkTasksAssembly in Microsoft.NET.ILLink.Tasks.props. -->
+    <!-- Keep the net5+ TFM in sync with the Mono.Linker.csproj condition below. -->
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <Description>MSBuild tasks for running the IL Linker</Description>
     <IsPackable>true</IsPackable>
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../linker/Mono.Linker.csproj" PrivateAssets="All" Condition=" '$(TargetFramework)' == 'net5.0' " />
+    <ProjectReference Include="../linker/Mono.Linker.csproj" PrivateAssets="All" Condition=" '$(TargetFramework)' == 'net6.0' " />
     <PackageReference Condition="'$(UseCecilPackage)' == 'true'" Include="Mono.Cecil" Version="$(MonoCecilVersion)" PrivateAssets="All" Publish="True" />
     <ProjectReference Condition="'$(UseCecilPackage)' != 'true'" Include="../../external/cecil/Mono.Cecil.csproj" PrivateAssets="All">
       <!-- https://github.com/dotnet/sdk/issues/2280#issuecomment-392815466 -->

--- a/src/ILLink.Tasks/LinkTask.cs
+++ b/src/ILLink.Tasks/LinkTask.cs
@@ -248,7 +248,7 @@ namespace ILLink.Tasks
 
 				var taskDirectory = Path.GetDirectoryName (Assembly.GetExecutingAssembly ().Location);
 				// The linker always runs on .NET Core, even when using desktop MSBuild to host ILLink.Tasks.
-				_illinkPath = Path.Combine (Path.GetDirectoryName (taskDirectory), "net5.0", "illink.dll");
+				_illinkPath = Path.Combine (Path.GetDirectoryName (taskDirectory), "net6.0", "illink.dll");
 				return _illinkPath;
 			}
 			set => _illinkPath = value;

--- a/src/ILLink.Tasks/build/Microsoft.NET.ILLink.Tasks.props
+++ b/src/ILLink.Tasks/build/Microsoft.NET.ILLink.Tasks.props
@@ -13,7 +13,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <PropertyGroup>
     <UsingILLinkTasksSdk>true</UsingILLinkTasksSdk>
-    <ILLinkTasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\net5.0\ILLink.Tasks.dll</ILLinkTasksAssembly>
+    <ILLinkTasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\net6.0\ILLink.Tasks.dll</ILLinkTasksAssembly>
     <ILLinkTasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\ILLink.Tasks.dll</ILLinkTasksAssembly>
   </PropertyGroup>
 

--- a/src/ILLink.Tasks/build/Microsoft.NET.ILLink.Tasks.targets
+++ b/src/ILLink.Tasks/build/Microsoft.NET.ILLink.Tasks.targets
@@ -2,7 +2,7 @@
 <Project>
 
   <PropertyGroup>
-    <ILLinkTasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\net5.0\ILLink.Tasks.dll</ILLinkTasksAssembly>
+    <ILLinkTasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\net6.0\ILLink.Tasks.dll</ILLinkTasksAssembly>
     <ILLinkTasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\ILLink.Tasks.dll</ILLinkTasksAssembly>
   </PropertyGroup>
 

--- a/test/Mono.Linker.Tests/TestCasesRunner/TestCaseSandbox.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestCaseSandbox.cs
@@ -16,7 +16,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 		static NPath GetArtifactsTestPath ()
 		{
-			// Converts paths like /root-folder/linker/artifacts/bin/Mono.Linker.Tests/Debug/net5.0/illink.dll
+			// Converts paths like /root-folder/linker/artifacts/bin/Mono.Linker.Tests/Debug/net6.0/illink.dll
 			// to /root-folder/linker/artifacts/testcases/
 			string artifacts = Path.GetFullPath (Path.Combine (Path.GetDirectoryName (_linkerAssemblyPath), "..", "..", "..", ".."));
 			string tests = Path.Combine (artifacts, "testcases");


### PR DESCRIPTION
This is so that linker can rely on new 6.0 APIs, like `DynamicallyAccessedMemberTypes.Interfaces`.