### PR TITLE
Add line number/position info to warnings from XML files

### DIFF
--- a/src/linker/Linker.Steps/BodySubstituterStep.cs
+++ b/src/linker/Linker.Steps/BodySubstituterStep.cs
@@ -1,17 +1,17 @@
-using System.Xml.XPath;
+using System.IO;
 
 namespace Mono.Linker.Steps
 {
 	public class BodySubstituterStep : ProcessLinkerXmlStepBase
 	{
-		public BodySubstituterStep (XPathDocument document, string xmlDocumentLocation)
-			: base (document, xmlDocumentLocation)
+		public BodySubstituterStep (Stream documentStream, string xmlDocumentLocation)
+			: base (documentStream, xmlDocumentLocation)
 		{
 		}
 
 		protected override void Process ()
 		{
-			new BodySubstitutionParser (Context, _document, _xmlDocumentLocation).Parse (Context.Annotations.MemberActions.PrimarySubstitutionInfo);
+			new BodySubstitutionParser (Context, _documentStream, _xmlDocumentLocation).Parse (Context.Annotations.MemberActions.PrimarySubstitutionInfo);
 		}
 	}
 }

--- a/src/linker/Linker.Steps/DescriptorMarker.cs
+++ b/src/linker/Linker.Steps/DescriptorMarker.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Text;
 using System.Xml.XPath;
 
@@ -22,13 +23,13 @@ namespace Mono.Linker.Steps
 		static readonly string[] _accessorsAll = new string[] { "all" };
 		static readonly char[] _accessorsSep = new char[] { ';' };
 
-		public DescriptorMarker (LinkContext context, XPathDocument document, string xmlDocumentLocation)
-			: base (context, document, xmlDocumentLocation)
+		public DescriptorMarker (LinkContext context, Stream documentStream, string xmlDocumentLocation)
+			: base (context, documentStream, xmlDocumentLocation)
 		{
 		}
 
-		public DescriptorMarker (LinkContext context, XPathDocument document, EmbeddedResource resource, AssemblyDefinition resourceAssembly, string xmlDocumentLocation = "<unspecified>")
-			: base (context, document, resource, resourceAssembly, xmlDocumentLocation)
+		public DescriptorMarker (LinkContext context, Stream documentStream, EmbeddedResource resource, AssemblyDefinition resourceAssembly, string xmlDocumentLocation = "<unspecified>")
+			: base (context, documentStream, resource, resourceAssembly, xmlDocumentLocation)
 		{
 		}
 
@@ -72,7 +73,7 @@ namespace Mono.Linker.Steps
 				}
 
 				if (!foundMatch) {
-					_context.LogWarning ($"Could not find any type in namespace '{fullname}'", 2044, _xmlDocumentLocation);
+					LogWarning ($"Could not find any type in namespace '{fullname}'", 2044, iterator.Current);
 				}
 			}
 		}
@@ -135,7 +136,7 @@ namespace Mono.Linker.Steps
 		protected override void ProcessField (TypeDefinition type, FieldDefinition field, XPathNavigator nav)
 		{
 			if (_context.Annotations.IsMarked (field))
-				_context.LogWarning ($"Duplicate preserve of '{field.FullName}'", 2025, _xmlDocumentLocation);
+				LogWarning ($"Duplicate preserve of '{field.FullName}'", 2025, nav);
 
 			_context.Annotations.Mark (field, new DependencyInfo (DependencyKind.XmlDescriptor, _xmlDocumentLocation));
 		}
