### PR TITLE
Add a library mode for type hierarchy marking

### DIFF
--- a/src/linker/Linker.Dataflow/DynamicallyAccessedMembersTypeHierarchy.cs
+++ b/src/linker/Linker.Dataflow/DynamicallyAccessedMembersTypeHierarchy.cs
@@ -91,6 +91,9 @@ namespace Mono.Linker.Dataflow
 
 			Debug.Assert (!apply || annotation != DynamicallyAccessedMemberTypes.None);
 
+			// If OptimizeTypeHierarchyAnnotations is disabled, we will apply the annotations without seeing object.GetType()
+			apply |= (annotation != DynamicallyAccessedMemberTypes.None) && !_context.IsOptimizationEnabled (CodeOptimizations.OptimizeTypeHierarchyAnnotations, type);
+
 			// Store the results in the cache
 			// Don't store empty annotations for non-interface types - we can use the presence of the row
 			// in the cache as indication of it instead.

--- a/src/linker/Linker.Dataflow/DynamicallyAccessedMembersTypeHierarchy.cs
+++ b/src/linker/Linker.Dataflow/DynamicallyAccessedMembersTypeHierarchy.cs
@@ -92,7 +92,9 @@ namespace Mono.Linker.Dataflow
 			Debug.Assert (!apply || annotation != DynamicallyAccessedMemberTypes.None);
 
 			// If OptimizeTypeHierarchyAnnotations is disabled, we will apply the annotations without seeing object.GetType()
-			apply |= (annotation != DynamicallyAccessedMemberTypes.None) && !_context.IsOptimizationEnabled (CodeOptimizations.OptimizeTypeHierarchyAnnotations, type);
+			// Unfortunately, we cannot apply the annotation to type derived from EventSource - Revisit after https://github.com/dotnet/runtime/issues/54859
+			apply |= (annotation != DynamicallyAccessedMemberTypes.None) && !_context.IsOptimizationEnabled (CodeOptimizations.OptimizeTypeHierarchyAnnotations, type)
+				&& !_context.IsOptimizationEnabled (CodeOptimizations.RemoveEventSourceSpecialHandling, type) && !BCL.EventTracingForWindows.IsEventSourceImplementation (type, _context);
 
 			// Store the results in the cache
 			// Don't store empty annotations for non-interface types - we can use the presence of the row

--- a/src/linker/Linker.Dataflow/DynamicallyAccessedMembersTypeHierarchy.cs
+++ b/src/linker/Linker.Dataflow/DynamicallyAccessedMembersTypeHierarchy.cs
@@ -96,7 +96,7 @@ namespace Mono.Linker.Dataflow
 			// Unfortunately, we cannot apply the annotation to type derived from EventSource - Revisit after https://github.com/dotnet/runtime/issues/54859
 			// Breaking the logic to make it easier to maintain in the future since the logic is convoluted
 			// DisableEventSourceSpecialHandling is closely tied to a type derived from EventSource and should always go together
-			// However, logically it should be possible to use DisableEventSourceSpecialHandling to control OptimizeTypeHierarchyAnnotations
+			// However, logically it should be possible to use DisableEventSourceSpecialHandling to allow marking types derived from EventSource when OptimizeTypeHierarchyAnnotations is disabled
 			apply |= applyOptimizeTypeHierarchyAnnotations && (_context.DisableEventSourceSpecialHandling || !BCL.EventTracingForWindows.IsEventSourceImplementation (type, _context));
 
 			// Store the results in the cache

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -124,6 +124,9 @@ namespace Mono.Linker.Dataflow
 			Debug.Assert (annotation != DynamicallyAccessedMemberTypes.None);
 
 			reflectionPatternContext.AnalyzingPattern ();
+			// Handle cases where a type has no members but annotations are to be applied to derived type members
+			reflectionPatternContext.RecordHandledPattern ();
+
 			MarkTypeForDynamicallyAccessedMembers (ref reflectionPatternContext, type, annotation);
 		}
 

--- a/src/linker/Linker.Steps/RootAssemblyInputStep.cs
+++ b/src/linker/Linker.Steps/RootAssemblyInputStep.cs
@@ -81,7 +81,8 @@ namespace Mono.Linker.Steps
 					CodeOptimizations.RemoveDescriptors |
 					CodeOptimizations.RemoveLinkAttributes |
 					CodeOptimizations.RemoveSubstitutions |
