### PR TITLE
Enhance NestedTypes in DynamicallyAccessedMemberTypes

### DIFF
--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -2279,7 +2279,8 @@ namespace Mono.Linker.Dataflow
 					MarkField (ref reflectionContext, field, DependencyKind.DynamicallyAccessedMember);
 					break;
 				case TypeDefinition nestedType:
-					MarkType (ref reflectionContext, nestedType, DependencyKind.DynamicallyAccessedMember);
+					DependencyInfo nestedDependencyInfo = new DependencyInfo (DependencyKind.DynamicallyAccessedMember, reflectionContext.Source);
+					reflectionContext.RecordRecognizedPattern (nestedType, () => _markStep.MarkEntireType (nestedType, includeBaseAndInterfaceTypes: true, nestedDependencyInfo));
 					break;
 				case PropertyDefinition property:
 					MarkProperty (ref reflectionContext, property, DependencyKind.DynamicallyAccessedMember);

--- a/test/Mono.Linker.Tests.Cases/DataFlow/IReflectDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/IReflectDataflow.cs
@@ -35,6 +35,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			public C2 () { }
 
 			[Kept]
+			[KeptMember (".ctor()")]
 			public class Nested { }
 		}
 

--- a/test/Mono.Linker.Tests.Cases/DataFlow/MemberTypes.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/MemberTypes.cs
@@ -1043,15 +1043,19 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		class PublicNestedTypesType : PublicNestedTypesBaseType
 		{
 			[Kept]
+			[KeptMember (".ctor()")]
 			public class PublicNestedType { }
 			protected class ProtectedNestedType { }
 			private class PrivateNestedType { }
 			[Kept]
+			[KeptMember (".ctor()")]
 			public class HideNestedType { }
 
 			[Kept]
 			[KeptBaseType (typeof (MulticastDelegate))]
 			[KeptMember (".ctor(System.Object,System.IntPtr)")]
+			[KeptMember ("BeginInvoke(System.AsyncCallback,System.Object)")]
+			[KeptMember ("EndInvoke(System.IAsyncResult)")]
 			[KeptMember ("Invoke()")]
 			public delegate int PublicDelegate ();
 
@@ -1085,8 +1089,10 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		{
 			public class PublicNestedType { }
 			[Kept]
+			[KeptMember (".ctor()")]
 			protected class ProtectedNestedType { }
 			[Kept]
+			[KeptMember (".ctor()")]
 			private class PrivateNestedType { }
 			public class HideNestedType { }
 
@@ -1095,6 +1101,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[Kept]
 			[KeptBaseType (typeof (MulticastDelegate))]
 			[KeptMember (".ctor(System.Object,System.IntPtr)")]
+			[KeptMember ("BeginInvoke(System.AsyncCallback,System.Object)")]
+			[KeptMember ("EndInvoke(System.IAsyncResult)")]
 			[KeptMember ("Invoke()")]
 			private delegate int PrivateDelegate ();
 		}
@@ -1125,23 +1133,31 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		class AllNestedTypesType : AllNestedTypesBaseType
 		{
 			[Kept]
+			[KeptMember (".ctor()")]
 			public class PublicNestedType { }
 			[Kept]
+			[KeptMember (".ctor()")]
 			protected class ProtectedNestedType { }
 			[Kept]
+			[KeptMember (".ctor()")]
 			private class PrivateNestedType { }
 			[Kept]
+			[KeptMember (".ctor()")]
 			public class HideNestedType { }
 
 			[Kept]
 			[KeptBaseType (typeof (MulticastDelegate))]
 			[KeptMember (".ctor(System.Object,System.IntPtr)")]
+			[KeptMember ("BeginInvoke(System.AsyncCallback,System.Object)")]
+			[KeptMember ("EndInvoke(System.IAsyncResult)")]
 			[KeptMember ("Invoke()")]
 			public delegate int PublicDelegate ();
 
 			[Kept]
 			[KeptBaseType (typeof (MulticastDelegate))]
 			[KeptMember (".ctor(System.Object,System.IntPtr)")]
+			[KeptMember ("BeginInvoke(System.AsyncCallback,System.Object)")]
+			[KeptMember ("EndInvoke(System.IAsyncResult)")]
 			[KeptMember ("Invoke()")]
 			private delegate int PrivateDelegate ();
 		}

--- a/test/Mono.Linker.Tests.Cases/Reflection/MembersUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/MembersUsedViaReflection.cs
@@ -138,7 +138,9 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[Kept]
 			public static class PublicNestedType
 			{
+				[Kept]
 				public static int _nestedPublicField;
+				[Kept]
 				public static void NestedPublicMethod ()
 				{ }
 			}
@@ -193,7 +195,9 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			public static class PublicNestedType
 			{
 				// PublicNestedType should be kept but linker won't mark anything besides the declaration
+				[Kept]
 				public static int _nestedPublicField;
+				[Kept]
 				public static void NestedPublicMethod ()
 				{ }
 			}
@@ -258,7 +262,9 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			public static class PublicNestedType
 			{
 				// PublicNestedType should be kept but linker won't mark anything besides the declaration
+				[Kept]
 				public static int _nestedPublicField;
+				[Kept]
 				public static void NestedPublicMethod ()
 				{ }
 			}
@@ -313,7 +319,9 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			public static class PublicNestedType
 			{
 				// PublicNestedType should be kept but linker won't mark anything besides the declaration
+				[Kept]
 				public static int _nestedPublicField;
+				[Kept]
 				public static void NestedPublicMethod ()
 				{ }
 			}
@@ -368,7 +376,9 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			public static class PublicNestedType
 			{
 				// PublicNestedType should be kept but linker won't mark anything besides the declaration
+				[Kept]
 				public static int _nestedPublicField;
+				[Kept]
 				public static void NestedPublicMethod ()
 				{ }
 			}
@@ -423,7 +433,9 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			public static class PublicNestedType
 			{
 				// PublicNestedType should be kept but linker won't mark anything besides the declaration
+				[Kept]
 				public static int _nestedPublicField;
+				[Kept]
 				public static void NestedPublicMethod ()
 				{ }
 			}

--- a/test/Mono.Linker.Tests.Cases/Reflection/ObjectGetType.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ObjectGetType.cs
@@ -1102,18 +1102,23 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			class Derived : AnnotatedBase
 			{
 				[Kept]
+				[KeptMember (".ctor()")]
 				[KeptBaseType (typeof (AnnotatedBase))]
 				public class NestedDerived : AnnotatedBase
 				{
 					[Kept]
 					[KeptBaseType (typeof (NestedDerived))]
+					[KeptMember (".ctor()")]
 					public class DeepNestedDerived : NestedDerived
 					{
 						[Kept] // Marked due to the annotation
+						[KeptMember (".ctor()")]
 						public class DeepNestedChild
 						{
 						}
 
+						[Kept] // Marked due to the annotation
+						[KeptMember (".ctor()")]
 						private class DeepNestedPrivateChild
 						{
 						}
@@ -1121,6 +1126,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
 					[Kept] // Marked due to the annotation
 					[KeptInterface (typeof (IUnannotatedInterface))]
+					[KeptMember (".ctor()")]
 					public class NestedChild : IUnannotatedInterface
 					{
 					}


### PR DESCRIPTION
We don't do much for nested type options in `DynamicallyAccessedMemberTypes`, forcing the much broader scope `All `to be used if we want to preserve members inside nested types. This fixes by keeping all the members for nested types

Fixes #1174