### PR TITLE
Warning suppressions in compiler generated code

### DIFF
--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -1613,7 +1613,7 @@ class Test
 
   ```C#
   class <compiler_generated_state_machine>_type {
-      void MoveNext ()
+      void MoveNext()
       {
           // This should normally produce IL2026
           CallSomethingWhichRequiresUnreferencedCode ();
@@ -1622,7 +1622,7 @@ class Test
 
   [RequiresUnreferencedCode ("")] // This should suppress all warnings from the method
   [IteratorStateMachine(typeof(<compiler_generated_state_machine>_type))]
-  IEnumerable<int> UserDefinedMethod ()
+  IEnumerable<int> UserDefinedMethod()
   {
       // Uses the state machine type
       // The IL2026 from the state machine should be suppressed in this case
@@ -1630,12 +1630,11 @@ class Test
 
   // IL2107: Methods 'UserDefinedMethod' and 'SecondUserDefinedMethod' are both associated with state machine type '<compiler_generated_state_machine>_type'.
   [IteratorStateMachine(typeof(<compiler_generated_state_machine>_type))]
-  IEnumerable<int> SecondUserDefinedMethod ()
+  IEnumerable<int> SecondUserDefinedMethod()
   {
       // Uses the state machine type
       // The IL2026 from the state should be reported in this case
   }
-
   ```
 
 ## Single-File Warning Codes

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -1561,36 +1561,36 @@ class Test
 
 #### `IL2103`: Trim analysis: Value passed to the 'propertyAccessor' parameter of method 'System.Linq.Expressions.Expression.Property(Expression, MethodInfo)' cannot be statically determined as a property accessor
 
-The value passed to the `propertyAccessor` parameter of `Expression.Property(expression, propertyAccessor)` was not recognized as a property accessor method. Trimmer can't guarantee the presence of the property.
+- The value passed to the `propertyAccessor` parameter of `Expression.Property(expression, propertyAccessor)` was not recognized as a property accessor method. Trimmer can't guarantee the presence of the property.
 
-```C#
-void TestMethod(MethodInfo methodInfo)
-{
-  // IL2103: Value passed to the 'propertyAccessor' parameter of method 'System.Linq.Expressions.Expression.Property(Expression, MethodInfo)' cannot be statically determined as a property accessor.
-  Expression.Property(null, methodInfo);
-}
-```
+  ```C#
+  void TestMethod(MethodInfo methodInfo)
+  {
+    // IL2103: Value passed to the 'propertyAccessor' parameter of method 'System.Linq.Expressions.Expression.Property(Expression, MethodInfo)' cannot be statically determined as a property accessor.
+    Expression.Property(null, methodInfo);
+  }
+  ```
 
 #### `IL2104`: Assembly 'assembly' produced trim warnings. For more information see https://aka.ms/dotnet-illink/libraries
 
-The assembly 'assembly' produced trim analysis warnings in the context of the app. This means the assembly has not been fully annotated for trimming. Consider contacting the library author to request they add trim annotations to the library. To see detailed warnings for this assembly, turn off grouped warnings by passing either `--singlewarn-` to show detailed warnings for all assemblies, or `--singlewarn- "assembly"` to show detailed warnings for that assembly. https://aka.ms/dotnet-illink/libraries has more information on annotating libraries for trimming.
+- The assembly 'assembly' produced trim analysis warnings in the context of the app. This means the assembly has not been fully annotated for trimming. Consider contacting the library author to request they add trim annotations to the library. To see detailed warnings for this assembly, turn off grouped warnings by passing either `--singlewarn-` to show detailed warnings for all assemblies, or `--singlewarn- "assembly"` to show detailed warnings for that assembly. https://aka.ms/dotnet-illink/libraries has more information on annotating libraries for trimming.
 
 #### `IL2105`: Type 'type' was not found in the caller assembly nor in the base library. Type name strings used for dynamically accessing a type should be assembly qualified.
 
-Type name strings representing dynamically accessed types must be assembly qualified, otherwise linker will first search for the type name in the caller's assembly and then in System.Private.CoreLib.
-If the linker fails to resolve the type name, null will be returned.
+- Type name strings representing dynamically accessed types must be assembly qualified, otherwise linker will first search for the type name in the caller's assembly and then in System.Private.CoreLib.
+  If the linker fails to resolve the type name, null will be returned.
 
-```C#
-void TestInvalidTypeName()
-{
-    RequirePublicMethodOnAType("Foo.Unqualified.TypeName");
-}
-void RequirePublicMethodOnAType(
-    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
-    string typeName)
-{
-}
-```
+  ```C#
+  void TestInvalidTypeName()
+  {
+      RequirePublicMethodOnAType("Foo.Unqualified.TypeName");
+  }
+  void RequirePublicMethodOnAType(
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+      string typeName)
+  {
+  }
+  ```
 
 #### `IL2106`: Trim analysis: Return type of method 'method' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'
 