-					CodeOptimizations.RemoveDynamicDependencyAttribute, assembly.Name.Name);
+					CodeOptimizations.RemoveDynamicDependencyAttribute |
+					CodeOptimizations.OptimizeTypeHierarchyAnnotations, assembly.Name.Name);
 
 				// No metadata trimming
 				Context.MetadataTrimming = MetadataTrimming.None;

--- a/src/linker/Linker.Steps/RootAssemblyInputStep.cs
+++ b/src/linker/Linker.Steps/RootAssemblyInputStep.cs
@@ -82,8 +82,10 @@ namespace Mono.Linker.Steps
 					CodeOptimizations.RemoveLinkAttributes |
 					CodeOptimizations.RemoveSubstitutions |
 					CodeOptimizations.RemoveDynamicDependencyAttribute |
-					CodeOptimizations.OptimizeTypeHierarchyAnnotations |
-					CodeOptimizations.RemoveEventSourceSpecialHandling, assembly.Name.Name);
+					CodeOptimizations.OptimizeTypeHierarchyAnnotations, assembly.Name.Name);
+
+				// Enable EventSource special handling
+				Context.DisableEventSourceSpecialHandling = false;
 
 				// No metadata trimming
 				Context.MetadataTrimming = MetadataTrimming.None;

--- a/src/linker/Linker.Steps/RootAssemblyInputStep.cs
+++ b/src/linker/Linker.Steps/RootAssemblyInputStep.cs
@@ -82,7 +82,8 @@ namespace Mono.Linker.Steps
 					CodeOptimizations.RemoveLinkAttributes |
 					CodeOptimizations.RemoveSubstitutions |
 					CodeOptimizations.RemoveDynamicDependencyAttribute |
-					CodeOptimizations.OptimizeTypeHierarchyAnnotations, assembly.Name.Name);
+					CodeOptimizations.OptimizeTypeHierarchyAnnotations |
+					CodeOptimizations.RemoveEventSourceSpecialHandling, assembly.Name.Name);
 
 				// No metadata trimming
 				Context.MetadataTrimming = MetadataTrimming.None;

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -246,7 +246,8 @@ namespace Mono.Linker
 				CodeOptimizations.RemoveDescriptors |
 				CodeOptimizations.RemoveLinkAttributes |
 				CodeOptimizations.RemoveSubstitutions |
-				CodeOptimizations.RemoveDynamicDependencyAttribute;
+				CodeOptimizations.RemoveDynamicDependencyAttribute |
+				CodeOptimizations.OptimizeTypeHierarchyAnnotations;
 
 			Optimizations = new CodeOptimizationsSettings (defaultOptimizations);
 		}
@@ -986,5 +987,12 @@ namespace Mono.Linker
 		RemoveSubstitutions = 1 << 21,
 		RemoveLinkAttributes = 1 << 22,
 		RemoveDynamicDependencyAttribute = 1 << 23,
+
+		/// <summary>
+		/// Option to apply annotations to type heirarchy
+		/// Enable type heirarchy apply in library mode to annotate derived types eagerly
+		/// Otherwise, type annotation will only be applied with calls to object.GetType()
+		/// </summary>
+		OptimizeTypeHierarchyAnnotations = 1 << 24,
 	}
 }

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -125,6 +125,12 @@ namespace Mono.Linker
 
 		public bool DisableOperatorDiscovery { get; set; }
 
+		/// <summary>
+		/// Option to not special case EventSource.
+		/// Currently, values are hard-coded and does not have a command line option to control
+		/// </summary>
+		public bool DisableEventSourceSpecialHandling { get; set; }
+
 		public bool IgnoreDescriptors { get; set; }
 
 		public bool IgnoreSubstitutions { get; set; }
@@ -247,8 +253,9 @@ namespace Mono.Linker
 				CodeOptimizations.RemoveLinkAttributes |
 				CodeOptimizations.RemoveSubstitutions |
 				CodeOptimizations.RemoveDynamicDependencyAttribute |
-				CodeOptimizations.OptimizeTypeHierarchyAnnotations |
-				CodeOptimizations.RemoveEventSourceSpecialHandling;
+				CodeOptimizations.OptimizeTypeHierarchyAnnotations;
+
+			DisableEventSourceSpecialHandling = true;
 
 			Optimizations = new CodeOptimizationsSettings (defaultOptimizations);
 		}