@@ -143,7 +144,7 @@ namespace Mono.Linker.Steps
 		protected override void ProcessMethod (TypeDefinition type, MethodDefinition method, XPathNavigator nav, object customData)
 		{
 			if (_context.Annotations.IsMarked (method))
-				_context.LogWarning ($"Duplicate preserve of '{method.GetDisplayName ()}'", 2025, _xmlDocumentLocation);
+				LogWarning ($"Duplicate preserve of '{method.GetDisplayName ()}'", 2025, nav);
 
 			_context.Annotations.MarkIndirectlyCalledMethod (method);
 			_context.Annotations.SetAction (method, MethodAction.Parse);
@@ -155,12 +156,12 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		void ProcessMethodIfNotNull (TypeDefinition type, MethodDefinition method, object customData)
+		void ProcessMethodIfNotNull (TypeDefinition type, MethodDefinition method, XPathNavigator nav, object customData)
 		{
 			if (method == null)
 				return;
 
-			ProcessMethod (type, method, null, customData);
+			ProcessMethod (type, method, nav, customData);
 		}
 
 		protected override MethodDefinition GetMethod (TypeDefinition type, string signature)
@@ -200,11 +201,11 @@ namespace Mono.Linker.Steps
 		protected override void ProcessEvent (TypeDefinition type, EventDefinition @event, XPathNavigator nav, object customData)
 		{
 			if (_context.Annotations.IsMarked (@event))
-				_context.LogWarning ($"Duplicate preserve of '{@event.FullName}'", 2025, _xmlDocumentLocation);
+				LogWarning ($"Duplicate preserve of '{@event.FullName}'", 2025, nav);
 
-			ProcessMethod (type, @event.AddMethod, null, customData);
-			ProcessMethod (type, @event.RemoveMethod, null, customData);
-			ProcessMethodIfNotNull (type, @event.InvokeMethod, customData);
+			ProcessMethod (type, @event.AddMethod, nav, customData);
+			ProcessMethod (type, @event.RemoveMethod, nav, customData);
+			ProcessMethodIfNotNull (type, @event.InvokeMethod, nav, customData);
 		}
 
 		protected override void ProcessProperty (TypeDefinition type, PropertyDefinition property, XPathNavigator nav, object customData, bool fromSignature)
@@ -212,28 +213,23 @@ namespace Mono.Linker.Steps
 			string[] accessors = fromSignature ? GetAccessors (nav) : _accessorsAll;
 
 			if (_context.Annotations.IsMarked (property))
-				_context.LogWarning ($"Duplicate preserve of '{property.FullName}'", 2025, _xmlDocumentLocation);
+				LogWarning ($"Duplicate preserve of '{property.FullName}'", 2025, nav);
 
-			ProcessPropertyAccessors (type, property, accessors, customData);
-		}
-
-		void ProcessPropertyAccessors (TypeDefinition type, PropertyDefinition property, string[] accessors, object customData)
-		{
 			if (Array.IndexOf (accessors, "all") >= 0) {
-				ProcessMethodIfNotNull (type, property.GetMethod, customData);
-				ProcessMethodIfNotNull (type, property.SetMethod, customData);
+				ProcessMethodIfNotNull (type, property.GetMethod, nav, customData);
+				ProcessMethodIfNotNull (type, property.SetMethod, nav, customData);
 				return;
 			}
 
 			if (property.GetMethod != null && Array.IndexOf (accessors, "get") >= 0)
-				ProcessMethod (type, property.GetMethod, null, customData);
+				ProcessMethod (type, property.GetMethod, nav, customData);
 			else if (property.GetMethod == null)
-				_context.LogWarning ($"Could not find the get accessor of property '{property.Name}' on type '{type.FullName}'", 2018, _xmlDocumentLocation);
+				LogWarning ($"Could not find the get accessor of property '{property.Name}' on type '{type.FullName}'", 2018, nav);
 
 			if (property.SetMethod != null && Array.IndexOf (accessors, "set") >= 0)
-				ProcessMethod (type, property.SetMethod, null, customData);
+				ProcessMethod (type, property.SetMethod, nav, customData);
 			else if (property.SetMethod == null)
-				_context.LogWarning ($"Could not find the set accessor of property '{property.Name}' in type '{type.FullName}' specified in {_xmlDocumentLocation}", 2019, _xmlDocumentLocation);
+				LogWarning ($"Could not find the set accessor of property '{property.Name}' in type '{type.FullName}'", 2019, nav);
 		}
 
 		static bool IsRequired (XPathNavigator nav)

--- a/src/linker/Linker.Steps/LinkAttributesStep.cs
+++ b/src/linker/Linker.Steps/LinkAttributesStep.cs
@@ -2,20 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Xml.XPath;
+using System.IO;
 
 namespace Mono.Linker.Steps
 {
 	public class LinkAttributesStep : ProcessLinkerXmlStepBase
 	{
-		public LinkAttributesStep (XPathDocument document, string xmlDocumentLocation)
-			: base (document, xmlDocumentLocation)
+		public LinkAttributesStep (Stream documentStream, string xmlDocumentLocation)
+			: base (documentStream, xmlDocumentLocation)
 		{
 		}
 
 		protected override void Process ()
 		{
-			new LinkAttributesParser (Context, _document, _xmlDocumentLocation).Parse (Context.CustomAttributes.PrimaryAttributeInfo);
+			new LinkAttributesParser (Context, _documentStream, _xmlDocumentLocation).Parse (Context.CustomAttributes.PrimaryAttributeInfo);
 		}
 	}
 }

