### PR TITLE
Handle PInvoke analysis similar to other methods

### DIFF
--- a/src/linker/Linker.Dataflow/MethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/MethodBodyScanner.cs
@@ -526,14 +526,13 @@ namespace Mono.Linker.Dataflow
 						}
 
 						// Pop arguments
-						PopUnknown (currentStack, signature.Parameters.Count, methodBody, operation.Offset);
+						if (signature.Parameters.Count > 0)
+							PopUnknown (currentStack, signature.Parameters.Count, methodBody, operation.Offset);
 
 						// Pop function pointer
 						PopUnknown (currentStack, 1, methodBody, operation.Offset);
 
-						// Push return value - BUG: signature.ReturnType.MetadataType sometime doesn't show void for valid cases
-						// Revisit after https://github.com/mono/linker/issues/2090
-						if (signature.ReturnType.GetElementType ().MetadataType != MetadataType.Void)
+						if (GetReturnTypeWithoutModifiers (signature.ReturnType).MetadataType != MetadataType.Void)
 							PushUnknown (currentStack);
 					}
 					break;
@@ -568,7 +567,9 @@ namespace Mono.Linker.Dataflow
 					break;
 
 				case Code.Ret: {
-						bool hasReturnValue = methodBody.Method.ReturnType.MetadataType != MetadataType.Void;
+
+						bool hasReturnValue = GetReturnTypeWithoutModifiers (methodBody.Method.ReturnType).MetadataType != MetadataType.Void;
+
 						if (currentStack.Count != (hasReturnValue ? 1 : 0)) {
 							WarnAboutInvalidILInMethod (methodBody, operation.Offset);
 						}
@@ -893,7 +894,7 @@ namespace Mono.Linker.Dataflow
 					else
 						methodReturnValue = newObjValue;
 				} else {
-					if (calledMethod.ReturnType.MetadataType != MetadataType.Void) {
+					if (GetReturnTypeWithoutModifiers (calledMethod.ReturnType).MetadataType != MetadataType.Void) {
 						methodReturnValue = UnknownValue.Instance;
 					}
 				}
@@ -907,6 +908,14 @@ namespace Mono.Linker.Dataflow
 					MarkArrayValuesAsUnknown (arr, curBasicBlock);
 				}
 			}
+		}
+
+		protected static TypeReference GetReturnTypeWithoutModifiers (TypeReference returnType)
+		{
+			while (returnType is IModifierType) {
+				returnType = ((IModifierType) returnType).ElementType;
+			}
+			return returnType;
 		}
 
 		// Array types that are dynamically accessed should resolve to System.Array instead of its element type - which is what Cecil resolves to.

--- a/src/linker/Linker.Dataflow/MethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/MethodBodyScanner.cs
@@ -531,8 +531,9 @@ namespace Mono.Linker.Dataflow
 						// Pop function pointer
 						PopUnknown (currentStack, 1, methodBody, operation.Offset);
 
