### PR TITLE
Parsing update for native header files with feature switch

### DIFF
--- a/src/ILLink.Tasks/CreateRuntimeRootDescriptorFile.cs
+++ b/src/ILLink.Tasks/CreateRuntimeRootDescriptorFile.cs
@@ -316,8 +316,8 @@ namespace ILLink.Tasks
 					featureDefault.Value = fsMembers.FeatureDefault;
 					featureAssemblyNode.Attributes.Append (featureDefault);
 
-					foreach (string typeName in featureSwitchMembers[fsMembers].Keys) {
-						AddXmlTypeNode (doc, featureAssemblyNode, typeName, featureSwitchMembers[fsMembers][typeName]);
+					foreach (var type in featureSwitchMembers[fsMembers]) {
+						AddXmlTypeNode (doc, featureAssemblyNode, type.Key, type.Value);
 					}
 					linkerNode.AppendChild (featureAssemblyNode);
 				}

--- a/src/ILLink.Tasks/CreateRuntimeRootDescriptorFile.cs
+++ b/src/ILLink.Tasks/CreateRuntimeRootDescriptorFile.cs
@@ -77,7 +77,7 @@ namespace ILLink.Tasks
 
 			public override int GetHashCode ()
 			{
-				return _key.GetHashCode();
+				return _key.GetHashCode ();
 			}
 
 			public override bool Equals (object obj)
@@ -90,7 +90,7 @@ namespace ILLink.Tasks
 		readonly Dictionary<string, string> namespaceDictionary = new Dictionary<string, string> ();
 		readonly Dictionary<string, string> classIdsToClassNames = new Dictionary<string, string> ();
 		readonly Dictionary<string, ClassMembers> classNamesToClassMembers = new Dictionary<string, ClassMembers> ();
-		readonly Dictionary<FeatureSwitchMembers, Dictionary<string, ClassMembers>> featureSwitchMembers = new Dictionary<FeatureSwitchMembers, Dictionary<string, ClassMembers>> ();
+		readonly Dictionary<FeatureSwitchMembers, Dictionary<string, ClassMembers>> featureSwitchMembers = new ();
 		readonly HashSet<string> defineConstants = new HashSet<string> (StringComparer.Ordinal);
 
 		public override bool Execute ()