--- a/src/linker/Linker.Steps/ProcessLinkerXmlStepBase.cs
+++ b/src/linker/Linker.Steps/ProcessLinkerXmlStepBase.cs
@@ -2,18 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Xml.XPath;
+using System.IO;
 
 namespace Mono.Linker.Steps
 {
 	public class ProcessLinkerXmlStepBase : BaseStep
 	{
-		protected readonly XPathDocument _document;
 		protected readonly string _xmlDocumentLocation;
+		protected readonly Stream _documentStream;
 
-		public ProcessLinkerXmlStepBase (XPathDocument document, string xmlDocumentLocation)
+		public ProcessLinkerXmlStepBase (Stream documentStream, string xmlDocumentLocation)
 		{
-			_document = document;
+			_documentStream = documentStream;
 			_xmlDocumentLocation = xmlDocumentLocation;
 		}
 	}

--- a/src/linker/Linker.Steps/ResolveFromXmlStep.cs
+++ b/src/linker/Linker.Steps/ResolveFromXmlStep.cs
@@ -28,20 +28,20 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-using System.Xml.XPath;
+using System.IO;
 
 namespace Mono.Linker.Steps
 {
 	public class ResolveFromXmlStep : ProcessLinkerXmlStepBase
 	{
-		public ResolveFromXmlStep (XPathDocument document, string xmlDocumentLocation)
-			: base (document, xmlDocumentLocation)
+		public ResolveFromXmlStep (Stream documentStream, string xmlDocumentLocation)
+			: base (documentStream, xmlDocumentLocation)
 		{
 		}
 
 		protected override void Process ()
 		{
-			new DescriptorMarker (Context, _document, _xmlDocumentLocation).Mark ();
+			new DescriptorMarker (Context, _documentStream, _xmlDocumentLocation).Mark ();
 		}
 	}
 }

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -595,7 +595,7 @@ namespace Mono.Linker
 								return -1;
 							}
 
-							inputs.Add (new ResolveFromXmlStep (new XPathDocument (xmlFile), xmlFile));
+							inputs.Add (new ResolveFromXmlStep (File.OpenRead (xmlFile), xmlFile));
 							continue;
 						}
 					case "a": {
@@ -822,17 +822,17 @@ namespace Mono.Linker
 
 		protected virtual void AddResolveFromXmlStep (Pipeline pipeline, string file)
 		{
-			pipeline.PrependStep (new ResolveFromXmlStep (new XPathDocument (file), file));
+			pipeline.PrependStep (new ResolveFromXmlStep (File.OpenRead (file), file));
 		}
 
 		protected virtual void AddLinkAttributesStep (Pipeline pipeline, string file)
 		{
-			pipeline.AddStepBefore (typeof (MarkStep), new LinkAttributesStep (new XPathDocument (file), file));
+			pipeline.AddStepBefore (typeof (MarkStep), new LinkAttributesStep (File.OpenRead (file), file));
 		}
 
 		static void AddBodySubstituterStep (Pipeline pipeline, string file)
 		{
-			pipeline.AddStepBefore (typeof (MarkStep), new BodySubstituterStep (new XPathDocument (file), file));
+			pipeline.AddStepBefore (typeof (MarkStep), new BodySubstituterStep (File.OpenRead (file), file));
 		}
 
 		protected virtual void AddXmlDependencyRecorder (LinkContext context, string fileName)

--- a/src/linker/Linker/EmbeddedXmlInfo.cs
+++ b/src/linker/Linker/EmbeddedXmlInfo.cs
@@ -126,24 +126,17 @@ namespace Mono.Linker
 
 		static DescriptorMarker GetExternalResolveStep (LinkContext context, EmbeddedResource resource, AssemblyDefinition assembly)
 		{
-			return new DescriptorMarker (context, GetExternalDescriptor (resource), resource, assembly, "resource " + resource.Name + " in " + assembly.FullName);
+			return new DescriptorMarker (context, resource.GetResourceStream (), resource, assembly, "resource " + resource.Name + " in " + assembly.FullName);
 		}
 
 		static BodySubstitutionParser GetExternalSubstitutionParser (LinkContext context, EmbeddedResource resource, AssemblyDefinition assembly)
 		{
-			return new BodySubstitutionParser (context, GetExternalDescriptor (resource), resource, assembly, "resource " + resource.Name + " in " + assembly.FullName);
+			return new BodySubstitutionParser (context, resource.GetResourceStream (), resource, assembly, "resource " + resource.Name + " in " + assembly.FullName);
 		}
 
 		static LinkAttributesParser GetExternalLinkAttributesParser (LinkContext context, EmbeddedResource resource, AssemblyDefinition assembly)
 		{
-			return new LinkAttributesParser (context, GetExternalDescriptor (resource), resource, assembly, "resource " + resource.Name + " in " + assembly.FullName);
-		}
-
-		static XPathDocument GetExternalDescriptor (EmbeddedResource resource)
-		{
-			using (var sr = new StreamReader (resource.GetResourceStream ())) {
-				return new XPathDocument (sr);
-			}
+			return new LinkAttributesParser (context, resource.GetResourceStream (), resource, assembly, "resource " + resource.Name + " in " + assembly.FullName);
 		}
 	}
 }