-						// Push return value
-						if (signature.ReturnType.MetadataType != MetadataType.Void)
+						// Push return value - BUG: signature.ReturnType.MetadataType sometime doesn't show void for valid cases
+						// Revisit after https://github.com/mono/linker/issues/2090
+						if (signature.ReturnType.GetElementType ().MetadataType != MetadataType.Void)
 							PushUnknown (currentStack);
 					}
 					break;

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -1734,10 +1734,7 @@ namespace Mono.Linker.Dataflow
 						// Is the PInvoke dangerous?
 						bool comDangerousMethod = IsComInterop (calledMethodDefinition.MethodReturnType, calledMethodDefinition.ReturnType);
 						foreach (ParameterDefinition pd in calledMethodDefinition.Parameters) {
-							TypeReference paramTypeReference = pd.ParameterType;
-							if (paramTypeReference != null) {
-								comDangerousMethod |= IsComInterop (pd, paramTypeReference);
-							}
+							comDangerousMethod |= IsComInterop (pd, pd.ParameterType);
 						}
 
 						if (comDangerousMethod) {

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -3036,27 +3036,12 @@ namespace Mono.Linker.Steps
 
 			TypeDefinition returnTypeDefinition = _context.TryResolve (method.ReturnType);
 
-			bool didWarnAboutCom = false;
-
 			const bool includeStaticFields = false;
 			if (returnTypeDefinition != null) {
 				if (!returnTypeDefinition.IsImport) {
 					// What we keep here is correct most of the time, but not every time. Fine for now.
 					MarkDefaultConstructor (returnTypeDefinition, new DependencyInfo (DependencyKind.InteropMethodDependency, method));
 					MarkFields (returnTypeDefinition, includeStaticFields, new DependencyInfo (DependencyKind.InteropMethodDependency, method));
-				}
-
-				// Best-effort attempt to find COM marshalling.
-				// It might seem reasonable to allow out parameters, but once we get a foreign object back (an RCW), it's going to look
-				// like a regular managed class/interface, but every method invocation that takes a class/interface implies COM
-				// marshalling. We can't detect that once we have an RCW.
-				if (method.IsPInvokeImpl) {
-					if (IsComInterop (method.MethodReturnType, method.ReturnType) && !didWarnAboutCom) {
-						_context.LogWarning (
-							$"P/invoke method '{method.GetDisplayName ()}' declares a parameter with COM marshalling. Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.",
-							2050, method, subcategory: MessageSubCategory.TrimAnalysis);
-						didWarnAboutCom = true;
-					}
 				}
 			}
 
@@ -3079,75 +3064,8 @@ namespace Mono.Linker.Steps
 							MarkDefaultConstructor (paramTypeDefinition, new DependencyInfo (DependencyKind.InteropMethodDependency, method));
 						}
 					}
-
-					// Best-effort attempt to find COM marshalling.
-					// It might seem reasonable to allow out parameters, but once we get a foreign object back (an RCW), it's going to look
-					// like a regular managed class/interface, but every method invocation that takes a class/interface implies COM
-					// marshalling. We can't detect that once we have an RCW.
-					if (method.IsPInvokeImpl) {
-						if (IsComInterop (pd, paramTypeReference) && !didWarnAboutCom) {
-							_context.LogWarning ($"P/invoke method '{method.GetDisplayName ()}' declares a parameter with COM marshalling. Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.", 2050, method);
-							didWarnAboutCom = true;
-						}
-					}
 				}
 			}
-		}
-
-		bool IsComInterop (IMarshalInfoProvider marshalInfoProvider, TypeReference parameterType)
-		{
-			// This is best effort. One can likely find ways how to get COM without triggering these alarms.
-			// AsAny marshalling of a struct with an object-typed field would be one, for example.
-
-			// This logic roughly corresponds to MarshalInfo::MarshalInfo in CoreCLR,
-			// not trying to handle invalid cases and distinctions that are not interesting wrt
-			// "is this COM?" question.
-
-			NativeType nativeType = NativeType.None;
-			if (marshalInfoProvider.HasMarshalInfo) {
-				nativeType = marshalInfoProvider.MarshalInfo.NativeType;
-			}
-
-			if (nativeType == NativeType.IUnknown || nativeType == NativeType.IDispatch || nativeType == NativeType.IntF) {
-				// This is COM by definition
-				return true;
-			}
-
-			if (nativeType == NativeType.None) {
-				if (parameterType.IsTypeOf ("System", "Array")) {
-					// System.Array marshals as IUnknown by default
-					return true;
-				} else if (parameterType.IsTypeOf ("System", "String") ||
-					parameterType.IsTypeOf ("System.Text", "StringBuilder")) {
-					// String and StringBuilder are special cased by interop
-					return false;
-				}
-
-				var parameterTypeDef = _context.TryResolve (parameterType);
-				if (parameterTypeDef != null) {
-					if (parameterTypeDef.IsValueType) {
-						// Value types don't marshal as COM
-						return false;
-					} else if (parameterTypeDef.IsInterface) {
-						// Interface types marshal as COM by default
-						return true;
-					} else if (parameterTypeDef.IsMulticastDelegate ()) {
-						// Delegates are special cased by interop
-						return false;
-					} else if (parameterTypeDef.IsSubclassOf ("System.Runtime.InteropServices", "CriticalHandle")) {
-						// Subclasses of CriticalHandle are special cased by interop
-						return false;
-					} else if (parameterTypeDef.IsSubclassOf ("System.Runtime.InteropServices", "SafeHandle")) {
-						// Subclasses of SafeHandle are special cased by interop
-						return false;
-					} else if (!parameterTypeDef.IsSequentialLayout && !parameterTypeDef.IsExplicitLayout) {
-						// Rest of classes that don't have layout marshal as COM
-						return true;
-					}
-				}
-			}
-
-			return false;
 		}
 
 		protected virtual bool ShouldParseMethodBody (MethodDefinition method)

