### PR TITLE
Implement IMetadataResolver for LinkContext

### DIFF
--- a/src/linker/Linker.Dataflow/DynamicallyAccessedMembersBinder.cs
+++ b/src/linker/Linker.Dataflow/DynamicallyAccessedMembersBinder.cs
@@ -160,7 +160,7 @@ namespace Mono.Linker
 					yield return method;
 				}
 
-				type = context.TryResolveTypeDefinition (type.BaseType);
+				type = context.TryResolve (type.BaseType);
 				onBaseType = true;
 			}
 		}
@@ -196,7 +196,7 @@ namespace Mono.Linker
 					yield return field;
 				}
 
-				type = context.TryResolveTypeDefinition (type.BaseType);
+				type = context.TryResolve (type.BaseType);
 				onBaseType = true;
 			}
 		}
@@ -261,7 +261,7 @@ namespace Mono.Linker
 					yield return property;
 				}
 
-				type = context.TryResolveTypeDefinition (type.BaseType);
+				type = context.TryResolve (type.BaseType);
 				onBaseType = true;
 			}
 		}
@@ -306,7 +306,7 @@ namespace Mono.Linker
 					yield return @event;
 				}
 
-				type = context.TryResolveTypeDefinition (type.BaseType);
+				type = context.TryResolve (type.BaseType);
 				onBaseType = true;
 			}
 		}
@@ -317,14 +317,14 @@ namespace Mono.Linker
 				foreach (var i in type.Interfaces) {
 					yield return i;
 
-					TypeDefinition interfaceType = context.TryResolveTypeDefinition (i.InterfaceType);
+					TypeDefinition interfaceType = context.TryResolve (i.InterfaceType);
 					if (interfaceType != null) {
 						foreach (var innerInterface in interfaceType.GetAllInterfaceImplementations (context))
 							yield return innerInterface;
 					}
 				}
 
-				type = context.TryResolveTypeDefinition (type.BaseType);
+				type = context.TryResolve (type.BaseType);
 			}
 		}
 	}

--- a/src/linker/Linker.Dataflow/FlowAnnotations.cs
+++ b/src/linker/Linker.Dataflow/FlowAnnotations.cs
@@ -77,7 +77,7 @@ namespace Mono.Linker.Dataflow
 
 		public DynamicallyAccessedMemberTypes GetGenericParameterAnnotation (GenericParameter genericParameter)
 		{
-			TypeDefinition declaringType = _context.ResolveTypeDefinition (genericParameter.DeclaringType);
+			TypeDefinition declaringType = _context.Resolve (genericParameter.DeclaringType);
 			if (declaringType != null) {
 				if (GetAnnotations (declaringType).TryGetAnnotation (genericParameter, out var annotation))
 					return annotation;
@@ -85,7 +85,7 @@ namespace Mono.Linker.Dataflow
 				return DynamicallyAccessedMemberTypes.None;
 			}
 
-			MethodDefinition declaringMethod = _context.ResolveMethodDefinition (genericParameter.DeclaringMethod);
+			MethodDefinition declaringMethod = _context.Resolve (genericParameter.DeclaringMethod);
 			if (declaringMethod != null && GetAnnotations (declaringMethod.DeclaringType).TryGetAnnotation (declaringMethod, out var methodTypeAnnotations) &&
 				methodTypeAnnotations.TryGetAnnotation (genericParameter, out var methodAnnotation))
 				return methodAnnotation;
@@ -384,7 +384,7 @@ namespace Mono.Linker.Dataflow
 				return true;
 			}
 
