### PR TITLE
Revert "Remove custom marking of nested types for event sources (#2032)"

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1762,7 +1762,7 @@ namespace Mono.Linker.Steps
 			MarkSerializable (type);
 
 			// This marks static fields of KeyWords/OpCodes/Tasks subclasses of an EventSource type.
-			if (_context.GetTargetRuntimeVersion () < TargetRuntimeVersion.NET6 && BCL.EventTracingForWindows.IsEventSourceImplementation (type, _context)) {
+			if (BCL.EventTracingForWindows.IsEventSourceImplementation (type, _context)) {
 				MarkEventSourceProviders (type);
 			}
 

--- a/test/Mono.Linker.Tests.Cases/BCLFeatures/ETW/CustomEventSource.cs
+++ b/test/Mono.Linker.Tests.Cases/BCLFeatures/ETW/CustomEventSource.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Diagnostics.Tracing;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.BCLFeatures.ETW
+{
+	public class CustomEventSource
+	{
+		public static void Main ()
+		{
+			var b = MyCompanyEventSource.Log.IsEnabled ();
+		}
+	}
+
+	[Kept]
+	[KeptBaseType (typeof (EventSource))]
+	[KeptAttributeAttribute (typeof (EventSourceAttribute))]
+	[KeptMember (".ctor()")]
+	[KeptMember (".cctor()")]
+
+	[EventSource (Name = "MyCompany")]
+	class MyCompanyEventSource : EventSource
+	{
+		[Kept]
+		public class Keywords
+		{
+			[Kept]
+			public const EventKeywords Page = (EventKeywords) 1;
+
+			public int Unused;
+		}
+
+		[Kept]
+		public class Tasks
+		{
+			[Kept]
+			public const EventTask Page = (EventTask) 1;
+
+			public int Unused;
+		}
+
+		class NotMatching
+		{
+		}
+
+		[Kept]
+		public static MyCompanyEventSource Log = new MyCompanyEventSource ();
+	}
+}


### PR DESCRIPTION
We still cannot take out the special handling for EventSource due to [test failures ](https://dev.azure.com/dnceng/public/_build/results?buildId=1159451&view=ms.vss-test-web.build-test-results-tab&runId=34991568&paneView=debug&resultId=163140)in runtime repo. Will reopen #1949

This reverts commit 2cf308289ea6140bbee332318e3ac45c1a6d0342.