@@ -186,7 +186,7 @@ namespace ILLink.Tasks
 					} else {
 						char[] separators = { ',', '(', ')', ' ', '\t', '/' };
 						string[] featureSwitchElements = def.Split (separators, StringSplitOptions.RemoveEmptyEntries);
-						if(featureSwitchElements.Length !=4 ) {
+						if (featureSwitchElements.Length != 4) {
 							Log.LogError ($"BEGIN_ILLINK_FEATURE_SWITCH is not formatted correctly '{typeFile}' for line {def}");
 							return;
 						}

--- a/src/ILLink.Tasks/CreateRuntimeRootDescriptorFile.cs
+++ b/src/ILLink.Tasks/CreateRuntimeRootDescriptorFile.cs
@@ -182,6 +182,10 @@ namespace ILLink.Tasks
 					} else {
 						char[] separators = { ',', '(', ')', ' ', '\t', '/' };
 						string[] featureSwitchElements = def.Split (separators, StringSplitOptions.RemoveEmptyEntries);
+						if(featureSwitchElements.Length !=4 ) {
+							Log.LogError ($"BEGIN_ILLINK_FEATURE_SWITCH is not formatted correctly '{typeFile}' for line {def}");
+							return;
+						}
 						currentFeatureSwitch = new FeatureSwitchMembers (featureSwitchElements[1], featureSwitchElements[2], featureSwitchElements[3]);
 						if (!featureSwitchMembers.ContainsKey (currentFeatureSwitch.Value)) {
 							featureSwitchMembers.Add (currentFeatureSwitch.Value, new Dictionary<string, ClassMembers> ());
@@ -313,7 +317,7 @@ namespace ILLink.Tasks
 					featureAssemblyNode.Attributes.Append (featureDefault);
 
 					foreach (string typeName in featureSwitchMembers[fsMembers].Keys) {
-						AddXmlTypeNode (doc, featureAssemblyNode, typeName, featureSwitchMembers[fsMembers]);
+						AddXmlTypeNode (doc, featureAssemblyNode, typeName, featureSwitchMembers[fsMembers][typeName]);
 					}
 					linkerNode.AppendChild (featureAssemblyNode);
 				}
@@ -322,19 +326,17 @@ namespace ILLink.Tasks
 			XmlNode assemblyNode = linkerNode["assembly"];
 
 			foreach (string typeName in classNamesToClassMembers.Keys) {
-				AddXmlTypeNode (doc, assemblyNode, typeName, classNamesToClassMembers);
+				AddXmlTypeNode (doc, assemblyNode, typeName, classNamesToClassMembers[typeName]);
 			}
 			doc.Save (outputFileName);
 		}
 
-		static void AddXmlTypeNode (XmlDocument doc, XmlNode assemblyNode, string typeName, Dictionary<string, ClassMembers> classToClassMems)
+		static void AddXmlTypeNode (XmlDocument doc, XmlNode assemblyNode, string typeName, ClassMembers members)
 		{
 			XmlNode typeNode = doc.CreateElement ("type");
 			XmlAttribute typeFullName = doc.CreateAttribute ("fullname");
 			typeFullName.Value = typeName;
 			typeNode.Attributes.Append (typeFullName);
-
-			ClassMembers members = classToClassMems[typeName];
 
 			// We need to keep everyting in System.Runtime.InteropServices.WindowsRuntime and
 			// System.Threading.Volatile.

--- a/src/ILLink.Tasks/CreateRuntimeRootDescriptorFile.cs
+++ b/src/ILLink.Tasks/CreateRuntimeRootDescriptorFile.cs
@@ -325,8 +325,8 @@ namespace ILLink.Tasks
 
 			XmlNode assemblyNode = linkerNode["assembly"];
 
-			foreach (string typeName in classNamesToClassMembers.Keys) {
-				AddXmlTypeNode (doc, assemblyNode, typeName, classNamesToClassMembers[typeName]);
+			foreach (var type in classNamesToClassMembers) {
+				AddXmlTypeNode (doc, assemblyNode, type.Key, type.Value);
 			}
 			doc.Save (outputFileName);
 		}

--- a/src/ILLink.Tasks/CreateRuntimeRootDescriptorFile.cs
+++ b/src/ILLink.Tasks/CreateRuntimeRootDescriptorFile.cs
@@ -63,23 +63,27 @@ namespace ILLink.Tasks
 			public string Feature { get; }
 			public string FeatureValue { get; }
 			public string FeatureDefault { get; }
+			// Unique value to track the key
+			private readonly String _key;
 
 			public FeatureSwitchMembers (string feature, string featureValue, string featureDefault)
 			{
 				Feature = feature;
 				FeatureValue = featureValue;
 				FeatureDefault = featureDefault;
+				// Use a separator that is not going to be in any of the strings to ensure uniqueness
+				_key = feature + ',' + featureValue + ',' + featureDefault;
 			}
 
 			public override int GetHashCode ()
 			{
-				return HashCode.Combine (Feature, FeatureValue, FeatureDefault);
+				return _key.GetHashCode();
 			}
 
 			public override bool Equals (object obj)
 			{
 				FeatureSwitchMembers other = (FeatureSwitchMembers) obj;
-				return other.Feature.Equals (Feature) && other.FeatureValue.Equals (FeatureValue) && other.FeatureDefault.Equals (FeatureDefault);
+				return other._key.Equals (_key);
 			}
 		}
 

--- a/src/ILLink.Tasks/CreateRuntimeRootDescriptorFile.cs
+++ b/src/ILLink.Tasks/CreateRuntimeRootDescriptorFile.cs
@@ -54,9 +54,33 @@ namespace ILLink.Tasks
 			public HashSet<string> fields;
 		}
 
+		/// <summary>
+		/// Helper utility to track feature switch macros in header file
+		/// This type is used in a dictionary as a key and only uses
+		/// the feature name since value and default are not expected to change
+		/// </summary>
+		class FeatureSwitchMembers
+		{
+			public string feature;
+			public string featureValue;
+			public string featureDefault;
+
+			public override int GetHashCode ()
+			{
+				return feature.GetHashCode ();
+			}
+
+			public override bool Equals (object obj)
+			{
+				FeatureSwitchMembers other = obj as FeatureSwitchMembers;
+				return other.feature.Equals (feature);
+			}
+		}
+
 		readonly Dictionary<string, string> namespaceDictionary = new Dictionary<string, string> ();
 		readonly Dictionary<string, string> classIdsToClassNames = new Dictionary<string, string> ();
 		readonly Dictionary<string, ClassMembers> classNamesToClassMembers = new Dictionary<string, ClassMembers> ();
