### PR TITLE
Fix issue in const propagation if there's a ret instruction during method parameter processing

### DIFF
--- a/src/linker/Linker.Steps/UnreachableBlocksOptimizer.cs
+++ b/src/linker/Linker.Steps/UnreachableBlocksOptimizer.cs
@@ -581,6 +581,11 @@ namespace Mono.Linker.Steps
 						break;
 					}
 
+					if (instruction.OpCode == OpCodes.Ret) {
+						unknown = true;
+						return 0;
+					}
+
 					Debug.Fail (instruction.Operand?.ToString ());
 					unknown = true;
 					return 0;

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/MethodWithParametersSubstitutions.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/MethodWithParametersSubstitutions.cs
@@ -22,6 +22,7 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 			TestMethodWithComplexParams_2 ();
 			TestMethodWithComplexParams_3 (3);
 			TestMethodWithComplexParams_4 ();
+			TestMethodWithComplexParams_5 ();
 			instance.TestMethodWithMultipleInParamsInstance ();
 			// TestMethodWithOutParam ();
 			TestMethodWithRefParam ();
@@ -153,6 +154,27 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 
 		[Kept] static void TestMethodWithComplexParams_4_Used () { }
 		[Kept] static void TestMethodWithComplexParams_4_Unused () { }
+
+		[Kept]
+		static void TestMethodWithComplexParams_5 ()
+		{
+			MethodWithParametersSubstitutions instance = new MethodWithParametersSubstitutions ();
+			instance._TestMethodWithComplexParameters_5_field = instance;
+			instance.TestMethodWithComplexParams_5_Propagate ();
+		}
+
+		[Kept]
+		MethodWithParametersSubstitutions _TestMethodWithComplexParameters_5_field;
+
+		[Kept]
+		// Special crafted body which has a sequence of "ret; call <substituted instance method>;"
+		// This causes the method param "unroll" logic to hit the "ret" instruction which is problematic.
+		bool TestMethodWithComplexParams_5_Propagate ()
+			=> _TestMethodWithComplexParameters_5_field?.TestMethodWithComplexParams_5_Substituted () ?? false;
+
+		[Kept]
+		[ExpectBodyModified]
+		bool TestMethodWithComplexParams_5_Substituted () => true;
 
 		[Kept]
 		[ExpectBodyModified]

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/MethodWithParametersSubstitutions.xml
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/MethodWithParametersSubstitutions.xml
@@ -10,6 +10,7 @@
       <method signature="System.Boolean IsEnabledWithMultipleRefParams(System.Int32,System.Int32&amp;,Mono.Linker.Tests.Cases.UnreachableBlock.MethodWithParametersSubstitutions/TestStruct&amp;,System.String)" body="stub" value="true" />
       <method signature="System.Boolean IsEnabledWithVarArgs()" body="stub" value="true" />
       <method signature="System.Boolean IsEnabledWithParamAndVarArgs(System.Int32)" body="stub" value="true" />
+      <method signature="System.Boolean TestMethodWithComplexParams_5_Substituted()" body="stub" value="false" />
     </type>
   </assembly>
 </linker>


### PR DESCRIPTION
In some cases the compiler can generate instructions like:
```
ret;
call instance bool SomeMethod()
```

If `SomeMethod` is substituted via XML, this can lead to the logic which tries to overwrite method parameter loading with nops to encounter the `ret` instruction. This was not handled before.

Handle the `ret` by bailing out (it would mean we would have to start understanding branches, which adds lot of complexity).

Added a test case.

Fixes https://github.com/mono/linker/issues/2061