### PR TITLE
Type get type generic annotation test

### DIFF
--- a/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflection.cs
@@ -41,6 +41,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestInvalidTypeName ();
 			TestUnkownIgnoreCase3Params (1);
 			TestUnkownIgnoreCase5Params (1);
+			TestGenericTypeWithAnnotations ();
 		}
 
 		[Kept]
@@ -381,6 +382,32 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			const string reflectionTypeKeptString = "mono.linker.tests.cases.reflection.TypeUsedViaReflection+CaseUnknown2, test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null";
 			bool unknownValue = num + 1 == 1;
 			var typeKept = Type.GetType (reflectionTypeKeptString, AssemblyResolver, GetTypeFromAssembly, false, unknownValue);
+		}
+
+		[Kept]
+		public class GenericTypeWithAnnotations_OuterType<
+			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicProperties)] T>
+		{
+		}
+
+		[Kept]
+		public class GenericTypeWithAnnotations_InnerType
+		{
+			[Kept]
+			[KeptBackingField]
+			private static bool PrivateProperty { [Kept] get; [Kept] set; }
+
+			private static void PrivateMethod () { }
+		}
+
+		[Kept]
+		static void TestGenericTypeWithAnnotations ()
+		{
+			const string reflectionTypeKeptString = "Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+GenericTypeWithAnnotations_OuterType`1" +
+				"[[Mono.Linker.Tests.Cases.Reflection.TypeUsedViaReflection+GenericTypeWithAnnotations_InnerType, test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]]," +
+				" test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null";
+			Type.GetType (reflectionTypeKeptString);
 		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflection.cs
@@ -386,8 +386,8 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
 		[Kept]
 		public class GenericTypeWithAnnotations_OuterType<
-			[KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
-			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicProperties)] T>
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicProperties)] T>
 		{
 		}
 


### PR DESCRIPTION
Add a test that Type.GetType correctly handles generic parameter annotations

Add a test that if a gener parameter has annotation and the type with that parameter is referenced via `Type.GetType`, the annotation gets applied.
There is already a test for `string` data flow handling in `ApplyTypeAnnotations.TestFromConstantWithGeneric`, but there was no test for `Type.GetType` (which uses slightly different codepath in the product).