### PR TITLE
Fix validation of ExpectedWarning attribute

### DIFF
--- a/test/Mono.Linker.Tests.Cases.Expectations/Assertions/ExpectedWarningAttribute.cs
+++ b/test/Mono.Linker.Tests.Cases.Expectations/Assertions/ExpectedWarningAttribute.cs
@@ -3,7 +3,7 @@
 namespace Mono.Linker.Tests.Cases.Expectations.Assertions
 {
 	[AttributeUsage (
-		AttributeTargets.Struct | AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Constructor | AttributeTargets.Field,
+		AttributeTargets.Struct | AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Constructor | AttributeTargets.Field | AttributeTargets.Interface,
 		AllowMultiple = true,
 		Inherited = false)]
 	public class ExpectedWarningAttribute : EnableLoggerAttribute
@@ -15,5 +15,8 @@ namespace Mono.Linker.Tests.Cases.Expectations.Assertions
 		public string FileName { get; set; }
 		public int SourceLine { get; set; }
 		public int SourceColumn { get; set; }
+
+		// Set to true if the warning only applies to global analysis (ILLinker, as opposed to Roslyn Analyzer)
+		public bool GlobalAnalysisOnly { get; set; }
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/Dependencies/RequiresUnreferencedCodeInCopyAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/Dependencies/RequiresUnreferencedCodeInCopyAssembly.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.RequiresCapability.Dependencies
@@ -88,6 +89,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability.Dependencies
 			void MethodInBaseInterface ();
 		}
 
+		[ExpectedWarning ("IL2026", "--IBaseInterface.MethodInBaseInterface--")]
 		public interface IDerivedInterface : IBaseInterface
 		{
 			[RequiresUnreferencedCode ("Message for --IDerivedInterface.MethodInDerivedInterface--")]

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
@@ -28,12 +28,11 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 	[LogDoesNotContain ("--UnusedVirtualMethod2--")]
 	[LogDoesNotContain ("--IUnusedInterface.UnusedMethod--")]
 	[LogDoesNotContain ("--UnusedImplementationClass.UnusedMethod--")]
-	[ExpectedWarning ("IL2026", "--DynamicallyAccessedTypeWithRequiresUnreferencedCode.RequiresUnreferencedCode--")]
-	[ExpectedWarning ("IL2026", "--IDerivedInterface.MethodInDerivedInterface--")]
-	[ExpectedWarning ("IL2026", "--IBaseInterface.MethodInBaseInterface--")]
-	[ExpectedWarning ("IL2026", "--BaseType.VirtualMethodRequiresUnreferencedCode--")]
 	public class RequiresUnreferencedCodeCapability
 	{
+		[ExpectedWarning ("IL2026", "--IDerivedInterface.MethodInDerivedInterface--", GlobalAnalysisOnly = true)]
+		[ExpectedWarning ("IL2026", "--DynamicallyAccessedTypeWithRequiresUnreferencedCode.RequiresUnreferencedCode--", GlobalAnalysisOnly = true)]
+		[ExpectedWarning ("IL2026", "--BaseType.VirtualMethodRequiresUnreferencedCode--", GlobalAnalysisOnly = true)]
 		public static void Main ()
 		{
 			TestRequiresWithMessageOnlyOnMethod ();

--- a/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -732,7 +732,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 										if (mc.Origin?.MemberDefinition?.FullName == attrProvider.FullName)
 											return true;
 
-										if (loggedMessages.Any (m => m.Text.Contains (attrProvider.FullName)))
+										if (mc.Text.Contains (attrProvider.FullName))
 											return true;
 
 										return false;

--- a/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -729,9 +729,6 @@ namespace Mono.Linker.Tests.TestCasesRunner
 										if (sourceColumn != null && mc.Origin?.SourceColumn != sourceColumn.Value)
 											return false;
 									} else {
-										if (attrProvider.FullName.Contains ("PropertyWithUnsupportedType"))
-											System.Diagnostics.Debug.WriteLine ("");
-
 										if (mc.Origin?.MemberDefinition?.FullName == attrProvider.FullName)
 											return true;
 

--- a/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -729,10 +729,16 @@ namespace Mono.Linker.Tests.TestCasesRunner
 										if (sourceColumn != null && mc.Origin?.SourceColumn != sourceColumn.Value)
 											return false;
 									} else {
+										if (attrProvider.FullName.Contains ("PropertyWithUnsupportedType"))
+											System.Diagnostics.Debug.WriteLine ("");
+
 										if (mc.Origin?.MemberDefinition?.FullName == attrProvider.FullName)
 											return true;
 
-										if (mc.Text.Contains (attrProvider.FullName))
+										// Compensate for cases where for some reason the OM doesn't preserve the declaring types
+										// on certain things after trimming.
+										if (mc.Origin?.MemberDefinition != null && mc.Origin?.MemberDefinition.DeclaringType == null &&
+											mc.Origin?.MemberDefinition.Name == attrProvider.Name)
 											return true;
 
 										return false;


### PR DESCRIPTION
Probably due to copy/paste error we've validated the attribute by looking at all warning messages at once. This means that potentially any warning can be matched to the attribute even if its location doesn't match.

This change fixes that but uncovers some small test issues:
* The expected warnings happen in different places - fixed that
* Some warnings can't be reported by the Roslyn Analyzer as they require global view - added a mechanism to mark these

Refactored a bit of the Roslyn analyzer validation code to support named properties in attributes.