@@ -995,10 +1002,5 @@ namespace Mono.Linker
 		/// Otherwise, type annotation will only be applied with calls to object.GetType()
 		/// </summary>
 		OptimizeTypeHierarchyAnnotations = 1 << 24,
-
-		/// <summary>
-		/// Option to not special case EventSource
-		/// </summary>
-		RemoveEventSourceSpecialHandling = 1 << 25,
 	}
 }

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -997,7 +997,7 @@ namespace Mono.Linker
 		OptimizeTypeHierarchyAnnotations = 1 << 24,
 
 		/// <summary>
-		/// Pption to not special case EventSource
+		/// Option to not special case EventSource
 		/// </summary>
 		RemoveEventSourceSpecialHandling = 1 << 25,
 	}

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -247,7 +247,8 @@ namespace Mono.Linker
 				CodeOptimizations.RemoveLinkAttributes |
 				CodeOptimizations.RemoveSubstitutions |
 				CodeOptimizations.RemoveDynamicDependencyAttribute |
-				CodeOptimizations.OptimizeTypeHierarchyAnnotations;
+				CodeOptimizations.OptimizeTypeHierarchyAnnotations |
+				CodeOptimizations.RemoveEventSourceSpecialHandling;
 
 			Optimizations = new CodeOptimizationsSettings (defaultOptimizations);
 		}
@@ -994,5 +995,10 @@ namespace Mono.Linker
 		/// Otherwise, type annotation will only be applied with calls to object.GetType()
 		/// </summary>
 		OptimizeTypeHierarchyAnnotations = 1 << 24,
+
+		/// <summary>
+		/// Pption to not special case EventSource
+		/// </summary>
+		RemoveEventSourceSpecialHandling = 1 << 25,
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/BCLFeatures/ETW/CustomEventSource.cs
+++ b/test/Mono.Linker.Tests.Cases/BCLFeatures/ETW/CustomEventSource.cs
@@ -53,7 +53,6 @@ namespace Mono.Linker.Tests.Cases.BCLFeatures.ETW
 		[Kept]
 		public static MyCompanyEventSource Log = new MyCompanyEventSource ();
 
-		// Revisit after https://github.com/mono/linker/issues/1174 is fixed
 		[Kept]
 		int private_member;
 