--- a/src/linker/Linker/UnconditionalSuppressMessageAttributeState.cs
+++ b/src/linker/Linker/UnconditionalSuppressMessageAttributeState.cs
@@ -10,9 +10,9 @@ namespace Mono.Linker
 		internal const string TargetProperty = "Target";
 		internal const string MessageIdProperty = "MessageId";
 
-		private readonly LinkContext _context;
-		private readonly Dictionary<ICustomAttributeProvider, Dictionary<int, SuppressMessageInfo>> _suppressions;
-		private HashSet<AssemblyDefinition> InitializedAssemblies { get; }
+		readonly LinkContext _context;
+		readonly Dictionary<ICustomAttributeProvider, Dictionary<int, SuppressMessageInfo>> _suppressions;
+		HashSet<AssemblyDefinition> InitializedAssemblies { get; }
 
 		public UnconditionalSuppressMessageAttributeState (LinkContext context)
 		{
@@ -30,7 +30,7 @@ namespace Mono.Linker
 			AddSuppression (info, provider);
 		}
 
-		private void AddSuppression (SuppressMessageInfo info, ICustomAttributeProvider provider)
+		void AddSuppression (SuppressMessageInfo info, ICustomAttributeProvider provider)
 		{
 			if (!_suppressions.TryGetValue (provider, out var suppressions)) {
 				suppressions = new Dictionary<int, SuppressMessageInfo> ();
@@ -67,7 +67,7 @@ namespace Mono.Linker
 			return false;
 		}
 
-		private bool IsSuppressed (int id, ICustomAttributeProvider provider, out SuppressMessageInfo info)
+		bool IsSuppressed (int id, ICustomAttributeProvider provider, out SuppressMessageInfo info)
 		{
 			info = default;
 			if (provider == null)
@@ -77,7 +77,7 @@ namespace Mono.Linker
 				suppressions.TryGetValue (id, out info);
 		}
 
-		private static bool TryDecodeSuppressMessageAttributeData (CustomAttribute attribute, out SuppressMessageInfo info)
+		static bool TryDecodeSuppressMessageAttributeData (CustomAttribute attribute, out SuppressMessageInfo info)
 		{
 			info = default;
 
@@ -138,7 +138,7 @@ namespace Mono.Linker
 			}
 		}
 
