### PR TITLE
Always show IL2026 for IsTrimmable assemblies

### DIFF
--- a/test/Mono.Linker.Tests.Cases/Warnings/Dependencies/TriggerWarnings_TrimmableLib.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/Dependencies/TriggerWarnings_TrimmableLib.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+
+[assembly: AssemblyMetadata ("IsTrimmable", "True")]
+
+namespace Mono.Linker.Tests.Cases.Warnings.Dependencies
+{
+	public class TriggerWarnings_TrimmableLib
+	{
+		public static void Main ()
+		{
+			RequirePublicMethods (UnknownType ());
+			RUCIntentional ();
+		}
+
+		static Type UnknownType () => null;
+
+		static void RequirePublicMethods ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] Type type) { }
+
+		[RequiresUnreferencedCode ("RUC warning left in the trimmable assembly.")]
+		static void RUCIntentional () { }
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningsFromTrimmableAssembliesCanSurviveSingleWarn.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningsFromTrimmableAssembliesCanSurviveSingleWarn.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Warnings.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.Warnings
+{
+	[SkipKeptItemsValidation]
+	[SetupCompileBefore ("library.dll", new[] { typeof (TriggerWarnings_TrimmableLib) })]
+	[SetupLinkerArgument ("--singlewarn")]
+	[LogContains (".*warning IL2026: .*TriggerWarnings_TrimmableLib.RUCIntentional.*RUC warning left in the trimmable assembly.*", regexMatch: true)]
+	[LogDoesNotContain ("IL2072")]
+	[LogContains ("warning IL2104: Assembly 'library' produced trim warnings")]
+	[LogDoesNotContain ("IL2026")]
+	public class WarningsFromTrimmableAssembliesCanSurviveSingleWarn
+	{
+		public static void Main ()
+		{
+			TriggerWarnings_TrimmableLib.Main ();
+		}
+	}
+}


### PR DESCRIPTION
This lets RUC warnings intentionally left in IsTrimmable-attributed assemblies survive collapsing, so that the user-readable message is shown.

This is a workaround for the lack of a more well-defined model for "global" warnings (such as RUC methods behind a disabled feature switch, or RUC code that's part of an override which _may_ be called virtually). In the framework libraries we took the approach of moving `RUC` to helper methods that always have a direct callsite in managed code, and we gave the attribute a message indicating the global problem. These warnings will no longer be collapsed, but they still have a message and origin mentioning a call from non-RUC to RUC inside of the library. 

Addresses part of https://github.com/mono/linker/issues/2004.