### PR TITLE
Use full MessageOrigin when reporting data flow warnings

### DIFF
--- a/src/linker/Linker.Dataflow/ReflectionPatternContext.cs
+++ b/src/linker/Linker.Dataflow/ReflectionPatternContext.cs
@@ -25,7 +25,8 @@ namespace Mono.Linker.Dataflow
 		bool _patternReported;
 #endif
 
-		public IMemberDefinition Source { get; private set; }
+		public MessageOrigin Origin { get; private set; }
+		public IMemberDefinition Source { get => Origin.MemberDefinition; }
 		public IMetadataTokenProvider MemberWithRequirements { get; private set; }
 		public Instruction Instruction { get; private set; }
 		public bool ReportingEnabled { get; private set; }
@@ -33,13 +34,13 @@ namespace Mono.Linker.Dataflow
 		public ReflectionPatternContext (
 			LinkContext context,
 			bool reportingEnabled,
-			IMemberDefinition source,
+			in MessageOrigin origin,
 			IMetadataTokenProvider memberWithRequirements,
 			Instruction instruction = null)
 		{
 			_context = context;
 			ReportingEnabled = reportingEnabled;
-			Source = source;
+			Origin = origin;
 			MemberWithRequirements = memberWithRequirements;
 			Instruction = instruction;
 
@@ -92,7 +93,7 @@ namespace Mono.Linker.Dataflow
 #endif
 
 			if (ReportingEnabled)
-				_context.ReflectionPatternRecorder.UnrecognizedReflectionAccessPattern (Source, Instruction, MemberWithRequirements, message, messageCode);
+				_context.ReflectionPatternRecorder.UnrecognizedReflectionAccessPattern (Origin, Source, Instruction, MemberWithRequirements, message, messageCode);
 		}
 
 		public void Dispose ()

--- a/src/linker/Linker.Dataflow/ReflectionPatternContext.cs
+++ b/src/linker/Linker.Dataflow/ReflectionPatternContext.cs
@@ -25,11 +25,11 @@ namespace Mono.Linker.Dataflow
 		bool _patternReported;
 #endif
 
-		public MessageOrigin Origin { get; private set; }
+		public MessageOrigin Origin { get; init; }
 		public IMemberDefinition Source { get => Origin.MemberDefinition; }
-		public IMetadataTokenProvider MemberWithRequirements { get; private set; }
-		public Instruction Instruction { get; private set; }
-		public bool ReportingEnabled { get; private set; }
+		public IMetadataTokenProvider MemberWithRequirements { get; init; }
+		public Instruction Instruction { get; init; }
+		public bool ReportingEnabled { get; init; }
 
 		public ReflectionPatternContext (
 			LinkContext context,

--- a/src/linker/Linker/IReflectionPatternRecorder.cs
+++ b/src/linker/Linker/IReflectionPatternRecorder.cs
@@ -54,6 +54,7 @@ namespace Mono.Linker
 		/// <summary>
 		/// Called when the linker detected a reflection access but was not able to recognize the entire pattern.
 		/// </summary>
+		/// <param name="origin">The origin to use for reporting diagnostic messages.</param>
 		/// <param name="source">The item which is the source of the reflection pattern. Typically this is the method in which the pattern is detected, but it can also be other things..</param>
 		/// <param name="instruction">The il instruction which is at the heart of the reflection access pattern. For example the call to the reflection API.
 		/// This can be null if there's no logical instruction to assign to the pattern.</param>
@@ -63,6 +64,6 @@ namespace Mono.Linker
 		/// <param name="messageCode">Message code to use when reporting the unrecognized pattern as a warning.</param>
 		/// <remarks>This effectively means that there's a potential hole in the linker marking - some items which are accessed only through
 		/// reflection may not be marked correctly and thus may fail at runtime.</remarks>
-		void UnrecognizedReflectionAccessPattern (IMemberDefinition source, Instruction sourceInstruction, IMetadataTokenProvider accessedItem, string message, int messageCode);
+		void UnrecognizedReflectionAccessPattern (in MessageOrigin origin, IMemberDefinition source, Instruction sourceInstruction, IMetadataTokenProvider accessedItem, string message, int messageCode);
 	}
 }

--- a/src/linker/Linker/LoggingReflectionPatternRecorder.cs
+++ b/src/linker/Linker/LoggingReflectionPatternRecorder.cs
@@ -42,9 +42,8 @@ namespace Mono.Linker
 			// Do nothing - there's no logging for successfully recognized patterns
 		}
 