@@ -1604,6 +1604,39 @@ void RequirePublicMethodOnAType(
   }
   ```
 
+#### `IL2107`: Trim analysis: Methods 'method1' and 'method2' are both associated with state machine type 'type'. This is currently unsupported and may lead to incorrectly reported warnings.
+
+- Trimmer currently can't correctly handle if the same compiler generated state machine type is associated (via the state machine attributes) with two different methods.
+  Since the trimmer currently derives warning suppressions from the method which produced the state machine and currently doesn't support reprocessing the same method/type more than once.
+
+  Only a meta-sample:
+
+  ```C#
+  class <compiler_generated_state_machine>_type {
+      void MoveNext ()
+      {
+          // This should normally produce IL2026
+          CallSomethingWhichRequiresUnreferencedCode ();
+      }
+  }
+
+  [RequiresUnreferencedCode ("")] // This should suppress all warnings from the method
+  [IteratorStateMachine(typeof(<compiler_generated_state_machine>_type))]
+  IEnumerable<int> UserDefinedMethod ()
+  {
+      // Uses the state machine type
+      // The IL2026 from the state machine should be suppressed in this case
+  }
+
+  // IL2107: Methods 'UserDefinedMethod' and 'SecondUserDefinedMethod' are both associated with state machine type '<compiler_generated_state_machine>_type'.
+  [IteratorStateMachine(typeof(<compiler_generated_state_machine>_type))]
+  IEnumerable<int> SecondUserDefinedMethod ()
+  {
+      // Uses the state machine type
+      // The IL2026 from the state should be reported in this case
+  }
+
+  ```
 
 ## Single-File Warning Codes
 

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -61,18 +61,7 @@ namespace Mono.Linker.Dataflow
 
 		bool ShouldEnableReflectionPatternReporting ()
 		{
-			// Check if the current scope method has RequiresUnreferencedCode on it
-			// since that attribute automatically suppresses all trim analysis warnings.
-			// Check both the immediate origin method as well as suppression context method
-			// since that will be different for compiler generated code.
-			IMemberDefinition suppressionContextMember = _scopeStack.CurrentScope.Origin.SuppressionContextMember;
-			if (suppressionContextMember is MethodDefinition suppressionContextMethod &&
-				_context.Annotations.HasLinkerAttribute<RequiresUnreferencedCodeAttribute> (suppressionContextMethod))
-				return false;
-
-			IMemberDefinition originMember = _scopeStack.CurrentScope.Origin.MemberDefinition;
-			if (suppressionContextMember != originMember && originMember is MethodDefinition originMethod &&
-				_context.Annotations.HasLinkerAttribute<RequiresUnreferencedCodeAttribute> (originMethod))
+			if (_markStep.ShouldSuppressAnalysisWarningsForRequiresUnreferencedCode ())
 				return false;
 
 			return true;

--- a/src/linker/Linker.Steps/MarkScopeStack.cs
+++ b/src/linker/Linker.Steps/MarkScopeStack.cs
@@ -36,18 +36,12 @@ namespace Mono.Linker.Steps
 
 				// Compiler generated methods and types should "inherit" suppression context
 				// from the user defined method from which the compiler generated them.
-				// This is transfered through the SuppressionContextMember as that should
-				// always point to user defined code (and not compiler generated code).
-				// So if the newly added scope is for compiler generated code
-				// keep the suppression context from the current top of the scope stack.
-				// Otherwise the scope is from user code and so its suppression context
-				// should be the same as the scope itself.
-				IMemberDefinition suppressionContextMember = origin.MemberDefinition;
-				if (origin.MemberDefinition is MemberReference memberRef &&
-					_scopeStack._context.CompilerGeneratedState.IsCompilerGenerated (memberRef)) {
-					suppressionContextMember = _scopeStack.CurrentScope.Origin.SuppressionContextMember;
-				}
-
+				// Detecting which method produced which piece of compiler generated code
+				// is currently not possible in all cases, but in cases where it works
+				// we will store the suppression context in the SuppressionContextMember.
+				// For code which is not compiler generated the suppression context
+				// is the same as the message's origin member.
+				IMemberDefinition suppressionContextMember = _scopeStack.GetSuppressionContext (origin.MemberDefinition);
 				_scopeStack.Push (new Scope (new MessageOrigin (origin.MemberDefinition, origin.ILOffset, suppressionContextMember)));
 			}
 
@@ -143,5 +137,8 @@ namespace Mono.Linker.Steps
 
 		[Conditional ("DEBUG")]
 		public void AssertIsEmpty () => Debug.Assert (_scopeStack.Count == 0);
+
+		IMemberDefinition GetSuppressionContext (IMemberDefinition sourceMember) =>
+			_context.CompilerGeneratedState.GetUserDefinedMethodForCompilerGeneratedMember (sourceMember) ?? sourceMember;
 	}
 }

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -60,7 +60,7 @@ namespace Mono.Linker.Steps
 		MarkStepContext _markContext;
 		readonly Dictionary<TypeDefinition, bool> _entireTypesMarked; // The value is markBaseAndInterfaceTypes flag used to mark the type
 		DynamicallyAccessedMembersTypeHierarchy _dynamicallyAccessedMembersTypeHierarchy;
-		readonly MarkScopeStack _scopeStack;
+		MarkScopeStack _scopeStack;
 
 		internal DynamicallyAccessedMembersTypeHierarchy DynamicallyAccessedMembersTypeHierarchy {
 			get => _dynamicallyAccessedMembersTypeHierarchy;
@@ -192,7 +192,6 @@ namespace Mono.Linker.Steps
 			_unreachableBodies = new List<(MethodBody, MarkScopeStack.Scope)> ();
 			_pending_isinst_instr = new List<(TypeDefinition, MethodBody, Instruction)> ();
 			_entireTypesMarked = new Dictionary<TypeDefinition, bool> ();
-			_scopeStack = new MarkScopeStack ();
 		}
 
 		public AnnotationStore Annotations => _context.Annotations;
@@ -204,6 +203,7 @@ namespace Mono.Linker.Steps
 			_context = context;
 			_unreachableBlocksOptimizer = new UnreachableBlocksOptimizer (_context);
 			_markContext = new MarkStepContext ();
+			_scopeStack = new MarkScopeStack (_context);
 			_dynamicallyAccessedMembersTypeHierarchy = new DynamicallyAccessedMembersTypeHierarchy (_context, this, _scopeStack);
 
 			Initialize ();
@@ -2716,12 +2716,20 @@ namespace Mono.Linker.Steps
 
 		internal void CheckAndReportRequiresUnreferencedCode (MethodDefinition method)
 		{
-			var currentScope = _scopeStack.CurrentScope;
+			var currentOrigin = _scopeStack.CurrentScope.Origin;
 
 			// If the caller of a method is already marked with `RequiresUnreferencedCodeAttribute` a new warning should not
 			// be produced for the callee.
-			if (currentScope.Origin.MemberDefinition != null &&
-				Annotations.HasLinkerAttribute<RequiresUnreferencedCodeAttribute> (currentScope.Origin.MemberDefinition))
+			// Check both the origin's member (the direct method which contains the call to RUC)
+			// as well as the suppression context member (the "user code" source in case of compiler generated code)
+			IMemberDefinition suppressionContextMember = currentOrigin.SuppressionContextMember;
+			if (suppressionContextMember != null &&
+				Annotations.HasLinkerAttribute<RequiresUnreferencedCodeAttribute> (suppressionContextMember))
+				return;
+
+			IMemberDefinition originMember = currentOrigin.MemberDefinition;
+			if (suppressionContextMember != originMember && originMember != null &&
+				Annotations.HasLinkerAttribute<RequiresUnreferencedCodeAttribute> (originMember))
 				return;
 
 			if (Annotations.TryGetLinkerAttribute (method, out RequiresUnreferencedCodeAttribute requiresUnreferencedCode)) {
@@ -2732,7 +2740,7 @@ namespace Mono.Linker.Steps
 				if (!string.IsNullOrEmpty (requiresUnreferencedCode.Url))
 					message += " " + requiresUnreferencedCode.Url;
 
-				_context.LogWarning (message, 2026, currentScope.Origin, MessageSubCategory.TrimAnalysis);
+				_context.LogWarning (message, 2026, currentOrigin, MessageSubCategory.TrimAnalysis);
 			}
 		}
 

--- a/src/linker/Linker/CompilerGeneratedState.cs
+++ b/src/linker/Linker/CompilerGeneratedState.cs
@@ -21,8 +21,8 @@ namespace Mono.Linker
 			_typesWithPopulatedCache = new HashSet<TypeDefinition> ();
 		}
 
-		static bool HasRoslynCompilerGeneratedName (IMemberDefinition member) =>
-			member.Name.Contains ('<') || member.DeclaringType == null || HasRoslynCompilerGeneratedName (member.DeclaringType);
+		static bool HasRoslynCompilerGeneratedName (TypeDefinition type) =>
+			type.Name.Contains ('<') || (type.DeclaringType != null && HasRoslynCompilerGeneratedName (type.DeclaringType));
 
 		void PopulateCacheForType (TypeDefinition type)
 		{

--- a/src/linker/Linker/CompilerGeneratedState.cs
+++ b/src/linker/Linker/CompilerGeneratedState.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Mono.Cecil;
+
+namespace Mono.Linker
+{
+	// Currently this is implemented using heuristics
+	public class CompilerGeneratedState
+	{
+		enum Language
+		{
+			CSharp = 0,
+			FSharp = 1
+		}
+
+		readonly LinkContext _context;
+		readonly Dictionary<AssemblyDefinition, Language> _assumedAssemblyLanguage;
+
+		public CompilerGeneratedState (LinkContext context)
+		{
+			_context = context;
+			_assumedAssemblyLanguage = new Dictionary<AssemblyDefinition, Language> ();
+		}
+
+		public bool IsCompilerGenerated (MemberReference memberReference)
+		{
+			switch (GetAssumedLanguage (memberReference)) {
+			case Language.CSharp:
+				if (memberReference.Name.Contains ('<'))
+					return true;
+				break;
+
+			case Language.FSharp:
+				if (memberReference.Name.Contains ('@'))
+					return true;
+				break;
+			}
+
+			if (memberReference.DeclaringType != null)
+				return IsCompilerGenerated (memberReference.DeclaringType);
+
+			return false;
+		}
+
+		Language GetAssumedLanguage (MemberReference memberReference)
+		{
+			AssemblyDefinition asm = memberReference.Module.Assembly;
+			if (_assumedAssemblyLanguage.TryGetValue (asm, out Language language))
+				return language;
+
+			language = Language.CSharp;
+			foreach (var attribute in _context.CustomAttributes.GetCustomAttributes (asm)) {
+				if (attribute.AttributeType.IsTypeOf ("Microsoft.FSharp.Core", "FSharpInterfaceDataVersionAttribute")) {
+					language = Language.FSharp;
+					break;
+				}
+			}
+
+			_assumedAssemblyLanguage.Add (asm, language);
+			return language;
+		}
+	}
+}

--- a/src/linker/Linker/CompilerGeneratedState.cs
+++ b/src/linker/Linker/CompilerGeneratedState.cs
@@ -14,8 +14,9 @@ namespace Mono.Linker
 		readonly Dictionary<TypeDefinition, MethodDefinition> _compilerGeneratedTypeToUserCodeMethod;
 		readonly HashSet<TypeDefinition> _typesWithPopulatedCache;
 
-		public CompilerGeneratedState ()
+		public CompilerGeneratedState (LinkContext context)
 		{
+			_context = context;
 			_compilerGeneratedTypeToUserCodeMethod = new Dictionary<TypeDefinition, MethodDefinition> ();
 			_typesWithPopulatedCache = new HashSet<TypeDefinition> ();
 		}

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -70,6 +70,7 @@ namespace Mono.Linker
 
 		readonly AnnotationStore _annotations;
 		readonly CustomAttributeSource _customAttributes;
+		readonly CompilerGeneratedState _compilerGeneratedState;
 		readonly List<MessageContainer> _cachedWarningMessageContainers;
 		readonly ILogger _logger;
 
@@ -77,13 +78,11 @@ namespace Mono.Linker
 			get { return _pipeline; }
 		}
 
-		public CustomAttributeSource CustomAttributes {
-			get { return _customAttributes; }
-		}
+		public CustomAttributeSource CustomAttributes { get => _customAttributes; }
 
-		public AnnotationStore Annotations {
-			get { return _annotations; }
-		}
+		public CompilerGeneratedState CompilerGeneratedState { get => _compilerGeneratedState; }
+
+		public AnnotationStore Annotations { get => _annotations; }
 
 		public bool DeterministicOutput { get; set; }
 
@@ -209,6 +208,7 @@ namespace Mono.Linker
 			_actions = new Dictionary<string, AssemblyAction> ();
 			_parameters = new Dictionary<string, string> (StringComparer.Ordinal);
 			_customAttributes = new CustomAttributeSource (this);
+			_compilerGeneratedState = new CompilerGeneratedState (this);
 			_cachedWarningMessageContainers = new List<MessageContainer> ();
 			FeatureSettings = new Dictionary<string, bool> (StringComparer.Ordinal);
 

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -78,11 +78,11 @@ namespace Mono.Linker
 			get { return _pipeline; }
 		}
 
-		public CustomAttributeSource CustomAttributes { get => _customAttributes; }
+		public CustomAttributeSource CustomAttributes => _customAttributes;
 
-		public CompilerGeneratedState CompilerGeneratedState { get => _compilerGeneratedState; }
+		public CompilerGeneratedState CompilerGeneratedState => _compilerGeneratedState;
 
-		public AnnotationStore Annotations { get => _annotations; }
+		public AnnotationStore Annotations => _annotations;
 
 		public bool DeterministicOutput { get; set; }
 

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -208,7 +208,7 @@ namespace Mono.Linker
 			_actions = new Dictionary<string, AssemblyAction> ();
 			_parameters = new Dictionary<string, string> (StringComparer.Ordinal);
 			_customAttributes = new CustomAttributeSource (this);
-			_compilerGeneratedState = new CompilerGeneratedState (this);
+			_compilerGeneratedState = new CompilerGeneratedState ();
 			_cachedWarningMessageContainers = new List<MessageContainer> ();
 			FeatureSettings = new Dictionary<string, bool> (StringComparer.Ordinal);
 

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -208,7 +208,7 @@ namespace Mono.Linker
 			_actions = new Dictionary<string, AssemblyAction> ();
 			_parameters = new Dictionary<string, string> (StringComparer.Ordinal);
 			_customAttributes = new CustomAttributeSource (this);
-			_compilerGeneratedState = new CompilerGeneratedState ();
+			_compilerGeneratedState = new CompilerGeneratedState (this);
 			_cachedWarningMessageContainers = new List<MessageContainer> ();
 			FeatureSettings = new Dictionary<string, bool> (StringComparer.Ordinal);
 

--- a/src/linker/Linker/MessageOrigin.cs
+++ b/src/linker/Linker/MessageOrigin.cs
@@ -105,15 +105,17 @@ namespace Mono.Linker
 		public int CompareTo (MessageOrigin other)
 		{
 			if (MemberDefinition != null && other.MemberDefinition != null) {
-				int result = (MemberDefinition.DeclaringType?.Module?.Assembly?.Name?.Name, MemberDefinition.DeclaringType?.Name, MemberDefinition?.Name).CompareTo
-					((other.MemberDefinition.DeclaringType?.Module?.Assembly?.Name?.Name, other.MemberDefinition.DeclaringType?.Name, other.MemberDefinition?.Name));
+				TypeDefinition thisTypeDef = (MemberDefinition as TypeDefinition) ?? MemberDefinition.DeclaringType;
+				TypeDefinition otherTypeDef = (other.MemberDefinition as TypeDefinition) ?? other.MemberDefinition.DeclaringType;
+				int result = (thisTypeDef?.Module?.Assembly?.Name?.Name, thisTypeDef?.Name, MemberDefinition?.Name).CompareTo
+					((otherTypeDef?.Module?.Assembly?.Name?.Name, otherTypeDef?.Name, other.MemberDefinition?.Name));
 				if (result != 0)
 					return result;
 
 				if (ILOffset != null && other.ILOffset != null)
 					return ILOffset.Value.CompareTo (other.ILOffset);
 
-				return ILOffset == null ? 1 : -1;
+				return ILOffset == null ? (other.ILOffset == null ? 0 : 1) : -1;
 			} else if (MemberDefinition == null && other.MemberDefinition == null) {
 				if (FileName != null && other.FileName != null) {
 					return string.Compare (FileName, other.FileName);

--- a/test/Mono.Linker.Tests.Cases.Expectations/Assertions/ExpectedWarningAttribute.cs
+++ b/test/Mono.Linker.Tests.Cases.Expectations/Assertions/ExpectedWarningAttribute.cs
@@ -18,5 +18,7 @@ namespace Mono.Linker.Tests.Cases.Expectations.Assertions
 
 		// Set to true if the warning only applies to global analysis (ILLinker, as opposed to Roslyn Analyzer)
 		public bool GlobalAnalysisOnly { get; set; }
+
+		public bool CompilerGeneratedCode { get; set; }
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/Logging/CommonLogs.cs
+++ b/test/Mono.Linker.Tests.Cases/Logging/CommonLogs.cs
@@ -7,7 +7,7 @@ namespace Mono.Linker.Tests.Cases.Logging
 #if !NETCOREAPP
 	[IgnoreTestCase ("Can be enabled once MonoBuild produces a dll from which we can grab the types in the Mono.Linker namespace.")]
 #else
-	[SetupCompileBefore ("LogStep.dll", new[] { "Dependencies/LogStep.cs" }, new[] { "illink.dll" })]
+	[SetupCompileBefore ("LogStep.dll", new[] { "Dependencies/LogStep.cs" }, new[] { "illink.dll", "Mono.Cecil.dll" })]
 #endif
 	[SetupLinkerArgument ("--custom-step", "Log.LogStep,LogStep.dll")]
 	[SetupLinkerArgument ("--verbose")]

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
@@ -39,7 +39,8 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			TestRequiresWithMessageAndUrlOnMethod ();
 			TestRequiresOnConstructor ();
 			TestRequiresOnPropertyGetterAndSetter ();
-			TestRequiresSuppressesWarningsFromReflectionAnalysis ();
+			SuppressMethodBodyReferences.Test ();
+			SuppressGenericParameters<TestType, TestType>.Test ();
 			TestDuplicateRequiresAttribute ();
 			TestRequiresUnreferencedCodeOnlyThroughReflection ();
 			TestBaseTypeVirtualMethodRequiresUnreferencedCode ();
@@ -60,7 +61,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			TestRequiresInDynamicDependency ();
 			TestThatTrailingPeriodIsAddedToMessage ();
 			TestThatTrailingPeriodIsNotDuplicatedInWarningMessage ();
-			TestRequiresOnAttributeOnGenericParameter ();
+			RequiresOnAttribute.Test ();
 		}
 
 		[ExpectedWarning ("IL2026", "Message for --RequiresWithMessageOnly--.")]
@@ -115,45 +116,113 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			set { }
 		}
 
-		[ExpectedWarning ("IL2026", "Message for --RequiresAndCallsOtherRequiresMethods--.")]
-		static void TestRequiresSuppressesWarningsFromReflectionAnalysis ()
+		[ExpectedNoWarnings]
+		class SuppressMethodBodyReferences
 		{
-			RequiresAndCallsOtherRequiresMethods<TestType> ();
+			static Type _unknownType;
+			static Type GetUnknownType () => null;
+
+			[RequiresUnreferencedCode ("Message for --RequiresUnreferencedCodeMethod--")]
+			static void RequiresUnreferencedCodeMethod ()
+			{
+			}
+
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)]
+			static Type _requiresPublicConstructors;
+
+			[RequiresUnreferencedCode ("")]
+			static void TestRUCMethod ()
+			{
+				// Normally this would warn, but with the attribute on this method it should be auto-suppressed
+				RequiresUnreferencedCodeMethod ();
+			}
+
+			[RequiresUnreferencedCode ("")]
+			static void TestParameter ()
+			{
+				_unknownType.RequiresPublicMethods ();
+			}
+
+			[RequiresUnreferencedCode ("")]
+			static void TestReturnValue ()
+			{
+				GetUnknownType ().RequiresPublicEvents ();
+			}
+
+			[RequiresUnreferencedCode ("")]
+			static void TestField ()
+			{
+				_requiresPublicConstructors = _unknownType;
+			}
+
+			[UnconditionalSuppressMessage ("Trimming", "IL2026")]
+			public static void Test ()
+			{
+				TestRUCMethod ();
+				TestParameter ();
+				TestReturnValue ();
+				TestField ();
+			}
 		}
 
-		[RequiresUnreferencedCode ("Message for --RequiresAndCallsOtherRequiresMethods--")]
-		[LogDoesNotContain ("Message for --RequiresUnreferencedCodeMethod--")]
-		[RecognizedReflectionAccessPattern]
-		static void RequiresAndCallsOtherRequiresMethods<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] TPublicMethods> ()
+		[ExpectedNoWarnings]
+		class SuppressGenericParameters<TUnknown, [DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicProperties)] TPublicProperties>
 		{
-			// Normally this would warn, but with the attribute on this method it should be auto-suppressed
-			RequiresUnreferencedCodeMethod ();
+			static Type _unknownType;
 
-			// Normally this would warn due to incompatible annotations, but with the attribute on this method it should be auto-suppressed
-			GetTypeWithPublicMethods ().RequiresPublicFields ();
+			static void GenericMethodRequiresPublicMethods<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] T> () { }
 
-			TypeRequiresPublicFields<TPublicMethods>.Method ();
+			class GenericTypeRequiresPublicFields<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T> { }
 
-			MethodRequiresPublicFields<TPublicMethods> ();
+			[RequiresUnreferencedCode ("")]
+			static void TestGenericMethod ()
+			{
+				GenericMethodRequiresPublicMethods<TUnknown> ();
+			}
+
+			[RequiresUnreferencedCode ("")]
+			static void TestGenericMethodMismatch ()
+			{
+				GenericMethodRequiresPublicMethods<TPublicProperties> ();
+			}
+
+			[RequiresUnreferencedCode ("")]
+			static void TestGenericType ()
+			{
+				new GenericTypeRequiresPublicFields<TUnknown> ();
+			}
+
+			[RequiresUnreferencedCode ("")]
+			static void TestMakeGenericTypeWithStaticTypes ()
+			{
+				typeof (GenericTypeRequiresPublicFields<>).MakeGenericType (typeof (TUnknown));
+			}
+
+			[RequiresUnreferencedCode ("")]
+			static void TestMakeGenericTypeWithDynamicTypes ()
+			{
+				typeof (GenericTypeRequiresPublicFields<>).MakeGenericType (_unknownType);
+			}
+
+			[RequiresUnreferencedCode ("")]
+			static void TestMakeGenericMethod ()
+			{
+				typeof (SuppressGenericParameters<TUnknown, TPublicProperties>)
+					.GetMethod ("GenericMethodRequiresPublicMethods", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)
+					.MakeGenericMethod (typeof (TPublicProperties));
+			}
+
+			[UnconditionalSuppressMessage ("Trimming", "IL2026")]
+			public static void Test ()
+			{
+				TestGenericMethod ();
+				TestGenericMethodMismatch ();
+				TestGenericType ();
+				TestMakeGenericTypeWithStaticTypes ();
+				TestMakeGenericTypeWithDynamicTypes ();
+				TestMakeGenericMethod ();
+			}
 		}
-
-		[RequiresUnreferencedCode ("Message for --RequiresUnreferencedCodeMethod--")]
-		static void RequiresUnreferencedCodeMethod ()
-		{
-		}
-
-		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
-		static Type GetTypeWithPublicMethods ()
-		{
-			return null;
-		}
-
-		class TypeRequiresPublicFields<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T>
-		{
-			public static void Method () { }
-		}
-
-		static void MethodRequiresPublicFields<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] T> () { }
 
 		class TestType { }
 
@@ -426,23 +495,72 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			WarningMessageEndsWithPeriod ();
 		}
 
-		class AttributeWhichRequiresUnreferencedCodeAttribute : Attribute
+		[ExpectedNoWarnings]
+		class RequiresOnAttribute
 		{
-			[RequiresUnreferencedCode ("Message for --AttributeWhichRequiresUnreferencedCodeAttribute.ctor--")]
-			public AttributeWhichRequiresUnreferencedCodeAttribute ()
+			class AttributeWhichRequiresUnreferencedCodeAttribute : Attribute
+			{
+				[RequiresUnreferencedCode ("Message for --AttributeWhichRequiresUnreferencedCodeAttribute.ctor--")]
+				public AttributeWhichRequiresUnreferencedCodeAttribute ()
+				{
+				}
+			}
+
+			[ExpectedWarning ("IL2026", "--AttributeWhichRequiresUnreferencedCodeAttribute.ctor--")]
+			class GenericTypeWithAttributedParameter<[AttributeWhichRequiresUnreferencedCode] T>
+			{
+				public static void TestMethod () { }
+			}
+
+			// TODO: Should this be supported by analyzer?
+			[ExpectedWarning ("IL2026", "--AttributeWhichRequiresUnreferencedCodeAttribute.ctor--", GlobalAnalysisOnly = true)]
+			static void GenericMethodWithAttributedParameter<[AttributeWhichRequiresUnreferencedCode] T> () { }
+
+			static void TestRequiresOnAttributeOnGenericParameter ()
+			{
+				GenericTypeWithAttributedParameter<int>.TestMethod ();
+				GenericMethodWithAttributedParameter<int> ();
+			}
+
+			// TODO: Should this be supported by analyzer?
+			[ExpectedWarning ("IL2026", "--AttributeWhichRequiresUnreferencedCodeAttribute.ctor--", GlobalAnalysisOnly = true)]
+			[AttributeWhichRequiresUnreferencedCode]
+			class TypeWithAttributeWhichRequires
 			{
 			}
-		}
 
-		[ExpectedWarning ("IL2026", "--AttributeWhichRequiresUnreferencedCodeAttribute.ctor--")]
-		class GenericTypeWithAttributedParameter<[AttributeWhichRequiresUnreferencedCode] T>
-		{
-			public static void TestMethod () { }
-		}
+			// TODO: Should this be supported by analyzer?
+			[ExpectedWarning ("IL2026", "--AttributeWhichRequiresUnreferencedCodeAttribute.ctor--", GlobalAnalysisOnly = true)]
+			[AttributeWhichRequiresUnreferencedCode]
+			static void MethodWithAttributeWhichRequires () { }
 
-		static void TestRequiresOnAttributeOnGenericParameter ()
-		{
-			GenericTypeWithAttributedParameter<int>.TestMethod ();
+			[ExpectedWarning ("IL2026", "--AttributeWhichRequiresUnreferencedCodeAttribute.ctor--")]
+			[AttributeWhichRequiresUnreferencedCode]
+			static int _fieldWithAttributeWhichRequires;
+
+			[ExpectedWarning ("IL2026", "--AttributeWhichRequiresUnreferencedCodeAttribute.ctor--")]
+			[AttributeWhichRequiresUnreferencedCode]
+			static bool PropertyWithAttributeWhichRequires { get; set; }
+
+			[AttributeWhichRequiresUnreferencedCode]
+			[RequiresUnreferencedCode ("--MethodWhichRequiresWithAttributeWhichRequires--")]
+			static void MethodWhichRequiresWithAttributeWhichRequires () { }
+
+			[ExpectedWarning ("IL2026", "--MethodWhichRequiresWithAttributeWhichRequires--")]
+			static void TestMethodWhichRequiresWithAttributeWhichRequires ()
+			{
+				MethodWhichRequiresWithAttributeWhichRequires ();
+			}
+
+			public static void Test ()
+			{
+				TestRequiresOnAttributeOnGenericParameter ();
+				new TypeWithAttributeWhichRequires ();
+				MethodWithAttributeWhichRequires ();
+				_fieldWithAttributeWhichRequires = 0;
+				PropertyWithAttributeWhichRequires = false;
+				TestMethodWhichRequiresWithAttributeWhichRequires ();
+			}
 		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
@@ -512,7 +512,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				public static void TestMethod () { }
 			}
 
-			// TODO: Should this be supported by analyzer?
+			// https://github.com/mono/linker/issues/2094 - should be supported by the analyzer
 			[ExpectedWarning ("IL2026", "--AttributeWhichRequiresUnreferencedCodeAttribute.ctor--", GlobalAnalysisOnly = true)]
 			static void GenericMethodWithAttributedParameter<[AttributeWhichRequiresUnreferencedCode] T> () { }
 
@@ -522,14 +522,14 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				GenericMethodWithAttributedParameter<int> ();
 			}
 
-			// TODO: Should this be supported by analyzer?
+			// https://github.com/mono/linker/issues/2094 - should be supported by the analyzer
 			[ExpectedWarning ("IL2026", "--AttributeWhichRequiresUnreferencedCodeAttribute.ctor--", GlobalAnalysisOnly = true)]
 			[AttributeWhichRequiresUnreferencedCode]
 			class TypeWithAttributeWhichRequires
 			{
 			}
 
-			// TODO: Should this be supported by analyzer?
+			// https://github.com/mono/linker/issues/2094 - should be supported by the analyzer
 			[ExpectedWarning ("IL2026", "--AttributeWhichRequiresUnreferencedCodeAttribute.ctor--", GlobalAnalysisOnly = true)]
 			[AttributeWhichRequiresUnreferencedCode]
 			static void MethodWithAttributeWhichRequires () { }

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeInCompilerGeneratedCode.cs
@@ -1,0 +1,731 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
+
+namespace Mono.Linker.Tests.Cases.RequiresCapability
+{
+	[SkipKeptItemsValidation]
+	[ExpectedNoWarnings]
+	public class RequiresUnreferencedCodeInCompilerGeneratedCode
+	{
+		public static void Main ()
+		{
+			WarnInIteratorBody.Test ();
+			SuppressInIteratorBody.Test ();
+
+			WarnInAsyncBody.Test ();
+			SuppressInAsyncBody.Test ();
+
+			WarnInLocalFunction.Test ();
+			SuppressInLocalFunction.Test ();
+
+			WarnInLambda.Test ();
+			SuppressInLambda.Test ();
+
+			WarnInComplex.Test ();
+			SuppressInComplex.Test ();
+		}
+
+		class WarnInIteratorBody
+		{
+			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true)]
+			static IEnumerable<int> TestCallBeforeYieldReturn ()
+			{
+				RequiresUnreferencedCodeMethod ();
+				yield return 0;
+			}
+
+			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true)]
+			static IEnumerable<int> TestCallAfterYieldReturn ()
+			{
+				yield return 0;
+				RequiresUnreferencedCodeMethod ();
+			}
+
+			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true, GlobalAnalysisOnly = true)]
+			static IEnumerable<int> TestReflectionAccess ()
+			{
+				yield return 0;
+				typeof (RequiresUnreferencedCodeInCompilerGeneratedCode)
+					.GetMethod ("RequiresUnreferencedCodeMethod", System.Reflection.BindingFlags.NonPublic)
+					.Invoke (null, new object[] { });
+				yield return 1;
+			}
+
+			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true)]
+			static IEnumerable<int> TestLdftn ()
+			{
+				yield return 0;
+				yield return 1;
+				var action = new Action (RequiresUnreferencedCodeMethod);
+			}
+
+			[ExpectedWarning ("IL2026", "--TypeWithRUCMethod.RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true, GlobalAnalysisOnly = true)]
+			static IEnumerable<int> TestDynamicallyAccessedMethod ()
+			{
+				typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
+				yield return 0;
+				yield return 1;
+			}
+
+			public static void Test ()
+			{
+				TestCallBeforeYieldReturn ();
+				TestCallAfterYieldReturn ();
+				TestReflectionAccess ();
+				TestLdftn ();
+				TestDynamicallyAccessedMethod ();
+			}
+		}
+
+		class SuppressInIteratorBody
+		{
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static IEnumerable<int> TestCall ()
+			{
+				RequiresUnreferencedCodeMethod ();
+				yield return 0;
+				RequiresUnreferencedCodeMethod ();
+				yield return 1;
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static IEnumerable<int> TestReflectionAccess ()
+			{
+				yield return 0;
+				typeof (RequiresUnreferencedCodeInCompilerGeneratedCode)
+					.GetMethod ("RequiresUnreferencedCodeMethod", System.Reflection.BindingFlags.NonPublic)
+					.Invoke (null, new object[] { });
+				yield return 1;
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static IEnumerable<int> TestLdftn ()
+			{
+				yield return 0;
+				yield return 1;
+				var action = new Action (RequiresUnreferencedCodeMethod);
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static IEnumerable<int> TestDynamicallyAccessedMethod ()
+			{
+				typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
+				yield return 0;
+				yield return 1;
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static IEnumerable<int> TestMethodParameterWithRequirements (Type unknownType = null)
+			{
+				unknownType.RequiresNonPublicMethods ();
+				yield return 0;
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static IEnumerable<int> TestGenericMethodParameterRequirement<TUnknown> ()
+			{
+				MethodWithGenericWhichRequiresMethods<TUnknown> ();
+				yield return 0;
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static IEnumerable<int> TestGenericTypeParameterRequirement<TUnknown> ()
+			{
+				new TypeWithGenericWhichRequiresNonPublicFields<TUnknown> ();
+				yield return 0;
+			}
+
+			[UnconditionalSuppressMessage ("Trimming", "IL2026")]
+			public static void Test ()
+			{
+				TestCall ();
+				TestReflectionAccess ();
+				TestLdftn ();
+				TestDynamicallyAccessedMethod ();
+				TestMethodParameterWithRequirements ();
+				TestGenericMethodParameterRequirement<TestType> ();
+				TestGenericTypeParameterRequirement<TestType> ();
+			}
+		}
+
+		class WarnInAsyncBody
+		{
+			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true)]
+			static async void TestCallBeforeYieldReturn ()
+			{
+				RequiresUnreferencedCodeMethod ();
+				await MethodAsync ();
+			}
+
+			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true)]
+			static async void TestCallAfterYieldReturn ()
+			{
+				await MethodAsync ();
+				RequiresUnreferencedCodeMethod ();
+			}
+
+			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true, GlobalAnalysisOnly = true)]
+			static async void TestReflectionAccess ()
+			{
+				await MethodAsync ();
+				typeof (RequiresUnreferencedCodeInCompilerGeneratedCode)
+					.GetMethod ("RequiresUnreferencedCodeMethod", System.Reflection.BindingFlags.NonPublic)
+					.Invoke (null, new object[] { });
+				await MethodAsync ();
+			}
+
+			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true)]
+			static async void TestLdftn ()
+			{
+				await MethodAsync ();
+				var action = new Action (RequiresUnreferencedCodeMethod);
+			}
+
+			[ExpectedWarning ("IL2026", "--TypeWithRUCMethod.RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true, GlobalAnalysisOnly = true)]
+			static async void TestDynamicallyAccessedMethod ()
+			{
+				typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
+				await MethodAsync ();
+			}
+
+			public static void Test ()
+			{
+				TestCallBeforeYieldReturn ();
+				TestCallAfterYieldReturn ();
+				TestReflectionAccess ();
+				TestLdftn ();
+				TestDynamicallyAccessedMethod ();
+			}
+		}
+
+		class SuppressInAsyncBody
+		{
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static async void TestCall ()
+			{
+				RequiresUnreferencedCodeMethod ();
+				await MethodAsync ();
+				RequiresUnreferencedCodeMethod ();
+				await MethodAsync ();
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static async void TestReflectionAccess ()
+			{
+				await MethodAsync ();
+				typeof (RequiresUnreferencedCodeInCompilerGeneratedCode)
+					.GetMethod ("RequiresUnreferencedCodeMethod", System.Reflection.BindingFlags.NonPublic)
+					.Invoke (null, new object[] { });
+				await MethodAsync ();
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static async void TestLdftn ()
+			{
+				await MethodAsync ();
+				var action = new Action (RequiresUnreferencedCodeMethod);
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static async void TestDynamicallyAccessedMethod ()
+			{
+				typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
+				await MethodAsync ();
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static async void TestMethodParameterWithRequirements (Type unknownType = null)
+			{
+				unknownType.RequiresNonPublicMethods ();
+				await MethodAsync ();
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static async void TestGenericMethodParameterRequirement<TUnknown> ()
+			{
+				MethodWithGenericWhichRequiresMethods<TUnknown> ();
+				await MethodAsync ();
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static async void TestGenericTypeParameterRequirement<TUnknown> ()
+			{
+				new TypeWithGenericWhichRequiresNonPublicFields<TUnknown> ();
+				await MethodAsync ();
+			}
+
+			[UnconditionalSuppressMessage ("Trimming", "IL2026")]
+			public static void Test ()
+			{
+				TestCall ();
+				TestReflectionAccess ();
+				TestLdftn ();
+				TestDynamicallyAccessedMethod ();
+				TestMethodParameterWithRequirements ();
+				TestGenericMethodParameterRequirement<TestType> ();
+				TestGenericTypeParameterRequirement<TestType> ();
+			}
+		}
+
+		class WarnInLocalFunction
+		{
+			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true)]
+			static void TestCall ()
+			{
+				LocalFunction ();
+
+				void LocalFunction () => RequiresUnreferencedCodeMethod ();
+			}
+
+			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true)]
+			static void TestCallWithClosure (int p = 0)
+			{
+				LocalFunction ();
+
+				void LocalFunction ()
+				{
+					p++;
+					RequiresUnreferencedCodeMethod ();
+				}
+			}
+
+			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true, GlobalAnalysisOnly = true)]
+			static void TestReflectionAccess ()
+			{
+				LocalFunction ();
+
+				void LocalFunction () => typeof (RequiresUnreferencedCodeInCompilerGeneratedCode)
+					.GetMethod ("RequiresUnreferencedCodeMethod", System.Reflection.BindingFlags.NonPublic)
+					.Invoke (null, new object[] { });
+			}
+
+			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true)]
+			static void TestLdftn ()
+			{
+				LocalFunction ();
+
+				void LocalFunction ()
+				{
+					var action = new Action (RequiresUnreferencedCodeMethod);
+				}
+			}
+
+			[ExpectedWarning ("IL2026", "--TypeWithRUCMethod.RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true, GlobalAnalysisOnly = true)]
+			static void TestDynamicallyAccessedMethod ()
+			{
+				LocalFunction ();
+
+				void LocalFunction () => typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
+			}
+
+			public static void Test ()
+			{
+				TestCall ();
+				TestCallWithClosure ();
+				TestReflectionAccess ();
+				TestLdftn ();
+				TestDynamicallyAccessedMethod ();
+			}
+		}
+
+		class SuppressInLocalFunction
+		{
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static void TestCall ()
+			{
+				LocalFunction ();
+
+				void LocalFunction () => RequiresUnreferencedCodeMethod ();
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static void TestCallWithClosure (int p = 0)
+			{
+				LocalFunction ();
+
+				void LocalFunction ()
+				{
+					p++;
+					RequiresUnreferencedCodeMethod ();
+				}
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static async void TestReflectionAccess ()
+			{
+				LocalFunction ();
+
+				void LocalFunction () => typeof (RequiresUnreferencedCodeInCompilerGeneratedCode)
+					.GetMethod ("RequiresUnreferencedCodeMethod", System.Reflection.BindingFlags.NonPublic)
+					.Invoke (null, new object[] { });
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static async void TestLdftn ()
+			{
+				LocalFunction ();
+
+				void LocalFunction ()
+				{
+					var action = new Action (RequiresUnreferencedCodeMethod);
+				}
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static async void TestDynamicallyAccessedMethod ()
+			{
+				LocalFunction ();
+
+				void LocalFunction () => typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static async void TestMethodParameterWithRequirements (Type unknownType = null)
+			{
+				LocalFunction ();
+
+				void LocalFunction () => unknownType.RequiresNonPublicMethods ();
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static void TestGenericMethodParameterRequirement<TUnknown> ()
+			{
+				LocalFunction ();
+
+				void LocalFunction () => MethodWithGenericWhichRequiresMethods<TUnknown> ();
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static void TestGenericTypeParameterRequirement<TUnknown> ()
+			{
+				LocalFunction ();
+
+				void LocalFunction () => new TypeWithGenericWhichRequiresNonPublicFields<TUnknown> ();
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static void TestGenericLocalFunction<TUnknown> ()
+			{
+				LocalFunction<TUnknown> ();
+
+				void LocalFunction<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] T> ()
+				{
+					typeof (T).RequiresPublicMethods ();
+				}
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static void TestGenericLocalFunctionInner<TUnknown> ()
+			{
+				LocalFunction<TUnknown> ();
+
+				void LocalFunction<TSecond> ()
+				{
+					typeof (TUnknown).RequiresPublicMethods ();
+					typeof (TSecond).RequiresPublicMethods ();
+				}
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static void TestCallRUCMethodInLtftnLocalFunction ()
+			{
+				var _ = new Action (LocalFunction);
+
+				void LocalFunction () => RequiresUnreferencedCodeMethod ();
+			}
+
+			class DynamicallyAccessedLocalFunction
+			{
+				[RequiresUnreferencedCode ("Suppress in body")]
+				public static void TestCallRUCMethodInDynamicallyAccessedLocalFunction ()
+				{
+					typeof (DynamicallyAccessedLocalFunction).RequiresNonPublicMethods ();
+
+					void LocalFunction () => RequiresUnreferencedCodeMethod ();
+				}
+			}
+
+			[ExpectedWarning ("IL2026")]
+			static void TestSuppressionLocalFunction ()
+			{
+				LocalFunction (); // This will produce a warning since the location function has RUC on it
+
+				[RequiresUnreferencedCode ("Suppress in body")]
+				void LocalFunction (Type unknownType = null)
+				{
+					RequiresUnreferencedCodeMethod ();
+					unknownType.RequiresNonPublicMethods ();
+				}
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static void TestSuppressionOnOuterAndLocalFunction ()
+			{
+				LocalFunction ();
+
+				[RequiresUnreferencedCode ("Suppress in body")]
+				void LocalFunction (Type unknownType = null)
+				{
+					RequiresUnreferencedCodeMethod ();
+					unknownType.RequiresNonPublicMethods ();
+				}
+			}
+
+			[UnconditionalSuppressMessage ("Trimming", "IL2026")]
+			public static void Test ()
+			{
+				TestCall ();
+				TestCallWithClosure ();
+				TestReflectionAccess ();
+				TestLdftn ();
+				TestMethodParameterWithRequirements ();
+				TestDynamicallyAccessedMethod ();
+				TestGenericMethodParameterRequirement<TestType> ();
+				TestGenericTypeParameterRequirement<TestType> ();
+				TestGenericLocalFunction<TestType> ();
+				TestGenericLocalFunctionInner<TestType> ();
+				TestCallRUCMethodInLtftnLocalFunction ();
+				DynamicallyAccessedLocalFunction.TestCallRUCMethodInDynamicallyAccessedLocalFunction ();
+				TestSuppressionLocalFunction ();
+				TestSuppressionOnOuterAndLocalFunction ();
+			}
+		}
+
+		class WarnInLambda
+		{
+			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true)]
+			static void TestCall ()
+			{
+				Action _ = () => RequiresUnreferencedCodeMethod ();
+			}
+
+			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true)]
+			static void TestCallWithClosure (int p = 0)
+			{
+				Action _ = () => {
+					p++;
+					RequiresUnreferencedCodeMethod ();
+				};
+			}
+
+			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true, GlobalAnalysisOnly = true)]
+			static void TestReflectionAccess ()
+			{
+				Action _ = () => {
+					typeof (RequiresUnreferencedCodeInCompilerGeneratedCode)
+						.GetMethod ("RequiresUnreferencedCodeMethod", System.Reflection.BindingFlags.NonPublic)
+						.Invoke (null, new object[] { });
+				};
+			}
+
+			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true)]
+			static void TestLdftn ()
+			{
+				Action _ = () => {
+					var action = new Action (RequiresUnreferencedCodeMethod);
+				};
+			}
+
+			[ExpectedWarning ("IL2026", "--TypeWithRUCMethod.RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true, GlobalAnalysisOnly = true)]
+			static void TestDynamicallyAccessedMethod ()
+			{
+				Action _ = () => {
+					typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
+				};
+			}
+
+			public static void Test ()
+			{
+				TestCall ();
+				TestCallWithClosure ();
+				TestReflectionAccess ();
+				TestLdftn ();
+				TestDynamicallyAccessedMethod ();
+			}
+		}
+
+		class SuppressInLambda
+		{
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static void TestCall ()
+			{
+				Action _ = () => RequiresUnreferencedCodeMethod ();
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static void TestCallWithReflectionAnalysisWarning ()
+			{
+				// This should not produce warning because the RUC
+				Action<Type> _ = (t) => t.RequiresPublicMethods ();
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static void TestCallWithClosure (int p = 0)
+			{
+				Action _ = () => {
+					p++;
+					RequiresUnreferencedCodeMethod ();
+				};
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static void TestReflectionAccess ()
+			{
+				Action _ = () => {
+					typeof (RequiresUnreferencedCodeInCompilerGeneratedCode)
+						.GetMethod ("RequiresUnreferencedCodeMethod", System.Reflection.BindingFlags.NonPublic)
+						.Invoke (null, new object[] { });
+				};
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static void TestLdftn ()
+			{
+				Action _ = () => {
+					var action = new Action (RequiresUnreferencedCodeMethod);
+				};
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static void TestDynamicallyAccessedMethod ()
+			{
+				Action _ = () => {
+					typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
+				};
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static async void TestMethodParameterWithRequirements (Type unknownType = null)
+			{
+				Action _ = () => unknownType.RequiresNonPublicMethods ();
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static void TestGenericMethodParameterRequirement<TUnknown> ()
+			{
+				Action _ = () => {
+					MethodWithGenericWhichRequiresMethods<TUnknown> ();
+				};
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static void TestGenericTypeParameterRequirement<TUnknown> ()
+			{
+				Action _ = () => {
+					new TypeWithGenericWhichRequiresNonPublicFields<TUnknown> ();
+				};
+			}
+
+			[UnconditionalSuppressMessage ("Trimming", "IL2026")]
+			public static void Test ()
+			{
+				TestCall ();
+				TestCallWithReflectionAnalysisWarning ();
+				TestCallWithClosure ();
+				TestReflectionAccess ();
+				TestLdftn ();
+				TestDynamicallyAccessedMethod ();
+				TestMethodParameterWithRequirements ();
+				TestGenericMethodParameterRequirement<TestType> ();
+				TestGenericTypeParameterRequirement<TestType> ();
+			}
+		}
+
+		class WarnInComplex
+		{
+			[ExpectedWarning ("IL2026", "--RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true)]
+			static async void TestIteratorLocalFunctionInAsync ()
+			{
+				await MethodAsync ();
+				LocalFunction ();
+				await MethodAsync ();
+
+				IEnumerable<int> LocalFunction ()
+				{
+					yield return 0;
+					RequiresUnreferencedCodeMethod ();
+					yield return 1;
+				}
+			}
+
+			[ExpectedWarning ("IL2026", "--TypeWithRUCMethod.RequiresUnreferencedCodeMethod--", CompilerGeneratedCode = true, GlobalAnalysisOnly = true)]
+			static IEnumerable<int> TestDynamicallyAccessedMethodViaGenericMethodParameterInIterator ()
+			{
+				yield return 1;
+				MethodWithGenericWhichRequiresMethods<TypeWithRUCMethod> ();
+			}
+
+			public static void Test ()
+			{
+				TestIteratorLocalFunctionInAsync ();
+				TestDynamicallyAccessedMethodViaGenericMethodParameterInIterator ();
+			}
+		}
+
+		class SuppressInComplex
+		{
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static async void TestIteratorLocalFunctionInAsync ()
+			{
+				await MethodAsync ();
+				LocalFunction ();
+				await MethodAsync ();
+
+				IEnumerable<int> LocalFunction ()
+				{
+					yield return 0;
+					RequiresUnreferencedCodeMethod ();
+					yield return 1;
+				}
+			}
+
+			[RequiresUnreferencedCode ("Suppress in body")]
+			static IEnumerable<int> TestDynamicallyAccessedMethodViaGenericMethodParameterInIterator ()
+			{
+				MethodWithGenericWhichRequiresMethods<TypeWithRUCMethod> ();
+				yield return 0;
+			}
+
+			[UnconditionalSuppressMessage ("Trimming", "IL2026")]
+			public static void Test ()
+			{
+				TestIteratorLocalFunctionInAsync ();
+				TestDynamicallyAccessedMethodViaGenericMethodParameterInIterator ();
+			}
+		}
+
+		static async Task<int> MethodAsync ()
+		{
+			return await Task.FromResult (0);
+		}
+
+		[RequiresUnreferencedCode ("--RequiresUnreferencedCodeMethod--")]
+		static void RequiresUnreferencedCodeMethod ()
+		{
+		}
+
+		class TypeWithRUCMethod
+		{
+			[RequiresUnreferencedCode ("--TypeWithRUCMethod.RequiresUnreferencedCodeMethod--")]
+			static void RequiresUnreferencedCodeMethod ()
+			{
+			}
+		}
+
+		static void MethodWithGenericWhichRequiresMethods<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicMethods)] T> ()
+		{
+		}
+
+		class TypeWithGenericWhichRequiresNonPublicFields<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicFields)] T> { }
+
+		class TestType { }
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCompilerGeneratedCode.cs
@@ -1,0 +1,417 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
+
+namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
+{
+	[SkipKeptItemsValidation]
+	[ExpectedNoWarnings]
+	public class SuppressWarningsInCompilerGeneratedCode
+	{
+		public static void Main ()
+		{
+			SuppressInIteratorBody.Test ();
+			SuppressInAsyncBody.Test ();
+			SuppressInLocalFunction.Test ();
+			SuppressInLambda.Test ();
+			SuppressInComplex.Test ();
+		}
+		class SuppressInIteratorBody
+		{
+			[UnconditionalSuppressMessage ("Test", "IL2026")]
+			static IEnumerable<int> TestCallRUCMethod ()
+			{
+				RequiresUnreferencedCodeMethod ();
+				yield return 0;
+			}
+
+			[UnconditionalSuppressMessage ("Test", "IL2026")]
+			static IEnumerable<int> TestReflectionAccessRUCMethod ()
+			{
+				yield return 0;
+				typeof (SuppressWarningsInCompilerGeneratedCode)
+					.GetMethod ("RequiresUnreferencedCodeMethod", System.Reflection.BindingFlags.NonPublic)
+					.Invoke (null, new object[] { });
+				yield return 0;
+			}
+
+			[UnconditionalSuppressMessage ("Test", "IL2026")]
+			static IEnumerable<int> TestLdftnOnRUCMethod ()
+			{
+				yield return 0;
+				var _ = new Action (RequiresUnreferencedCodeMethod);
+			}
+
+			[UnconditionalSuppressMessage ("Test", "IL2026")]
+			static IEnumerable<int> TestDynamicallyAccessedMethod ()
+			{
+				typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
+				yield return 0;
+			}
+
+			[UnconditionalSuppressMessage ("Test", "IL2077")]
+			static IEnumerable<int> TestMethodParameterWithRequirements (Type unknownType = null)
+			{
+				unknownType.RequiresNonPublicMethods ();
+				yield return 0;
+			}
+
+			[UnconditionalSuppressMessage ("Test", "IL2091")]
+			static IEnumerable<int> TestGenericMethodParameterRequirement<TUnknown> ()
+			{
+				MethodWithGenericWhichRequiresMethods<TUnknown> ();
+				yield return 0;
+			}
+
+			[UnconditionalSuppressMessage ("Test", "IL2091")]
+			static IEnumerable<int> TestGenericTypeParameterRequirement<TUnknown> ()
+			{
+				new TypeWithGenericWhichRequiresNonPublicFields<TUnknown> ();
+				yield return 0;
+			}
+
+			public static void Test ()
+			{
+				TestCallRUCMethod ();
+				TestReflectionAccessRUCMethod ();
+				TestLdftnOnRUCMethod ();
+				TestDynamicallyAccessedMethod ();
+				TestMethodParameterWithRequirements ();
+				TestGenericMethodParameterRequirement<TestType> ();
+				TestGenericTypeParameterRequirement<TestType> ();
+			}
+		}
+
+		class SuppressInAsyncBody
+		{
+			[UnconditionalSuppressMessage ("Test", "IL2026")]
+			static async void TestCallRUCMethod ()
+			{
+				RequiresUnreferencedCodeMethod ();
+				await MethodAsync ();
+			}
+
+			[UnconditionalSuppressMessage ("Test", "IL2026")]
+			static async void TestReflectionAccessRUCMethod ()
+			{
+				await MethodAsync ();
+				typeof (SuppressWarningsInCompilerGeneratedCode)
+					.GetMethod ("RequiresUnreferencedCodeMethod", System.Reflection.BindingFlags.NonPublic)
+					.Invoke (null, new object[] { });
+				await MethodAsync ();
+			}
+
+			[UnconditionalSuppressMessage ("Test", "IL2026")]
+			static async void TestLdftnOnRUCMethod ()
+			{
+				await MethodAsync ();
+				var _ = new Action (RequiresUnreferencedCodeMethod);
+			}
+
+			[UnconditionalSuppressMessage ("Test", "IL2026")]
+			static async void TestDynamicallyAccessedMethod ()
+			{
+				typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
+				await MethodAsync ();
+			}
+
+			[UnconditionalSuppressMessage ("Test", "IL2077")]
+			static async void TestMethodParameterWithRequirements (Type unknownType = null)
+			{
+				unknownType.RequiresNonPublicMethods ();
+				await MethodAsync ();
+			}
+
+			[UnconditionalSuppressMessage ("Test", "IL2091")]
+			static async void TestGenericMethodParameterRequirement<TUnknown> ()
+			{
+				MethodWithGenericWhichRequiresMethods<TUnknown> ();
+				await MethodAsync ();
+			}
+
+			[UnconditionalSuppressMessage ("Test", "IL2091")]
+			static async void TestGenericTypeParameterRequirement<TUnknown> ()
+			{
+				new TypeWithGenericWhichRequiresNonPublicFields<TUnknown> ();
+				await MethodAsync ();
+			}
+
+			public static void Test ()
+			{
+				TestCallRUCMethod ();
+				TestReflectionAccessRUCMethod ();
+				TestLdftnOnRUCMethod ();
+				TestDynamicallyAccessedMethod ();
+				TestMethodParameterWithRequirements ();
+				TestGenericMethodParameterRequirement<TestType> ();
+				TestGenericTypeParameterRequirement<TestType> ();
+			}
+		}
+
+		class SuppressInLocalFunction
+		{
+			[UnconditionalSuppressMessage ("Test", "IL2026")]
+			static void TestCallRUCMethod ()
+			{
+				LocalFunction ();
+
+				void LocalFunction () => RequiresUnreferencedCodeMethod ();
+			}
+
+			[UnconditionalSuppressMessage ("Test", "IL2026")]
+			static void TestReflectionAccessRUCMethod ()
+			{
+				LocalFunction ();
+
+				void LocalFunction () => typeof (SuppressWarningsInCompilerGeneratedCode)
+					.GetMethod ("RequiresUnreferencedCodeMethod", System.Reflection.BindingFlags.NonPublic)
+					.Invoke (null, new object[] { });
+			}
+
+			[UnconditionalSuppressMessage ("Test", "IL2026")]
+			static void TestLdftnOnRUCMethod ()
+			{
+				LocalFunction ();
+
+				void LocalFunction () { var _ = new Action (RequiresUnreferencedCodeMethod); }
+			}
+
+			[UnconditionalSuppressMessage ("Test", "IL2026")]
+			static void TestDynamicallyAccessedMethod ()
+			{
+				LocalFunction ();
+
+				void LocalFunction () => typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
+			}
+
+			[UnconditionalSuppressMessage ("Test", "IL2077")]
+			static void TestMethodParameterWithRequirements (Type unknownType = null)
+			{
+				LocalFunction ();
+
+				void LocalFunction () => unknownType.RequiresNonPublicMethods ();
+			}
+
+			[UnconditionalSuppressMessage ("Test", "IL2091")]
+			static void TestGenericMethodParameterRequirement<TUnknown> ()
+			{
+				LocalFunction ();
+
+				void LocalFunction () => MethodWithGenericWhichRequiresMethods<TUnknown> ();
+			}
+
+			[UnconditionalSuppressMessage ("Test", "IL2091")]
+			static void TestGenericTypeParameterRequirement<TUnknown> ()
+			{
+				LocalFunction ();
+
+				void LocalFunction () => new TypeWithGenericWhichRequiresNonPublicFields<TUnknown> ();
+			}
+
+			[UnconditionalSuppressMessage ("Test", "IL2091")]
+			static void TestGenericLocalFunction<TUnknown> ()
+			{
+				LocalFunction<TUnknown> ();
+
+				void LocalFunction<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] T> ()
+				{
+					typeof (T).RequiresPublicMethods ();
+				}
+			}
+
+			[UnconditionalSuppressMessage ("Test", "IL2087")]
+			static void TestGenericLocalFunctionInner<TUnknown> ()
+			{
+				LocalFunction<TUnknown> ();
+
+				void LocalFunction<TSecond> ()
+				{
+					typeof (TUnknown).RequiresPublicMethods ();
+					typeof (TSecond).RequiresPublicMethods ();
+				}
+			}
+
+			[UnconditionalSuppressMessage ("Test", "IL2026")]
+			static void TestCallRUCMethodInLtftnLocalFunction ()
+			{
+				var _ = new Action (LocalFunction);
+
+				void LocalFunction () => RequiresUnreferencedCodeMethod ();
+			}
+
+			class DynamicallyAccessedLocalFunction
+			{
+				[UnconditionalSuppressMessage ("Test", "IL2026")]
+				public static void TestCallRUCMethodInDynamicallyAccessedLocalFunction ()
+				{
+					typeof (DynamicallyAccessedLocalFunction).RequiresNonPublicMethods ();
+
+					void LocalFunction () => RequiresUnreferencedCodeMethod ();
+				}
+			}
+
+			static void TestSuppressionOnLocalFunction ()
+			{
+				LocalFunction ();
+
+				[UnconditionalSuppressMessage ("Test", "IL2026")] // This supresses the RequiresUnreferencedCodeMethod
+				void LocalFunction (Type unknownType = null)
+				{
+					RequiresUnreferencedCodeMethod ();
+				}
+			}
+
+			[UnconditionalSuppressMessage ("Test", "IL2067")] // This suppresses the unknownType.RequiresNonPublicMethods
+			static void TestSuppressionOnOuterAndLocalFunction ()
+			{
+				LocalFunction ();
+
+				[UnconditionalSuppressMessage ("Test", "IL2026")] // This supresses the RequiresUnreferencedCodeMethod
+				void LocalFunction (Type unknownType = null)
+				{
+					RequiresUnreferencedCodeMethod ();
+					unknownType.RequiresNonPublicMethods ();
+				}
+			}
+
+			public static void Test ()
+			{
+				TestCallRUCMethod ();
+				TestReflectionAccessRUCMethod ();
+				TestLdftnOnRUCMethod ();
+				TestDynamicallyAccessedMethod ();
+				TestMethodParameterWithRequirements ();
+				TestGenericMethodParameterRequirement<TestType> ();
+				TestGenericTypeParameterRequirement<TestType> ();
+				TestGenericLocalFunction<TestType> ();
+				TestGenericLocalFunctionInner<TestType> ();
+				TestCallRUCMethodInLtftnLocalFunction ();
+				DynamicallyAccessedLocalFunction.TestCallRUCMethodInDynamicallyAccessedLocalFunction ();
+				TestSuppressionOnLocalFunction ();
+				TestSuppressionOnOuterAndLocalFunction ();
+			}
+		}
+
+		class SuppressInLambda
+		{
+			[UnconditionalSuppressMessage ("Test", "IL2026")]
+			static void TestCallRUCMethod ()
+			{
+				Action _ = () => RequiresUnreferencedCodeMethod ();
+			}
+
+			[UnconditionalSuppressMessage ("Test", "IL2026")]
+			static void TestReflectionAccessRUCMethod ()
+			{
+				Action _ = () => typeof (SuppressWarningsInCompilerGeneratedCode)
+					.GetMethod ("RequiresUnreferencedCodeMethod", System.Reflection.BindingFlags.NonPublic)
+					.Invoke (null, new object[] { });
+			}
+
+			[UnconditionalSuppressMessage ("Test", "IL2026")]
+			static void TestLdftnOnRUCMethod ()
+			{
+				Action _ = () => { var _ = new Action (RequiresUnreferencedCodeMethod); };
+			}
+
+			[UnconditionalSuppressMessage ("Test", "IL2026")]
+			static void TestDynamicallyAccessedMethod ()
+			{
+				Action _ = () => typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
+			}
+
+			[UnconditionalSuppressMessage ("Test", "IL2077")]
+			static void TestMethodParameterWithRequirements (Type unknownType = null)
+			{
+				Action _ = () => unknownType.RequiresNonPublicMethods ();
+			}
+
+			[UnconditionalSuppressMessage ("Test", "IL2091")]
+			static void TestGenericMethodParameterRequirement<TUnknown> ()
+			{
+				Action _ = () => MethodWithGenericWhichRequiresMethods<TUnknown> ();
+			}
+
+			[UnconditionalSuppressMessage ("Test", "IL2091")]
+			static void TestGenericTypeParameterRequirement<TUnknown> ()
+			{
+				Action _ = () => new TypeWithGenericWhichRequiresNonPublicFields<TUnknown> ();
+			}
+
+			public static void Test ()
+			{
+				TestCallRUCMethod ();
+				TestReflectionAccessRUCMethod ();
+				TestLdftnOnRUCMethod ();
+				TestDynamicallyAccessedMethod ();
+				TestMethodParameterWithRequirements ();
+				TestGenericMethodParameterRequirement<TestType> ();
+				TestGenericTypeParameterRequirement<TestType> ();
+			}
+		}
+
+		class SuppressInComplex
+		{
+			[UnconditionalSuppressMessage ("Test", "IL2026")]
+			static async void TestIteratorLocalFunctionInAsync ()
+			{
+				await MethodAsync ();
+				LocalFunction ();
+				await MethodAsync ();
+
+				IEnumerable<int> LocalFunction ()
+				{
+					yield return 0;
+					RequiresUnreferencedCodeMethod ();
+					yield return 1;
+				}
+			}
+
+			[UnconditionalSuppressMessage ("Test", "IL2026")]
+			static IEnumerable<int> TestDynamicallyAccessedMethodViaGenericMethodParameterInIterator ()
+			{
+				MethodWithGenericWhichRequiresMethods<TypeWithRUCMethod> ();
+				yield return 0;
+			}
+
+			public static void Test ()
+			{
+				TestIteratorLocalFunctionInAsync ();
+				TestDynamicallyAccessedMethodViaGenericMethodParameterInIterator ();
+			}
+		}
+
+		static async Task<int> MethodAsync ()
+		{
+			return await Task.FromResult (0);
+		}
+
+		[RequiresUnreferencedCode ("--RequiresUnreferencedCodeMethod--")]
+		static void RequiresUnreferencedCodeMethod ()
+		{
+		}
+
+		class TypeWithRUCMethod
+		{
+			[RequiresUnreferencedCode ("--TypeWithRUCMethod.RequiresUnreferencedCodeMethod--")]
+			static void RequiresUnreferencedCodeMethod ()
+			{
+			}
+		}
+
+		static void MethodWithGenericWhichRequiresMethods<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicMethods)] T> ()
+		{
+		}
+
+		class TypeWithGenericWhichRequiresNonPublicFields<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicFields)] T> { }
+
+		class TestType { }
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCompilerGeneratedCode.cs
@@ -157,11 +157,14 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 
 		class SuppressInLocalFunction
 		{
+			// Suppression currently doesn't propagate to local functions
+
 			[UnconditionalSuppressMessage ("Test", "IL2026")]
 			static void TestCallRUCMethod ()
 			{
 				LocalFunction ();
 
+				[ExpectedWarning ("IL2026")]
 				void LocalFunction () => RequiresUnreferencedCodeMethod ();
 			}
 
@@ -170,6 +173,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				LocalFunction ();
 
+				[ExpectedWarning ("IL2026")]
 				void LocalFunction () => typeof (SuppressWarningsInCompilerGeneratedCode)
 					.GetMethod ("RequiresUnreferencedCodeMethod", System.Reflection.BindingFlags.NonPublic)
 					.Invoke (null, new object[] { });
@@ -180,7 +184,9 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				LocalFunction ();
 
-				void LocalFunction () { var _ = new Action (RequiresUnreferencedCodeMethod); }
+				[ExpectedWarning ("IL2026")]
+				void LocalFunction ()
+				{ var _ = new Action (RequiresUnreferencedCodeMethod); }
 			}
 
 			[UnconditionalSuppressMessage ("Test", "IL2026")]
@@ -188,6 +194,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				LocalFunction ();
 
+				[ExpectedWarning ("IL2026")]
 				void LocalFunction () => typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
 			}
 
@@ -196,6 +203,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				LocalFunction ();
 
+				[ExpectedWarning ("IL2077")]
 				void LocalFunction () => unknownType.RequiresNonPublicMethods ();
 			}
 
@@ -204,6 +212,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				LocalFunction ();
 
+				[ExpectedWarning ("IL2091")]
 				void LocalFunction () => MethodWithGenericWhichRequiresMethods<TUnknown> ();
 			}
 
@@ -212,6 +221,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				LocalFunction ();
 
+				[ExpectedWarning ("IL2091")]
 				void LocalFunction () => new TypeWithGenericWhichRequiresNonPublicFields<TUnknown> ();
 			}
 
@@ -231,10 +241,34 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				LocalFunction<TUnknown> ();
 
+				[ExpectedWarning ("IL2087")]
 				void LocalFunction<TSecond> ()
 				{
 					typeof (TUnknown).RequiresPublicMethods ();
 					typeof (TSecond).RequiresPublicMethods ();
+				}
+			}
+
+			static void TestGenericLocalFunctionWithAnnotations<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] TPublicMethods> ()
+			{
+				LocalFunction<TPublicMethods> ();
+
+				void LocalFunction<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] TInnerPublicMethods> ()
+				{
+					typeof (TPublicMethods).RequiresPublicMethods ();
+					typeof (TInnerPublicMethods).RequiresPublicMethods ();
+				}
+			}
+
+			static void TestGenericLocalFunctionWithAnnotationsAndClosure<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] TPublicMethods> (int p = 0)
+			{
+				LocalFunction<TPublicMethods> ();
+
+				void LocalFunction<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] TInnerPublicMethods> ()
+				{
+					p++;
+					typeof (TPublicMethods).RequiresPublicMethods ();
+					typeof (TInnerPublicMethods).RequiresPublicMethods ();
 				}
 			}
 
@@ -243,6 +277,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				var _ = new Action (LocalFunction);
 
+				[ExpectedWarning ("IL2026")]
 				void LocalFunction () => RequiresUnreferencedCodeMethod ();
 			}
 
@@ -253,6 +288,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 				{
 					typeof (DynamicallyAccessedLocalFunction).RequiresNonPublicMethods ();
 
+					[ExpectedWarning ("IL2026")]
 					void LocalFunction () => RequiresUnreferencedCodeMethod ();
 				}
 			}
@@ -273,6 +309,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				LocalFunction ();
 
+				[ExpectedWarning ("IL2067")]
 				[UnconditionalSuppressMessage ("Test", "IL2026")] // This supresses the RequiresUnreferencedCodeMethod
 				void LocalFunction (Type unknownType = null)
 				{
@@ -301,12 +338,16 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 
 		class SuppressInLambda
 		{
+			// Suppression currently doesn't propagate to local functions
+
+			[ExpectedWarning ("IL2026", CompilerGeneratedCode = true)]
 			[UnconditionalSuppressMessage ("Test", "IL2026")]
 			static void TestCallRUCMethod ()
 			{
 				Action _ = () => RequiresUnreferencedCodeMethod ();
 			}
 
+			[ExpectedWarning ("IL2026", CompilerGeneratedCode = true)]
 			[UnconditionalSuppressMessage ("Test", "IL2026")]
 			static void TestReflectionAccessRUCMethod ()
 			{
@@ -315,30 +356,35 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 					.Invoke (null, new object[] { });
 			}
 
+			[ExpectedWarning ("IL2026", CompilerGeneratedCode = true)]
 			[UnconditionalSuppressMessage ("Test", "IL2026")]
 			static void TestLdftnOnRUCMethod ()
 			{
 				Action _ = () => { var _ = new Action (RequiresUnreferencedCodeMethod); };
 			}
 
+			[ExpectedWarning ("IL2026", CompilerGeneratedCode = true)]
 			[UnconditionalSuppressMessage ("Test", "IL2026")]
 			static void TestDynamicallyAccessedMethod ()
 			{
 				Action _ = () => typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
 			}
 
+			[ExpectedWarning ("IL2077", CompilerGeneratedCode = true)]
 			[UnconditionalSuppressMessage ("Test", "IL2077")]
 			static void TestMethodParameterWithRequirements (Type unknownType = null)
 			{
 				Action _ = () => unknownType.RequiresNonPublicMethods ();
 			}
 
+			[ExpectedWarning ("IL2091", CompilerGeneratedCode = true)]
 			[UnconditionalSuppressMessage ("Test", "IL2091")]
 			static void TestGenericMethodParameterRequirement<TUnknown> ()
 			{
 				Action _ = () => MethodWithGenericWhichRequiresMethods<TUnknown> ();
 			}
 
+			[ExpectedWarning ("IL2091", CompilerGeneratedCode = true)]
 			[UnconditionalSuppressMessage ("Test", "IL2091")]
 			static void TestGenericTypeParameterRequirement<TUnknown> ()
 			{
@@ -366,6 +412,23 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 				LocalFunction ();
 				await MethodAsync ();
 
+				[UnconditionalSuppressMessage ("Test", "IL2026")]
+				IEnumerable<int> LocalFunction ()
+				{
+					yield return 0;
+					RequiresUnreferencedCodeMethod ();
+					yield return 1;
+				}
+			}
+
+			[UnconditionalSuppressMessage ("Test", "IL2026")]
+			static async void TestIteratorLocalFunctionInAsyncWithoutInner ()
+			{
+				await MethodAsync ();
+				LocalFunction ();
+				await MethodAsync ();
+
+				[ExpectedWarning ("IL2026", CompilerGeneratedCode = true)]
 				IEnumerable<int> LocalFunction ()
 				{
 					yield return 0;
@@ -384,6 +447,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			public static void Test ()
 			{
 				TestIteratorLocalFunctionInAsync ();
+				TestIteratorLocalFunctionInAsyncWithoutInner ();
 				TestDynamicallyAccessedMethodViaGenericMethodParameterInIterator ();
 			}
 		}

--- a/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -707,6 +707,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 								string fileName = (string) attr.GetPropertyValue ("FileName");
 								int? sourceLine = (int?) attr.GetPropertyValue ("SourceLine");
 								int? sourceColumn = (int?) attr.GetPropertyValue ("SourceColumn");
+								bool? isCompilerGeneratedCode = (bool?) attr.GetPropertyValue ("CompilerGeneratedCode");
 
 								int expectedWarningCodeNumber = int.Parse (expectedWarningCode.Substring (2));
 								var actualMethod = attrProvider as MethodDefinition;
@@ -751,6 +752,16 @@ namespace Mono.Linker.Tests.TestCasesRunner
 											if (!actualOrigin.ToString ().EndsWith (expectedOrigin, StringComparison.OrdinalIgnoreCase))
 												return false;
 										}
+									} else if (isCompilerGeneratedCode == true) {
+										MethodDefinition methodDefinition = mc.Origin?.MemberDefinition as MethodDefinition;
+										if (methodDefinition != null) {
+											string actualName = methodDefinition.DeclaringType.FullName + "." + methodDefinition.Name;
+											if (actualName.StartsWith (attrProvider.DeclaringType.FullName) &&
+												actualName.Contains ("<" + attrProvider.Name + ">"))
+												return true;
+										}
+
+										return false;
 									} else {
 										if (mc.Origin?.MemberDefinition?.FullName == attrProvider.FullName)
 											return true;


### PR DESCRIPTION
This change implements the following high-level functionality:
* `UnconditionalSuppressMessage` applies to the entire method body even for iterators, async methods
* `RequiresUnreferencedCode` automatically suppresses trim analysis warnings from entire method body for iterators, async methods

Solution approach:
* Detect compiler generated code by using the `IteratorStateMachineAttribute`, `AsyncStateMachineAttribute` and `AyncIteratorStateMachineAttribute`.
  * When a method which is compiler generated (detected by looing for `<` in its name) is processed the original "user method" is determined by looking for a method with the "state machine" attribute pointing to the compiler generated type.
  * This information is cached to avoid duplication of relatively expensive detection logic.
* Looks for `UnconditionalSuppressMessage` and `RequriesUnreferencedCode` in:
  * If the warning origin is not a compiler generated code - simply use the warning origin (method) - existing behavior
  * If the warning origin is compiler generated use both the origin as well as the user defined method (non-compiler-generated) which is the source of the code for the compiler generated origin

This is done by storing additional `SuppressionContextMember` on `MessageOrigin` which should always point to non-compiler-generated item.

Added lot of new tests for these scenarios.

This implements warning suppression part of https://github.com/mono/linker/issues/2001 for state machines.