--- a/test/Mono.Linker.Tests.Cases/Interop/PInvoke/Warnings/ComPInvokeWarning.cs
+++ b/test/Mono.Linker.Tests.Cases/Interop/PInvoke/Warnings/ComPInvokeWarning.cs
@@ -17,6 +17,14 @@ namespace Mono.Linker.Tests.Cases.Interop.PInvoke.Warnings
 		{
 			Call_SomeMethodTakingInterface ();
 			Call_SomeMethodTakingObject ();
+			Call_SomeMethodTakingArray ();
+			Call_SomeMethodTakingString ();
+			Call_SomeMethodTakingStringBuilder ();
+			Call_SomeMethodTakingCriticalHandle ();
+			Call_SomeMethodTakingSafeHandle ();
+			Call_SomeMethodTakingExplicitLayoutClass ();
+			Call_SomeMethodTakingSequentialLayoutClass ();
+			Call_SomeMethodTakingAutoLayoutClass ();
 			Call_GetInterface ();
 			Call_CanSuppressWarningOnParameter ();
 			Call_CanSuppressWarningOnReturnType ();
@@ -38,6 +46,66 @@ namespace Mono.Linker.Tests.Cases.Interop.PInvoke.Warnings
 		}
 		[DllImport ("Foo")]
 		static extern void SomeMethodTakingObject ([MarshalAs (UnmanagedType.IUnknown)] object obj);
+
+		[ExpectedWarning ("IL2050")]
+		static void Call_SomeMethodTakingArray ()
+		{
+			SomeMethodTakingArray (null);
+		}
+		[DllImport ("Foo")]
+		static extern void SomeMethodTakingArray (Array array);
+
+		static void Call_SomeMethodTakingStringBuilder ()
+		{
+			SomeMethodTakingStringBuilder (null);
+		}
+		[DllImport ("Foo")]
+		static extern void SomeMethodTakingStringBuilder (StringBuilder str);
+
+		static void Call_SomeMethodTakingCriticalHandle ()
+		{
+			SomeMethodTakingCriticalHandle (null);
+		}
+		[DllImport ("Foo")]
+		static extern void SomeMethodTakingCriticalHandle (MyCriticalHandle handle);
+
+
+		static void Call_SomeMethodTakingSafeHandle ()
+		{
+			SomeMethodTakingSafeHandle (null);
+		}
+		[DllImport ("Foo")]
+		static extern void SomeMethodTakingSafeHandle (TestSafeHandle handle);
+
+		static void Call_SomeMethodTakingExplicitLayoutClass ()
+		{
+			SomeMethodTakingExplicitLayout (null);
+		}
+		[DllImport ("Foo")]
+		static extern void SomeMethodTakingExplicitLayout (ExplicitLayout _class);
+
+		static void Call_SomeMethodTakingSequentialLayoutClass ()
+		{
+			SomeMethodTakingSequentialLayout (null);
+		}
+		[DllImport ("Foo")]
+		static extern void SomeMethodTakingSequentialLayout (SequentialLayout _class);
+
+		[ExpectedWarning ("IL2050")]
+		static void Call_SomeMethodTakingAutoLayoutClass ()
+		{
+			SomeMethodTakingAutoLayout (null);
+		}
+		[DllImport ("Foo")]
+		static extern void SomeMethodTakingAutoLayout (AutoLayout _class);
+
+
+		static void Call_SomeMethodTakingString ()
+		{
+			SomeMethodTakingString (null);
+		}
+		[DllImport ("Foo")]
+		static extern void SomeMethodTakingString (String str);
 
 		[ExpectedWarning ("IL2050")]
 		static void Call_GetInterface ()
@@ -73,5 +141,49 @@ namespace Mono.Linker.Tests.Cases.Interop.PInvoke.Warnings
 		static extern void CanSuppressWithRequiresUnreferencedCode (IFoo foo);
 
 		interface IFoo { }