--- a/test/Mono.Linker.Tests.Cases/BCLFeatures/ETW/CustomLibraryEventSource.cs
+++ b/test/Mono.Linker.Tests.Cases/BCLFeatures/ETW/CustomLibraryEventSource.cs
@@ -25,30 +25,25 @@ namespace Mono.Linker.Tests.Cases.BCLFeatures.ETW
 	[EventSource (Name = "MyLibraryCompany")]
 	class CustomEventSourceInLibraryMode : EventSource
 	{
-		[KeptMember (".ctor()")]
+		// In library mode, we special case nested types
 		[Kept]
 		public class Keywords
 		{
 			[Kept]
 			public const EventKeywords Page = (EventKeywords) 1;
 
-			[Kept]
 			public int Unused;
 		}
 
-		[KeptMember (".ctor()")]
 		[Kept]
 		public class Tasks
 		{
 			[Kept]
 			public const EventTask Page = (EventTask) 1;
 
-			[Kept]
 			public int Unused;
 		}
 
-		[KeptMember (".ctor()")]
-		[Kept]
 		class NotMatching
 		{
 		}
@@ -56,11 +51,8 @@ namespace Mono.Linker.Tests.Cases.BCLFeatures.ETW
 		[Kept]
 		public static CustomEventSourceInLibraryMode Log = new CustomEventSourceInLibraryMode ();
 
-		// Revisit after https://github.com/mono/linker/issues/1174 is fixed
-		[Kept]
 		int private_member;
 
-		[Kept]
 		void PrivateMethod () { }
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/BCLFeatures/ETW/CustomLibraryEventSource.cs
+++ b/test/Mono.Linker.Tests.Cases/BCLFeatures/ETW/CustomLibraryEventSource.cs
@@ -1,15 +1,18 @@
 ﻿using System;
 using System.Diagnostics.Tracing;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.BCLFeatures.ETW
 {
-	public class CustomEventSource
+	[SetupLinkerArgument ("-a", "test.exe", "library")]
+	[KeptMember (".ctor()")]
+	public class CustomLibraryEventSource
 	{
 		public static void Main ()
 		{
-			// This call will trigger Object.GetType() Reflection pattern that will preserve all
-			EventSource.GenerateManifest (typeof (MyCompanyEventSource), null);
+			// Reference to a derived EventSource but does not trigger Object.GetType()
+			var b = CustomEventSourceInLibraryMode.Log.IsEnabled ();
 		}
 	}
 
@@ -19,8 +22,8 @@ namespace Mono.Linker.Tests.Cases.BCLFeatures.ETW
 	[KeptMember (".ctor()")]
 	[KeptMember (".cctor()")]
 
-	[EventSource (Name = "MyCompany")]
-	class MyCompanyEventSource : EventSource
+	[EventSource (Name = "MyLibraryCompany")]
+	class CustomEventSourceInLibraryMode : EventSource
 	{
 		[KeptMember (".ctor()")]
 		[Kept]
@@ -51,7 +54,7 @@ namespace Mono.Linker.Tests.Cases.BCLFeatures.ETW
 		}
 
 		[Kept]
-		public static MyCompanyEventSource Log = new MyCompanyEventSource ();
+		public static CustomEventSourceInLibraryMode Log = new CustomEventSourceInLibraryMode ();
 
 		// Revisit after https://github.com/mono/linker/issues/1174 is fixed
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/Reflection/MembersUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/MembersUsedViaReflection.cs
@@ -194,7 +194,6 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[Kept]
 			public static class PublicNestedType
 			{
-				// PublicNestedType should be kept but linker won't mark anything besides the declaration
 				[Kept]
 				public static int _nestedPublicField;
 				[Kept]
@@ -261,7 +260,6 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[Kept]
 			public static class PublicNestedType
 			{
-				// PublicNestedType should be kept but linker won't mark anything besides the declaration
 				[Kept]
 				public static int _nestedPublicField;
 				[Kept]
@@ -318,7 +316,6 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[Kept]
 			public static class PublicNestedType
 			{
-				// PublicNestedType should be kept but linker won't mark anything besides the declaration
 				[Kept]
 				public static int _nestedPublicField;
 				[Kept]
@@ -375,7 +372,6 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[Kept]
 			public static class PublicNestedType
 			{
-				// PublicNestedType should be kept but linker won't mark anything besides the declaration
 				[Kept]
 				public static int _nestedPublicField;
 				[Kept]
@@ -432,7 +428,6 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[Kept]
 			public static class PublicNestedType
 			{
-				// PublicNestedType should be kept but linker won't mark anything besides the declaration
 				[Kept]
 				public static int _nestedPublicField;
 				[Kept]

--- a/test/Mono.Linker.Tests.Cases/Reflection/ObjectGetTypeLibraryMode.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ObjectGetTypeLibraryMode.cs
@@ -1,0 +1,158 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Reflection
+{
+	[SetupLinkerArgument ("-a", "test.exe", "library")]
+	[ExpectedNoWarnings]
+	[KeptMember (".ctor()")]
+	public class ObjectGetTypeLibraryMode
+	{
+		public static void Main ()
+		{
+			BasicAnnotationWithNoDerivedClasses.Test ();
+			BasicNoAnnotationWithNoDerivedClasses.Test ();
+		}
+
+		[Kept]
+		class BasicAnnotationWithNoDerivedClasses
+		{
+			[Kept]
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+			public interface IBasicAnnotatedInterface
+			{
+			}
+
+			[Kept]
+			[KeptMember (".ctor()")]
+			[KeptInterface (typeof (IBasicAnnotatedInterface))]
+			class ClassImplementingAnnotatedInterface : IBasicAnnotatedInterface
+			{
+				[Kept]
+				public void UsedMethod () { }
+				[Kept] // The type is not sealed, so trimmer will apply the annotation from the interface
+				public void UnusedMethod () { }
+			}
+
+			[Kept]
+			static void TestInterface ()
+			{
+				var classImplementingInterface = new ClassImplementingAnnotatedInterface ();
+			}
+
+			[Kept]
+			[KeptMember (".ctor()")]
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+			class BasicAnnotatedClass
+			{
+				[Kept]
+				public void UsedMethod () { }
+				[Kept] // The type is not sealed, so trimmer will apply the annotation from the interface
+				public void UnusedMethod () { }
+			}
+
+			[Kept]
+			static void TestClass ()
+			{
+				var instance = new BasicAnnotatedClass ();
+			}
+
+			[Kept]
+			[KeptMember (".ctor()")]
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+			struct BasicAnnotatedStruct
+			{
+				[Kept]
+				public void UsedMethod () { }
+				[Kept]
+				public void UnusedMethod () { }
+			}
+
+			[Kept]
+			static void TestStruct ()
+			{
+				var instance = new BasicAnnotatedStruct ();
+			}
+
+			[Kept]
+			public static void Test ()
+			{
+				TestInterface ();
+				TestClass ();
+				TestStruct ();
+			}
+		}
+
+		[Kept]
+		class BasicNoAnnotationWithNoDerivedClasses
+		{
+			[Kept]
+			public interface IBasicNoAnnotatedInterface
+			{
+			}
+
+			[Kept]
+			[KeptMember (".ctor()")]
+			[KeptInterface (typeof (IBasicNoAnnotatedInterface))]
+			class ClassImplementingNoAnnotatedInterface : IBasicNoAnnotatedInterface
+			{
+				public void UsedMethod () { }
+				public void UnusedMethod () { }
+			}
+
+			[Kept]
+			static void TestInterface ()
+			{
+				var classImplementingInterface = new ClassImplementingNoAnnotatedInterface ();
+			}
+
+			[Kept]
+			[KeptMember (".ctor()")]
+			class BasicNoAnnotatedClass
+			{
+				public void UsedMethod () { }
+				public void UnusedMethod () { }
+			}
+
+			[Kept]
+			static void TestClass ()
+			{
+				var instance = new BasicNoAnnotatedClass ();
+			}
+
+			[Kept]
+			[KeptMember (".ctor()")]
+			struct BasicNoAnnotatedStruct
+			{
+				public void UsedMethod () { }
+				public void UnusedMethod () { }
+			}
+
+			[Kept]
+			static void TestStruct ()
+			{
+				var instance = new BasicNoAnnotatedStruct ();
+			}
+
+			[Kept]
+			public static void Test ()
+			{
+				TestInterface ();
+				TestClass ();
+				TestStruct ();
+			}
+		}
+	}
+}


### PR DESCRIPTION
We added type hierarchy support to the linker via #1929 but the annotations to the derived types were only triggered via `object.GetType()` in code. This causes problems in library mode linking, especially for internal types when the assembly does not have code that triggers `object.GetType()`. Library mode linking can remove members in such cases which might be needed later by application code that invokes the removed internal code via reflection. A specific example is an internal type like [NetEventSource](https://github.com/dotnet/runtime/blob/3924d0308110f6365e47e784b8c7cf1e8f7efa2b/src/libraries/Common/src/System/Net/Logging/NetEventSource.Common.cs#L39) in `System.Net.Mail.dll` library, where the library does not have code that triggers `object.GetType()`. Library mode linking removes nested types in such cases and application code patterns like [this ](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Net.Mail/tests/Functional/LoggingTest.cs#L25) will fail in such cases.

Unfortunately, we cannot yet remove the special case handling that we currently have for `EventSource `in the trimmer with this change as discussed in #1949. This is because some library code relies in the trimmer to remove unused code in custom `EventSources `and that goal conflicts with this change since this change will keep all code in custom `EventSources`. There is a runtime issue [54859](https://github.com/dotnet/runtime/issues/54859) that tracks this. This change moves the EventSource special handling to library mode

- This fix is to allow a new `CodeOptimizations`, `OptimizeTypeHierarchyAnnotations`, that will be disabled in library mode linking. Disabling the optimization will cause types to be marked when `object.GetType()` is not seen and the type is used.
       - `EventSource `types will not be impacted due to the size concerns expressed above
- We continue to special case EventSource in the trimmer. This is done by disabling a new optimization `CodeOptimizations`, `RemoveEventSourceSpecialHandling` in library mode.
       - Type hierarchy annotation in `EventSource `types will not be triggered without `object.GetType()`
       - Also removed the special handling of the `EventDataAttribute `at `MarkTypeSpecialCustomAttributes` in this mode since `EventSource` type has annotations to keep all methods. 
       - We are keeping the special handling of EventSource for earlier runtimes than .NET6.
- Fixed the existing test case since it was not correctly testing `EventSource`
- Added some tests to cover missing scenarios for library mode linking

