### PR TITLE
Add support for UnrecognizedReflectionAccessPattern in analyzer test infra

### DIFF
--- a/src/ILLink.RoslynAnalyzer/ISymbolExtensions.cs
+++ b/src/ILLink.RoslynAnalyzer/ISymbolExtensions.cs
@@ -2,11 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Text;
 using Microsoft.CodeAnalysis;
 
 namespace ILLink.RoslynAnalyzer
 {
-	static class ISymbolExtensions
+	public static class ISymbolExtensions
 	{
 		/// <summary>
 		/// Returns true if symbol <see paramref="symbol"/> has an attribute with name <see paramref="attributeName"/>.
@@ -18,6 +19,30 @@ namespace ILLink.RoslynAnalyzer
 					return true;
 
 			return false;
+		}
+
+		public static string GetDisplayName (this ISymbol symbol)
+		{
+			var sb = new StringBuilder ();
+			switch (symbol) {
+			case IFieldSymbol fieldSymbol:
+				sb.Append (fieldSymbol.Type);
+				sb.Append (" ");
+				sb.Append (fieldSymbol.ContainingSymbol.ToDisplayString ());
+				sb.Append ("::");
+				sb.Append (fieldSymbol.MetadataName);
+				break;
+
+			case IParameterSymbol parameterSymbol:
+				sb.Append (parameterSymbol.Name);
+				break;
+
+			default:
+				sb.Append (symbol.ToDisplayString ());
+				break;
+			}
+
+			return sb.ToString ();
 		}
 	}
 }

--- a/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
@@ -181,7 +181,7 @@ namespace ILLink.RoslynAnalyzer
 			operationContext.ReportDiagnostic (Diagnostic.Create (
 				RequiresDiagnosticRule,
 				operationContext.Operation.Syntax.GetLocation (),
-				member.ToString (),
+				member.GetDisplayName (),
 				message,
 				url));
 		}

--- a/src/ILLink.RoslynAnalyzer/RequiresAssemblyFilesAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresAssemblyFilesAnalyzer.cs
@@ -93,16 +93,17 @@ namespace ILLink.RoslynAnalyzer
 				ImmutableArrayOperations.AddIfNotNull (dangerousPatternsBuilder, ImmutableArrayOperations.TryGetSingleSymbol<IPropertySymbol> (assemblyNameType.GetMembers ("CodeBase")));
 				ImmutableArrayOperations.AddIfNotNull (dangerousPatternsBuilder, ImmutableArrayOperations.TryGetSingleSymbol<IPropertySymbol> (assemblyNameType.GetMembers ("EscapedCodeBase")));
 			}
+
 			return dangerousPatternsBuilder.ToImmutable ();
 		}
 
 		protected override bool ReportSpecialIncompatibleMembersDiagnostic (OperationAnalysisContext operationContext, ImmutableArray<ISymbol> dangerousPatterns, ISymbol member)
 		{
 			if (member is IMethodSymbol && ImmutableArrayOperations.Contains (dangerousPatterns, member, SymbolEqualityComparer.Default)) {
-				operationContext.ReportDiagnostic (Diagnostic.Create (s_getFilesRule, operationContext.Operation.Syntax.GetLocation (), member));
+				operationContext.ReportDiagnostic (Diagnostic.Create (s_getFilesRule, operationContext.Operation.Syntax.GetLocation (), member.GetDisplayName ()));
 				return true;
 			} else if (member is IPropertySymbol && ImmutableArrayOperations.Contains (dangerousPatterns, member, SymbolEqualityComparer.Default)) {
-				operationContext.ReportDiagnostic (Diagnostic.Create (s_locationRule, operationContext.Operation.Syntax.GetLocation (), member));
+				operationContext.ReportDiagnostic (Diagnostic.Create (s_locationRule, operationContext.Operation.Syntax.GetLocation (), member.GetDisplayName ()));
 				return true;
 			}
 			return false;

--- a/test/ILLink.RoslynAnalyzer.Tests/LinkerTestCases.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/LinkerTestCases.cs
@@ -14,7 +14,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 	public class LinkerTestCases : TestCaseUtils
 	{
 		[Theory]
-		[MemberData (nameof (GetTestData), parameters: nameof (RequiresCapability))]
+		[MemberData (nameof (TestCaseUtils.GetTestData), parameters: nameof (RequiresCapability))]
 		public void RequiresCapability (MethodDeclarationSyntax m, List<AttributeSyntax> attrs)
 		{
 			switch (m.Identifier.ValueText) {
@@ -30,7 +30,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 				return;
 			}
 
-			RunTest (m, attrs, UseMSBuildProperties (MSBuildPropertyOptionNames.EnableTrimAnalyzer));
+			RunTest<RequiresUnreferencedCodeAnalyzer> (m, attrs, UseMSBuildProperties (MSBuildPropertyOptionNames.EnableTrimAnalyzer));
 		}
 	}
 }

