### PR TITLE
Ignore binlog files in the root.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,6 @@ bin/
 .dotnet
 .packages
 artifacts
+*.binlog
 
 test/Mono.Linker.Tests/TestResults.xml


### PR DESCRIPTION
formatDiagnosticLog.binlog was generated by .\lint.cmd -v diagnostic