### PR TITLE
[release/6.0] Fix applying All annotation on a type from "copy" assembly

### DIFF
--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -2210,7 +2210,7 @@ namespace Mono.Linker.Dataflow
 					break;
 				case null:
 					var source = reflectionContext.Source;
-					reflectionContext.RecordRecognizedPattern (typeDefinition, () => _markStep.MarkEntireType (typeDefinition, includeBaseTypes: true, includeInterfaceTypes: true, new DependencyInfo (DependencyKind.DynamicallyAccessedMember, source), source));
+					reflectionContext.RecordRecognizedPattern (typeDefinition, () => _markStep.MarkEntireType (typeDefinition, includeBaseAndInterfaceTypes: true, new DependencyInfo (DependencyKind.DynamicallyAccessedMember, source), source));
 					break;
 				}
 			}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/Dependencies/MemberTypesAllBaseTypeAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/Dependencies/MemberTypesAllBaseTypeAssembly.cs
@@ -1,0 +1,50 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Mono.Linker.Tests.Cases.DataFlow.Dependencies
+{
+	public class MemberTypesAllBaseType
+	{
+		static MemberTypesAllBaseType () { }
+		public MemberTypesAllBaseType () { }
+		private MemberTypesAllBaseType (bool _) { }
+
+		public void PublicMethod () { }
+		private void PrivateMethod () { }
+
+		public static void PublicStaticMethod () { }
+		private static void PrivateStaticMethod () { }
+
+		public int PublicField;
+		private int PrivateField;
+		public static int PublicStaticField;
+		private static int PrivateStaticField;
+
+		public bool PublicProperty { get; set; }
+		private bool PrivateProperty { get; set; }
+		public static bool PublicStaticProperty { get; set; }
+		private static bool PrivateStaticProperty { get; set; }
+
+		public event EventHandler<EventArgs> PublicEvent;
+		private event EventHandler<EventArgs> PrivateEvent;
+		public static event EventHandler<EventArgs> PublicStaticEvent;
+		private static event EventHandler<EventArgs> PrivateStaticEvent;
+
+		public class PublicNestedType
+		{
+			private void PrivateMethod () { }
+		}
+
+		private class PrivateNestedType
+		{
+			private void PrivateMethod () { }
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MemberTypesAllOnCopyAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MemberTypesAllOnCopyAssembly.cs
@@ -1,0 +1,82 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Mono.Linker.Tests.Cases.DataFlow.Dependencies;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.DataFlow
+{
+	[SetupCompileBefore ("base.dll", new[] { "Dependencies/MemberTypesAllBaseTypeAssembly.cs" })]
+	[KeptAssembly ("base.dll")]
+	[SetupLinkerAction ("link", "base")]
+	[SetupLinkerAction ("copy", "test")]
+
+	[KeptTypeInAssembly ("base.dll", "Mono.Linker.Tests.Cases.DataFlow.Dependencies.MemberTypesAllBaseType")]
+	[KeptMemberInAssembly ("base.dll", "Mono.Linker.Tests.Cases.DataFlow.Dependencies.MemberTypesAllBaseType", new string[] {
+		".cctor()",
+		".ctor()",
+		".ctor(System.Boolean)",
+		"PublicMethod()",
+		"PrivateMethod()",
+		"PublicStaticMethod()",
+		"PrivateStaticMethod()",
+		"PublicField",
+		"PrivateField",
+		"PublicStaticField",
+		"PrivateStaticField",
+		"PublicProperty",
+		"get_PublicProperty()",
+		"set_PublicProperty(System.Boolean)",
+		"PrivateProperty",
+		"get_PrivateProperty()",
+		"set_PrivateProperty(System.Boolean)",
+		"PublicStaticProperty",
+		"get_PublicStaticProperty()",
+		"set_PublicStaticProperty(System.Boolean)",
+		"PrivateStaticProperty",
+		"get_PrivateStaticProperty()",
+		"set_PrivateStaticProperty(System.Boolean)",
+		"PublicEvent",
+		"add_PublicEvent(System.EventHandler`1<System.EventArgs>)",
+		"remove_PublicEvent(System.EventHandler`1<System.EventArgs>)",
+		"PrivateEvent",
+		"add_PrivateEvent(System.EventHandler`1<System.EventArgs>)",
+		"remove_PrivateEvent(System.EventHandler`1<System.EventArgs>)",
+		"PublicStaticEvent",
+		"add_PublicStaticEvent(System.EventHandler`1<System.EventArgs>)",
+		"remove_PublicStaticEvent(System.EventHandler`1<System.EventArgs>)",
+		"PrivateStaticEvent",
+		"add_PrivateStaticEvent(System.EventHandler`1<System.EventArgs>)",
+		"remove_PrivateStaticEvent(System.EventHandler`1<System.EventArgs>)",
+	})]
+
+	[KeptTypeInAssembly ("base.dll", "Mono.Linker.Tests.Cases.DataFlow.Dependencies.MemberTypesAllBaseType/PublicNestedType")]
+	[KeptMemberInAssembly ("base.dll", "Mono.Linker.Tests.Cases.DataFlow.Dependencies.MemberTypesAllBaseType/PublicNestedType", new string[] { "PrivateMethod()" })]
+
+	[KeptTypeInAssembly ("base.dll", "Mono.Linker.Tests.Cases.DataFlow.Dependencies.MemberTypesAllBaseType/PrivateNestedType")]
+	[KeptMemberInAssembly ("base.dll", "Mono.Linker.Tests.Cases.DataFlow.Dependencies.MemberTypesAllBaseType/PrivateNestedType", new string[] { "PrivateMethod()" })]
+
+	[KeptMember (".ctor()")]
+	public class MemberTypesAllOnCopyAssembly
+	{
+		public static void Main ()
+		{
+			typeof (TestType).RequiresAll ();
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (MemberTypesAllBaseType))]
+		[KeptMember (".ctor()")]
+		class TestType : MemberTypesAllBaseType
+		{
+		}
+	}
+}


### PR DESCRIPTION
This is a port of https://github.com/mono/linker/pull/2060 to `release/6.0` branch - to include the fix in .NET 6 Preview 5.

"Copy" assembly calls `MarkEntireType` on all types in the assembly, but it specified to not include base and interface types. We cache if a type was marked as a whole, so to not repeat the process (and also to avoid potential recursion). But the cache doesn't differentiate if the type was mark with its base/interface types or not.

So in the "copy" assembly case, the type is first marked without base/interface marking, and that is cached. Later on we apply the All annotation to the type, which calls `MarkEntireType` again, but since it's already cached it doesn't do anything. But All annotation should preserve base/interface types as well, which will not happen in this case.

Fixed this by making the cache aware of the base/interface flag and repeat the marking if base/interface is requested even if the type has already been marked as a whole but without base/interface marking.

Added a test case.