### PR TITLE
Delete Microsoft.NET.ILLink.Tasks.targets

### DIFF
--- a/src/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/src/ILLink.Tasks/ILLink.Tasks.csproj
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <Content Include="sdk/Sdk.props" PackagePath="Sdk/" />
-    <Content Include="build/$(PackageId).*" PackagePath="build/" />
+    <Content Include="build/$(PackageId).props" PackagePath="build/" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ILLink.Tasks/build/Microsoft.NET.ILLink.Tasks.targets
+++ b/src/ILLink.Tasks/build/Microsoft.NET.ILLink.Tasks.targets
@@ -1,9 +1,0 @@
-<!-- TODO: Remove this file after the SDK consumes a new ILLink.Tasks package and dotnet/runtime consumes that newer SDK. -->
-<Project>
-
-  <PropertyGroup>
-    <ILLinkTasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\net5.0\ILLink.Tasks.dll</ILLinkTasksAssembly>
-    <ILLinkTasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\ILLink.Tasks.dll</ILLinkTasksAssembly>
-  </PropertyGroup>
-
-</Project>


### PR DESCRIPTION
We are upgrading the SDK to 6.0 Preview 3 in dotnet/runtime which means we can remove the workaround in this repository.