### PR TITLE
Improve tests for COM warnings from PInvokes

### DIFF
--- a/test/Mono.Linker.Tests.Cases/Interop/PInvoke/Warnings/ComPInvokeWarning.cs
+++ b/test/Mono.Linker.Tests.Cases/Interop/PInvoke/Warnings/ComPInvokeWarning.cs
@@ -1,31 +1,53 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Interop.PInvoke.Warnings
 {
-	[LogContains ("SomeMethodTakingInterface")]
-	[LogContains ("SomeMethodTakingObject")]
+	[SkipKeptItemsValidation]
+	[ExpectedNoWarnings]
 	[KeptModuleReference ("Foo")]
 	class ComPInvokeWarning
 	{
+		[UnconditionalSuppressMessage ("trim", "IL2026")]
 		static void Main ()
 		{
 			SomeMethodTakingInterface (null);
 			SomeMethodTakingObject (null);
+			GetInterface ();
+			CanSuppressWarningOnParameter (null);
+			CanSuppressWarningOnReturnType ();
+			CanSuppressWithRequiresUnreferencedCode (null);
 		}
 
-		[Kept]
+		[ExpectedWarning ("IL2050")]
 		[DllImport ("Foo")]
 		static extern void SomeMethodTakingInterface (IFoo foo);
 
-		[Kept]
+		[ExpectedWarning ("IL2050")]
 		[DllImport ("Foo")]
 		static extern void SomeMethodTakingObject ([MarshalAs (UnmanagedType.IUnknown)] object obj);
 
-		[Kept]
+		[ExpectedWarning ("IL2050")]
+		[DllImport ("Foo")]
+		static extern IFoo GetInterface ();
+
+		[UnconditionalSuppressMessage ("trim", "IL2050")]
+		[DllImport ("Foo")]
+		static extern void CanSuppressWarningOnParameter ([MarshalAs (UnmanagedType.IUnknown)] object obj);
+
+		[UnconditionalSuppressMessage ("trim", "IL2050")]
+		[DllImport ("Foo")]
+		static extern IFoo CanSuppressWarningOnReturnType ();
+
+		[ExpectedWarning ("IL2050")] // Issue https://github.com/mono/linker/issues/1989
+		[RequiresUnreferencedCode ("test")]
+		[DllImport ("Foo")]
+		static extern void CanSuppressWithRequiresUnreferencedCode (IFoo foo);
+
 		interface IFoo { }
 	}
 }


### PR DESCRIPTION
Use the ExpectedWarning test attributes. Add tests for more cases. Add tests for suppression and for RUC interaction.

Related to discussion in https://github.com/mono/linker/issues/1989.