### PR TITLE
Handle different dynamic member access for multiple branches

### DIFF
--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -1777,27 +1777,17 @@ namespace Mono.Linker.Dataflow
 			}
 
 			// Validate that the return value has the correct annotations as per the method return value annotations
-			if (returnValueDynamicallyAccessedMemberTypes != 0 && methodReturnValue != null) {
-				if (methodReturnValue is LeafValueWithDynamicallyAccessedMemberNode methodReturnValueWithMemberTypes) {
-					if (!methodReturnValueWithMemberTypes.DynamicallyAccessedMemberTypes.HasFlag (returnValueDynamicallyAccessedMemberTypes))
-						throw new InvalidOperationException ($"Internal linker error: processing of call from {callingMethodDefinition.GetDisplayName ()} to {calledMethod.GetDisplayName ()} returned value which is not correctly annotated with the expected dynamic member access kinds.");
-				} else if (methodReturnValue is SystemTypeValue) {
-					// SystemTypeValue can fullfill any requirement, so it's always valid
-					// The requirements will be applied at the point where it's consumed (passed as a method parameter, set as field value, returned from the method)
-				} else if (methodReturnValue is MergePointValue mergePointValue) {
-					foreach (var uniqueValue in mergePointValue.UniqueValues ()) {
-						if (uniqueValue is LeafValueWithDynamicallyAccessedMemberNode uniqueMethodReturnValueWithMemberTypes) {
-							if (!uniqueMethodReturnValueWithMemberTypes.DynamicallyAccessedMemberTypes.HasFlag (returnValueDynamicallyAccessedMemberTypes))
-								throw new InvalidOperationException ($"Internal linker error: processing of call from {callingMethodDefinition.GetDisplayName ()} to {calledMethod.GetDisplayName ()} returned value which is not correctly annotated with the expected dynamic member access kinds.");
-						} else if (uniqueValue is SystemTypeValue) {
-							// SystemTypeValue can fullfill any requirement, so it's always valid
-							// The requirements will be applied at the point where it's consumed (passed as a method parameter, set as field value, returned from the method)
-						} else {
+			if (returnValueDynamicallyAccessedMemberTypes != 0) {
+				foreach (var uniqueValue in methodReturnValue.UniqueValues ()) {
+					if (uniqueValue is LeafValueWithDynamicallyAccessedMemberNode methodReturnValueWithMemberTypes) {
+						if (!methodReturnValueWithMemberTypes.DynamicallyAccessedMemberTypes.HasFlag (returnValueDynamicallyAccessedMemberTypes))
 							throw new InvalidOperationException ($"Internal linker error: processing of call from {callingMethodDefinition.GetDisplayName ()} to {calledMethod.GetDisplayName ()} returned value which is not correctly annotated with the expected dynamic member access kinds.");
-						}
+					} else if (uniqueValue is SystemTypeValue) {
+						// SystemTypeValue can fullfill any requirement, so it's always valid
+						// The requirements will be applied at the point where it's consumed (passed as a method parameter, set as field value, returned from the method)
+					} else {
+						throw new InvalidOperationException ($"Internal linker error: processing of call from {callingMethodDefinition.GetDisplayName ()} to {calledMethod.GetDisplayName ()} returned value which is not correctly annotated with the expected dynamic member access kinds.");
 					}
-				} else {
-					throw new InvalidOperationException ($"Internal linker error: processing of call from {callingMethodDefinition.GetDisplayName ()} to {calledMethod.GetDisplayName ()} returned value which is not correctly annotated with the expected dynamic member access kinds.");
 				}
 			}
 

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -1784,6 +1784,18 @@ namespace Mono.Linker.Dataflow
 				} else if (methodReturnValue is SystemTypeValue) {
 					// SystemTypeValue can fullfill any requirement, so it's always valid
 					// The requirements will be applied at the point where it's consumed (passed as a method parameter, set as field value, returned from the method)
+				} else if (methodReturnValue is MergePointValue mergePointValue) {
+					foreach (var uniqueValue in mergePointValue.UniqueValues ()) {
+						if (uniqueValue is LeafValueWithDynamicallyAccessedMemberNode uniqueMethodReturnValueWithMemberTypes) {
+							if (!uniqueMethodReturnValueWithMemberTypes.DynamicallyAccessedMemberTypes.HasFlag (returnValueDynamicallyAccessedMemberTypes))
+								throw new InvalidOperationException ($"Internal linker error: processing of call from {callingMethodDefinition.GetDisplayName ()} to {calledMethod.GetDisplayName ()} returned value which is not correctly annotated with the expected dynamic member access kinds.");
+						} else if (uniqueValue is SystemTypeValue) {
+							// SystemTypeValue can fullfill any requirement, so it's always valid
+							// The requirements will be applied at the point where it's consumed (passed as a method parameter, set as field value, returned from the method)
+						} else {
+							throw new InvalidOperationException ($"Internal linker error: processing of call from {callingMethodDefinition.GetDisplayName ()} to {calledMethod.GetDisplayName ()} returned value which is not correctly annotated with the expected dynamic member access kinds.");
+						}
+					}
 				} else {
 					throw new InvalidOperationException ($"Internal linker error: processing of call from {callingMethodDefinition.GetDisplayName ()} to {calledMethod.GetDisplayName ()} returned value which is not correctly annotated with the expected dynamic member access kinds.");
 				}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/GetInterfaceDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/GetInterfaceDataFlow.cs
@@ -69,7 +69,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[ExpectedWarning ("IL2075", nameof (DynamicallyAccessedMemberTypes) + "." + nameof (DynamicallyAccessedMemberTypes.Interfaces))]
 			static void TestMergedValues (int p, [DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] Type typeWithAll)
 			{
-				Type type = new TestType().GetType();
+				Type type = new TestType ().GetType ();
 				if (p == 0) {
 					type = typeWithAll;
 					type.GetInterface ("ITestInterface").RequiresInterfaces ();

--- a/test/Mono.Linker.Tests.Cases/DataFlow/GetInterfaceDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/GetInterfaceDataFlow.cs
@@ -66,6 +66,16 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				type.GetInterface ("ITestInterface").RequiresAll (); // Warns since only one of the values is guaranteed All
 			}
 
+			[ExpectedWarning ("IL2075", nameof (DynamicallyAccessedMemberTypes) + "." + nameof (DynamicallyAccessedMemberTypes.Interfaces))]
+			static void TestMergedValues (int p, [DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] Type typeWithAll)
+			{
+				Type type = new TestType().GetType();
+				if (p == 0) {
+					type = typeWithAll;
+					type.GetInterface ("ITestInterface").RequiresInterfaces ();
+				}
+			}
+
 			public static void Test ()
 			{
 				TestNoAnnotation (typeof (TestType));
@@ -74,6 +84,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				TestWithAll (typeof (TestType));
 				TestKnownType ();
 				TestMultipleValues (0, typeof (TestType));
+				TestMergedValues (0, typeof (TestType));
 			}
 		}
 


### PR DESCRIPTION
This case assume that all code branches should have same minimal dynamic access pattern

Was discovered as part of https://github.com/dotnet/runtimelab/issues/1187

Issue happens when 2 code blocks has diferent requirements for dynamic code access, and this produce MergePoint. This case was not handled.