### PR TITLE
Check target of module/assembly level suppressions

### DIFF
--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -1683,6 +1683,11 @@ class Test
   }
   ```
 
+#### `IL2108`: Invalid scope 'scope' used in 'UnconditionalSuppressMessageAttribute' on module 'module'.
+
+The only scopes supported on global unconditional suppressions are 'module', 'type' and 'member'. If the scope argument is null or missing on a global suppression,
+it is assumed that the suppression is put on the module. Global unconditional suppressions using invalid scopes are ignored.
+
 ## Single-File Warning Codes
 
 #### `IL3000`: 'member' always returns an empty string for assemblies embedded in a single-file app. If the path to the app directory is needed, consider calling 'System.AppContext.BaseDirectory'

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -1683,14 +1683,14 @@ class Test
   }
   ```
 
-#### `IL2108`: Invalid scope 'scope' used in 'UnconditionalSuppressMessageAttribute' on module 'module'.
+#### `IL2108`: Invalid scope 'scope' used in 'UnconditionalSuppressMessageAttribute' on module 'module' with target 'target'.
 
-The only scopes supported on global unconditional suppressions are 'module', 'type' and 'member'. If the scope argument is null or missing on a global suppression,
+The only scopes supported on global unconditional suppressions are 'module', 'type' and 'member'. If the scope and target arguments are null or missing on a global suppression,
 it is assumed that the suppression is put on the module. Global unconditional suppressions using invalid scopes are ignored.
 
 ```C#
-// Invalid scope 'method' used in 'UnconditionalSuppressMessageAttribute' on module 'Warning'.
-[module: UnconditionalSuppressMessage ("Test suppression with invalid scope", "IL2026", Scope = "method", Target = "...")]
+// Invalid scope 'method' used in 'UnconditionalSuppressMessageAttribute' on module 'Warning' with target 'MyTarget'.
+[module: UnconditionalSuppressMessage ("Test suppression with invalid scope", "IL2026", Scope = "method", Target = "MyTarget")]
 
 class Warning
 {

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -1688,6 +1688,24 @@ class Test
 The only scopes supported on global unconditional suppressions are 'module', 'type' and 'member'. If the scope argument is null or missing on a global suppression,
 it is assumed that the suppression is put on the module. Global unconditional suppressions using invalid scopes are ignored.
 
+```C#
+// Invalid scope 'method' used in 'UnconditionalSuppressMessageAttribute' on module 'Warning'.
+[module: UnconditionalSuppressMessage ("Test suppression with invalid scope", "IL2026", Scope = "method", Target = "...")]
+
+class Warning
+{
+   static void Main(string[] args)
+   {
+      Foo();
+   }
+
+   [RequiresUnreferencedCode("Warn when Foo() is called")]
+   static void Foo()
+   {
+   }
+}
+```
+
 ## Single-File Warning Codes
 
 #### `IL3000`: 'member' always returns an empty string for assemblies embedded in a single-file app. If the path to the app directory is needed, consider calling 'System.AppContext.BaseDirectory'

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -808,7 +808,7 @@ namespace Mono.Linker.Steps
 						continue;
 					}
 
-					if (UnconditionalSuppressMessageAttributeState.TypeRefHasUnconditionalSuppressions (ca.Constructor.DeclaringType) && 
+					if (UnconditionalSuppressMessageAttributeState.TypeRefHasUnconditionalSuppressions (ca.Constructor.DeclaringType) &&
 						provider is not ModuleDefinition && provider is not AssemblyDefinition)
 						_context.Suppressions.AddSuppression (ca, provider);
 

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -808,7 +808,8 @@ namespace Mono.Linker.Steps
 						continue;
 					}
 
-					if (UnconditionalSuppressMessageAttributeState.TypeRefHasUnconditionalSuppressions (ca.Constructor.DeclaringType))
+					if (UnconditionalSuppressMessageAttributeState.TypeRefHasUnconditionalSuppressions (ca.Constructor.DeclaringType) && 
+						provider is not ModuleDefinition && provider is not AssemblyDefinition)
 						_context.Suppressions.AddSuppression (ca, provider);
 
 					var resolvedAttributeType = _context.Resolve (ca.AttributeType);

--- a/src/linker/Linker/DocumentationSignatureParser.cs
+++ b/src/linker/Linker/DocumentationSignatureParser.cs
@@ -42,13 +42,10 @@ namespace Mono.Linker
 
 		public static IEnumerable<IMemberDefinition> GetMembersForDocumentationSignature (string id, ModuleDefinition module)
 		{
-			if (id == null)
-				throw new ArgumentNullException (nameof (id));
-
-			if (module == null)
-				throw new ArgumentNullException (nameof (module));
-
 			var results = new List<IMemberDefinition> ();
+			if (id == null || module == null)
+				return results;
+
 			ParseDocumentationSignature (id, module, results);
 			return results;
 		}

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -33,7 +33,6 @@ using System.IO;
 using System.Reflection;
 using System.Runtime.Loader;
 using System.Text;
-using System.Xml.XPath;
 using Mono.Cecil;
 using Mono.Linker.Steps;
 

--- a/src/linker/Linker/UnconditionalSuppressMessageAttributeState.cs
+++ b/src/linker/Linker/UnconditionalSuppressMessageAttributeState.cs
@@ -173,14 +173,17 @@ namespace Mono.Linker
 				if (!TryDecodeSuppressMessageAttributeData (instance, out info))
 					continue;
 
-				// If the scope is missing we treat the suppression as if it was placed on the module.
 				var scope = info.Scope?.ToLower ();
-				if (scope == "module" || scope == null) {
+				if (info.Target == null && (scope == "module" || scope == null)) {
 					AddSuppression (info, provider);
 					continue;
 				}
 
 				switch (scope) {
+				case "module":
+					AddSuppression (info, provider);
+					break;
+
 				case "type":
 				case "member":
 					foreach (var result in DocumentationSignatureParser.GetMembersForDocumentationSignature (info.Target, module))
@@ -188,7 +191,8 @@ namespace Mono.Linker
 
 					break;
 				default:
-					_context.LogWarning ($"Invalid scope '{info.Scope}' used in 'UnconditionalSuppressMessageAttribute' on module '{module.Name}'.",
+					_context.LogWarning ($"Invalid scope '{info.Scope}' used in 'UnconditionalSuppressMessageAttribute' on module '{module.Name}' " +
+						$"with target '{info.Target}'.",
 						2108, _context.GetAssemblyLocation (module.Assembly));
 					break;
 				}

--- a/src/linker/Linker/UnconditionalSuppressMessageAttributeState.cs
+++ b/src/linker/Linker/UnconditionalSuppressMessageAttributeState.cs
@@ -175,7 +175,7 @@ namespace Mono.Linker
 					continue;
 
 				// If the scope is missing we treat the suppression as if it was placed on the module.
-				var scope = info.Scope ?.ToLower ();
+				var scope = info.Scope?.ToLower ();
 				if (info.Target == null && (scope == "module" || scope == null)) {
 					AddSuppression (info, provider);
 					continue;

--- a/src/linker/Linker/UnconditionalSuppressMessageAttributeState.cs
+++ b/src/linker/Linker/UnconditionalSuppressMessageAttributeState.cs
@@ -90,8 +90,7 @@ namespace Mono.Linker
 				return false;
 
 			return _suppressions.TryGetValue (provider, out var suppressions) &&
-				suppressions.TryGetValue (id, out info) &&
-				(provider is ModuleDefinition || provider is AssemblyDefinition ? info.Target == null : true);
+				suppressions.TryGetValue (id, out info);
 		}
 
 		static bool TryDecodeSuppressMessageAttributeData (CustomAttribute attribute, out SuppressMessageInfo info)
@@ -176,13 +175,10 @@ namespace Mono.Linker
 
 				// If the scope is missing we treat the suppression as if it was placed on the module.
 				var scope = info.Scope?.ToLower ();
-				if (info.Target == null && (scope == "module" || scope == null)) {
+				if (scope == "module" || scope == null) {
 					AddSuppression (info, provider);
 					continue;
 				}
-
-				if (info.Target == null || scope == null)
-					continue;
 
 				switch (scope) {
 				case "type":

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/ModuleSuppressionWithMemberScopeNullTarget.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/ModuleSuppressionWithMemberScopeNullTarget.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+// A module level suppression with a 'type' or 'member' scope must also specify the target, pointing
+// to the type or member where the suppression should be put.
+[module: UnconditionalSuppressMessage ("Test", "IL2026", Scope = "member", Target = null)]
+
+namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
+{
+	[SkipKeptItemsValidation]
+	[LogContains ("IL2026")]
+	class ModuleSuppressionWithMemberScopeNullTarget
+	{
+		static void Main ()
+		{
+			TriggerWarning ();
+		}
+
+		[RequiresUnreferencedCode ("TriggerWarning")]
+		public static Type TriggerWarning ()
+		{
+			return typeof (ModuleSuppressionWithMemberScopeNullTarget);
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/ModuleSuppressionWithModuleScopeNullTarget.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/ModuleSuppressionWithModuleScopeNullTarget.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+[module: UnconditionalSuppressMessage ("Test", "IL2026", Scope = "module", Target = null)]
+
+namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
+{
+	[SkipKeptItemsValidation]
+	[LogDoesNotContain ("IL2026")]
+	class ModuleSuppressionWithModuleScopeNullTarget
+	{
+		static void Main ()
+		{
+			TriggerWarning ();
+		}
+
+		[RequiresUnreferencedCode ("TriggerWarning")]
+		public static Type TriggerWarning ()
+		{
+			return typeof (ModuleSuppressionWithModuleScopeNullTarget);
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/ModuleSuppressionWithNullScopeNullTarget.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/ModuleSuppressionWithNullScopeNullTarget.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+// A module level suppression with a null scope will be put on the current module.
+[module: UnconditionalSuppressMessage ("Test", "IL2026", Scope = null, Target = null)]
+
+namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
+{
+	[SkipKeptItemsValidation]
+	[LogDoesNotContain ("IL2026")]
+	class ModuleSuppressionWithNullScopeNullTarget
+	{
+		static void Main ()
+		{
+			TriggerWarning ();
+		}
+
+		[RequiresUnreferencedCode ("TriggerWarning")]
+		public static Type TriggerWarning ()
+		{
+			return typeof (ModuleSuppressionWithNullScopeNullTarget);
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInModule.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInModule.cs
@@ -5,6 +5,8 @@ using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 [module: UnconditionalSuppressMessage ("Test", "IL2072:Suppress unrecognized reflection pattern warnings in this module")]
+[module: UnconditionalSuppressMessage ("Test", "IL2072:Test that specifying an invalid scope will result on a global suppression being ignored.",
+	Scope = "invalidScope", Target = "Non-existent target")]
 
 namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 {
@@ -13,13 +15,16 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 #endif
 	[SkipKeptItemsValidation]
 	[LogDoesNotContain ("TriggerUnrecognizedPattern()")]
+	[LogContains ("warning IL2108: Invalid scope 'invalidScope' used in 'UnconditionalSuppressMessageAttribute'")]
 	public class SuppressWarningsInModule
 	{
+		[ExpectedWarning ("IL2026", "TriggerUnrecognizedPattern()")]
 		public static void Main ()
 		{
 			Expression.Call (TriggerUnrecognizedPattern (), "", Type.EmptyTypes);
 		}
 
+		[RequiresUnreferencedCode ("Test that the global unconditional suppression will not work when using an invalid scope.")]
 		public static Type TriggerUnrecognizedPattern ()
 		{
 			return typeof (SuppressWarningsInModule);

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/TargettedModuleSuppressionWithUnmatchedScope.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/TargettedModuleSuppressionWithUnmatchedScope.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+// Module suppressions that have scope argument `type` or `member` will always cause the value of the target parameter
+// to be parsed using the DocumentationSignatureParser, this parser rules where will the suppression be put depending upon the
+// prefix used in the fully qualified member specified for the target.
+[module: UnconditionalSuppressMessage ("Test", "IL2026",
+	Scope = "type", Target = "M:Mono.Linker.Tests.Cases.Warnings.WarningSuppression.TargettedModuleSuppressionWithUnmatchedScope.Main()")]
+// The target of this suppression will be ignored since the suppression was put on a higher scope -- this suppression will be
+// put on the module.
+[module: UnconditionalSuppressMessage ("Test", "IL2072",
+	Scope = "module", Target = "T:Mono.Linker.Tests.Cases.Warnings.WarningSuppression.TargettedModuleSuppressionWithUnmatchedScope")]
+
+namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
+{
+	[SkipKeptItemsValidation]
+	[LogDoesNotContain ("IL2026")]
+	[LogDoesNotContain ("IL2072")]
+	class TargettedModuleSuppressionWithUnmatchedScope
+	{
+		static void Main ()
+		{
+			// IL2072
+			Expression.Call (TriggerWarning (), "", Type.EmptyTypes);
+			// IL2026
+			TriggerWarning ();
+		}
+
+		[RequiresUnreferencedCode ("TriggerWarning")]
+		public static Type TriggerWarning ()
+		{
+			return typeof (TargettedModuleSuppressionWithUnmatchedScope);
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/TargettedModuleSuppressionWithUnmatchedScope.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/TargettedModuleSuppressionWithUnmatchedScope.cs
@@ -21,10 +21,13 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 // put on the module.
 [module: UnconditionalSuppressMessage ("Test", "IL2072",
 	Scope = "module", Target = "T:Mono.Linker.Tests.Cases.Warnings.WarningSuppression.TargettedModuleSuppressionWithUnmatchedScope")]
+[module: UnconditionalSuppressMessage ("Test", "IL2026",
+	Target = "M:Mono.Linker.Tests.Cases.Warnings.WarningSuppression.TargettedModuleSuppressionWithUnmatchedScope.Main()")]
 
 namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 {
 	[SkipKeptItemsValidation]
+	[LogContains ("warning IL2108: Invalid scope '' used in 'UnconditionalSuppressMessageAttribute'")]
 	[LogDoesNotContain ("IL2026")]
 	[LogDoesNotContain ("IL2072")]
 	class TargettedModuleSuppressionWithUnmatchedScope


### PR DESCRIPTION
The `Scope` parameter is only relevant in the context of global suppressions (put in a module or an assembly); and the only scopes that we support are `module`, `type` and `member`. Whenever the scope is set to a value other than these three, we log a message stating that the used argument is not supported -- this was changed to log a warning instead.

Unconditional suppressions put on a module/assembly that specify a target are registered as if they were put on the target (e.g., on a type, field, etc.); thus, when looking if a warning is suppressed on a global level, we must make sure to only look in global suppressions that do not specify a target -- this was fixed.