### PR TITLE
Fix a problem where generating an empty FS assembly element roots the whole assembly

### DIFF
--- a/src/ILLink.Tasks/CreateRuntimeRootDescriptorFile.cs
+++ b/src/ILLink.Tasks/CreateRuntimeRootDescriptorFile.cs
@@ -302,7 +302,7 @@ namespace ILLink.Tasks
 			XmlNode linkerNode = doc["linker"];
 
 			if (featureSwitchMembers.Count > 0) {
-				foreach ((var fs, var members) in featureSwitchMembers.Select(kv => (kv.Key, kv.Value))) {
+				foreach ((var fs, var members) in featureSwitchMembers.Select (kv => (kv.Key, kv.Value))) {
 					if (members.Count == 0)
 						continue;
 

--- a/src/ILLink.Tasks/CreateRuntimeRootDescriptorFile.cs
+++ b/src/ILLink.Tasks/CreateRuntimeRootDescriptorFile.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Xml;
 using Microsoft.Build.Framework; // ITaskItem
 using Microsoft.Build.Utilities; // Task
@@ -301,7 +302,10 @@ namespace ILLink.Tasks
 			XmlNode linkerNode = doc["linker"];
 
 			if (featureSwitchMembers.Count > 0) {
-				foreach (var fsMembers in featureSwitchMembers.Keys) {
+				foreach ((var fs, var members) in featureSwitchMembers.Select(kv => (kv.Key, kv.Value))) {
+					if (members.Count == 0)
+						continue;
+
 					// <assembly fullname="System.Private.CoreLib" feature="System.Diagnostics.Tracing.EventSource.IsSupported" featurevalue="true" featuredefault="true">
 					XmlNode featureAssemblyNode = doc.CreateElement ("assembly");
 					XmlAttribute featureAssemblyFullName = doc.CreateAttribute ("fullname");
@@ -309,18 +313,18 @@ namespace ILLink.Tasks
 					featureAssemblyNode.Attributes.Append (featureAssemblyFullName);
 
 					XmlAttribute featureName = doc.CreateAttribute ("feature");
-					featureName.Value = fsMembers.Feature;
+					featureName.Value = fs.Feature;
 					featureAssemblyNode.Attributes.Append (featureName);
 
 					XmlAttribute featureValue = doc.CreateAttribute ("featurevalue");
-					featureValue.Value = fsMembers.FeatureValue;
+					featureValue.Value = fs.FeatureValue;
 					featureAssemblyNode.Attributes.Append (featureValue);
 
 					XmlAttribute featureDefault = doc.CreateAttribute ("featuredefault");
-					featureDefault.Value = fsMembers.FeatureDefault;
+					featureDefault.Value = fs.FeatureDefault;
 					featureAssemblyNode.Attributes.Append (featureDefault);
 
-					foreach (var type in featureSwitchMembers[fsMembers]) {
+					foreach (var type in members) {
 						AddXmlTypeNode (doc, featureAssemblyNode, type.Key, type.Value);
 					}
 					linkerNode.AppendChild (featureAssemblyNode);

--- a/test/ILLink.Tasks.Tests/CreateRuntimeRootDescriptorFileTests.cs
+++ b/test/ILLink.Tasks.Tests/CreateRuntimeRootDescriptorFileTests.cs
@@ -131,6 +131,12 @@ namespace ILLink.Tasks.Tests
 				"#if FOR_ILLINK",
 				"DEFINE_METHOD(TESTCLASS, TESTMETHODFORILLINK, TestMethodForILLink, 5)",
 				"#endif",
+				"END_ILLINK_FEATURE_SWITCH()",
+				"BEGIN_ILLINK_FEATURE_SWITCH(TestFeature2Name, false, false)",
+				"#ifdef FEATURE_OFF",
+				"DEFINE_CLASS(TESTCLASS)",
+				"DEFINE_METHOD(TESTCLASS, TESTMETHODFEATURE2, TestMethodFeature2, 6)",
+				"#endif",
 				"END_ILLINK_FEATURE_SWITCH()"
 				});
 


### PR DESCRIPTION
Descriptors have the behavior that specifying just the assembly element without any children will root the entire assembly (and everything in it). The same applies to types (specifying just the type element will mark the entire type).
With the new feature switches, we have to be careful to not generate an empty assembly element, otherwise we will accidentally root the entire corelib.

Fixes the problem seen in https://github.com/dotnet/runtime/pull/53144.