-		private void DecodeModuleLevelAndGlobalSuppressMessageAttributes (ModuleDefinition module)
+		void DecodeModuleLevelAndGlobalSuppressMessageAttributes (ModuleDefinition module)
 		{
 			AssemblyDefinition assembly = module.Assembly;
 			if (InitializedAssemblies.Add (assembly)) {

--- a/test/ILLink.Tasks.Tests/Mock.cs
+++ b/test/ILLink.Tasks.Tests/Mock.cs
@@ -140,7 +140,7 @@ namespace ILLink.Tasks.Tests
 		protected override void AddResolveFromXmlStep (Pipeline pipeline, string file)
 		{
 			// Don't try to load an xml file - just pretend it exists.
-			pipeline.PrependStep (new ResolveFromXmlStep (document: null, file));
+			pipeline.PrependStep (new ResolveFromXmlStep (documentStream: null, file));
 		}
 
 		protected override void AddXmlDependencyRecorder (LinkContext context, string file)

--- a/test/Mono.Linker.Tests.Cases/LinkAttributes/LinkAttributeErrorCases.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkAttributes/LinkAttributeErrorCases.cs
@@ -11,18 +11,18 @@ namespace Mono.Linker.Tests.Cases.LinkAttributes
 	[SetupCompileBefore ("library.dll", new string[] { "Dependencies/EmbeddedAttributeErrorCases.cs" },
 		resources: new object[] { new string[] { "Dependencies/EmbeddedAttributeErrorCases.xml", "ILLink.LinkAttributes.xml" } })]
 
-	[ExpectedWarning ("IL2007", "NonExistentAssembly2", FileName = "LinkAttributeErrorCases.xml")]
-	[ExpectedWarning ("IL2030", "NonExistentAssembly1", FileName = "LinkAttributeErrorCases.xml")]
-	[ExpectedWarning ("IL2030", "MalformedAssemblyName, thisiswrong", FileName = "LinkAttributeErrorCases.xml")]
-	[ExpectedWarning ("IL2031", "NonExistentAttribute", FileName = "LinkAttributeErrorCases.xml")]
-	[ExpectedWarning ("IL2022", "AttributeWithNoParametersAttribute", FileName = "LinkAttributeErrorCases.xml")]
-	[ExpectedWarning ("IL2023", "GetTypeMethod", FileName = "LinkAttributeErrorCases.xml")]
-	[ExpectedWarning ("IL2024", "methodParameter", "MethodWithParameter", FileName = "LinkAttributeErrorCases.xml")]
-	[ExpectedWarning ("IL2029", FileName = "LinkAttributeErrorCases.xml")]
-	[ExpectedWarning ("IL2051", FileName = "LinkAttributeErrorCases.xml")]
-	[ExpectedWarning ("IL2052", "NonExistentPropertyName", FileName = "LinkAttributeErrorCases.xml")]
-	[ExpectedWarning ("IL2100", FileName = "ILLink.LinkAttributes.xml")]
-	[ExpectedWarning ("IL2101", "library", "test", FileName = "ILLink.LinkAttributes.xml")]
+	[ExpectedWarning ("IL2007", "NonExistentAssembly2", FileName = "LinkAttributeErrorCases.xml", SourceLine = 67, SourceColumn = 4)]
+	[ExpectedWarning ("IL2030", "NonExistentAssembly1", FileName = "LinkAttributeErrorCases.xml", SourceLine = 6, SourceColumn = 8)]
+	[ExpectedWarning ("IL2030", "MalformedAssemblyName, thisiswrong", FileName = "LinkAttributeErrorCases.xml", SourceLine = 7, SourceColumn = 8)]
+	[ExpectedWarning ("IL2031", "NonExistentAttribute", FileName = "LinkAttributeErrorCases.xml", SourceLine = 10, SourceColumn = 8)]
+	[ExpectedWarning ("IL2022", "AttributeWithNoParametersAttribute", FileName = "LinkAttributeErrorCases.xml", SourceLine = 13, SourceColumn = 8)]
+	[ExpectedWarning ("IL2023", "GetTypeMethod", FileName = "LinkAttributeErrorCases.xml", SourceLine = 47, SourceColumn = 10)]
+	[ExpectedWarning ("IL2024", "methodParameter", "MethodWithParameter", FileName = "LinkAttributeErrorCases.xml", SourceLine = 57, SourceColumn = 10)]
+	[ExpectedWarning ("IL2029", FileName = "LinkAttributeErrorCases.xml", SourceLine = 64, SourceColumn = 6)]
+	[ExpectedWarning ("IL2051", FileName = "LinkAttributeErrorCases.xml", SourceLine = 29, SourceColumn = 10)]
+	[ExpectedWarning ("IL2052", "NonExistentPropertyName", FileName = "LinkAttributeErrorCases.xml", SourceLine = 34, SourceColumn = 10)]
+	[ExpectedWarning ("IL2100", FileName = "ILLink.LinkAttributes.xml", SourceLine = 3, SourceColumn = 4)]
+	[ExpectedWarning ("IL2101", "library", "test", FileName = "ILLink.LinkAttributes.xml", SourceLine = 5, SourceColumn = 4)]
 	class LinkAttributeErrorCases
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/LinkXml/LinkXmlErrorCases.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/LinkXmlErrorCases.cs
@@ -7,20 +7,20 @@ namespace Mono.Linker.Tests.Cases.LinkXml
 	[SetupLinkerDescriptorFile ("LinkXmlErrorCases.xml")]
 	[SetupLinkerArgument ("--skip-unresolved", "true")]
 
-	[ExpectedWarning ("IL2007", "NonExistentAssembly", FileName = "LinkXmlErrorCases.xml")]
-	[ExpectedWarning ("IL2008", "NonExistentType", FileName = "LinkXmlErrorCases.xml")]
-	[ExpectedWarning ("IL2009", "NonExistentMethod", "TypeWithNoMethods", FileName = "LinkXmlErrorCases.xml")]
-	[ExpectedWarning ("IL2012", "NonExistentField", "TypeWithNoFields", FileName = "LinkXmlErrorCases.xml")]
-	[ExpectedWarning ("IL2016", "NonExistentEvent", "TypeWithNoEvents", FileName = "LinkXmlErrorCases.xml")]
-	[ExpectedWarning ("IL2017", "NonExistentProperty", "TypeWithNoProperties", FileName = "LinkXmlErrorCases.xml")]
-	[ExpectedWarning ("IL2018", "SetOnlyProperty", "TypeWithProperties", FileName = "LinkXmlErrorCases.xml")]
-	[ExpectedWarning ("IL2019", "GetOnlyProperty", "TypeWithProperties", FileName = "LinkXmlErrorCases.xml")]
+	[ExpectedWarning ("IL2007", "NonExistentAssembly", FileName = "LinkXmlErrorCases.xml", SourceLine = 47, SourceColumn = 4)]
+	[ExpectedWarning ("IL2008", "NonExistentType", FileName = "LinkXmlErrorCases.xml", SourceLine = 6, SourceColumn = 6)]
+	[ExpectedWarning ("IL2009", "NonExistentMethod", "TypeWithNoMethods", FileName = "LinkXmlErrorCases.xml", SourceLine = 9, SourceColumn = 8)]
+	[ExpectedWarning ("IL2012", "NonExistentField", "TypeWithNoFields", FileName = "LinkXmlErrorCases.xml", SourceLine = 13, SourceColumn = 8)]
+	[ExpectedWarning ("IL2016", "NonExistentEvent", "TypeWithNoEvents", FileName = "LinkXmlErrorCases.xml", SourceLine = 17, SourceColumn = 8)]
+	[ExpectedWarning ("IL2017", "NonExistentProperty", "TypeWithNoProperties", FileName = "LinkXmlErrorCases.xml", SourceLine = 21, SourceColumn = 8)]
+	[ExpectedWarning ("IL2018", "SetOnlyProperty", "TypeWithProperties", FileName = "LinkXmlErrorCases.xml", SourceLine = 25, SourceColumn = 8)]
+	[ExpectedWarning ("IL2019", "GetOnlyProperty", "TypeWithProperties", FileName = "LinkXmlErrorCases.xml", SourceLine = 26, SourceColumn = 8)]
 
-	[ExpectedWarning ("IL2025", "Method", FileName = "LinkXmlErrorCases.xml")]
-	[ExpectedWarning ("IL2025", "Event", FileName = "LinkXmlErrorCases.xml")]
-	[ExpectedWarning ("IL2025", "Field", FileName = "LinkXmlErrorCases.xml")]
-	[ExpectedWarning ("IL2025", "Property", FileName = "LinkXmlErrorCases.xml")]
-	[ExpectedWarning ("IL2100", FileName = "LinkXmlErrorCases.xml")]
+	[ExpectedWarning ("IL2025", "Method", FileName = "LinkXmlErrorCases.xml", SourceLine = 39, SourceColumn = 8)]
+	[ExpectedWarning ("IL2025", "Event", FileName = "LinkXmlErrorCases.xml", SourceLine = 40, SourceColumn = 8)]
+	[ExpectedWarning ("IL2025", "Field", FileName = "LinkXmlErrorCases.xml", SourceLine = 41, SourceColumn = 8)]
+	[ExpectedWarning ("IL2025", "Property", FileName = "LinkXmlErrorCases.xml", SourceLine = 42, SourceColumn = 8)]
+	[ExpectedWarning ("IL2100", FileName = "LinkXmlErrorCases.xml", SourceLine = 50, SourceColumn = 4)]
 	class LinkXmlErrorCases
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/Substitutions/SubstitutionsErrorCases.cs
+++ b/test/Mono.Linker.Tests.Cases/Substitutions/SubstitutionsErrorCases.cs
@@ -9,14 +9,14 @@ namespace Mono.Linker.Tests.Cases.Substitutions
 	[SetupCompileBefore ("library.dll", new string[] { "Dependencies/EmbeddedSubstitutionsErrorCases.cs" },
 		resources: new object[] { new string[] { "Dependencies/EmbeddedSubstitutionsErrorCases.xml", "ILLink.Substitutions.xml" } })]
 
-	[ExpectedWarning ("IL2010", "TestMethod_1", "stub", FileName = "SubstitutionsErrorCases.xml")]
-	[ExpectedWarning ("IL2011", "TestMethod_2", "noaction", FileName = "SubstitutionsErrorCases.xml")]
-	[ExpectedWarning ("IL2013", "SubstitutionsErrorCases::InstanceField", FileName = "SubstitutionsErrorCases.xml")]
-	[ExpectedWarning ("IL2014", "SubstitutionsErrorCases::IntField", FileName = "SubstitutionsErrorCases.xml")]
-	[ExpectedWarning ("IL2015", "SubstitutionsErrorCases::IntField", "NonNumber", FileName = "SubstitutionsErrorCases.xml")]
-	[ExpectedWarning ("IL2007", "NonExistentAssembly", FileName = "SubstitutionsErrorCases.xml")]
-	[ExpectedWarning ("IL2100", FileName = "SubstitutionsErrorCases.xml")]
-	[ExpectedWarning ("IL2101", "library", "test", FileName = "ILLink.Substitutions.xml")]
+	[ExpectedWarning ("IL2010", "TestMethod_1", "stub", FileName = "SubstitutionsErrorCases.xml", SourceLine = 5, SourceColumn = 8)]
+	[ExpectedWarning ("IL2011", "TestMethod_2", "noaction", FileName = "SubstitutionsErrorCases.xml", SourceLine = 6, SourceColumn = 8)]
+	[ExpectedWarning ("IL2013", "SubstitutionsErrorCases::InstanceField", FileName = "SubstitutionsErrorCases.xml", SourceLine = 8, SourceColumn = 8)]
+	[ExpectedWarning ("IL2014", "SubstitutionsErrorCases::IntField", FileName = "SubstitutionsErrorCases.xml", SourceLine = 9, SourceColumn = 8)]
+	[ExpectedWarning ("IL2015", "SubstitutionsErrorCases::IntField", "NonNumber", FileName = "SubstitutionsErrorCases.xml", SourceLine = 10, SourceColumn = 8)]
+	[ExpectedWarning ("IL2007", "NonExistentAssembly", FileName = "SubstitutionsErrorCases.xml", SourceLine = 13, SourceColumn = 4)]
+	[ExpectedWarning ("IL2100", FileName = "SubstitutionsErrorCases.xml", SourceLine = 15, SourceColumn = 4)]
+	[ExpectedWarning ("IL2101", "library", "test", FileName = "ILLink.Substitutions.xml", SourceLine = 3, SourceColumn = 4)]
 
 	[KeptMember (".ctor()")]
 	class SubstitutionsErrorCases


### PR DESCRIPTION
This basically improves the precision of errors we report from XML files by providing sourceline/column information.

Required refactoring how we create XML, since I wanted only one place to actually parse the XML (since we need to do it in a special way to get line/position info).

Also required to change to use XDocument instead of XPathDocument, as the latter doesn't store line/position info. This will slightly increase memory consumption for any XML processed, but since that number is already very low and we don't expect it to go high, it's not a problem.