### PR TITLE
Ruc on classes

### DIFF
--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -39,8 +39,9 @@ namespace Mono.Linker.Dataflow
 
 			return GetIntrinsicIdForMethod (methodDefinition) > IntrinsicId.RequiresReflectionBodyScanner_Sentinel ||
 				context.Annotations.FlowAnnotations.RequiresDataFlowAnalysis (methodDefinition) ||
-				context.Annotations.HasLinkerAttribute<RequiresUnreferencedCodeAttribute> (methodDefinition)
-				|| methodDefinition.IsPInvokeImpl;
+				context.Annotations.HasLinkerAttribute<RequiresUnreferencedCodeAttribute> (methodDefinition) ||
+				context.Annotations.HasRequiresUnreferencedCodeOnTypeHyerarchy (methodDefinition.DeclaringType) ||
+				methodDefinition.IsPInvokeImpl;
 		}
 
 		public static bool RequiresReflectionMethodBodyScannerForMethodBody (FlowAnnotations flowAnnotations, MethodDefinition methodDefinition)

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -40,7 +40,7 @@ namespace Mono.Linker.Dataflow
 			return GetIntrinsicIdForMethod (methodDefinition) > IntrinsicId.RequiresReflectionBodyScanner_Sentinel ||
 				context.Annotations.FlowAnnotations.RequiresDataFlowAnalysis (methodDefinition) ||
 				context.Annotations.HasLinkerAttribute<RequiresUnreferencedCodeAttribute> (methodDefinition) ||
-				context.Annotations.HasRequiresUnreferencedCodeOnTypeHyerarchy (methodDefinition.DeclaringType) ||
+				context.Annotations.HasRequiresUnreferencedCodeOnTypeHierarchy (methodDefinition.DeclaringType) ||
 				methodDefinition.IsPInvokeImpl;
 		}
 

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2792,14 +2792,14 @@ namespace Mono.Linker.Steps
 			if (suppressionContextMember != null &&
 				(Annotations.HasLinkerAttribute<RequiresUnreferencedCodeAttribute> (suppressionContextMember) ||
 				(suppressionContextMember.DeclaringType != null &&
-				Annotations.HasRequiresUnreferencedCodeOnTypeHyerarchy (suppressionContextMember.DeclaringType))))
+				Annotations.HasRequiresUnreferencedCodeOnTypeHierarchy (suppressionContextMember.DeclaringType))))
 				return true;
 
 			IMemberDefinition originMember = currentOrigin.MemberDefinition;
 			if (suppressionContextMember != originMember && originMember != null &&
 				(Annotations.HasLinkerAttribute<RequiresUnreferencedCodeAttribute> (originMember) ||
 				(originMember.DeclaringType != null &&
-				Annotations.HasRequiresUnreferencedCodeOnTypeHyerarchy (originMember.DeclaringType))))
+				Annotations.HasRequiresUnreferencedCodeOnTypeHierarchy (originMember.DeclaringType))))
 				return true;
 
 			return false;

--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -553,7 +553,7 @@ namespace Mono.Linker
 			return marked_types_with_cctor.Add (type);
 		}
 
-		public bool HasRequiresUnreferencedCodeOnTypeHyerarchy (TypeDefinition type)
+		public bool HasRequiresUnreferencedCodeOnTypeHierarchy (TypeDefinition type)
 		{
 			if (!ruc_on_type_hierarchy.TryGetValue (type, out var hasRucOnTypeHierarchy))
 				return TryGetRequiresUnreferencedCodeAttributeOnTypeHierarchy (type, out var _);

--- a/src/linker/Linker/LinkerAttributesInformation.cs
+++ b/src/linker/Linker/LinkerAttributesInformation.cs
@@ -87,7 +87,7 @@ namespace Mono.Linker
 
 		static Attribute ProcessRequiresUnreferencedCodeAttribute (LinkContext context, ICustomAttributeProvider provider, CustomAttribute customAttribute)
 		{
-			if (!(provider is MethodDefinition method))
+			if (!(provider is MethodDefinition || provider is TypeDefinition))
 				return null;
 
 			if (customAttribute.HasConstructorArguments && customAttribute.ConstructorArguments[0].Value is string message) {
@@ -106,7 +106,7 @@ namespace Mono.Linker
 
 			context.LogWarning (
 				$"Attribute '{typeof (RequiresUnreferencedCodeAttribute).FullName}' doesn't have the required number of parameters specified",
-				2028, method);
+				2028, (IMemberDefinition) provider);
 			return null;
 		}
 


### PR DESCRIPTION
 Add support for RequiresUnreferencedCode on classes
 Added a cache to fast lookup for RequiresUnreferencedCode on the type hierarchy
 Added special case for warning in constructors while marking types
 Added logic to handle suppressions of other trim analysis warnings when the declaring type has RUC
 Added tests

Fixes #1742