+
+		class TestSafeHandle : SafeHandle
+		{
+			public TestSafeHandle ()
+				: base (IntPtr.Zero, true)
+			{ }
+
+			public override bool IsInvalid => handle == IntPtr.Zero;
+
+			protected override bool ReleaseHandle ()
+			{
+				return true;
+			}
+		}
+
+		class MyCriticalHandle : CriticalHandle
+		{
+			public MyCriticalHandle () : base (new IntPtr (-1)) { }
+
+			public override bool IsInvalid {
+				get { return false; }
+			}
+
+			protected override bool ReleaseHandle ()
+			{
+				return false;
+			}
+		}
+
+		[StructLayout (LayoutKind.Explicit)]
+		public class ExplicitLayout
+		{
+		}
+
+		[StructLayout (LayoutKind.Sequential)]
+		public class SequentialLayout
+		{
+		}
+
+		[StructLayout (LayoutKind.Auto)]
+		public class AutoLayout
+		{
+		}
+
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/Interop/PInvoke/Warnings/ComPInvokeWarning.cs
+++ b/test/Mono.Linker.Tests.Cases/Interop/PInvoke/Warnings/ComPInvokeWarning.cs
@@ -30,6 +30,7 @@ namespace Mono.Linker.Tests.Cases.Interop.PInvoke.Warnings
 			Call_CanSuppressWarningOnReturnType ();
 			Call_CanSuppressWithRequiresUnreferencedCode ();
 			Call_CanSuppressPInvokeWithRequiresUnreferencedCode ();
+			Call_PInvokeWithRequiresUnreferencedCode ();
 		}
 
 		[ExpectedWarning ("IL2050")]
@@ -151,6 +152,16 @@ namespace Mono.Linker.Tests.Cases.Interop.PInvoke.Warnings
 		[DllImport ("Foo")]
 		static extern void CanSuppressPInvokeWithRequiresUnreferencedCode (IFoo foo);
 
+		[ExpectedWarning ("IL2050")]
+		[ExpectedWarning ("IL2026")]
+		static void Call_PInvokeWithRequiresUnreferencedCode ()
+		{
+			PInvokeWithRequiresUnreferencedCode (null);
+		}
+
+		[RequiresUnreferencedCode ("test")]
+		[DllImport ("Foo")]
+		static extern void PInvokeWithRequiresUnreferencedCode (IFoo foo);
 
 		interface IFoo { }
 

--- a/test/Mono.Linker.Tests.Cases/Interop/PInvoke/Warnings/ComPInvokeWarning.cs
+++ b/test/Mono.Linker.Tests.Cases/Interop/PInvoke/Warnings/ComPInvokeWarning.cs
@@ -29,6 +29,7 @@ namespace Mono.Linker.Tests.Cases.Interop.PInvoke.Warnings
 			Call_CanSuppressWarningOnParameter ();
 			Call_CanSuppressWarningOnReturnType ();
 			Call_CanSuppressWithRequiresUnreferencedCode ();
+			Call_CanSuppressPInvokeWithRequiresUnreferencedCode ();
 		}
 
 		[ExpectedWarning ("IL2050")]
@@ -139,6 +140,17 @@ namespace Mono.Linker.Tests.Cases.Interop.PInvoke.Warnings
 
 		[DllImport ("Foo")]
 		static extern void CanSuppressWithRequiresUnreferencedCode (IFoo foo);
+
+		[RequiresUnreferencedCode ("test")]
+		static void Call_CanSuppressPInvokeWithRequiresUnreferencedCode ()
+		{
+			CanSuppressPInvokeWithRequiresUnreferencedCode (null);
+		}
+
+		[RequiresUnreferencedCode ("test")]
+		[DllImport ("Foo")]
+		static extern void CanSuppressPInvokeWithRequiresUnreferencedCode (IFoo foo);
+
 
 		interface IFoo { }
 

