### PR TITLE
Warn when method return type is annotated but it's not Type or String

### DIFF
--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -1592,7 +1592,17 @@ void RequirePublicMethodOnAType(
 }
 ```
 
-#### `IL2106`: Invalid assembly action '{action}' specified for assembly '{assembly}'. C++/CLI assemblies can only be copied or skipped. 
+#### `IL2106`: Trim analysis: Return type of method 'method' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'
+
+- `DynamicallyAccessedMembersAttribute` is only applicable to items of type `System.Type` or `System.String` (or derived), on all other types the attribute will be ignored. Using the attribute on any other type is likely incorrect and unintentional.
+
+  ```C#
+  // IL2106: Return type of method 'TestMethod' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'
+  [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] object TestMethod()
+  {
+      return typeof(TestType);
+  }
+  ```
 
 
 ## Single-File Warning Codes

--- a/src/linker/Linker.Dataflow/FlowAnnotations.cs
+++ b/src/linker/Linker.Dataflow/FlowAnnotations.cs
@@ -120,7 +120,7 @@ namespace Mono.Linker.Dataflow
 					return (DynamicallyAccessedMemberTypes) (int) attribute.ConstructorArguments[0].Value;
 				else
 					_context.LogWarning (
-						$"Attribute 'System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute' doesn't have the required number of parameters specified",
+						$"Attribute 'System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute' doesn't have the required number of parameters specified.",
 						2028, locationMember ?? (provider as IMemberDefinition));
 			}
 			return DynamicallyAccessedMemberTypes.None;
@@ -144,7 +144,7 @@ namespace Mono.Linker.Dataflow
 					if (!IsTypeInterestingForDataflow (field.FieldType)) {
 						// Already know that there's a non-empty annotation on a field which is not System.Type/String and we're about to ignore it
 						_context.LogWarning (
-							$"Field '{field.GetDisplayName ()}' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'",
+							$"Field '{field.GetDisplayName ()}' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'.",
 							2097, field, subcategory: MessageSubCategory.TrimAnalysis);
 						continue;
 					}
@@ -209,8 +209,12 @@ namespace Mono.Linker.Dataflow
 						paramAnnotations[i + offset] = pa;
 					}
 
-					DynamicallyAccessedMemberTypes returnAnnotation = IsTypeInterestingForDataflow (method.ReturnType) ?
-						GetMemberTypesForDynamicallyAccessedMembersAttribute (method.MethodReturnType, method) : DynamicallyAccessedMemberTypes.None;
+					DynamicallyAccessedMemberTypes returnAnnotation = GetMemberTypesForDynamicallyAccessedMembersAttribute (method.MethodReturnType, method);
+					if (returnAnnotation != DynamicallyAccessedMemberTypes.None && !IsTypeInterestingForDataflow (method.ReturnType)) {
+						_context.LogWarning (
+							$"Return type of method '{method.GetDisplayName ()}' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.",
+							2106, method, subcategory: MessageSubCategory.TrimAnalysis);
+					}
 
 					DynamicallyAccessedMemberTypes[] genericParameterAnnotations = null;
 					if (method.HasGenericParameters) {
@@ -253,7 +257,7 @@ namespace Mono.Linker.Dataflow
 
 					if (!IsTypeInterestingForDataflow (property.PropertyType)) {
 						_context.LogWarning (
-							$"Property '{property.GetDisplayName ()}' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'",
+							$"Property '{property.GetDisplayName ()}' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.",
 							2099, property, subcategory: MessageSubCategory.TrimAnalysis);
 						continue;
 					}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MethodReturnParameterDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MethodReturnParameterDataFlow.cs
@@ -38,6 +38,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			instance.PropagateReturnToReturn (0);
 
 			instance.ReturnWithRequirementsAlwaysThrows ();
+
+			UnsupportedReturnType ();
 		}
 
 		static Type NoRequirements ()
@@ -188,6 +190,10 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		{
 			throw new NotImplementedException ();
 		}
+
+		[ExpectedWarning ("IL2106", nameof (UnsupportedReturnType))]
+		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+		static object UnsupportedReturnType () => null;
 
 		class TestType
 		{

--- a/test/Mono.Linker.Tests/TestCasesRunner/LinkerTestLogger.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/LinkerTestLogger.cs
@@ -18,6 +18,11 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 		public void LogMessage (MessageContainer message)
 		{
+			// This is to force Cecil to load all the information from the assembly
+			// When the message is logged, the assembly is still opened by the linker and available
+			// later on during validation, it may already be closed and Cecil's lazy loading might fail.
+			message.ToString ();
+
 			MessageContainers.Add (message);
 		}
 	}


### PR DESCRIPTION
Also added a small fix in the test infra

Fixes https://github.com/mono/linker/issues/2065