-			found = _context.ResolveFieldDefinition (foundReference);
+			found = _context.Resolve (foundReference);
 
 			if (found == null) {
 				// If the field doesn't resolve, it can't be a field on the current type
@@ -409,7 +409,7 @@ namespace Mono.Linker.Dataflow
 			if (typeReference.MetadataType == MetadataType.String)
 				return true;
 
-			TypeDefinition type = _context.TryResolveTypeDefinition (typeReference);
+			TypeDefinition type = _context.TryResolve (typeReference);
 			return type != null && (
 				_hierarchyInfo.IsSystemType (type) ||
 				_hierarchyInfo.IsSystemReflectionIReflect (type));

--- a/src/linker/Linker.Dataflow/MethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/MethodBodyScanner.cs
@@ -729,7 +729,7 @@ namespace Mono.Linker.Dataflow
 					return;
 				}
 			} else if (operation.Operand is MethodReference methodReference) {
-				var resolvedMethod = _context.TryResolveMethodDefinition (methodReference);
+				var resolvedMethod = _context.TryResolve (methodReference);
 				if (resolvedMethod != null) {
 					StackSlot slot = new StackSlot (new RuntimeMethodHandleValue (resolvedMethod));
 					currentStack.Push (slot);
@@ -789,7 +789,7 @@ namespace Mono.Linker.Dataflow
 
 			bool isByRef = code == Code.Ldflda || code == Code.Ldsflda;
 
-			FieldDefinition field = _context.TryResolveFieldDefinition (operation.Operand as FieldReference);
+			FieldDefinition field = _context.TryResolve (operation.Operand as FieldReference);
 			if (field != null) {
 				StackSlot slot = new StackSlot (GetFieldValue (thisMethod, field), isByRef);
 				currentStack.Push (slot);
@@ -817,7 +817,7 @@ namespace Mono.Linker.Dataflow
 			if (operation.OpCode.Code == Code.Stfld)
 				PopUnknown (currentStack, 1, methodBody, operation.Offset);
 
-			FieldDefinition field = _context.TryResolveFieldDefinition (operation.Operand as FieldReference);
+			FieldDefinition field = _context.TryResolve (operation.Operand as FieldReference);
 			if (field != null) {
 				HandleStoreField (thisMethod, field, operation, valueToStoreSlot.Value);
 			}
@@ -916,7 +916,7 @@ namespace Mono.Linker.Dataflow
 			if (typeReference is ArrayType)
 				return BCL.FindPredefinedType ("System", "Array", _context);
 
-			return _context.TryResolveTypeDefinition (typeReference);
+			return _context.TryResolve (typeReference);
 		}
 
 		public abstract bool HandleCall (

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -32,7 +32,7 @@ namespace Mono.Linker.Dataflow
 
 		public static bool RequiresReflectionMethodBodyScannerForCallSite (LinkContext context, MethodReference calledMethod)
 		{
-			MethodDefinition methodDefinition = context.TryResolveMethodDefinition (calledMethod);
+			MethodDefinition methodDefinition = context.TryResolve (calledMethod);
 			if (methodDefinition == null)
 				return false;
 
@@ -51,7 +51,7 @@ namespace Mono.Linker.Dataflow
 
 		public static bool RequiresReflectionMethodBodyScannerForAccess (LinkContext context, FieldReference field)
 		{
-			FieldDefinition fieldDefinition = context.TryResolveFieldDefinition (field);
+			FieldDefinition fieldDefinition = context.TryResolve (field);
 			if (fieldDefinition == null)
 				return false;
 
@@ -637,7 +637,7 @@ namespace Mono.Linker.Dataflow
 				return false;
 
 			var callingMethodDefinition = callingMethodBody.Method;
-			var calledMethodDefinition = _context.TryResolveMethodDefinition (calledMethod);
+			var calledMethodDefinition = _context.TryResolve (calledMethod);
 			if (calledMethodDefinition == null)
 				return false;
 
@@ -1306,7 +1306,7 @@ namespace Mono.Linker.Dataflow
 
 								methodReturnValue = MergePointValue.MergeValues (methodReturnValue, CreateMethodReturnValue (calledMethod, propagatedMemberTypes));
 							} else if (value is SystemTypeValue systemTypeValue) {
-								TypeDefinition baseTypeDefinition = _context.TryResolveTypeDefinition (systemTypeValue.TypeRepresented.BaseType);
+								TypeDefinition baseTypeDefinition = _context.TryResolve (systemTypeValue.TypeRepresented.BaseType);
 								if (baseTypeDefinition != null)
 									methodReturnValue = MergePointValue.MergeValues (methodReturnValue, new SystemTypeValue (baseTypeDefinition));
 								else
@@ -1863,7 +1863,7 @@ namespace Mono.Linker.Dataflow
 							}
 
 							var typeRef = _context.TypeNameResolver.ResolveTypeName (resolvedAssembly, typeNameStringValue.Contents);
-							var resolvedType = _context.TryResolveTypeDefinition (typeRef);
+							var resolvedType = _context.TryResolve (typeRef);
 							if (resolvedType == null || typeRef is ArrayType) {
 								// It's not wrong to have a reference to non-existing type - the code may well expect to get an exception in this case
 								// Note that we did find the assembly, so it's not a linker config problem, it's either intentional, or wrong versions of assemblies
@@ -2219,7 +2219,7 @@ namespace Mono.Linker.Dataflow
 		void MarkType (ref ReflectionPatternContext reflectionContext, TypeReference typeReference, DependencyKind dependencyKind = DependencyKind.AccessedViaReflection)
 		{
 			var source = reflectionContext.Source;
-			TypeDefinition type = _context.TryResolveTypeDefinition (typeReference);
+			TypeDefinition type = _context.TryResolve (typeReference);
 			reflectionContext.RecordRecognizedPattern (type, () => _markStep.MarkTypeVisibleToReflection (typeReference, type, new DependencyInfo (dependencyKind, source), source));
 		}
 

--- a/src/linker/Linker.Steps/CodeRewriterStep.cs
+++ b/src/linker/Linker.Steps/CodeRewriterStep.cs
@@ -153,7 +153,7 @@ namespace Mono.Linker.Steps
 
 			var il = body.GetILProcessor ();
 			if (method.IsInstanceConstructor () && !method.DeclaringType.IsValueType) {
-				var baseType = Context.ResolveTypeDefinition (method.DeclaringType.BaseType);
+				var baseType = Context.Resolve (method.DeclaringType.BaseType);
 				if (baseType is null)
 					return body;
 
@@ -218,14 +218,14 @@ namespace Mono.Linker.Steps
 		{
 			switch (rtype.MetadataType) {
 			case MetadataType.ValueType:
-				var definition = context.TryResolveTypeDefinition (rtype);
+				var definition = context.TryResolve (rtype);
 				if (definition?.IsEnum == true) {
 					rtype = definition.GetEnumUnderlyingType ();
 				}
 
 				break;
 			case MetadataType.GenericInstance:
-				rtype = context.TryResolveTypeDefinition (rtype);
+				rtype = context.TryResolve (rtype);
 				break;
 			}
 

--- a/src/linker/Linker.Steps/LinkAttributesParser.cs
+++ b/src/linker/Linker.Steps/LinkAttributesParser.cs
@@ -259,7 +259,7 @@ namespace Mono.Linker.Steps
 				return new CustomAttributeArgument (typeref, ConvertStringValue (svalue, typeref));
 
 			case MetadataType.ValueType:
-				var enumType = _context.ResolveTypeDefinition (typeref);
+				var enumType = _context.Resolve (typeref);
 				if (enumType?.IsEnum != true)
 					goto default;
 
@@ -377,7 +377,7 @@ namespace Mono.Linker.Steps
 					return false;
 				}
 
-				attributeType = _context.TryResolveTypeDefinition (assembly, attributeFullName);
+				attributeType = _context.TryResolve (assembly, attributeFullName);
 			}
 
 			if (attributeType == null) {

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -323,7 +323,7 @@ namespace Mono.Linker.Steps
 			}
 
 			Annotations.Mark (type, reason);
-			var baseTypeDefinition = _context.ResolveTypeDefinition (type.BaseType);
+			var baseTypeDefinition = _context.Resolve (type.BaseType);
 			if (includeBaseTypes && baseTypeDefinition != null) {
 				MarkEntireTypeInternal (baseTypeDefinition, includeBaseTypes: true, includeInterfaceTypes, new DependencyInfo (DependencyKind.BaseType, type), type);
 			}
@@ -332,7 +332,7 @@ namespace Mono.Linker.Steps
 
 			if (type.HasInterfaces) {
 				foreach (InterfaceImplementation iface in type.Interfaces) {
-					var interfaceTypeDefinition = _context.ResolveTypeDefinition (iface.InterfaceType);
+					var interfaceTypeDefinition = _context.Resolve (iface.InterfaceType);
 					if (includeInterfaceTypes && interfaceTypeDefinition != null)
 						MarkEntireTypeInternal (interfaceTypeDefinition, includeBaseTypes, includeInterfaceTypes: true, new DependencyInfo (reason.Kind, type), type);
 
@@ -713,7 +713,7 @@ namespace Mono.Linker.Steps
 		{
 			if (type.HasInterfaces) {
 				foreach (var intf in type.Interfaces) {
-					TypeDefinition resolvedInterface = _context.ResolveTypeDefinition (intf.InterfaceType);
+					TypeDefinition resolvedInterface = _context.Resolve (intf.InterfaceType);
 					if (resolvedInterface == null)
 						continue;
 
@@ -732,7 +732,7 @@ namespace Mono.Linker.Steps
 
 			if (typeToExamine.HasInterfaces) {
 				foreach (var iface in typeToExamine.Interfaces) {
-					var resolved = _context.TryResolveTypeDefinition (iface.InterfaceType);
+					var resolved = _context.TryResolve (iface.InterfaceType);
 					if (resolved == null)
 						continue;
 
@@ -759,7 +759,7 @@ namespace Mono.Linker.Steps
 
 			if (spec.MarshalInfo is CustomMarshalInfo marshaler) {
 				MarkType (marshaler.ManagedType, reason, sourceLocationMember);
-				TypeDefinition type = _context.ResolveTypeDefinition (marshaler.ManagedType);
+				TypeDefinition type = _context.Resolve (marshaler.ManagedType);
 				if (type != null) {
 					MarkICustomMarshalerMethods (type, in reason, sourceLocationMember);
 					MarkCustomMarshalerGetInstance (type, in reason, sourceLocationMember);
@@ -785,7 +785,7 @@ namespace Mono.Linker.Steps
 					if (UnconditionalSuppressMessageAttributeState.TypeRefHasUnconditionalSuppressions (ca.Constructor.DeclaringType))
 						_context.Suppressions.AddSuppression (ca, provider);
 
-					var resolvedAttributeType = _context.ResolveTypeDefinition (ca.AttributeType);
+					var resolvedAttributeType = _context.Resolve (ca.AttributeType);
 					if (resolvedAttributeType == null) {
 						continue;
 					}
@@ -886,13 +886,13 @@ namespace Mono.Linker.Steps
 
 				MarkingHelpers.MarkMatchingExportedType (type, assembly, new DependencyInfo (DependencyKind.DynamicDependency, type));
 			} else if (dynamicDependency.Type is TypeReference typeReference) {
-				type = _context.TryResolveTypeDefinition (typeReference);
+				type = _context.TryResolve (typeReference);
 				if (type == null) {
 					_context.LogWarning ($"Unresolved type '{typeReference}' in DynamicDependencyAtribute", 2036, context);
 					return;
 				}
 			} else {
-				type = _context.TryResolveTypeDefinition (context.DeclaringType);
+				type = _context.TryResolve (context.DeclaringType);
 				if (type == null) {
 					_context.LogWarning ($"Unresolved type '{context.DeclaringType}' in DynamicDependencyAttribute", 2036, context);
 					return;
@@ -980,7 +980,7 @@ namespace Mono.Linker.Steps
 			TypeDefinition td;
 			if (args.Count >= 2 && args[1].Value is string typeName) {
 				AssemblyDefinition assemblyDef = assembly ?? (context as MemberReference).Module.Assembly;
-				td = _context.TryResolveTypeDefinition (assemblyDef, typeName);
+				td = _context.TryResolve (assemblyDef, typeName);
 
 				if (td == null) {
 					_context.LogWarning (
@@ -990,7 +990,7 @@ namespace Mono.Linker.Steps
 
 				MarkingHelpers.MarkMatchingExportedType (td, assemblyDef, new DependencyInfo (DependencyKind.PreservedDependency, ca));
 			} else {
-				td = _context.TryResolveTypeDefinition (context.DeclaringType);
+				td = _context.TryResolve (context.DeclaringType);
 			}
 
 			string member = null;
@@ -1087,7 +1087,7 @@ namespace Mono.Linker.Steps
 			MarkCustomAttributeArguments (source, ca);
 
 			TypeReference constructor_type = ca.Constructor.DeclaringType;
-			TypeDefinition type = _context.ResolveTypeDefinition (constructor_type);
+			TypeDefinition type = _context.Resolve (constructor_type);
 
 			if (type == null) {
 				return;
@@ -1116,7 +1116,7 @@ namespace Mono.Linker.Steps
 					return true;
 				}
 
-				TypeDefinition type = _context.ResolveTypeDefinition (attr_type);
+				TypeDefinition type = _context.Resolve (attr_type);
 				if (type is null || !Annotations.IsMarked (type))
 					return false;
 			}
@@ -1190,7 +1190,7 @@ namespace Mono.Linker.Steps
 		protected virtual void MarkSecurityAttribute (SecurityAttribute sa, in DependencyInfo reason, IMemberDefinition sourceLocationMember)
 		{
 			TypeReference security_type = sa.AttributeType;
-			TypeDefinition type = _context.ResolveTypeDefinition (security_type);
+			TypeDefinition type = _context.Resolve (security_type);
 			if (type == null) {
 				return;
 			}
@@ -1232,7 +1232,7 @@ namespace Mono.Linker.Steps
 				if (property != null)
 					return property;
 
-				type = _context.TryResolveTypeDefinition (type.BaseType);
+				type = _context.TryResolve (type.BaseType);
 			}
 
 			return null;
@@ -1268,7 +1268,7 @@ namespace Mono.Linker.Steps
 				if (field != null)
 					return field;
 
-				type = _context.TryResolveTypeDefinition (type.BaseType);
+				type = _context.TryResolve (type.BaseType);
 			}
 
 			return null;
@@ -1281,7 +1281,7 @@ namespace Mono.Linker.Steps
 				if (method != null)
 					return method;
 
-				type = _context.TryResolveTypeDefinition (type.BaseType);
+				type = _context.TryResolve (type.BaseType);
 			}
 
 			return null;
@@ -1295,7 +1295,7 @@ namespace Mono.Linker.Steps
 			foreach (var argument in ca.ConstructorArguments)
 				MarkCustomAttributeArgument (argument, ca, source);
 
-			var resolvedConstructor = _context.TryResolveMethodDefinition (ca.Constructor);
+			var resolvedConstructor = _context.TryResolve (ca.Constructor);
 			if (resolvedConstructor != null && _context.Annotations.FlowAnnotations.RequiresDataFlowAnalysis (resolvedConstructor)) {
 				var scanner = new ReflectionMethodBodyScanner (_context, this);
 				scanner.ProcessAttributeDataflow (source, resolvedConstructor, ca.ConstructorArguments);
@@ -1419,7 +1419,7 @@ namespace Mono.Linker.Steps
 				var assemblyLevelAttribute = _assemblyLevelAttributes.Dequeue ();
 				var customAttribute = assemblyLevelAttribute.Attribute;
 
-				var resolved = _context.ResolveMethodDefinition (customAttribute.Constructor);
+				var resolved = _context.Resolve (customAttribute.Constructor);
 				if (resolved == null) {
 					continue;
 				}
@@ -1470,7 +1470,7 @@ namespace Mono.Linker.Steps
 				var customAttribute = attributeProviderPair.Attribute;
 				var provider = attributeProviderPair.Provider;
 
-				var resolved = _context.ResolveMethodDefinition (customAttribute.Constructor);
+				var resolved = _context.Resolve (customAttribute.Constructor);
 				if (resolved == null) {
 					continue;
 				}
@@ -1504,7 +1504,7 @@ namespace Mono.Linker.Steps
 				reason = new DependencyInfo (DependencyKind.FieldOnGenericInstance, reference);
 			}
 
-			FieldDefinition field = _context.ResolveFieldDefinition (reference);
+			FieldDefinition field = _context.Resolve (reference);
 
 			if (field == null) {
 				return;
@@ -1549,7 +1549,7 @@ namespace Mono.Linker.Steps
 				TypeDefinition typeWithFields = field.DeclaringType;
 				while (typeWithFields != null) {
 					MarkImplicitlyUsedFields (typeWithFields);
-					typeWithFields = _context.TryResolveTypeDefinition (typeWithFields.BaseType);
+					typeWithFields = _context.TryResolve (typeWithFields.BaseType);
 				}
 			}
 
@@ -1648,7 +1648,7 @@ namespace Mono.Linker.Steps
 			if (reference is GenericParameter)
 				return null;
 
-			TypeDefinition type = _context.ResolveTypeDefinition (reference);
+			TypeDefinition type = _context.Resolve (reference);
 
 			if (type == null)
 				return null;
@@ -1803,17 +1803,17 @@ namespace Mono.Linker.Steps
 		{
 			foreach (var property in ca.Properties) {
 				if (property.Name == "Target")
-					return _context.TryResolveTypeDefinition ((TypeReference) property.Argument.Value);
+					return _context.TryResolve ((TypeReference) property.Argument.Value);
 
 				if (property.Name == "TargetTypeName") {
 					string targetTypeName = (string) property.Argument.Value;
 					TypeName typeName = TypeParser.ParseTypeName (targetTypeName);
 					if (typeName is AssemblyQualifiedTypeName assemblyQualifiedTypeName) {
 						AssemblyDefinition assembly = _context.TryResolve (assemblyQualifiedTypeName.AssemblyName.Name);
-						return _context.TryResolveTypeDefinition (assembly, targetTypeName);
+						return _context.TryResolve (assembly, targetTypeName);
 					}
 
-					return _context.TryResolveTypeDefinition (asm, targetTypeName);
+					return _context.TryResolve (asm, targetTypeName);
 				}
 			}
 
@@ -1827,7 +1827,7 @@ namespace Mono.Linker.Steps
 
 			foreach (CustomAttribute attribute in type.CustomAttributes) {
 				var attrType = attribute.Constructor.DeclaringType;
-				var resolvedAttributeType = _context.ResolveTypeDefinition (attrType);
+				var resolvedAttributeType = _context.Resolve (attrType);
 				if (resolvedAttributeType == null) {
 					continue;
 				}
@@ -1911,7 +1911,7 @@ namespace Mono.Linker.Steps
 
 				break;
 			case TypeReference type:
-				typeDefinition = _context.ResolveTypeDefinition (type);
+				typeDefinition = _context.Resolve (type);
 				break;
 			}
 
@@ -1985,7 +1985,7 @@ namespace Mono.Linker.Steps
 						// This can be improved: mono/linker/issues/1873
 						MarkMethods (type, new DependencyInfo (DependencyKind.KeptForSpecialAttribute, attribute), type);
 						MarkFields (type, includeStatic: true, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute));
-						type = _context.TryResolveTypeDefinition (type.BaseType);
+						type = _context.TryResolve (type.BaseType);
 					}
 					return;
 				}
@@ -2010,7 +2010,7 @@ namespace Mono.Linker.Steps
 				Tracer.AddDirectDependency (attribute, new DependencyInfo (DependencyKind.CustomAttribute, type), marked: false);
 				MarkType (proxyTypeReference, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute), type);
 
-				TypeDefinition proxyType = _context.TryResolveTypeDefinition (proxyTypeReference);
+				TypeDefinition proxyType = _context.TryResolve (proxyTypeReference);
 				if (proxyType != null) {
 					MarkMethods (proxyType, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute), type);
 					MarkFields (proxyType, includeStatic: true, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, attribute));
@@ -2095,7 +2095,7 @@ namespace Mono.Linker.Steps
 			foreach (var iface in type.Interfaces) {
 				// Only mark interface implementations of interface types that have been marked.
 				// This enables stripping of interfaces that are never used
-				var resolvedInterfaceType = _context.ResolveTypeDefinition (iface.InterfaceType);
+				var resolvedInterfaceType = _context.Resolve (iface.InterfaceType);
 				if (resolvedInterfaceType == null) {
 					continue;
 				}
@@ -2246,7 +2246,7 @@ namespace Mono.Linker.Steps
 					// Instead of trying to guess where to find the interface declaration linker walks
 					// the list of implemented interfaces and resolve the declaration from there
 					//
-					var tdef = _context.ResolveTypeDefinition (iface_type);
+					var tdef = _context.Resolve (iface_type);
 					if (tdef == null) {
 						return;
 					}
@@ -2256,7 +2256,7 @@ namespace Mono.Linker.Steps
 					MarkInterfaceImplementation (iface, type);
 					return;
 				}
-			} while ((type = _context.TryResolveTypeDefinition (type.BaseType)) != null);
+			} while ((type = _context.TryResolve (type.BaseType)) != null);
 		}
 
 		static bool IsNonEmptyStaticConstructor (MethodDefinition method)
@@ -2402,10 +2402,10 @@ namespace Mono.Linker.Steps
 		IGenericParameterProvider GetGenericProviderFromInstance (IGenericInstance instance)
 		{
 			if (instance is GenericInstanceMethod method)
-				return _context.TryResolveMethodDefinition (method.ElementMethod);
+				return _context.TryResolve (method.ElementMethod);
 
 			if (instance is GenericInstanceType type)
-				return _context.TryResolveTypeDefinition (type.ElementType);
+				return _context.TryResolve (type.ElementType);
 
 			return null;
 		}
@@ -2599,7 +2599,7 @@ namespace Mono.Linker.Steps
 				MarkType (reference.DeclaringType, new DependencyInfo (DependencyKind.DeclaringType, reference), origin?.MemberDefinition);
 
 				if (reference.Name == ".ctor") {
-					Annotations.MarkRelevantToVariantCasting (_context.TryResolveTypeDefinition (arrayType));
+					Annotations.MarkRelevantToVariantCasting (_context.TryResolve (arrayType));
 				}
 				return null;
 			}
@@ -2612,7 +2612,7 @@ namespace Mono.Linker.Steps
 				reason = new DependencyInfo (DependencyKind.MethodOnGenericInstance, reference);
 			}
 
-			MethodDefinition method = _context.ResolveMethodDefinition (reference);
+			MethodDefinition method = _context.Resolve (reference);
 			if (method == null)
 				return null;
 
@@ -2849,14 +2849,14 @@ namespace Mono.Linker.Steps
 
 		void MarkExplicitInterfaceImplementation (MethodDefinition method, MethodReference ov)
 		{
-			MethodDefinition resolvedOverride = _context.ResolveMethodDefinition (ov);
+			MethodDefinition resolvedOverride = _context.Resolve (ov);
 
 			if (resolvedOverride == null)
 				return;
 
 			if (resolvedOverride.DeclaringType.IsInterface) {
 				foreach (var ifaceImpl in method.DeclaringType.Interfaces) {
-					var resolvedInterfaceType = _context.ResolveTypeDefinition (ifaceImpl.InterfaceType);
+					var resolvedInterfaceType = _context.Resolve (ifaceImpl.InterfaceType);
 					if (resolvedInterfaceType == null) {
 						continue;
 					}
@@ -2876,7 +2876,7 @@ namespace Mono.Linker.Steps
 				if (!method.IsInstanceConstructor ())
 					return;
 
-				var baseType = _context.ResolveTypeDefinition (method.DeclaringType.BaseType);
+				var baseType = _context.Resolve (method.DeclaringType.BaseType);
 				if (!MarkDefaultConstructor (baseType, new DependencyInfo (DependencyKind.BaseDefaultCtorForStubbedMethod, method), method))
 					throw new LinkerFatalErrorException (MessageContainer.CreateErrorMessage ($"Cannot stub constructor on '{method.DeclaringType}' when base type does not have default constructor",
 						1006, origin: new MessageOrigin (method)));
@@ -2963,7 +2963,7 @@ namespace Mono.Linker.Steps
 				}
 			}
 
-			TypeDefinition returnTypeDefinition = _context.TryResolveTypeDefinition (method.ReturnType);
+			TypeDefinition returnTypeDefinition = _context.TryResolve (method.ReturnType);
 
 			bool didWarnAboutCom = false;
 
@@ -2999,7 +2999,7 @@ namespace Mono.Linker.Steps
 				if (paramTypeReference is TypeSpecification) {
 					paramTypeReference = (paramTypeReference as TypeSpecification).ElementType;
 				}
-				TypeDefinition paramTypeDefinition = _context.TryResolveTypeDefinition (paramTypeReference);
+				TypeDefinition paramTypeDefinition = _context.TryResolve (paramTypeReference);
 				if (paramTypeDefinition != null) {
 					if (!paramTypeDefinition.IsImport) {
 						// What we keep here is correct most of the time, but not every time. Fine for now.
@@ -3052,7 +3052,7 @@ namespace Mono.Linker.Steps
 					return false;
 				}
 
-				var parameterTypeDef = _context.TryResolveTypeDefinition (parameterType);
+				var parameterTypeDef = _context.TryResolve (parameterType);
 				if (parameterTypeDef != null) {
 					if (parameterTypeDef.IsValueType) {
 						// Value types don't marshal as COM
@@ -3223,7 +3223,7 @@ namespace Mono.Linker.Steps
 					var reason = new DependencyInfo (DependencyKind.Ldtoken, method);
 					if (token is TypeReference typeReference) {
 						// Error will be reported as part of MarkType
-						TypeDefinition type = _context.TryResolveTypeDefinition (typeReference);
+						TypeDefinition type = _context.TryResolve (typeReference);
 						MarkTypeVisibleToReflection (typeReference, type, reason, method);
 					} else if (token is MethodReference methodReference) {
 						MarkMethod (methodReference, reason, new MessageOrigin (method, instruction.Offset));
@@ -3237,7 +3237,7 @@ namespace Mono.Linker.Steps
 				var operand = (TypeReference) instruction.Operand;
 				switch (instruction.OpCode.Code) {
 				case Code.Newarr:
-					Annotations.MarkRelevantToVariantCasting (_context.TryResolveTypeDefinition (operand));
+					Annotations.MarkRelevantToVariantCasting (_context.TryResolve (operand));
 					break;
 				case Code.Isinst:
 					if (operand is TypeSpecification || operand is GenericParameter)
@@ -3246,7 +3246,7 @@ namespace Mono.Linker.Steps
 					if (!_context.CanApplyOptimization (CodeOptimizations.UnusedTypeChecks, method.DeclaringType.Module.Assembly))
 						break;
 
-					TypeDefinition type = _context.ResolveTypeDefinition (operand);
+					TypeDefinition type = _context.Resolve (operand);
 					if (type == null)
 						return;
 

--- a/src/linker/Linker.Steps/SealerStep.cs
+++ b/src/linker/Linker.Steps/SealerStep.cs
@@ -44,7 +44,7 @@ namespace Mono.Linker.Steps
 					void PopulateCache (Collection<TypeDefinition> types)
 					{
 						foreach (var t in types) {
-							var btd = Context.TryResolveTypeDefinition (t.BaseType);
+							var btd = Context.TryResolve (t.BaseType);
 							if (btd != null)
 								referencedBaseTypeCache.Add (btd);
 
@@ -56,7 +56,7 @@ namespace Mono.Linker.Steps
 				}
 			}
 
-			var bt = Context.TryResolveTypeDefinition (type);
+			var bt = Context.TryResolve (type);
 			return referencedBaseTypeCache.Contains (bt);
 		}
 

--- a/src/linker/Linker.Steps/SweepStep.cs
+++ b/src/linker/Linker.Steps/SweepStep.cs
@@ -391,7 +391,7 @@ namespace Mono.Linker.Steps
 			if (!providerAsSecurity.HasSecurityDeclarations) {
 				// If the method or type had security before and all attributes were removed, or no remaining attributes are security attributes,
 				// then we need to set HasSecurity to false
-				if (!provider.HasCustomAttributes || provider.CustomAttributes.All (attr => !IsSecurityAttributeType (Context.TryResolveTypeDefinition (attr.AttributeType))))
+				if (!provider.HasCustomAttributes || provider.CustomAttributes.All (attr => !IsSecurityAttributeType (Context.TryResolve (attr.AttributeType))))
 					return true;
 			}
 
@@ -412,7 +412,7 @@ namespace Mono.Linker.Steps
 				};
 			}
 
-			definition = Context.TryResolveTypeDefinition (definition.BaseType);
+			definition = Context.TryResolve (definition.BaseType);
 			if (definition == null)
 				return false;
 

--- a/src/linker/Linker.Steps/UnreachableBlocksOptimizer.cs
+++ b/src/linker/Linker.Steps/UnreachableBlocksOptimizer.cs
@@ -358,7 +358,7 @@ namespace Mono.Linker.Steps
 
 				case Code.Call:
 				case Code.Callvirt:
-					var md = _context.TryResolveMethodDefinition ((MethodReference) instr.Operand);
+					var md = _context.TryResolve ((MethodReference) instr.Operand);
 					if (md == null)
 						break;
 
@@ -412,7 +412,7 @@ namespace Mono.Linker.Steps
 
 				case Code.Ldsfld:
 					var ftarget = (FieldReference) instr.Operand;
-					var field = _context.TryResolveFieldDefinition (ftarget);
+					var field = _context.TryResolve (ftarget);
 					if (field == null)
 						break;
 
@@ -435,9 +435,9 @@ namespace Mono.Linker.Steps
 
 					var operand = (TypeReference) instr.Operand;
 					if (operand.MetadataType == MetadataType.UIntPtr) {
-						sizeOfImpl = (UIntPtrSize ??= FindSizeMethod (_context.TryResolveTypeDefinition (operand)));
+						sizeOfImpl = (UIntPtrSize ??= FindSizeMethod (_context.TryResolve (operand)));
 					} else if (operand.MetadataType == MetadataType.IntPtr) {
-						sizeOfImpl = (IntPtrSize ??= FindSizeMethod (_context.TryResolveTypeDefinition (operand)));
+						sizeOfImpl = (IntPtrSize ??= FindSizeMethod (_context.TryResolve (operand)));
 					}
 
 					if (sizeOfImpl != null) {

--- a/src/linker/Linker/BCL.cs
+++ b/src/linker/Linker/BCL.cs
@@ -12,7 +12,7 @@ namespace Mono.Linker
 					return false;
 
 				while (type.BaseType != null) {
-					var bt = context.ResolveTypeDefinition (type.BaseType);
+					var bt = context.Resolve (type.BaseType);
 
 					if (bt == null)
 						return false;

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -50,7 +50,7 @@ namespace Mono.Linker
 		NET6 = 6,
 	}
 
-	public class LinkContext : IDisposable
+	public class LinkContext : IMetadataResolver, IDisposable
 	{
 
 		readonly Pipeline _pipeline;
@@ -671,7 +671,7 @@ namespace Mono.Linker
 		readonly Dictionary<FieldReference, FieldDefinition> fieldresolveCache = new ();
 		readonly Dictionary<TypeReference, TypeDefinition> typeresolveCache = new ();
 
-		public MethodDefinition ResolveMethodDefinition (MethodReference methodReference)
+		public MethodDefinition Resolve (MethodReference methodReference)
 		{
 			if (methodReference is MethodDefinition md)
 				return md;
@@ -695,7 +695,7 @@ namespace Mono.Linker
 			return md;
 		}
 
-		public MethodDefinition TryResolveMethodDefinition (MethodReference methodReference)
+		public MethodDefinition TryResolve (MethodReference methodReference)
 		{
 			if (methodReference is MethodDefinition md)
 				return md;
@@ -711,7 +711,7 @@ namespace Mono.Linker
 			return md;
 		}
 
-		public FieldDefinition ResolveFieldDefinition (FieldReference fieldReference)
+		public FieldDefinition Resolve (FieldReference fieldReference)
 		{
 			if (fieldReference is FieldDefinition fd)
 				return fd;
@@ -735,7 +735,7 @@ namespace Mono.Linker
 			return fd;
 		}
 
-		public FieldDefinition TryResolveFieldDefinition (FieldReference fieldReference)
+		public FieldDefinition TryResolve (FieldReference fieldReference)
 		{
 			if (fieldReference is FieldDefinition fd)
 				return fd;
@@ -751,7 +751,7 @@ namespace Mono.Linker
 			return fd;
 		}
 
-		public TypeDefinition ResolveTypeDefinition (TypeReference typeReference)
+		public TypeDefinition Resolve (TypeReference typeReference)
 		{
 			if (typeReference is TypeDefinition td)
 				return td;
@@ -781,7 +781,7 @@ namespace Mono.Linker
 			return td;
 		}
 
-		public TypeDefinition TryResolveTypeDefinition (TypeReference typeReference)
+		public TypeDefinition TryResolve (TypeReference typeReference)
 		{
 			if (typeReference is TypeDefinition td)
 				return td;
@@ -799,7 +799,7 @@ namespace Mono.Linker
 					//
 					// It returns element-type for arrays and also element type for wrapping types like ByReference, PinnedType, etc
 					//
-					td = TryResolveTypeDefinition (ts.GetElementType ());
+					td = TryResolve (ts.GetElementType ());
 				}
 			} else {
 				td = typeReference.Resolve ();
@@ -809,10 +809,10 @@ namespace Mono.Linker
 			return td;
 		}
 
-		public TypeDefinition TryResolveTypeDefinition (AssemblyDefinition assembly, string typeNameString)
+		public TypeDefinition TryResolve (AssemblyDefinition assembly, string typeNameString)
 		{
 			// It could be cached if it shows up on fast path
-			return TryResolveTypeDefinition (_typeNameResolver.ResolveTypeName (assembly, typeNameString));
+			return TryResolve (_typeNameResolver.ResolveTypeName (assembly, typeNameString));
 		}
 
 		readonly HashSet<MemberReference> unresolved_reported = new ();

--- a/src/linker/Linker/MarkingHelpers.cs
+++ b/src/linker/Linker/MarkingHelpers.cs
@@ -35,7 +35,7 @@ namespace Mono.Linker
 
 			if (typeReference.Scope is AssemblyNameReference) {
 				var assembly = _context.Resolve (typeReference.Scope);
-				if (assembly != null && assembly.MainModule.GetMatchingExportedType (_context.TryResolveTypeDefinition (typeReference), out var exportedType))
+				if (assembly != null && assembly.MainModule.GetMatchingExportedType (_context.TryResolve (typeReference), out var exportedType))
 					MarkExportedType (exportedType, assembly.MainModule, new DependencyInfo (DependencyKind.ExportedType, typeReference));
 			}
 		}

--- a/src/linker/Linker/MethodBodyScanner.cs
+++ b/src/linker/Linker/MethodBodyScanner.cs
@@ -84,7 +84,7 @@ namespace Mono.Linker
 				while (currentType?.BaseType != null) // Checking BaseType != null to skip System.Object
 				{
 					AddMatchingInterfaces (interfaceImplementations, currentType, interfaceTypes);
-					currentType = context.TryResolveTypeDefinition (currentType.BaseType);
+					currentType = context.TryResolve (currentType.BaseType);
 				}
 			}
 
@@ -113,7 +113,7 @@ namespace Mono.Linker
 
 			foreach (Instruction instruction in body.Instructions) {
 				if (instruction.Operand is FieldReference fieldReference) {
-					AddIfResolved (types, context.TryResolveFieldDefinition (fieldReference)?.FieldType);
+					AddIfResolved (types, context.TryResolve (fieldReference)?.FieldType);
 				} else if (instruction.Operand is MethodReference methodReference) {
 					if (methodReference is GenericInstanceMethod genericInstanceMethod)
 						AddFromGenericInstance (types, genericInstanceMethod);
@@ -121,7 +121,7 @@ namespace Mono.Linker
 					if (methodReference.DeclaringType is GenericInstanceType genericInstanceType)
 						AddFromGenericInstance (types, genericInstanceType);
 
-					var resolvedMethod = context.TryResolveMethodDefinition (methodReference);
+					var resolvedMethod = context.TryResolve (methodReference);
 					if (resolvedMethod != null) {
 						if (resolvedMethod.HasParameters) {
 							foreach (var param in resolvedMethod.Parameters)
@@ -157,7 +157,7 @@ namespace Mono.Linker
 				return false;
 
 			foreach (var iface in type.Interfaces) {
-				if (context.TryResolveTypeDefinition (iface.InterfaceType) == interfaceType) {
+				if (context.TryResolve (iface.InterfaceType) == interfaceType) {
 					implementation = iface;
 					return true;
 				}
@@ -188,7 +188,7 @@ namespace Mono.Linker
 
 		void AddIfResolved (HashSet<TypeDefinition> set, TypeReference item)
 		{
-			var resolved = context.TryResolveTypeDefinition (item);
+			var resolved = context.TryResolve (item);
 			if (resolved == null)
 				return;
 

--- a/src/linker/Linker/TypeHierarchyCache.cs
+++ b/src/linker/Linker/TypeHierarchyCache.cs
@@ -45,7 +45,7 @@ namespace Mono.Linker
 					}
 				}
 
-				baseType = context.TryResolveTypeDefinition (baseType.BaseType);
+				baseType = context.TryResolve (baseType.BaseType);
 			}
 
 			if (resolvedType != null)

--- a/src/linker/Linker/TypeMapInfo.cs
+++ b/src/linker/Linker/TypeMapInfo.cs
@@ -125,7 +125,7 @@ namespace Mono.Linker
 			// to find the method implementation and record it.
 			foreach (var interfaceImpl in type.GetInflatedInterfaces ()) {
 				foreach (MethodReference interfaceMethod in interfaceImpl.InflatedInterface.GetMethods (context)) {
-					MethodDefinition resolvedInterfaceMethod = context.TryResolveMethodDefinition (interfaceMethod);
+					MethodDefinition resolvedInterfaceMethod = context.TryResolve (interfaceMethod);
 					if (resolvedInterfaceMethod == null)
 						continue;
 
@@ -188,7 +188,7 @@ namespace Mono.Linker
 		void MapOverrides (MethodDefinition method)
 		{
 			foreach (MethodReference override_ref in method.Overrides) {
-				MethodDefinition @override = context.TryResolveMethodDefinition (override_ref);
+				MethodDefinition @override = context.TryResolve (override_ref);
 				if (@override == null)
 					continue;
 
@@ -239,7 +239,7 @@ namespace Mono.Linker
 				return GetInflatedBaseType (requiredModifierType.ElementType);
 
 			if (type is GenericInstanceType genericInstance) {
-				var baseType = context.TryResolveTypeDefinition (type)?.BaseType;
+				var baseType = context.TryResolve (type)?.BaseType;
 
 				if (baseType is GenericInstanceType)
 					return TypeReferenceExtensions.InflateGenericType (genericInstance, baseType);
@@ -247,7 +247,7 @@ namespace Mono.Linker
 				return baseType;
 			}
 
-			return context.TryResolveTypeDefinition (type)?.BaseType;
+			return context.TryResolve (type)?.BaseType;
 		}
 
 		// Returns a list of default implementations of the given interface method on this type.
@@ -259,7 +259,7 @@ namespace Mono.Linker
 			// Go over all interfaces, trying to find a method that is an explicit MethodImpl of the
 			// interface method in question.
 			foreach (var interfaceImpl in type.Interfaces) {
-				var potentialImplInterface = context.TryResolveTypeDefinition (interfaceImpl.InterfaceType);
+				var potentialImplInterface = context.TryResolve (interfaceImpl.InterfaceType);
 				if (potentialImplInterface == null)
 					continue;
 
@@ -276,7 +276,7 @@ namespace Mono.Linker
 
 					// This method is an override of something. Let's see if it's the method we are looking for.
 					foreach (var @override in potentialImplMethod.Overrides) {
-						if (context.TryResolveMethodDefinition (@override) == interfaceMethod) {
+						if (context.TryResolve (@override) == interfaceMethod) {
 							yield return interfaceImpl;
 							foundImpl = true;
 							break;
@@ -300,7 +300,7 @@ namespace Mono.Linker
 		MethodDefinition TryMatchMethod (TypeReference type, MethodReference method)
 		{
 			foreach (var candidate in type.GetMethods (context)) {
-				var md = context.TryResolveMethodDefinition (candidate);
+				var md = context.TryResolve (candidate);
 				if (md?.IsVirtual != true)
 					continue;
 

--- a/src/linker/Linker/TypeReferenceExtensions.cs
+++ b/src/linker/Linker/TypeReferenceExtensions.cs
@@ -260,7 +260,7 @@ namespace Mono.Linker
 
 		public static IEnumerable<MethodReference> GetMethods (this TypeReference type, LinkContext context)
 		{
-			TypeDefinition typeDef = context.ResolveTypeDefinition (type);
+			TypeDefinition typeDef = context.Resolve (type);
 			if (typeDef?.HasMethods != true)
 				yield break;
 

--- a/src/linker/ref/Linker/LinkContext.cs
+++ b/src/linker/ref/Linker/LinkContext.cs
@@ -7,7 +7,7 @@ using Mono.Cecil;
 namespace Mono.Linker
 {
 
-	public class LinkContext
+	public class LinkContext : IMetadataResolver
 	{
 		internal LinkContext () { }
 		public AnnotationStore Annotations { get { throw null; } }
@@ -21,12 +21,12 @@ namespace Mono.Linker
 		public bool HasCustomData (string key) { throw null; }
 		public bool TryGetCustomData (string key, out string value) { throw null; }
 
-		public MethodDefinition ResolveMethodDefinition (MethodReference methodReference) { throw null; }
-		public FieldDefinition ResolveFieldDefinition (FieldReference fieldReference) { throw null; }
-		public TypeDefinition ResolveTypeDefinition (TypeReference typeReference) { throw null; }
+		public MethodDefinition Resolve (MethodReference methodReference) { throw null; }
+		public FieldDefinition Resolve (FieldReference fieldReference) { throw null; }
+		public TypeDefinition Resolve (TypeReference typeReference) { throw null; }
 
-		public MethodDefinition TryResolveMethodDefinition (MethodReference methodReference) { throw null; }
-		public FieldDefinition TryResolveFieldDefinition (FieldReference fieldReference) { throw null; }
-		public TypeDefinition TryResolveTypeDefinition (TypeReference typeReference) { throw null; }
+		public MethodDefinition TryResolve (MethodReference methodReference) { throw null; }
+		public FieldDefinition TryResolve (FieldReference fieldReference) { throw null; }
+		public TypeDefinition TryResolve (TypeReference typeReference) { throw null; }
 	}
 }


### PR DESCRIPTION
This will allow extension methods that take an `IMetadataResolver` like
in https://github.com/xamarin/java.interop/pull/842/ to use the
LinkContext Resolve cache.

Context: https://github.com/xamarin/xamarin-android/pull/5748#discussion_r633948697

The Resolve cache added in https://github.com/mono/linker/pull/1979
requires calling `Resolve*Definition` methods directly on `LinkContext`,
which means that any extension methods that do resolution logic need to
take a `LinkContext`. This doesn't work well with the layering in
xamarin-android, where java.interop uses a resolution cache with cecil,
but doesn't depend on the linker. Instead it uses a custom
`TypeResolutionCache` for extension methods like `GetBaseDefinition`:
https://github.com/xamarin/java.interop/blob/main/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/MethodDefinitionRocks.cs#L16
These extension methods are also used from xamarin-android, but there's
a desire to use the `LinkContext` cache in this case.

@jonpryor had the idea to change the extension methods to use cecil's
`IMetadataResolver`, which can be implemented by `TypeDefinitionCache`
and by `LinkContext`. Java.interop will continue using their `TypeDefinitionCache`,
and xamarin-android will use `LinkContext`.

One limitation of this approach is that `LinkContext.TryResolve*Definition`
(renamed to just `TryResolve` for consistency) methods aren't usable from
the extension methods.

This will also need to be updated in xamarin-macios, which ~~has already started
using~~ should also be use the `(Try)Resolve*Definition` methods. /cc @spouliot @rolfbjarne