--- a/test/Mono.Linker.Tests.Cases/Interop/PInvoke/Warnings/ComPInvokeWarning.cs
+++ b/test/Mono.Linker.Tests.Cases/Interop/PInvoke/Warnings/ComPInvokeWarning.cs
@@ -15,36 +15,60 @@ namespace Mono.Linker.Tests.Cases.Interop.PInvoke.Warnings
 		[UnconditionalSuppressMessage ("trim", "IL2026")]
 		static void Main ()
 		{
-			SomeMethodTakingInterface (null);
-			SomeMethodTakingObject (null);
-			GetInterface ();
-			CanSuppressWarningOnParameter (null);
-			CanSuppressWarningOnReturnType ();
-			CanSuppressWithRequiresUnreferencedCode (null);
+			Call_SomeMethodTakingInterface ();
+			Call_SomeMethodTakingObject ();
+			Call_GetInterface ();
+			Call_CanSuppressWarningOnParameter ();
+			Call_CanSuppressWarningOnReturnType ();
+			Call_CanSuppressWithRequiresUnreferencedCode ();
 		}
 
 		[ExpectedWarning ("IL2050")]
+		static void Call_SomeMethodTakingInterface ()
+		{
+			SomeMethodTakingInterface (null);
+		}
 		[DllImport ("Foo")]
 		static extern void SomeMethodTakingInterface (IFoo foo);
 
 		[ExpectedWarning ("IL2050")]
+		static void Call_SomeMethodTakingObject ()
+		{
+			SomeMethodTakingObject (null);
+		}
 		[DllImport ("Foo")]
 		static extern void SomeMethodTakingObject ([MarshalAs (UnmanagedType.IUnknown)] object obj);
 
 		[ExpectedWarning ("IL2050")]
+		static void Call_GetInterface ()
+		{
+			GetInterface ();
+		}
 		[DllImport ("Foo")]
 		static extern IFoo GetInterface ();
 
 		[UnconditionalSuppressMessage ("trim", "IL2050")]
+		static void Call_CanSuppressWarningOnParameter ()
+		{
+			CanSuppressWarningOnParameter (null);
+		}
 		[DllImport ("Foo")]
 		static extern void CanSuppressWarningOnParameter ([MarshalAs (UnmanagedType.IUnknown)] object obj);
 
 		[UnconditionalSuppressMessage ("trim", "IL2050")]
+		static void Call_CanSuppressWarningOnReturnType ()
+		{
+			CanSuppressWarningOnReturnType ();
+		}
 		[DllImport ("Foo")]
 		static extern IFoo CanSuppressWarningOnReturnType ();
 
-		[ExpectedWarning ("IL2050")] // Issue https://github.com/mono/linker/issues/1989
 		[RequiresUnreferencedCode ("test")]
+		static void Call_CanSuppressWithRequiresUnreferencedCode ()
+		{
+			CanSuppressWithRequiresUnreferencedCode (null);
+		}
+
 		[DllImport ("Foo")]
 		static extern void CanSuppressWithRequiresUnreferencedCode (IFoo foo);
 


### PR DESCRIPTION
This fixes `PInvoke` analysis similar to other methods as discussed in issue #1989. 

- We now generate the warnings from the `callsite` as opposed to for the `PInvoke `call itself. We do this by moving the analysis to `MethodBodyScanner `and `ReflectionMethodBodyScanner`
- Dangerous `PInvokes `(the ones that we generate warnings) have an implicit relationship with built-in COM interop support. Specifically, [IsComInterop](https://github.com/mono/linker/blob/caeaf2a3fb3f636805fdd4881df4f9a539fff8f6/src/linker/Linker.Steps/MarkStep.cs#L3103)method in the linker tries to match the logic in [MarshalInfo::MarshalInfo](https://github.com/dotnet/runtime/blob/fef9b592b28bc4b906091b1361f097da63bf418c/src/coreclr/vm/mlinfo.cpp#L1086). This means that when `BuiltInComInteropSupport `property is false (`netcore `app default), dangerous `PInvokes `will not work. Created a doc [bug ](https://github.com/dotnet/docs/issues/24645)to track this.
- Needed to change the `calli `instruction handling since we dont always detect methods that return void (issue #2090)
- Updated `ComPInvokeWarning `test to now check for warnings from the call sites

Plan regarding the OOB library warnings

- Runtime libraries fix plan: We have around 40 new warnings since we moved the warning location. Creating a draft PR in the runtime repo that will address this that can be used when the linker gets merged