+		readonly Dictionary<FeatureSwitchMembers, Dictionary<string, ClassMembers>> featureSwitchMembers = new Dictionary<FeatureSwitchMembers, Dictionary<string, ClassMembers>> ();
 		readonly HashSet<string> defineConstants = new HashSet<string> (StringComparer.Ordinal);
 
 		public override bool Execute ()
@@ -139,10 +163,37 @@ namespace ILLink.Tasks
 			string[] types = File.ReadAllLines (typeFile);
 			DefineTracker defineTracker = new DefineTracker (defineConstants, Log, typeFile);
 			string classId;
+			bool insideFeatureSwitch = false;
+			FeatureSwitchMembers currentFeatureSwitch = null;
 
 			foreach (string def in types) {
 				if (defineTracker.ProcessLine (def) || !defineTracker.IsActiveSection)
 					continue;
+
+				//We will handle BEGIN_ILLINK_FEATURE_SWITCH and END_ILLINK_FEATURE_SWITCH
+				if (def.StartsWith ("BEGIN_ILLINK_FEATURE_SWITCH")) {
+					if (insideFeatureSwitch) {
+						Log.LogError ($"Could not figure out feature switch status in '{typeFile}' for line {def}");
+					} else {
+						insideFeatureSwitch = true;
+						char[] separators = { ',', '(', ')', ' ', '\t', '/' };
+						string[] featureSwitchElements = def.Split (separators, StringSplitOptions.RemoveEmptyEntries);
+						currentFeatureSwitch = new FeatureSwitchMembers ();
+						currentFeatureSwitch.feature = featureSwitchElements[1];
+						currentFeatureSwitch.featureValue = featureSwitchElements[2];
+						currentFeatureSwitch.featureDefault = featureSwitchElements[3];
+						if (!featureSwitchMembers.ContainsKey (currentFeatureSwitch)) {
+							featureSwitchMembers.Add (currentFeatureSwitch, new Dictionary<string, ClassMembers> ());
+						}
+					}
+				}
+				if (def.StartsWith ("END_ILLINK_FEATURE_SWITCH")) {
+					if (!insideFeatureSwitch) {
+						Log.LogError ($"Could not figure out feature switch status in '{typeFile}' for line {def}");
+					} else {
+						insideFeatureSwitch = false;
+					}
+				}
 
 				string[] defElements = null;
 				if (def.StartsWith ("DEFINE_") || def.StartsWith ("// DEFINE_")) {
@@ -155,7 +206,7 @@ namespace ILLink.Tasks
 					classId = defElements[1];               // APP_DOMAIN
 					string classNamespace = defElements[2]; // System
 					string className = defElements[3];      // AppDomain
-					AddClass (classNamespace, className, classId);
+					AddClass (classNamespace, className, classId, false, insideFeatureSwitch, currentFeatureSwitch);
 				} else if (def.StartsWith ("DEFINE_CLASS_U(")) {
 					// E.g., DEFINE_CLASS_U(System,                 AppDomain,      AppDomainBaseObject)
 					string classNamespace = defElements[1]; // System
@@ -164,29 +215,29 @@ namespace ILLink.Tasks
 															// For these classes the sizes of managed and unmanaged classes and field offsets
 															// are compared so we need to preserve all fields.
 					const bool keepAllFields = true;
-					AddClass (classNamespace, className, classId, keepAllFields);
+					AddClass (classNamespace, className, classId, keepAllFields, insideFeatureSwitch, currentFeatureSwitch);
 				} else if (def.StartsWith ("DEFINE_FIELD(")) {
 					// E.g., DEFINE_FIELD(ACCESS_VIOLATION_EXCEPTION, IP,                _ip)
 					classId = defElements[1];          // ACCESS_VIOLATION_EXCEPTION
 					string fieldName = defElements[3]; // _ip
-					AddField (fieldName, classId);
+					AddField (fieldName, classId, insideFeatureSwitch, currentFeatureSwitch);
 				} else if (def.StartsWith ("DEFINE_METHOD(")) {
 					// E.g., DEFINE_METHOD(APP_DOMAIN,           ON_ASSEMBLY_LOAD,       OnAssemblyLoadEvent,        IM_Assembly_RetVoid)
 					string methodName = defElements[3]; // OnAssemblyLoadEvent
 					classId = defElements[1];           // APP_DOMAIN
-					AddMethod (methodName, classId);
+					AddMethod (methodName, classId, null, null, insideFeatureSwitch, currentFeatureSwitch);
 				} else if (def.StartsWith ("DEFINE_PROPERTY(") || def.StartsWith ("DEFINE_STATIC_PROPERTY(")) {
 					// E.g., DEFINE_PROPERTY(ARRAY,              LENGTH,                 Length,                     Int)
 					// or    DEFINE_STATIC_PROPERTY(THREAD,      CURRENT_THREAD,         CurrentThread,              Thread)
 					string propertyName = defElements[3];          // Length or CurrentThread
 					classId = defElements[1];                      // ARRAY or THREAD
-					AddMethod ("get_" + propertyName, classId);
+					AddMethod ("get_" + propertyName, classId, null, null, insideFeatureSwitch, currentFeatureSwitch);
 				} else if (def.StartsWith ("DEFINE_SET_PROPERTY(")) {
 					// E.g., DEFINE_SET_PROPERTY(THREAD,         UI_CULTURE,             CurrentUICulture,           CultureInfo)
 					string propertyName = defElements[3]; // CurrentUICulture
 					classId = defElements[1];             // THREAD
-					AddMethod ("get_" + propertyName, classId);
-					AddMethod ("set_" + propertyName, classId);
+					AddMethod ("get_" + propertyName, classId, null, null, insideFeatureSwitch, currentFeatureSwitch);
+					AddMethod ("set_" + propertyName, classId, null, null, insideFeatureSwitch, currentFeatureSwitch);
 				}
 			}
 		}
