### PR TITLE
Move EventSource special handling to library mode

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1775,7 +1775,7 @@ namespace Mono.Linker.Steps
 			MarkSerializable (type);
 
 			// This marks static fields of KeyWords/OpCodes/Tasks subclasses of an EventSource type.
-			if (BCL.EventTracingForWindows.IsEventSourceImplementation (type, _context)) {
+			if ((_context.GetTargetRuntimeVersion () < TargetRuntimeVersion.NET6 || !_context.IsOptimizationEnabled (CodeOptimizations.RemoveEventSourceSpecialHandling, type)) && BCL.EventTracingForWindows.IsEventSourceImplementation (type, _context)) {
 				MarkEventSourceProviders (type);
 			}
 
@@ -1910,7 +1910,7 @@ namespace Mono.Linker.Steps
 				case "DebuggerTypeProxyAttribute" when attrType.Namespace == "System.Diagnostics":
 					MarkTypeWithDebuggerTypeProxyAttribute (type, attribute);
 					break;
-				case "EventDataAttribute" when attrType.Namespace == "System.Diagnostics.Tracing":
+				case "EventDataAttribute" when attrType.Namespace == "System.Diagnostics.Tracing" && (_context.GetTargetRuntimeVersion () < TargetRuntimeVersion.NET6 || !_context.IsOptimizationEnabled (CodeOptimizations.RemoveEventSourceSpecialHandling, type)):
 					if (MarkMethodsIf (type.Methods, MethodDefinitionExtensions.IsPublicInstancePropertyMethod, new DependencyInfo (DependencyKind.ReferencedBySpecialAttribute, type)))
 						Tracer.AddDirectDependency (attribute, new DependencyInfo (DependencyKind.CustomAttribute, type), marked: false);
 					break;

--- a/src/linker/Linker.Steps/RootAssemblyInputStep.cs
+++ b/src/linker/Linker.Steps/RootAssemblyInputStep.cs
@@ -81,7 +81,8 @@ namespace Mono.Linker.Steps
 					CodeOptimizations.RemoveDescriptors |
 					CodeOptimizations.RemoveLinkAttributes |
 					CodeOptimizations.RemoveSubstitutions |
-					CodeOptimizations.RemoveDynamicDependencyAttribute, assembly.Name.Name);
+					CodeOptimizations.RemoveDynamicDependencyAttribute |
+					CodeOptimizations.RemoveEventSourceSpecialHandling, assembly.Name.Name);
 
 				// No metadata trimming
 				Context.MetadataTrimming = MetadataTrimming.None;

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -246,7 +246,8 @@ namespace Mono.Linker
 				CodeOptimizations.RemoveDescriptors |
 				CodeOptimizations.RemoveLinkAttributes |
 				CodeOptimizations.RemoveSubstitutions |
-				CodeOptimizations.RemoveDynamicDependencyAttribute;
+				CodeOptimizations.RemoveDynamicDependencyAttribute |
+				CodeOptimizations.RemoveEventSourceSpecialHandling;
 
 			Optimizations = new CodeOptimizationsSettings (defaultOptimizations);
 		}
@@ -986,5 +987,9 @@ namespace Mono.Linker
 		RemoveSubstitutions = 1 << 21,
 		RemoveLinkAttributes = 1 << 22,
 		RemoveDynamicDependencyAttribute = 1 << 23,
+		/// <summary>
+		/// option to not special case EventSource
+		/// </summary>
+		RemoveEventSourceSpecialHandling = 1 << 24,
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/BCLFeatures/ETW/CustomEventSource.cs
+++ b/test/Mono.Linker.Tests.Cases/BCLFeatures/ETW/CustomEventSource.cs
@@ -21,19 +21,16 @@ namespace Mono.Linker.Tests.Cases.BCLFeatures.ETW
 	[EventSource (Name = "MyCompany")]
 	class MyCompanyEventSource : EventSource
 	{
-		[Kept]
+		// Although EventSource has a type level attribute, marking of it is not triggered unless object.GetType() gets called from GenerateManifest which doesn't happen here
 		public class Keywords
 		{
-			[Kept]
 			public const EventKeywords Page = (EventKeywords) 1;
 
 			public int Unused;
 		}
 
-		[Kept]
 		public class Tasks
 		{
-			[Kept]
 			public const EventTask Page = (EventTask) 1;
 
 			public int Unused;

--- a/test/Mono.Linker.Tests.Cases/Reflection/MembersUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/MembersUsedViaReflection.cs
@@ -194,7 +194,6 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[Kept]
 			public static class PublicNestedType
 			{
-				// PublicNestedType should be kept but linker won't mark anything besides the declaration
 				[Kept]
 				public static int _nestedPublicField;
 				[Kept]
@@ -261,7 +260,6 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[Kept]
 			public static class PublicNestedType
 			{
-				// PublicNestedType should be kept but linker won't mark anything besides the declaration
 				[Kept]
 				public static int _nestedPublicField;
 				[Kept]
@@ -318,7 +316,6 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[Kept]
 			public static class PublicNestedType
 			{
-				// PublicNestedType should be kept but linker won't mark anything besides the declaration
 				[Kept]
 				public static int _nestedPublicField;
 				[Kept]
@@ -375,7 +372,6 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[Kept]
 			public static class PublicNestedType
 			{
-				// PublicNestedType should be kept but linker won't mark anything besides the declaration
 				[Kept]
 				public static int _nestedPublicField;
 				[Kept]
@@ -432,7 +428,6 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[Kept]
 			public static class PublicNestedType
 			{
-				// PublicNestedType should be kept but linker won't mark anything besides the declaration
 				[Kept]
 				public static int _nestedPublicField;
 				[Kept]


### PR DESCRIPTION
Trimmer cannot remove special handling of `EventSource` without some work from the library side due to some [size concerns](https://github.com/dotnet/runtime/issues/54859). This fix moves the `EventSource` special handling to library mode since the general case will be handled via the type hierarchy support feature.