### PR TITLE
Add a test case for string->type resolution with forwarded type in generic argument

### DIFF
--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/UsedForwarderInGenericIsDynamicallyAccessedWithAssemblyCopyUsed.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/UsedForwarderInGenericIsDynamicallyAccessedWithAssemblyCopyUsed.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.CodeAnalysis;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.TypeForwarding.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.TypeForwarding
+{
+
+	[SetupLinkerAction ("copyused", "Forwarder")]
+	[KeepTypeForwarderOnlyAssemblies ("false")]
+
+	[SetupCompileBefore ("Forwarder.dll", new[] { "Dependencies/ReferenceImplementationLibrary.cs" }, defines: new[] { "INCLUDE_REFERENCE_IMPL" })]
+
+	// After compiling the test case we then replace the reference impl with implementation + type forwarder
+	[SetupCompileAfter ("Implementation.dll", new[] { "Dependencies/ImplementationLibrary.cs" })]
+	[SetupCompileAfter ("Forwarder.dll", new[] { "Dependencies/ForwarderLibrary.cs" }, references: new[] { "Implementation.dll" })]
+
+	// https://github.com/mono/linker/issues/1536
+	//[KeptMemberInAssembly ("Forwarder.dll", typeof (ImplementationLibrary))]
+	[KeptMemberInAssembly ("Implementation.dll", typeof (ImplementationLibrary))]
+	class UsedForwarderInGenericIsDynamicallyAccessedWithAssemblyCopyUsed
+	{
+		static void Main ()
+		{
+			PointToTypeInFacade ("Mono.Linker.Tests.Cases.TypeForwarding.OuterGeneric`1[[Mono.Linker.Tests.Cases.TypeForwarding.Dependencies.ImplementationLibrary, Forwarder]], test");
+		}
+
+		[Kept]
+		static void PointToTypeInFacade (
+			[KeptAttributeAttribute (typeof(DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] string typeName)
+		{
+		}
+	}
+
+	[Kept]
+	class OuterGeneric<T>
+	{
+		[Kept]
+		public OuterGeneric () { }
+	}
+}


### PR DESCRIPTION
This test is the easy repro for https://github.com/mono/linker/issues/1536 (which is relatively complicated to understand).

In short when we resolve type name to type reference where the type is a generic and the generic parameter is a fully qualified type name pointing to a facade, linker will not preserve that facade (even though it will correctly resolve the type and mark it in the implementation assembly).

This works if the facade type is resolved directly, but not if it's used as a generic argument.