@@ -239,6 +290,70 @@ namespace ILLink.Tasks
 			XmlDocument doc = new XmlDocument ();
 			doc.Load (iLLinkTrimXmlFilePath);
 			XmlNode linkerNode = doc["linker"];
+
+			if (featureSwitchMembers.Count > 0) {
+				foreach (var fsMembers in featureSwitchMembers.Keys) {
+					// <assembly fullname="System.Private.CoreLib" feature="System.Diagnostics.Tracing.EventSource.IsSupported" featurevalue="true" featuredefault="true">
+					XmlNode featureAssemblyNode = doc.CreateElement ("assembly");
+					XmlAttribute featureAssemblyFullName = doc.CreateAttribute ("fullname");
+					featureAssemblyFullName.Value = "System.Private.CoreLib";
+					featureAssemblyNode.Attributes.Append (featureAssemblyFullName);
+
+					XmlAttribute featureName = doc.CreateAttribute ("feature");
+					featureName.Value = fsMembers.feature;
+					featureAssemblyNode.Attributes.Append (featureName);
+
+					XmlAttribute featureValue = doc.CreateAttribute ("featurevalue");
+					featureValue.Value = fsMembers.featureValue;
+					featureAssemblyNode.Attributes.Append (featureValue);
+
+					XmlAttribute featureDefault = doc.CreateAttribute ("featuredefault");
+					featureDefault.Value = fsMembers.featureDefault;
+					featureAssemblyNode.Attributes.Append (featureDefault);
+
+					foreach (string typeName in featureSwitchMembers[fsMembers].Keys) {
+						XmlNode typeNode = doc.CreateElement ("type");
+						XmlAttribute typeFullName = doc.CreateAttribute ("fullname");
+						typeFullName.Value = typeName;
+						typeNode.Attributes.Append (typeFullName);
+
+						ClassMembers members = featureSwitchMembers[fsMembers][typeName];
+
+						if (members.keepAllFields) {
+							XmlAttribute preserve = doc.CreateAttribute ("preserve");
+							preserve.Value = "fields";
+							typeNode.Attributes.Append (preserve);
+						} else if ((members.fields == null) && (members.methods == null)) {
+							XmlAttribute preserve = doc.CreateAttribute ("preserve");
+							preserve.Value = "nothing";
+							typeNode.Attributes.Append (preserve);
+						}
+
+						if (!members.keepAllFields && (members.fields != null)) {
+							foreach (string field in members.fields) {
+								XmlNode fieldNode = doc.CreateElement ("field");
+								XmlAttribute fieldName = doc.CreateAttribute ("name");
+								fieldName.Value = field;
+								fieldNode.Attributes.Append (fieldName);
+								typeNode.AppendChild (fieldNode);
+							}
+						}
+
+						if (members.methods != null) {
+							foreach (string method in members.methods) {
+								XmlNode methodNode = doc.CreateElement ("method");
+								XmlAttribute methodName = doc.CreateAttribute ("name");
+								methodName.Value = method;
+								methodNode.Attributes.Append (methodName);
+								typeNode.AppendChild (methodNode);
+							}
+						}
+						featureAssemblyNode.AppendChild (typeNode);
+					}
+					linkerNode.AppendChild (featureAssemblyNode);
+				}
+			}
+
 			XmlNode assemblyNode = linkerNode["assembly"];
 
 			foreach (string typeName in classNamesToClassMembers.Keys) {
@@ -288,26 +403,40 @@ namespace ILLink.Tasks
 			doc.Save (outputFileName);
 		}
 
