### PR TITLE
Use net6.0 reference assemblies in analyzer tests

### DIFF
--- a/test/ILLink.RoslynAnalyzer.Tests/ILLink.RoslynAnalyzer.Tests.csproj
+++ b/test/ILLink.RoslynAnalyzer.Tests/ILLink.RoslynAnalyzer.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <Nullable>enable</Nullable>
+    <DeterministicSourcePaths>false</DeterministicSourcePaths>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/ILLink.RoslynAnalyzer.Tests/RequiresAssemblyFilesAnalyzerTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/RequiresAssemblyFilesAnalyzerTests.cs
@@ -15,20 +15,6 @@ namespace ILLink.RoslynAnalyzer.Tests
 {
 	public class RequiresAssemblyFilesAnalyzerTests
 	{
-		private readonly static MetadataReference _rafReference = CSharpAnalyzerVerifier<RequiresAssemblyFilesAnalyzer>.GetCompilation (rafSourceDefinition).Result.EmitToImageReference ();
-
-		private const string rafSourceDefinition = @"
-#nullable enable
-namespace System.Diagnostics.CodeAnalysis
-{
-	[AttributeUsage(AttributeTargets.Constructor | AttributeTargets.Event | AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
-	public sealed class RequiresAssemblyFilesAttribute : Attribute
-	{
-		public RequiresAssemblyFilesAttribute () { }
-		public string? Message { get; set; }
-		public string? Url { get; set; }
-	}
-}";
 		static Task VerifyRequiresAssemblyFilesAnalyzer (string source, params DiagnosticResult[] expected)
 		{
 			return VerifyRequiresAssemblyFilesAnalyzer (source, null, expected);
@@ -39,7 +25,7 @@ namespace System.Diagnostics.CodeAnalysis
 
 			await VerifyCS.VerifyAnalyzerAsync (source,
 				TestCaseUtils.UseMSBuildProperties (MSBuildPropertyOptionNames.EnableSingleFileAnalyzer),
-				new[] { _rafReference }.Concat (additionalReferences ?? Array.Empty<MetadataReference> ()),
+				additionalReferences ?? Array.Empty<MetadataReference> (),
 				expected);
 		}
 
@@ -51,8 +37,9 @@ namespace System.Diagnostics.CodeAnalysis
 			int? numberOfIterations = null)
 		{
 			var test = new VerifyCS.Test {
-				TestCode = source + rafSourceDefinition,
-				FixedCode = fixedSource + rafSourceDefinition,
+				TestCode = source,
+				FixedCode = fixedSource,
+				ReferenceAssemblies = TestCaseUtils.Net6PreviewAssemblies
 			};
 			test.ExpectedDiagnostics.AddRange (baselineExpected);
 			test.TestState.AnalyzerConfigFiles.Add (
@@ -148,14 +135,14 @@ class C
 	bool field;
 
 	[RequiresAssemblyFiles]
-	bool P { 
+	bool P {
 		get {
 			return field;
 		}
 		set {
 			CallDangerousMethod ();
 			field = value;
-		} 
+		}
 	}
 
 	[RequiresAssemblyFiles]
@@ -1165,7 +1152,7 @@ class AnotherImplementation : IRAF
 	}
 }
 ";
-			var compilation = (await CSharpAnalyzerVerifier<RequiresAssemblyFilesAnalyzer>.GetCompilation (references, additionalReferences: new[] { _rafReference })).EmitToImageReference ();
+			var compilation = (await CSharpAnalyzerVerifier<RequiresAssemblyFilesAnalyzer>.GetCompilation (references)).EmitToImageReference ();
 
 			await VerifyRequiresAssemblyFilesAnalyzer (src, additionalReferences: new[] { compilation },
 				// (4,14): warning IL3003: Interface member 'IRAF.Method()' with 'RequiresAssemblyFilesAttribute' has an implementation member 'Implementation.Method()' without 'RequiresAssemblyFilesAttribute'. Attributes must match across all interface implementations or overrides.
@@ -1237,7 +1224,7 @@ class AnotherImplementation : IRAF
 	}
 }
 ";
-			var compilation = (await CSharpAnalyzerVerifier<RequiresAssemblyFilesAnalyzer>.GetCompilation (references, additionalReferences: new[] { _rafReference })).EmitToImageReference ();
+			var compilation = (await CSharpAnalyzerVerifier<RequiresAssemblyFilesAnalyzer>.GetCompilation (references)).EmitToImageReference ();
 
 			await VerifyRequiresAssemblyFilesAnalyzer (src, additionalReferences: new[] { compilation },
 				// (7,14): warning IL3003: Member 'Implementation.Method()' with 'RequiresAssemblyFilesAttribute' implements interface member 'IRAF.Method()' without 'RequiresAssemblyFilesAttribute'. Attributes must match across all interface implementations or overrides.

--- a/test/ILLink.RoslynAnalyzer.Tests/RequiresUnreferencedCodeAnalyzerTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/RequiresUnreferencedCodeAnalyzerTests.cs
@@ -36,7 +36,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 			var test = new VerifyCS.Test {
 				TestCode = source,
 				FixedCode = fixedSource,
-				ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
+				ReferenceAssemblies = TestCaseUtils.Net6PreviewAssemblies
 			};
 			test.ExpectedDiagnostics.AddRange (baselineExpected);
 			test.TestState.AnalyzerConfigFiles.Add (

--- a/test/ILLink.RoslynAnalyzer.Tests/TestCaseUtils.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/TestCaseUtils.cs
@@ -17,7 +17,7 @@ using Xunit;
 
 namespace ILLink.RoslynAnalyzer.Tests
 {
-    public abstract class TestCaseUtils
+	public abstract class TestCaseUtils
 	{
 		public static readonly ReferenceAssemblies Net6PreviewAssemblies =
 			new ReferenceAssemblies (
@@ -27,11 +27,11 @@ namespace ILLink.RoslynAnalyzer.Tests
 			.WithNuGetConfigFilePath (Path.Combine (TestCaseUtils.GetRepoRoot (), "NuGet.config"));
 
 		private static ImmutableArray<MetadataReference> s_net6Refs;
-		public async static ValueTask<ImmutableArray<MetadataReference>> GetNet6References()
+		public async static ValueTask<ImmutableArray<MetadataReference>> GetNet6References ()
 		{
 			if (s_net6Refs.IsDefault) {
 				var refs = await Net6PreviewAssemblies.ResolveAsync (null, default);
-				ImmutableInterlocked.InterlockedInitialize(ref s_net6Refs, refs);
+				ImmutableInterlocked.InterlockedInitialize (ref s_net6Refs, refs);
 			}
 			return s_net6Refs;
 		}
@@ -194,11 +194,11 @@ namespace ILLink.RoslynAnalyzer.Tests
 			return MSBuildProperties.Select (msbp => ($"build_property.{msbp}", "true")).ToArray ();
 		}
 
-		public static string GetRepoRoot()
+		public static string GetRepoRoot ()
 		{
-			return Directory.GetParent(ThisFile())!.Parent!.Parent!.FullName;
+			return Directory.GetParent (ThisFile ())!.Parent!.Parent!.FullName;
 
-			string ThisFile([CallerFilePath]string path = "") => path;
+			string ThisFile ([CallerFilePath] string path = "") => path;
 		}
 	}
 }

--- a/test/ILLink.RoslynAnalyzer.Tests/TestCaseUtils.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/TestCaseUtils.cs
@@ -2,22 +2,40 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
-using System.Text;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 
 namespace ILLink.RoslynAnalyzer.Tests
 {
-	public abstract class TestCaseUtils
+    public abstract class TestCaseUtils
 	{
+		public static readonly ReferenceAssemblies Net6PreviewAssemblies =
+			new ReferenceAssemblies (
+				"net6.0",
+				new PackageIdentity ("Microsoft.NETCore.App.Ref", "6.0.0-preview.5.21224.4"),
+				Path.Combine ("ref", "net6.0"))
+			.WithNuGetConfigFilePath (Path.Combine (TestCaseUtils.GetRepoRoot (), "NuGet.config"));
+
+		private static ImmutableArray<MetadataReference> s_net6Refs;
+		public async static ValueTask<ImmutableArray<MetadataReference>> GetNet6References()
+		{
+			if (s_net6Refs.IsDefault) {
+				var refs = await Net6PreviewAssemblies.ResolveAsync (null, default);
+				ImmutableInterlocked.InterlockedInitialize(ref s_net6Refs, refs);
+			}
+			return s_net6Refs;
+		}
+
 		public static IEnumerable<object[]> GetTestData (string testSuiteName)
 		{
 			foreach (var testFile in s_testFiles[testSuiteName]) {
@@ -57,8 +75,6 @@ namespace ILLink.RoslynAnalyzer.Tests
 				.CreateCompilation (m.SyntaxTree.GetRoot ().SyntaxTree, MSBuildProperties).Result);
 			test.ValidateAttributes (attrs);
 		}
-
-
 
 		public static readonly ImmutableDictionary<string, List<string>> s_testFiles = GetTestFilesByDirName ();
 
@@ -176,6 +192,13 @@ namespace ILLink.RoslynAnalyzer.Tests
 		public static (string, string)[] UseMSBuildProperties (params string[] MSBuildProperties)
 		{
 			return MSBuildProperties.Select (msbp => ($"build_property.{msbp}", "true")).ToArray ();
+		}
+
+		public static string GetRepoRoot()
+		{
+			return Directory.GetParent(ThisFile())!.Parent!.Parent!.FullName;
+
+			string ThisFile([CallerFilePath]string path = "") => path;
 		}
 	}
 }

--- a/test/ILLink.RoslynAnalyzer.Tests/UnconditionalSuppressMessageCodeFixTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/UnconditionalSuppressMessageCodeFixTests.cs
@@ -32,7 +32,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 			var test = new VerifyCSUSMwithRUC.Test {
 				TestCode = source,
 				FixedCode = fixedSource,
-				ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
+				ReferenceAssemblies = TestCaseUtils.Net6PreviewAssemblies
 			};
 			test.ExpectedDiagnostics.AddRange (baselineExpected);
 			test.TestState.AnalyzerConfigFiles.Add (
@@ -69,7 +69,7 @@ namespace System.Diagnostics.CodeAnalysis
 			var test = new VerifyCSUSMwithRAF.Test {
 				TestCode = source + attributeDefinition,
 				FixedCode = fixedSource + attributeDefinition,
-				ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
+				ReferenceAssemblies = TestCaseUtils.Net6PreviewAssemblies
 			};
 			test.ExpectedDiagnostics.AddRange (baselineExpected);
 			test.TestState.AnalyzerConfigFiles.Add (

--- a/test/ILLink.RoslynAnalyzer.Tests/Verifiers/CSharpAnalyzerVerifier`1.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/Verifiers/CSharpAnalyzerVerifier`1.cs
@@ -52,7 +52,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 			var comp = CSharpCompilation.Create (
 				assemblyName: Guid.NewGuid ().ToString ("N"),
 				syntaxTrees: new SyntaxTree[] { src },
-				references: (await TestCaseUtils.GetNet6References()).Add (mdRef).AddRange (additionalReferences),
+				references: (await TestCaseUtils.GetNet6References ()).Add (mdRef).AddRange (additionalReferences),
 				new CSharpCompilationOptions (OutputKind.DynamicallyLinkedLibrary));
 
 			var analyzerOptions = new AnalyzerOptions (

--- a/test/ILLink.RoslynAnalyzer.Tests/Verifiers/CSharpAnalyzerVerifier`1.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/Verifiers/CSharpAnalyzerVerifier`1.cs
@@ -42,7 +42,6 @@ namespace ILLink.RoslynAnalyzer.Tests
 		public static async Task<Compilation> GetCompilation (string source, IEnumerable<MetadataReference>? additionalReferences = null)
 			=> (await CSharpAnalyzerVerifier<RequiresAssemblyFilesAnalyzer>.CreateCompilation (source, additionalReferences: additionalReferences ?? Array.Empty<MetadataReference> ())).Compilation.Compilation;
 
-
 		public static async Task<(CompilationWithAnalyzers Compilation, SemanticModel SemanticModel)> CreateCompilation (
 			SyntaxTree src,
 			(string, string)[]? globalAnalyzerOptions = null,
@@ -53,7 +52,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 			var comp = CSharpCompilation.Create (
 				assemblyName: Guid.NewGuid ().ToString ("N"),
 				syntaxTrees: new SyntaxTree[] { src },
-				references: (await ReferenceAssemblies.Net.Net50.ResolveAsync (null, default)).Add (mdRef).AddRange (additionalReferences),
+				references: (await TestCaseUtils.GetNet6References()).Add (mdRef).AddRange (additionalReferences),
 				new CSharpCompilationOptions (OutputKind.DynamicallyLinkedLibrary));
 
 			var analyzerOptions = new AnalyzerOptions (


### PR DESCRIPTION
The version is currently hardcoded in TestCaseUtils.cs, but since
these are reference assemblies, as long as the surface area isn't
predicted to change, we can update as necessary.