### PR TITLE
Don't warn for RUC from DebuggerDisplayAttribute

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2747,6 +2747,10 @@ namespace Mono.Linker.Steps
 
 			case DependencyKind.Custom:
 			case DependencyKind.Unspecified:
+
+			// Don't warn for methods kept due to non-understood DebuggerDisplayAttribute
+			// until https://github.com/mono/linker/issues/1873 is fixed.
+			case DependencyKind.KeptForSpecialAttribute:
 				return;
 
 			default:

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
@@ -689,7 +689,8 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 		class AccessThroughSpecialAttribute
 		{
-			[ExpectedWarning ("IL2026", "--DebuggerProxyType.Method--")]
+			// https://github.com/mono/linker/issues/1873
+			// [ExpectedWarning ("IL2026", "--DebuggerProxyType.Method--")]
 			[DebuggerDisplay ("Some{*}value")]
 			class TypeWithDebuggerDisplay
 			{


### PR DESCRIPTION
Fixes https://github.com/mono/linker/issues/2122