--- a/test/ILLink.RoslynAnalyzer.Tests/TestCaseUtils.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/TestCaseUtils.cs
@@ -58,7 +58,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 			test.ValidateAttributes (attrs);
 		}
 
-		
+
 
 		public static readonly ImmutableDictionary<string, List<string>> s_testFiles = GetTestFilesByDirName ();
 
@@ -81,7 +81,6 @@ namespace ILLink.RoslynAnalyzer.Tests
 
 		public static void GetDirectoryPaths (out string rootSourceDirectory, out string testAssemblyPath)
 		{
-
 #if DEBUG
 			var configDirectoryName = "Debug";
 #else

--- a/test/ILLink.RoslynAnalyzer.Tests/TestCaseUtils.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/TestCaseUtils.cs
@@ -7,9 +7,11 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Xunit;
 
 namespace ILLink.RoslynAnalyzer.Tests
@@ -19,11 +21,10 @@ namespace ILLink.RoslynAnalyzer.Tests
 		public static IEnumerable<object[]> GetTestData (string testSuiteName)
 		{
 			foreach (var testFile in s_testFiles[testSuiteName]) {
-
 				var root = CSharpSyntaxTree.ParseText (File.ReadAllText (testFile)).GetRoot ();
 
 				foreach (var node in root.DescendantNodes ()) {
-					if (node is MethodDeclarationSyntax m) {
+					if (node is MemberDeclarationSyntax m) {
 						var attrs = m.AttributeLists.SelectMany (al => al.Attributes.Where (IsWellKnown)).ToList ();
 						if (attrs.Count > 0) {
 							yield return new object[] { m, attrs };
@@ -34,140 +35,34 @@ namespace ILLink.RoslynAnalyzer.Tests
 				static bool IsWellKnown (AttributeSyntax attr)
 				{
 					switch (attr.Name.ToString ()) {
+					// Currently, the analyzer's test infra only understands these attributes when placed on methods.
 					case "ExpectedWarning":
 					case "LogContains":
 					case "LogDoesNotContain":
+						return attr.Ancestors ().OfType<MemberDeclarationSyntax> ().First ().IsKind (SyntaxKind.MethodDeclaration);
+
+					case "UnrecognizedReflectionAccessPattern":
 						return true;
 					}
+
 					return false;
 				}
 			}
 		}
 
-		internal static void RunTest (MethodDeclarationSyntax m, List<AttributeSyntax> attrs, params (string, string)[] MSBuildProperties)
+		public static void RunTest<TAnalyzer> (MemberDeclarationSyntax m, List<AttributeSyntax> attrs, params (string, string)[] MSBuildProperties)
+			where TAnalyzer : DiagnosticAnalyzer, new()
 		{
-			var comp = CSharpAnalyzerVerifier<RequiresUnreferencedCodeAnalyzer>.CreateCompilation (m.SyntaxTree, MSBuildProperties).Result;
-			var diags = comp.GetAnalyzerDiagnosticsAsync ().Result;
-
-			var filtered = diags.Where (d => d.Location.SourceSpan.IntersectsWith (m.Span))
-								.Select (d => new { Id = d.Id, Message = d.GetMessage () });
-			foreach (var attr in attrs) {
-				switch (attr.Name.ToString ()) {
-				case "ExpectedWarning": {
-						var args = GetAttributeArguments (attr);
-						string expectedWarningCode = GetStringFromExpr (args["#0"]);
-
-						if (!expectedWarningCode.StartsWith ("IL"))
-							break;
-
-						if (args.TryGetValue ("GlobalAnalysisOnly", out var globalAnalysisOnly) &&
-							globalAnalysisOnly is LiteralExpressionSyntax { Token: { Value: true } })
-							break;
-
-						List<string> expectedMessages = args
-							.Where (arg => arg.Key.StartsWith ("#") && arg.Key != "#0")
-							.Select (arg => GetStringFromExpr (arg.Value))
-							.ToList ();
-
-						Assert.True (
-							filtered.Any (mc => {
-								if (mc.Id != expectedWarningCode)
-									return false;
-
-								foreach (var expectedMessage in expectedMessages)
-									if (!mc.Message.Contains (expectedMessage))
-										return false;
-
-								return true;
-							}),
-						$"Expected to find warning containing:{string.Join (" ", expectedMessages.Select (m => "'" + m + "'"))}" +
-						$", but no such message was found.{ Environment.NewLine}In diagnostics: {string.Join (Environment.NewLine, filtered)}");
-					}
-					break;
-				case "LogContains": {
-						var arg = Assert.Single (attr.ArgumentList!.Arguments);
-						var text = GetStringFromExpr (arg.Expression);
-						// If the text starts with `warning IL...` then it probably follows the pattern
-						//	'warning <diagId>: <location>:'
-						// We don't want to repeat the location in the error message for the analyzer, so
-						// it's better to just trim here. We've already filtered by diagnostic location so
-						// the text location shouldn't matter
-						if (text.StartsWith ("warning IL")) {
-							var firstColon = text.IndexOf (": ");
-							if (firstColon > 0) {
-								var secondColon = text.IndexOf (": ", firstColon + 1);
-								if (secondColon > 0) {
-									text = text.Substring (secondColon + 2);
-								}
-							}
-						}
-						bool found = false;
-						foreach (var d in filtered) {
-							if (d.Message.Contains (text)) {
-								found = true;
-								break;
-							}
-						}
-						if (!found) {
-							var diagStrings = string.Join (Environment.NewLine, filtered);
-							Assert.True (false, $@"Could not find text:
-{text}
-In diagnostics:
-{diagStrings}");
-						}
-					}
-					break;
-				case "LogDoesNotContain": {
-						var arg = Assert.Single (attr.ArgumentList!.Arguments);
-						var text = GetStringFromExpr (arg.Expression);
-						foreach (var d in filtered) {
-							Assert.DoesNotContain (text, d.Message);
-						}
-					}
-					break;
-				}
-			}
-
-			// Accepts string literal expressions or binary expressions concatenating strings
-			static string GetStringFromExpr (ExpressionSyntax expr)
-			{
-				switch (expr.Kind ()) {
-				case SyntaxKind.StringLiteralExpression:
-					var strLiteral = (LiteralExpressionSyntax) expr;
-					var token = strLiteral.Token;
-					Assert.Equal (SyntaxKind.StringLiteralToken, token.Kind ());
-					return token.ValueText;
-				case SyntaxKind.AddExpression:
-					var addExpr = (BinaryExpressionSyntax) expr;
-					return GetStringFromExpr (addExpr.Left) + GetStringFromExpr (addExpr.Right);
-				default:
-					Assert.True (false, "Unsupported expr kind " + expr.Kind ());
-					return null!;
-				}
-			}
-
-			static Dictionary<string, ExpressionSyntax> GetAttributeArguments (AttributeSyntax attribute)
-			{
-				Dictionary<string, ExpressionSyntax> arguments = new Dictionary<string, ExpressionSyntax> ();
-				int ordinal = 0;
-				foreach (var argument in attribute.ArgumentList!.Arguments) {
-					string argName;
-					if (argument.NameEquals != null) {
-						argName = argument.NameEquals.ChildNodes ().OfType<IdentifierNameSyntax> ().First ().Identifier.ValueText;
-					} else {
-						argName = "#" + ordinal.ToString ();
-						ordinal++;
-					}
-					arguments.Add (argName, argument.Expression);
-				}
-
-				return arguments;
-			}
+			var test = new TestChecker (m, CSharpAnalyzerVerifier<TAnalyzer>
+				.CreateCompilation (m.SyntaxTree.GetRoot ().SyntaxTree, MSBuildProperties).Result);
+			test.ValidateAttributes (attrs);
 		}
 
-		private static readonly ImmutableDictionary<string, List<string>> s_testFiles = GetTestFilesByDirName ();
+		
 
-		private static ImmutableDictionary<string, List<string>> GetTestFilesByDirName ()
+		public static readonly ImmutableDictionary<string, List<string>> s_testFiles = GetTestFilesByDirName ();
+
+		public static ImmutableDictionary<string, List<string>> GetTestFilesByDirName ()
 		{
 			var builder = ImmutableDictionary.CreateBuilder<string, List<string>> ();
 
@@ -184,7 +79,81 @@ In diagnostics:
 			return builder.ToImmutable ();
 		}
 
-		private static IEnumerable<string> GetTestFiles ()
+		public static void GetDirectoryPaths (out string rootSourceDirectory, out string testAssemblyPath)
+		{
+
+#if DEBUG
+			var configDirectoryName = "Debug";
+#else
+			var configDirectoryName = "Release";
+#endif
+
+#if NET6_0
+			const string tfm = "net6.0";
+#else
+			const string tfm = "net5.0";
+#endif
+
+			// Working directory is artifacts/bin/Mono.Linker.Tests/<config>/<tfm>
+			var artifactsBinDir = Path.Combine (Directory.GetCurrentDirectory (), "..", "..", "..");
+			rootSourceDirectory = Path.GetFullPath (Path.Combine (artifactsBinDir, "..", "..", "test", "Mono.Linker.Tests.Cases"));
+			testAssemblyPath = Path.GetFullPath (Path.Combine (artifactsBinDir, "ILLink.RoslynAnalyzer.Tests", configDirectoryName, tfm));
+		}
+
+		// Accepts string literal expressions or binary expressions concatenating strings
+		public static string GetStringFromExpression (ExpressionSyntax expr, SemanticModel? semanticModel = null)
+		{
+			if (expr == null)
+				return null!;
+
+			switch (expr.Kind ()) {
+			case SyntaxKind.AddExpression:
+				var addExpr = (BinaryExpressionSyntax) expr;
+				return GetStringFromExpression (addExpr.Left) + GetStringFromExpression (addExpr.Right);
+
+			case SyntaxKind.InvocationExpression:
+				var nameofValue = semanticModel!.GetConstantValue (expr);
+				if (nameofValue.HasValue)
+					return (nameofValue.Value as string)!;
+
+				return string.Empty;
+
+			case SyntaxKind.StringLiteralExpression:
+				var strLiteral = (LiteralExpressionSyntax) expr;
+				var token = strLiteral.Token;
+				Assert.Equal (SyntaxKind.StringLiteralToken, token.Kind ());
+				return token.ValueText;
+
+			case SyntaxKind.TypeOfExpression:
+				return semanticModel.GetTypeInfo (expr).Type!.GetDisplayName ();
+
+			default:
+				Assert.True (false, "Unsupported expr kind " + expr.Kind ());
+				return null!;
+			}
+		}
+
+		public static Dictionary<string, ExpressionSyntax> GetAttributeArguments (AttributeSyntax attribute)
+		{
+			Dictionary<string, ExpressionSyntax> arguments = new Dictionary<string, ExpressionSyntax> ();
+			int ordinal = 0;
+			foreach (var argument in attribute.ArgumentList!.Arguments) {
+				string argName;
+				if (argument.NameEquals != null) {
+					argName = argument.NameEquals.ChildNodes ().OfType<IdentifierNameSyntax> ().First ().Identifier.ValueText;
+				} else if (argument.NameColon is NameColonSyntax nameColon) {
+					argName = nameColon.Name.Identifier.ValueText;
+				} else {
+					argName = "#" + ordinal.ToString ();
+					ordinal++;
+				}
+				arguments.Add (argName, argument.Expression);
+			}
+
+			return arguments;
+		}
+
+		public static IEnumerable<string> GetTestFiles ()
 		{
 			GetDirectoryPaths (out var rootSourceDir, out _);
 
@@ -205,30 +174,9 @@ In diagnostics:
 			}
 		}
 
-		internal static (string, string)[] UseMSBuildProperties (params string[] MSBuildProperties)
+		public static (string, string)[] UseMSBuildProperties (params string[] MSBuildProperties)
 		{
 			return MSBuildProperties.Select (msbp => ($"build_property.{msbp}", "true")).ToArray ();
-		}
-
-		internal static void GetDirectoryPaths (out string rootSourceDirectory, out string testAssemblyPath)
-		{
-
-#if DEBUG
-			var configDirectoryName = "Debug";
-#else
-			var configDirectoryName = "Release";
-#endif
-
-#if NET6_0
-			const string tfm = "net6.0";
-#else
-			const string tfm = "net5.0";
-#endif
-
-			// working directory is artifacts/bin/Mono.Linker.Tests/<config>/<tfm>
-			var artifactsBinDir = Path.Combine (Directory.GetCurrentDirectory (), "..", "..", "..");
-			rootSourceDirectory = Path.GetFullPath (Path.Combine (artifactsBinDir, "..", "..", "test", "Mono.Linker.Tests.Cases"));
-			testAssemblyPath = Path.GetFullPath (Path.Combine (artifactsBinDir, "ILLink.RoslynAnalyzer.Tests", configDirectoryName, tfm));
 		}
 	}
 }

--- a/test/ILLink.RoslynAnalyzer.Tests/TestChecker.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/TestChecker.cs
@@ -1,0 +1,188 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Xunit;
+
+namespace ILLink.RoslynAnalyzer.Tests
+{
+	internal class TestChecker
+	{
+		private readonly CompilationWithAnalyzers Compilation;
+
+		private readonly SemanticModel SemanticModel;
+
+		private readonly List<(string Id, string Message)> DiagnosticMessages;
+
+		public TestChecker (SyntaxNode syntaxNode, (CompilationWithAnalyzers Compilation, SemanticModel SemanticModel) compilationResult)
+		{
+			Compilation = compilationResult.Compilation;
+			SemanticModel = compilationResult.SemanticModel;
+			DiagnosticMessages = Compilation.GetAnalyzerDiagnosticsAsync ().Result
+				.Where (d => d.Location.SourceSpan.IntersectsWith (syntaxNode.Span))
+				.Select (d => (d.Id, d.GetMessage ()))
+				.ToList ();
+		}
+
+		public void ValidateAttributes (List<AttributeSyntax> attributes)
+		{
+			foreach (var attribute in attributes) {
+				switch (attribute.Name.ToString ()) {
+				case "ExpectedWarning":
+					ValidateExpectedWarningAttribute (attribute!);
+					break;
+
+				case "LogContains":
+					ValidateLogContainsAttribute (attribute!);
+					break;
+
+				case "LogDoesNotContain":
+					ValidateLogDoesNotContainAttribute (attribute!);
+					break;
+
+				case "UnrecognizedReflectionAccessPattern":
+					ValidateUnrecognizedReflectionAccessPatternAttribute (attribute!);
+					break;
+				}
+			}
+		}
+
+		private void ValidateExpectedWarningAttribute (AttributeSyntax attribute)
+		{
+			var args = TestCaseUtils.GetAttributeArguments (attribute);
+			string expectedWarningCode = TestCaseUtils.GetStringFromExpression (args["#0"]);
+
+			if (!expectedWarningCode.StartsWith ("IL"))
+				return;
+
+			if (args.TryGetValue ("GlobalAnalysisOnly", out var globalAnalysisOnly) &&
+				globalAnalysisOnly is LiteralExpressionSyntax { Token: { Value: true } })
+				return;
+
+			List<string> expectedMessages = args
+				.Where (arg => arg.Key.StartsWith ("#") && arg.Key != "#0")
+				.Select (arg => TestCaseUtils.GetStringFromExpression (arg.Value))
+				.ToList ();
+
+			Assert.True (
+				DiagnosticMessages.Any (mc => {
+					if (mc.Id != expectedWarningCode)
+						return true;
+
+					foreach (var expectedMessage in expectedMessages)
+						if (!mc.Message.Contains (expectedMessage))
+							return false;
+
+					return true;
+				}),
+					$"Expected to find warning containing:{string.Join (" ", expectedMessages.Select (m => "'" + m + "'"))}" +
+					$", but no such message was found.{ Environment.NewLine}In diagnostics: {string.Join (Environment.NewLine, DiagnosticMessages)}");
+		}
+
+		private void ValidateLogContainsAttribute (AttributeSyntax attribute)
+		{
+			var arg = Assert.Single (TestCaseUtils.GetAttributeArguments (attribute));
+			var text = TestCaseUtils.GetStringFromExpression (arg.Value);
+
+			// If the text starts with `warning IL...` then it probably follows the pattern
+			//	'warning <diagId>: <location>:'
+			// We don't want to repeat the location in the error message for the analyzer, so
+			// it's better to just trim here. We've already filtered by diagnostic location so
+			// the text location shouldn't matter
+			if (text.StartsWith ("warning IL")) {
+				var firstColon = text.IndexOf (": ");
+				if (firstColon > 0) {
+					var secondColon = text.IndexOf (": ", firstColon + 1);
+					if (secondColon > 0) {
+						text = text.Substring (secondColon + 2);
+					}
+				}
+			}
+
+			Assert.True (DiagnosticMessages.Any (d => d.Message.Contains (text)),
+				$"Could not find text:\n{text}\nIn diagnostics:\n{(string.Join (Environment.NewLine, DiagnosticMessages))}");
+		}
+
+		private void ValidateLogDoesNotContainAttribute (AttributeSyntax attribute)
+		{
+			var arg = Assert.Single (TestCaseUtils.GetAttributeArguments (attribute));
+			var text = TestCaseUtils.GetStringFromExpression (arg.Value);
+			foreach (var diagnostic in DiagnosticMessages)
+				Assert.DoesNotContain (text, diagnostic.Message);
+		}
+
+		private void ValidateUnrecognizedReflectionAccessPatternAttribute (AttributeSyntax attribute)
+		{
+			var args = TestCaseUtils.GetAttributeArguments (attribute);
+
+			MemberDeclarationSyntax sourceMember = attribute.Ancestors ().OfType<MemberDeclarationSyntax> ().First ();
+			if (SemanticModel.GetDeclaredSymbol (sourceMember) is not ISymbol memberSymbol)
+				return;
+
+			string sourceMemberName = memberSymbol!.GetDisplayName ();
+			string expectedReflectionMemberMethodType = TestCaseUtils.GetStringFromExpression (args["#0"], SemanticModel);
+			string expectedReflectionMemberMethodName = TestCaseUtils.GetStringFromExpression (args["#1"], SemanticModel);
+
+			ArrayCreationExpressionSyntax reflectionMethodParametersExpr = (ArrayCreationExpressionSyntax) (args["#2"] ?? args["reflectionMethodParameters"]);
+			var reflectionMethodParameters = new List<string> ();
+			if (reflectionMethodParametersExpr != null) {
+				foreach (var rmp in reflectionMethodParametersExpr.Initializer!.Expressions)
+					reflectionMethodParameters.Add (TestCaseUtils.GetStringFromExpression (rmp, SemanticModel));
+			}
+
+			ArrayCreationExpressionSyntax messageExpr = (ArrayCreationExpressionSyntax) (args["#3"] ?? args["message"]);
+			var expectedStringsInMessage = new List<string> ();
+			if (messageExpr != null)
+				foreach (var m in messageExpr.Initializer!.Expressions)
+					expectedStringsInMessage.Add (TestCaseUtils.GetStringFromExpression (m, SemanticModel));
+
+			string expectedWarningCode = string.Empty;
+			if (args.TryGetValue ("#4", out var messageCodeExpr) || args.TryGetValue ("messageCode", out messageCodeExpr)) {
+				expectedWarningCode = TestCaseUtils.GetStringFromExpression (messageCodeExpr);
+				Assert.True (expectedWarningCode.StartsWith ("IL"),
+					$"The warning code specified in {messageCodeExpr.ToString ()} must start with the 'IL' prefix. Specified value: '{expectedWarningCode}'");
+			}
+
+			string expectedReturnType = string.Empty;
+			if (args.TryGetValue ("#5", out var returnTypeExpr) || args.TryGetValue ("returnType", out returnTypeExpr))
+				expectedReturnType = TestCaseUtils.GetStringFromExpression (returnTypeExpr, SemanticModel);
+
+			var sb = new StringBuilder ();
+			if (!string.IsNullOrEmpty (expectedReturnType))
+				sb.Append (expectedReturnType).Append (" ");
+
+			sb.Append (expectedReflectionMemberMethodType).Append ("::").Append (expectedReflectionMemberMethodName);
+			if (!expectedReflectionMemberMethodName.EndsWith (".get") &&
+				!expectedReflectionMemberMethodName.EndsWith (".set") &&
+				reflectionMethodParameters is not null)
+				sb.Append ("(").Append (string.Join (",", reflectionMethodParameters)).Append (")");
+
+			var reflectionAccessPattern = sb.ToString ();
+
+			Assert.True (
+				DiagnosticMessages.Any (mc => {
+					if (!string.IsNullOrEmpty (expectedWarningCode) && mc.Id != expectedWarningCode)
+						return false;
+
+					if (!mc.Message.Contains (sourceMemberName))
+						return false;
+
+					foreach (var expectedString in expectedStringsInMessage)
+						if (!mc.Message.Contains (expectedString))
+							return false;
+
+					return mc.Message.Contains (reflectionAccessPattern);
+				}), $"Expected to find unrecognized reflection access pattern '{(expectedWarningCode == string.Empty ? "" : expectedWarningCode + " ")}" +
+					$"{sourceMemberName}: Usage of {reflectionAccessPattern} unrecognized.");
+		}
+	}
+}

--- a/test/ILLink.RoslynAnalyzer.Tests/Verifiers/CSharpAnalyzerVerifier`1.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/Verifiers/CSharpAnalyzerVerifier`1.cs
@@ -33,12 +33,12 @@ namespace ILLink.RoslynAnalyzer.Tests
 		public static DiagnosticResult Diagnostic (DiagnosticDescriptor descriptor)
 			=> CSharpAnalyzerVerifier<TAnalyzer, XUnitVerifier>.Diagnostic (descriptor);
 
-		public static Task<CompilationWithAnalyzers> CreateCompilation (
+		public static Task<(CompilationWithAnalyzers Compilation, SemanticModel SemanticModel)> CreateCompilation (
 			string src,
 			(string, string)[]? globalAnalyzerOptions = null)
 			=> CreateCompilation (CSharpSyntaxTree.ParseText (src), globalAnalyzerOptions);
 
-		public static async Task<CompilationWithAnalyzers> CreateCompilation (
+		public static async Task<(CompilationWithAnalyzers Compilation, SemanticModel SemanticModel)> CreateCompilation (
 			SyntaxTree src,
 			(string, string)[]? globalAnalyzerOptions = null)
 		{
@@ -61,16 +61,13 @@ namespace ILLink.RoslynAnalyzer.Tests
 				logAnalyzerExecutionTime: false);
 
 			var analyzers = ImmutableArray.Create<DiagnosticAnalyzer> (new TAnalyzer ());
-			return new CompilationWithAnalyzers (
-				comp,
-				analyzers,
-				compWithAnalyzerOptions);
+			return (new CompilationWithAnalyzers (comp, analyzers, compWithAnalyzerOptions), comp.GetSemanticModel (src));
 		}
 
 		/// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.VerifyAnalyzerAsync(string, DiagnosticResult[])"/>
 		public static async Task VerifyAnalyzerAsync (string src, (string, string)[]? analyzerOptions = null, params DiagnosticResult[] expected)
 		{
-			var diags = await (await CreateCompilation (src, analyzerOptions)).GetAllDiagnosticsAsync ();
+			var diags = await (await CreateCompilation (src, analyzerOptions)).Compilation.GetAllDiagnosticsAsync ();
 
 			var analyzers = ImmutableArray.Create<DiagnosticAnalyzer> (new TAnalyzer ());
 			VerifyDiagnosticResults (diags, analyzers, expected, DefaultVerifier);

--- a/test/Mono.Linker.Tests.Cases.Expectations/Assertions/UnrecognizedReflectionAccessPatternAttribute.cs
+++ b/test/Mono.Linker.Tests.Cases.Expectations/Assertions/UnrecognizedReflectionAccessPatternAttribute.cs
@@ -20,7 +20,7 @@ namespace Mono.Linker.Tests.Cases.Expectations.Assertions
 			Type reflectionMethodType,
 			string reflectionMethodName,
 			Type[] reflectionMethodParameters,
-			object message = null,
+			string[] message = null,
 			string messageCode = null,
 			Type returnType = null)
 		{
@@ -30,7 +30,7 @@ namespace Mono.Linker.Tests.Cases.Expectations.Assertions
 			Type reflectionMethodType,
 			string reflectionMethodName,
 			string[] reflectionMethodParameters = null,
-			object message = null,
+			string[] message = null,
 			string messageCode = null,
 			Type returnType = null)
 		{

--- a/test/Mono.Linker.Tests.Cases/DataFlow/FieldDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/FieldDataFlow.cs
@@ -143,7 +143,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			TypeStore._staticTypeWithPublicParameterlessConstructor = GetUnkownType ();
 		}
 
-		[UnrecognizedReflectionAccessPattern (typeof (TypeStore), nameof (TypeStore._staticTypeWithPublicParameterlessConstructor), messageCode: "IL2064", message: nameof (TypeStore._staticTypeWithPublicParameterlessConstructor))]
+		[UnrecognizedReflectionAccessPattern (typeof (TypeStore), nameof (TypeStore._staticTypeWithPublicParameterlessConstructor), messageCode: "IL2064", message: new string[] { nameof (TypeStore._staticTypeWithPublicParameterlessConstructor) })]
 		private void WriteUnknownValue ()
 		{
 			var array = new object[1];

--- a/test/Mono.Linker.Tests.Cases/DataFlow/GetTypeDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/GetTypeDataFlow.cs
@@ -121,9 +121,9 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (GetTypeDataFlow), nameof (RequireNonPublicConstructors), new Type[] { typeof (Type) },
-			messageCode: "IL2072", message: "GetType")]
+			messageCode: "IL2072", message: new string[] { "GetType" })]
 		[UnrecognizedReflectionAccessPattern (typeof (Type), nameof (Type.GetType), new Type[] { typeof (string) },
-			messageCode: "IL2057", message: "System.Type.GetType(String)")]
+			messageCode: "IL2057", message: new string[] { "System.Type.GetType(String)" })]
 		static void TestMultipleMixedValues ()
 		{
 			string typeName = null;

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MethodReturnParameterDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MethodReturnParameterDataFlow.cs
@@ -125,7 +125,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		[UnrecognizedReflectionAccessPattern (typeof (MethodReturnParameterDataFlow), nameof (ReturnUnknownValue),
 			new Type[] { }, returnType: typeof (Type),
-			messageCode: "IL2063", message: nameof (ReturnUnknownValue))]
+			messageCode: "IL2063", message: new string[] { nameof (ReturnUnknownValue) })]
 		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)]
 		Type ReturnUnknownValue ()
 		{

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MethodThisDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MethodThisDataFlow.cs
@@ -95,7 +95,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[UnrecognizedReflectionAccessPattern (typeof (MethodThisDataFlowTypeTest), nameof (MethodThisDataFlowTypeTest.RequireThisNonPublicMethods), new Type[] { },
-			messageCode: "IL2065", message: nameof (MethodThisDataFlowTypeTest.RequireThisNonPublicMethods))]
+			messageCode: "IL2065", message: new string[] { nameof (MethodThisDataFlowTypeTest.RequireThisNonPublicMethods) })]
 		static void TestUnknownThis ()
 		{
 			var array = new object[1];

--- a/test/Mono.Linker.Tests.Cases/Reflection/ActivatorCreateInstance.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ActivatorCreateInstance.cs
@@ -307,7 +307,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
 		[Kept]
 		[UnrecognizedReflectionAccessPattern (typeof (Activator), nameof (Activator.CreateInstance), new Type[] { typeof (string), typeof (string) },
-			messageCode: "IL2032", message: "assemblyName")]
+			messageCode: "IL2032", message: new string[] { "assemblyName" })]
 		private static void WithNullAssemblyName ()
 		{
 			Activator.CreateInstance (null, "Mono.Linker.Tests.Cases.Reflection.ActivatorCreateInstance+WithAssemblyNameParameterless1");
@@ -315,7 +315,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
 		[Kept]
 		[UnrecognizedReflectionAccessPattern (typeof (Activator), nameof (Activator.CreateInstance), new Type[] { typeof (string), typeof (string) },
-			messageCode: "IL2061", message: "NonExistingAssembly")]
+			messageCode: "IL2061", message: new string[] { "NonExistingAssembly" })]
 		private static void WithNonExistingAssemblyName ()
 		{
 			Activator.CreateInstance ("NonExistingAssembly", "Mono.Linker.Tests.Cases.Reflection.ActivatorCreateInstance+WithAssemblyNameParameterless1");
@@ -326,7 +326,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
 		[Kept]
 		[UnrecognizedReflectionAccessPattern (typeof (Activator), nameof (Activator.CreateInstance), new Type[] { typeof (string), typeof (string), typeof (object[]) },
-			messageCode: "IL2032", message: "typeName")]
+			messageCode: "IL2032", message: new string[] { "typeName" })]
 		private static void WithAssemblyAndUnknownTypeName ()
 		{
 			Activator.CreateInstance ("test", _typeNameField, new object[] { });

--- a/test/Mono.Linker.Tests.Cases/Reflection/RunClassConstructorUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/RunClassConstructorUsedViaReflection.cs
@@ -48,7 +48,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
 		[Kept]
 		[UnrecognizedReflectionAccessPattern (typeof (RuntimeHelpers), nameof (RuntimeHelpers.RunClassConstructor), new Type[] { typeof (RuntimeTypeHandle) },
-			messageCode: "IL2059", message: "RunClassConstructor")]
+			messageCode: "IL2059", message: new string[] { "RunClassConstructor" })]
 
 		static void TestDataFlowType ()
 		{


### PR DESCRIPTION
This PR adds support for `UnrecognizedReflectionAccessPattern` in the analyzer test infra and refactors the existing code in ILLink.RoslynAnalyzer.Tests.TestCaseUtils.