### PR TITLE
Fix order of custom steps

### DIFF
--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -164,7 +164,7 @@ namespace Mono.Linker
 
 			var body_substituter_steps = new Stack<string> ();
 			var xml_custom_attribute_steps = new Stack<string> ();
-			var custom_steps = new Stack<string> ();
+			var custom_steps = new List<string> ();
 			var set_optimizations = new List<(CodeOptimizations, string, bool)> ();
 			bool dumpDependencies = false;
 			string dependenciesFileName = null;
@@ -298,7 +298,7 @@ namespace Mono.Linker
 							continue;
 						}
 					case "--custom-step":
-						if (!GetStringParam (token, l => custom_steps.Push (l)))
+						if (!GetStringParam (token, l => custom_steps.Add (l)))
 							return -1;
 
 						continue;

--- a/test/ILLink.Tasks.Tests/Mock.cs
+++ b/test/ILLink.Tasks.Tests/Mock.cs
@@ -190,4 +190,25 @@ namespace ILLink.Tasks.Tests
 		public void Process (LinkContext context) { }
 	}
 
+	public class MockCustomStep2 : MockCustomStep { }
+
+	public class MockCustomStep3 : MockCustomStep { }
+
+	public class MockCustomStep4 : MockCustomStep { }
+
+	public class MockCustomStep5 : MockCustomStep { }
+
+	public class MockCustomStep6 : MockCustomStep { }
+
+	public class MockMarkHandler : IMarkHandler
+	{
+		public void Initialize (LinkContext context, MarkContext markContext) { }
+	}
+
+	public class MockMarkHandler2 : MockMarkHandler { }
+
+	public class MockMarkHandler3 : MockMarkHandler { }
+
+	public class MockMarkHandler4 : MockMarkHandler { }
+
 }

--- a/test/Mono.Linker.Tests.Cases/Extensibility/CustomStepsCanShareState.cs
+++ b/test/Mono.Linker.Tests.Cases/Extensibility/CustomStepsCanShareState.cs
@@ -4,8 +4,8 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.Extensibility
 {
 	[SetupCompileBefore ("SharedCustomSteps.dll", new[] { "Dependencies/CustomStepsWithSharedState.cs" }, new[] { "illink.dll", "Mono.Cecil.dll", "netstandard.dll" })]
-	[SetupLinkerArgument ("--custom-step", "SharedStateHandler2,SharedCustomSteps.dll")]
 	[SetupLinkerArgument ("--custom-step", "SharedStateHandler1,SharedCustomSteps.dll")]
+	[SetupLinkerArgument ("--custom-step", "SharedStateHandler2,SharedCustomSteps.dll")]
 	public class CustomStepsCanShareState
 	{
 		public static void Main ()


### PR DESCRIPTION
One of the issues I hit in https://github.com/xamarin/xamarin-macios/pull/11739 was caused by the custom steps being processed backwards. This fixes the order so they're processed in the order specified.

It's unfortunately still easy to get this wrong - I filed https://github.com/mono/linker/issues/2081 to track it.