### PR TITLE
Avoid showing hidden lines in warning location

### DIFF
--- a/test/Mono.Linker.Tests.Cases/Logging/SourceLines.cs
+++ b/test/Mono.Linker.Tests.Cases/Logging/SourceLines.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
@@ -8,27 +9,42 @@ namespace Mono.Linker.Tests.Cases.Logging
 	[SkipKeptItemsValidation]
 	[SetupCompileBefore ("FakeSystemAssembly.dll", new[] { "../PreserveDependencies/Dependencies/PreserveDependencyAttribute.cs" })]
 	[SetupCompileArgument ("/debug:full")]
-	[LogContains ("(30,4): Trim analysis warning IL2074")]
-	[LogContains ("(31,4): Trim analysis warning IL2074")]
+	[LogContains ("(33,4): Trim analysis warning IL2074")]
+	[LogContains ("(34,4): Trim analysis warning IL2074")]
+	[LogContains ("(38,3): Trim analysis warning IL2091")]
 	public class SourceLines
 	{
 		public static void Main ()
 		{
 			UnrecognizedReflectionPattern ();
+			GenericMethodIteratorWithRequirement<SourceLines> ();
 		}
 
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)]
-		private static Type type;
+		static Type type;
 
-		private static Type GetUnknownType ()
+		static Type GetUnknownType ()
 		{
 			return typeof (SourceLines);
 		}
 
-		private static void UnrecognizedReflectionPattern ()
+		static void UnrecognizedReflectionPattern ()
 		{
 			type = GetUnknownType ();
 			type = GetUnknownType ();
+		}
+
+		static IEnumerable<int> GenericMethodIteratorWithRequirement<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] TOuterMethod> ()
+		{
+			// Since this is iterator it will turn into a subclass with generic T
+			// but this T doesn't inherit the DAM annotation.
+			// So calling the LocationFunction which requires the DAM on T will generate a warning
+			// but that warning comes from compiler generated code - there's no user code doing that.
+			LocalFunction ();
+			yield return 1;
+
+			// The generator code for LocalFunction inherits the DAM on the T
+			static void LocalFunction () => type = typeof (TOuterMethod);
 		}
 	}
 }


### PR DESCRIPTION
In specific cases (see the test added) there might be a warning comming from compiler generated code with no user code to assign to it. In such case the compiler generates a sequence point with a special line number, marking it as "hidden code". Showing that line number is weird and doesn't make any sense. Especially if the warning comes from method which has several overloads, it's basically impossible to tell which one it was.

So instead use the first sequence point with non-hiden line number.