-		void AddClass (string classNamespace, string className, string classId, bool keepAllFields = false)
+		void AddClass (string classNamespace, string className, string classId, bool keepAllFields = false, bool featureSwitchOn = false, FeatureSwitchMembers featureSwitch = null)
 		{
 			string fullClassName = GetFullClassName (classNamespace, className);
 			if (fullClassName != null) {
 				if ((classId != null) && (classId != "NoClass")) {
 					classIdsToClassNames[classId] = fullClassName;
 				}
-				if (!classNamesToClassMembers.TryGetValue (fullClassName, out ClassMembers members)) {
-					members = new ClassMembers ();
-					classNamesToClassMembers[fullClassName] = members;
+				if (!featureSwitchOn) {
+					if (!classNamesToClassMembers.TryGetValue (fullClassName, out ClassMembers members)) {
+						members = new ClassMembers ();
+						classNamesToClassMembers[fullClassName] = members;
+					}
+					members.keepAllFields |= keepAllFields;
+				} else {
+					Dictionary<string, ClassMembers> currentFeatureSwitchMembers = featureSwitchMembers[featureSwitch];
+					if (!currentFeatureSwitchMembers.TryGetValue (fullClassName, out ClassMembers members)) {
+						members = new ClassMembers ();
+						currentFeatureSwitchMembers[fullClassName] = members;
+					}
+					members.keepAllFields |= keepAllFields;
 				}
-				members.keepAllFields |= keepAllFields;
 			}
 		}
 
-		void AddField (string fieldName, string classId)
+		void AddField (string fieldName, string classId, bool featureSwitchOn = false, FeatureSwitchMembers featureSwitch = null)
 		{
 			string className = classIdsToClassNames[classId];
+			ClassMembers members;
 
-			ClassMembers members = classNamesToClassMembers[className];
+			if (!featureSwitchOn) {
+				members = classNamesToClassMembers[className];
+			} else {
+				members = featureSwitchMembers[featureSwitch][className];
+			}
 
 			if (members.fields == null) {
 				members.fields = new HashSet<string> ();
@@ -315,7 +444,7 @@ namespace ILLink.Tasks
 			members.fields.Add (fieldName);
 		}
 
-		void AddMethod (string methodName, string classId, string classNamespace = null, string className = null)
+		void AddMethod (string methodName, string classId, string classNamespace = null, string className = null, bool featureSwitchOn = false, FeatureSwitchMembers featureSwitch = null)
 		{
 			string fullClassName;
 			if (classId != null) {
@@ -324,7 +453,13 @@ namespace ILLink.Tasks
 				fullClassName = GetFullClassName (classNamespace, className);
 			}
 
-			ClassMembers members = classNamesToClassMembers[fullClassName];
+			ClassMembers members;
+
+			if (!featureSwitchOn) {
+				members = classNamesToClassMembers[fullClassName];
+			} else {
+				members = featureSwitchMembers[featureSwitch][fullClassName];
+			}
 
 			if (members.methods == null) {
 				members.methods = new HashSet<string> ();

--- a/test/ILLink.Tasks.Tests/CreateRuntimeRootDescriptorFileTests.cs
+++ b/test/ILLink.Tasks.Tests/CreateRuntimeRootDescriptorFileTests.cs
@@ -102,9 +102,9 @@ namespace ILLink.Tasks.Tests
 		}
 
 		[Fact]
-		public void TestCoreLibClassGenWithFeatureSwitch()
+		public void TestCoreLibClassGenWithFeatureSwitch ()
 		{
-			File.WriteAllLines("corelib.h", new string[] {
+			File.WriteAllLines ("corelib.h", new string[] {
 				"#ifndef TESTDEF",
 				"#define TESTDEF",
 				"#endif",
@@ -134,12 +134,12 @@ namespace ILLink.Tasks.Tests
 				"END_ILLINK_FEATURE_SWITCH()"
 				});
 
-			File.WriteAllText("namespace.h",
+			File.WriteAllText ("namespace.h",
 				"#define g_TestNS \"TestNS\"" + Environment.NewLine);
 
-			File.WriteAllLines("cortypeinfo.h", new string[] { });
+			File.WriteAllLines ("cortypeinfo.h", new string[] { });
 
-			File.WriteAllLines("rexcep.h", new string[] {
+			File.WriteAllLines ("rexcep.h", new string[] {
 				"DEFINE_EXCEPTION(g_TestNS, TestAlwaysException, false, C)",
 				"#ifdef FEATURE_ON",
 				"DEFINE_EXCEPTION(g_TestNS, TestFeatureOnException, false, C)",
@@ -149,49 +149,48 @@ namespace ILLink.Tasks.Tests
 				"#endif"
 				});
 
-			XElement existingAssembly = new XElement("assembly", new XAttribute("fullname", "testassembly"),
-					new XComment("Existing content"));
-			XElement existingContent = new XElement("linker", existingAssembly);
-			(new XDocument(existingContent)).Save("Test.ILLink.Descriptors.Combined.xml");
+			XElement existingAssembly = new XElement ("assembly", new XAttribute ("fullname", "testassembly"),
+					new XComment ("Existing content"));
+			XElement existingContent = new XElement ("linker", existingAssembly);
+			(new XDocument (existingContent)).Save ("Test.ILLink.Descriptors.Combined.xml");
 
-			var task = new CreateRuntimeRootILLinkDescriptorFile()
-			{
-				NamespaceFilePath = new TaskItem("namespace.h"),
-				MscorlibFilePath = new TaskItem("corelib.h"),
-				CortypeFilePath = new TaskItem("cortypeinfo.h"),
-				RexcepFilePath = new TaskItem("rexcep.h"),
-				ILLinkTrimXmlFilePath = new TaskItem("Test.ILLink.Descriptors.Combined.xml"),
+			var task = new CreateRuntimeRootILLinkDescriptorFile () {
+				NamespaceFilePath = new TaskItem ("namespace.h"),
+				MscorlibFilePath = new TaskItem ("corelib.h"),
+				CortypeFilePath = new TaskItem ("cortypeinfo.h"),
+				RexcepFilePath = new TaskItem ("rexcep.h"),
+				ILLinkTrimXmlFilePath = new TaskItem ("Test.ILLink.Descriptors.Combined.xml"),
 				DefineConstants = new TaskItem[] {
 					new TaskItem("FOR_ILLINK"),
 					new TaskItem("_TEST"),
 					new TaskItem("FEATURE_ON"),
 					new TaskItem("FEATURE_BOTH")
 				},
-				RuntimeRootDescriptorFilePath = new TaskItem("Test.ILLink.Descriptors.xml")
+				RuntimeRootDescriptorFilePath = new TaskItem ("Test.ILLink.Descriptors.xml")
 			};
 
-			Assert.True(task.Execute());
+			Assert.True (task.Execute ());
 
-			XDocument output = XDocument.Load("Test.ILLink.Descriptors.xml");
-			string expectedXml = new XElement("linker",
-				new XElement("assembly",
-					existingAssembly.Attributes(),
-					existingAssembly.Nodes(),
-					new XElement("type", new XAttribute("fullname", "TestNS.TestAlwaysException"),
-						new XElement("method", new XAttribute("name", ".ctor"))),
-					new XElement("type", new XAttribute("fullname", "TestNS.TestFeatureOnException"),
-						new XElement("method", new XAttribute("name", ".ctor")))
+			XDocument output = XDocument.Load ("Test.ILLink.Descriptors.xml");
+			string expectedXml = new XElement ("linker",
+				new XElement ("assembly",
+					existingAssembly.Attributes (),
+					existingAssembly.Nodes (),
+					new XElement ("type", new XAttribute ("fullname", "TestNS.TestAlwaysException"),
+						new XElement ("method", new XAttribute ("name", ".ctor"))),
+					new XElement ("type", new XAttribute ("fullname", "TestNS.TestFeatureOnException"),
+						new XElement ("method", new XAttribute ("name", ".ctor")))
 					),
-				new XElement("assembly", new XAttribute("fullname", "System.Private.CoreLib"), new XAttribute("feature", "TestFeatureName"), new XAttribute("featurevalue", "true"), new XAttribute("featuredefault", "true"),
-					new XElement("type", new XAttribute("fullname", "TestNS.TestClass"),
-						new XElement("method", new XAttribute("name", "TestMethod")),
-						new XElement("method", new XAttribute("name", "TestMethodIfOn")),
-						new XElement("method", new XAttribute("name", "TestMethodIfNotBoth")),
-						new XElement("method", new XAttribute("name", "TestMethodIfNotBothForILLink")),
-						new XElement("method", new XAttribute("name", "TestMethodForILLink")))
+				new XElement ("assembly", new XAttribute ("fullname", "System.Private.CoreLib"), new XAttribute ("feature", "TestFeatureName"), new XAttribute ("featurevalue", "true"), new XAttribute ("featuredefault", "true"),
+					new XElement ("type", new XAttribute ("fullname", "TestNS.TestClass"),
+						new XElement ("method", new XAttribute ("name", "TestMethod")),
+						new XElement ("method", new XAttribute ("name", "TestMethodIfOn")),
+						new XElement ("method", new XAttribute ("name", "TestMethodIfNotBoth")),
+						new XElement ("method", new XAttribute ("name", "TestMethodIfNotBothForILLink")),
+						new XElement ("method", new XAttribute ("name", "TestMethodForILLink")))
 					)
-				).ToString();
-			Assert.Equal(expectedXml, output.Root.ToString());
+				).ToString ();
+			Assert.Equal (expectedXml, output.Root.ToString ());
 		}
 
 	}

--- a/test/ILLink.Tasks.Tests/CreateRuntimeRootDescriptorFileTests.cs
+++ b/test/ILLink.Tasks.Tests/CreateRuntimeRootDescriptorFileTests.cs
@@ -100,5 +100,99 @@ namespace ILLink.Tasks.Tests
 					)).ToString ();
 			Assert.Equal (expectedXml, output.Root.ToString ());
 		}
+
+		[Fact]
+		public void TestCoreLibClassGenWithFeatureSwitch()
+		{
+			File.WriteAllLines("corelib.h", new string[] {
+				"#ifndef TESTDEF",
+				"#define TESTDEF",
+				"#endif",
+				"BEGIN_ILLINK_FEATURE_SWITCH(TestFeatureName, true, true)",
+				"DEFINE_CLASS(TESTCLASS, TestNS, TestClass)",
+				"DEFINE_METHOD(TESTCLASS, TESTMETHOD, TestMethod, 0)",
+				"#ifdef FEATURE_ON",
+				"DEFINE_METHOD(TESTCLASS, TESTMETHODIFON, TestMethodIfOn, 1)",
+				"#endif",
+				"#ifdef FEATURE_OFF",
+				"DEFINE_METHOD(TESTCLASS, TESTMETHODIFOFF, TestMethodIfOff, 2)",
+				"#endif",
+				"#ifndef FEATURE_BOTH // Comment",
+				"DEFINE_METHOD(TESTCLASS, TESTMETHODIFBOTH, TestMethodIfBoth, 3)",
+				"#if FOR_ILLINK",
+				"DEFINE_METHOD(TESTCLASS, TESTMETHODIFBOTH, TestMethodIfBothForILLink, 3)",
+				"#endif",
+				"#else",
+				"DEFINE_METHOD(TESTCLASS, TESTMETHODIFNOTBOTH, TestMethodIfNotBoth, 4)",
+				"#if FOR_ILLINK",
+				"DEFINE_METHOD(TESTCLASS, TESTMETHODIFNOTBOTH, TestMethodIfNotBothForILLink, 4)",
+				"#endif",
+				"#endif // FEATURE_BOTH",
+				"#if FOR_ILLINK",
+				"DEFINE_METHOD(TESTCLASS, TESTMETHODFORILLINK, TestMethodForILLink, 5)",
+				"#endif",
+				"END_ILLINK_FEATURE_SWITCH()"
+				});
+
+			File.WriteAllText("namespace.h",
+				"#define g_TestNS \"TestNS\"" + Environment.NewLine);
+
+			File.WriteAllLines("cortypeinfo.h", new string[] { });
+
+			File.WriteAllLines("rexcep.h", new string[] {
+				"DEFINE_EXCEPTION(g_TestNS, TestAlwaysException, false, C)",
+				"#ifdef FEATURE_ON",
+				"DEFINE_EXCEPTION(g_TestNS, TestFeatureOnException, false, C)",
+				"#endif",
+				"#ifdef FEATURE_OFF",
+				"DEFINE_EXCEPTION(g_TestNS, TestFeatureOffException, false, C)",
+				"#endif"
+				});
+
+			XElement existingAssembly = new XElement("assembly", new XAttribute("fullname", "testassembly"),
+					new XComment("Existing content"));
+			XElement existingContent = new XElement("linker", existingAssembly);
+			(new XDocument(existingContent)).Save("Test.ILLink.Descriptors.Combined.xml");
+
+			var task = new CreateRuntimeRootILLinkDescriptorFile()
+			{
+				NamespaceFilePath = new TaskItem("namespace.h"),
+				MscorlibFilePath = new TaskItem("corelib.h"),
+				CortypeFilePath = new TaskItem("cortypeinfo.h"),
+				RexcepFilePath = new TaskItem("rexcep.h"),
+				ILLinkTrimXmlFilePath = new TaskItem("Test.ILLink.Descriptors.Combined.xml"),
+				DefineConstants = new TaskItem[] {
+					new TaskItem("FOR_ILLINK"),
+					new TaskItem("_TEST"),
+					new TaskItem("FEATURE_ON"),
+					new TaskItem("FEATURE_BOTH")
+				},
+				RuntimeRootDescriptorFilePath = new TaskItem("Test.ILLink.Descriptors.xml")
+			};
+
+			Assert.True(task.Execute());
+
+			XDocument output = XDocument.Load("Test.ILLink.Descriptors.xml");
+			string expectedXml = new XElement("linker",
+				new XElement("assembly",
+					existingAssembly.Attributes(),
+					existingAssembly.Nodes(),
+					new XElement("type", new XAttribute("fullname", "TestNS.TestAlwaysException"),
+						new XElement("method", new XAttribute("name", ".ctor"))),
+					new XElement("type", new XAttribute("fullname", "TestNS.TestFeatureOnException"),
+						new XElement("method", new XAttribute("name", ".ctor")))
+					),
+				new XElement("assembly", new XAttribute("fullname", "System.Private.CoreLib"), new XAttribute("feature", "TestFeatureName"), new XAttribute("featurevalue", "true"), new XAttribute("featuredefault", "true"),
+					new XElement("type", new XAttribute("fullname", "TestNS.TestClass"),
+						new XElement("method", new XAttribute("name", "TestMethod")),
+						new XElement("method", new XAttribute("name", "TestMethodIfOn")),
+						new XElement("method", new XAttribute("name", "TestMethodIfNotBoth")),
+						new XElement("method", new XAttribute("name", "TestMethodIfNotBothForILLink")),
+						new XElement("method", new XAttribute("name", "TestMethodForILLink")))
+					)
+				).ToString();
+			Assert.Equal(expectedXml, output.Root.ToString());
+		}
+
 	}
 }


### PR DESCRIPTION
Added support to parse native header files that have the [feature switch macro](https://github.com/dotnet/runtime/pull/52940) defined. Should be a no-op if the feature switch macro is not defined in a header file