-		public void UnrecognizedReflectionAccessPattern (IMemberDefinition source, Instruction sourceInstruction, IMetadataTokenProvider accessedItem, string message, int messageCode)
+		public void UnrecognizedReflectionAccessPattern (in MessageOrigin origin, IMemberDefinition source, Instruction sourceInstruction, IMetadataTokenProvider accessedItem, string message, int messageCode)
 		{
-			var origin = new MessageOrigin (source, sourceInstruction?.Offset);
 			_context.LogWarning (message, messageCode, origin, MessageSubCategory.TrimAnalysis);
 		}
 	}

--- a/test/Mono.Linker.Tests.Cases/Logging/SourceLines.cs
+++ b/test/Mono.Linker.Tests.Cases/Logging/SourceLines.cs
@@ -7,11 +7,12 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.Logging
 {
 	[SkipKeptItemsValidation]
-	[SetupCompileBefore ("FakeSystemAssembly.dll", new[] { "../PreserveDependencies/Dependencies/PreserveDependencyAttribute.cs" })]
 	[SetupCompileArgument ("/debug:full")]
-	[LogContains ("(33,4): Trim analysis warning IL2074")]
-	[LogContains ("(34,4): Trim analysis warning IL2074")]
-	[LogContains ("(38,3): Trim analysis warning IL2091")]
+	[ExpectedNoWarnings]
+	[ExpectedWarning ("IL2074", FileName = "", SourceLine = 34, SourceColumn = 4)]
+	[ExpectedWarning ("IL2074", FileName = "", SourceLine = 35, SourceColumn = 4)]
+	[ExpectedWarning ("IL2091", FileName = "", SourceLine = 44, SourceColumn = 4)]
+	[ExpectedWarning ("IL2089", FileName = "", SourceLine = 48, SourceColumn = 36)]
 	public class SourceLines
 	{
 		public static void Main ()
@@ -30,8 +31,8 @@ namespace Mono.Linker.Tests.Cases.Logging
 
 		static void UnrecognizedReflectionPattern ()
 		{
-			type = GetUnknownType ();
-			type = GetUnknownType ();
+			type = GetUnknownType (); // IL2074
+			type = GetUnknownType (); // IL2074
 		}
 
 		static IEnumerable<int> GenericMethodIteratorWithRequirement<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] TOuterMethod> ()
@@ -40,11 +41,11 @@ namespace Mono.Linker.Tests.Cases.Logging
 			// but this T doesn't inherit the DAM annotation.
 			// So calling the LocationFunction which requires the DAM on T will generate a warning
 			// but that warning comes from compiler generated code - there's no user code doing that.
-			LocalFunction ();
+			LocalFunction (); // IL2091 - The issue with attributes not propagating to the iterator generics
 			yield return 1;
 
 			// The generator code for LocalFunction inherits the DAM on the T
-			static void LocalFunction () => type = typeof (TOuterMethod);
+			static void LocalFunction () => type = typeof (TOuterMethod); // IL2089 - TOuterMethod is PublicMethods, but type is PublicConstructors
 		}
 	}
 }

--- a/test/Mono.Linker.Tests/TestCasesRunner/TestReflectionPatternRecorder.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestReflectionPatternRecorder.cs
@@ -30,9 +30,9 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			});
 		}
 
-		public void UnrecognizedReflectionAccessPattern (IMemberDefinition source, Instruction sourceInstruction, IMetadataTokenProvider accessedItem, string message, int messageCode)
+		public void UnrecognizedReflectionAccessPattern (in MessageOrigin origin, IMemberDefinition source, Instruction sourceInstruction, IMetadataTokenProvider accessedItem, string message, int messageCode)
 		{
-			PreviousRecorder?.UnrecognizedReflectionAccessPattern (source, sourceInstruction, accessedItem, message, messageCode);
+			PreviousRecorder?.UnrecognizedReflectionAccessPattern (origin, source, sourceInstruction, accessedItem, message, messageCode);
 			UnrecognizedPatterns.Add (new ReflectionAccessPattern {
 				Source = source,
 				SourceInstruction = sourceInstruction,


### PR DESCRIPTION
Recent chaneg introduced a scope stack to marking which carries `MessageOrigin` around so that warnings can be reported with precise origin. The one exception to this was the `ReflectionMethodBodyScanner`.

This change integrates the scope stack with `ReflectionMethodBodyScanner`. The visible result is more precise reporting of some warnings. This change will be needed for the work around compiler generated code (since then MessageOrigin will carry even more information than it does currently).

The main API change is addition of the `MessageOrigin` parameter to the `IReflectionPatternRecorder.UnrecognizedReflectionAccessPattern`. There are plans to remove this interface completely, so there' not much need to clean it up right now (so I left the potentially duplicated `origin` and `source` arguments as is).

The rest of the change is just correctly flowing the information around.

I also improved the test infra to be able to correctly handle `ExpectedWarning` with source/line info on all warnings.

There are visible changes in the `SourceLines` test where some warnings changed location (more precise now).