### PR TITLE
Add line info in IL2001 and IL2002

### DIFF
--- a/src/linker/Linker.Steps/DescriptorMarker.cs
+++ b/src/linker/Linker.Steps/DescriptorMarker.cs
@@ -101,8 +101,21 @@ namespace Mono.Linker.Steps
 			Debug.Assert (ShouldProcessElement (nav));
 
 			TypePreserve preserve = GetTypePreserve (nav);
-			if (preserve != TypePreserve.Nothing)
-				_context.Annotations.SetPreserve (type, preserve);
+			switch (preserve) {
+			case TypePreserve.Fields when !type.HasFields:
+				LogWarning ($"Type {type.GetDisplayName ()} has no fields to preserve", 2001, nav);
+				break;
+
+			case TypePreserve.Methods when !type.HasMethods:
+				LogWarning ($"Type {type.GetDisplayName ()} has no methods to preserve", 2002, nav);
+				break;
+
+			default:
+				if (preserve != TypePreserve.Nothing)
+					_context.Annotations.SetPreserve (type, preserve);
+
+				break;
+			}
 
 			bool required = IsRequired (nav);
 			ProcessTypeChildren (type, nav, required);

--- a/src/linker/Linker.Steps/DescriptorMarker.cs
+++ b/src/linker/Linker.Steps/DescriptorMarker.cs
@@ -110,6 +110,8 @@ namespace Mono.Linker.Steps
 				LogWarning ($"Type {type.GetDisplayName ()} has no methods to preserve", 2002, nav);
 				break;
 
+			case TypePreserve.Fields:
+			case TypePreserve.Methods:
 			case TypePreserve.All:
 				_context.Annotations.SetPreserve (type, preserve);
 				break;

--- a/src/linker/Linker.Steps/DescriptorMarker.cs
+++ b/src/linker/Linker.Steps/DescriptorMarker.cs
@@ -110,10 +110,8 @@ namespace Mono.Linker.Steps
 				LogWarning ($"Type {type.GetDisplayName ()} has no methods to preserve", 2002, nav);
 				break;
 
-			default:
-				if (preserve != TypePreserve.Nothing)
-					_context.Annotations.SetPreserve (type, preserve);
-
+			case TypePreserve.All:
+				_context.Annotations.SetPreserve (type, preserve);
 				break;
 			}
 

--- a/test/Mono.Linker.Tests.Cases/LinkXml/LinkXmlErrorCases.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/LinkXmlErrorCases.cs
@@ -7,6 +7,8 @@ namespace Mono.Linker.Tests.Cases.LinkXml
 	[SetupLinkerDescriptorFile ("LinkXmlErrorCases.xml")]
 	[SetupLinkerArgument ("--skip-unresolved", "true")]
 
+	[ExpectedWarning ("IL2001", "TypeWithNoFields", FileName = "LinkXmlErrorCases.xml", SourceLine = 3, SourceColumn = 6)]
+	[ExpectedWarning ("IL2002", "TypeWithNoMethods", FileName = "LinkXmlErrorCases.xml", SourceLine = 4, SourceColumn = 6)]
 	[ExpectedWarning ("IL2007", "NonExistentAssembly", FileName = "LinkXmlErrorCases.xml", SourceLine = 47, SourceColumn = 4)]
 	[ExpectedWarning ("IL2008", "NonExistentType", FileName = "LinkXmlErrorCases.xml", SourceLine = 6, SourceColumn = 6)]
 	[ExpectedWarning ("IL2009", "NonExistentMethod", "TypeWithNoMethods", FileName = "LinkXmlErrorCases.xml", SourceLine = 9, SourceColumn = 8)]

--- a/test/Mono.Linker.Tests.Cases/LinkXml/LinkXmlErrorCases.cs
+++ b/test/Mono.Linker.Tests.Cases/LinkXml/LinkXmlErrorCases.cs
@@ -28,14 +28,12 @@ namespace Mono.Linker.Tests.Cases.LinkXml
 		}
 
 		[Kept]
-		[ExpectedWarning ("IL2001", "TypeWithNoFields")]
 		class TypeWithNoFields
 		{
 			private void Method () { }
 		}
 
 		[Kept]
-		[ExpectedWarning ("IL2002", "TypeWithNoMethods")]
 		struct TypeWithNoMethods
 		{
 		}


### PR DESCRIPTION
Following #2039, this adds line source line info. for warnings IL2001 and IL2002. This will cause the warnings to be triggered even in cases where the annotated types are trimmed.

Note that we still have to keep producing these warnings in `ApplyPreserveInfo` for cases where a user applies a `TypePreserve` using the Annotations API:

https://github.com/mono/linker/blob/30f2498c2a3de1f7e236d5793f5f1aca6e5ba456/src/linker/Linker.Steps/MarkStep.cs#L2427-L2434