### PR TITLE
Warn when accessing DAM annotated method via reflection

### DIFF
--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -1689,7 +1689,7 @@ The only scopes supported on global unconditional suppressions are 'module', 'ty
 it is assumed that the suppression is put on the module. Global unconditional suppressions using invalid scopes are ignored.
 
 ```C#
-// Invalid scope 'method' used in 'UnconditionalSuppressMessageAttribute' on module 'Warning' with target 'MyTarget'.
+// IL2108: Invalid scope 'method' used in 'UnconditionalSuppressMessageAttribute' on module 'Warning' with target 'MyTarget'.
 [module: UnconditionalSuppressMessage ("Test suppression with invalid scope", "IL2026", Scope = "method", Target = "MyTarget")]
 
 class Warning
@@ -1721,6 +1721,37 @@ class Warning
   // IL2109: Type 'Derived' derives from 'UnsafeClass' which has 'RequiresUnreferencedCodeAttribute'. Using any of the members inside this class is trim unsafe. http://help/unreferencedcode
   class Derived : UnsafeClass {}
   ```
+
+#### `IL2110`: Trim analysis: Field 'field' with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.
+
+- Trimmer currently can't guarantee that all requirements of the `DynamicallyAccessedMembersAttribute` are fulfilled if the field is accessed via reflection.
+
+```C#
+[DynamicallyAccessedMembers(DynamicallyAccessedMemeberTypes.PublicMethods)]
+Type _field;
+
+void TestMethod()
+{
+    // IL2110: Field '_field' with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.
+    typeof(Test).GetField("_field");
+}
+```
+
+#### `IL2111`: Trim analysis: Method 'method' with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.
+
+- Trimmer currently can't guarantee that all requirements of the `DynamicallyAccessedMembersAttribute` are fulfilled if the method is accessed via reflection.
+
+```C#
+void MethodWithRequirements([DynamicallyAccessedMembers(DynamicallyAccessedMemeberTypes.PublicMethods)] Type type)
+{
+}
+
+void TestMethod()
+{
+    // IL2111: Method 'MethodWithRequirements' with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.
+    typeof(Test).GetMethod("MethodWithRequirements");
+}
+```
 
 ## Single-File Warning Codes
 

--- a/src/linker/Linker.Dataflow/FlowAnnotations.cs
+++ b/src/linker/Linker.Dataflow/FlowAnnotations.cs
@@ -75,7 +75,11 @@ namespace Mono.Linker.Dataflow
 
 		public bool ShouldWarnWhenAccessedForReflection (MethodDefinition method) =>
 			GetAnnotations (method.DeclaringType).TryGetAnnotation (method, out var annotation) &&
-				(annotation.ParameterAnnotations != null || annotation.ReturnParameterAnnotation != DynamicallyAccessedMemberTypes.None);
+			(annotation.ParameterAnnotations != null || annotation.ReturnParameterAnnotation != DynamicallyAccessedMemberTypes.None);
+
+		public bool MethodHasNoAnnotatedParameters (MethodDefinition method) =>
+			GetAnnotations (method.DeclaringType).TryGetAnnotation (method, out var annotation) &&
+			annotation.ParameterAnnotations == null;
 
 		public bool ShouldWarnWhenAccessedForReflection (FieldDefinition field) =>
 			GetAnnotations (field.DeclaringType).TryGetAnnotation (field, out _);

--- a/src/linker/Linker.Dataflow/FlowAnnotations.cs
+++ b/src/linker/Linker.Dataflow/FlowAnnotations.cs
@@ -37,20 +37,30 @@ namespace Mono.Linker.Dataflow
 		/// </summary>
 		/// <param name="parameterIndex">Parameter index in the IL sense. Parameter 0 on instance methods is `this`.</param>
 		/// <returns></returns>
-		public DynamicallyAccessedMemberTypes GetParameterAnnotation (MethodDefinition method, int parameterIndex) =>
-			(GetAnnotations (method.DeclaringType).TryGetAnnotation (method, out var annotation) && annotation.ParameterAnnotations != null)
-				? annotation.ParameterAnnotations[parameterIndex]
-				: DynamicallyAccessedMemberTypes.None;
+		public DynamicallyAccessedMemberTypes GetParameterAnnotation (MethodDefinition method, int parameterIndex)
+		{
+			if (GetAnnotations (method.DeclaringType).TryGetAnnotation (method, out var annotation) &&
+				annotation.ParameterAnnotations != null)
+				return annotation.ParameterAnnotations[parameterIndex];
 
-		public DynamicallyAccessedMemberTypes GetReturnParameterAnnotation (MethodDefinition method) =>
-			GetAnnotations (method.DeclaringType).TryGetAnnotation (method, out var annotation)
-				? annotation.ReturnParameterAnnotation
-				: DynamicallyAccessedMemberTypes.None;
+			return DynamicallyAccessedMemberTypes.None;
+		}
 
-		public DynamicallyAccessedMemberTypes GetFieldAnnotation (FieldDefinition field) =>
-			GetAnnotations (field.DeclaringType).TryGetAnnotation (field, out var annotation)
-				? annotation.Annotation
-				: DynamicallyAccessedMemberTypes.None;
+		public DynamicallyAccessedMemberTypes GetReturnParameterAnnotation (MethodDefinition method)
+		{
+			if (GetAnnotations (method.DeclaringType).TryGetAnnotation (method, out var annotation))
+				return annotation.ReturnParameterAnnotation;
+
+			return DynamicallyAccessedMemberTypes.None;
+		}
+
+		public DynamicallyAccessedMemberTypes GetFieldAnnotation (FieldDefinition field)
+		{
+			if (GetAnnotations (field.DeclaringType).TryGetAnnotation (field, out var annotation))
+				return annotation.Annotation;
+
+			return DynamicallyAccessedMemberTypes.None;
+		}
 
 		public DynamicallyAccessedMemberTypes GetTypeAnnotation (TypeDefinition type) =>
 			GetAnnotations (type).TypeAnnotation;

--- a/src/linker/Linker.Dataflow/FlowAnnotations.cs
+++ b/src/linker/Linker.Dataflow/FlowAnnotations.cs
@@ -23,57 +23,37 @@ namespace Mono.Linker.Dataflow
 			_hierarchyInfo = new TypeHierarchyCache (context);
 		}
 
-		public bool RequiresDataFlowAnalysis (MethodDefinition method)
-		{
-			return GetAnnotations (method.DeclaringType).TryGetAnnotation (method, out _);
-		}
+		public bool RequiresDataFlowAnalysis (MethodDefinition method) =>
+			GetAnnotations (method.DeclaringType).TryGetAnnotation (method, out _);
 
-		public bool RequiresDataFlowAnalysis (FieldDefinition field)
-		{
-			return GetAnnotations (field.DeclaringType).TryGetAnnotation (field, out _);
-		}
+		public bool RequiresDataFlowAnalysis (FieldDefinition field) =>
+			GetAnnotations (field.DeclaringType).TryGetAnnotation (field, out _);
 
-		public bool RequiresDataFlowAnalysis (GenericParameter genericParameter)
-		{
-			return GetGenericParameterAnnotation (genericParameter) != DynamicallyAccessedMemberTypes.None;
-		}
+		public bool RequiresDataFlowAnalysis (GenericParameter genericParameter) =>
+			GetGenericParameterAnnotation (genericParameter) != DynamicallyAccessedMemberTypes.None;
 
 		/// <summary>
 		/// Retrieves the annotations for the given parameter.
 		/// </summary>
 		/// <param name="parameterIndex">Parameter index in the IL sense. Parameter 0 on instance methods is `this`.</param>
 		/// <returns></returns>
-		public DynamicallyAccessedMemberTypes GetParameterAnnotation (MethodDefinition method, int parameterIndex)
-		{
-			if (GetAnnotations (method.DeclaringType).TryGetAnnotation (method, out var annotation) && annotation.ParameterAnnotations != null) {
-				return annotation.ParameterAnnotations[parameterIndex];
-			}
+		public DynamicallyAccessedMemberTypes GetParameterAnnotation (MethodDefinition method, int parameterIndex) =>
+			(GetAnnotations (method.DeclaringType).TryGetAnnotation (method, out var annotation) && annotation.ParameterAnnotations != null)
+				? annotation.ParameterAnnotations[parameterIndex]
+				: DynamicallyAccessedMemberTypes.None;
 
-			return DynamicallyAccessedMemberTypes.None;
-		}
+		public DynamicallyAccessedMemberTypes GetReturnParameterAnnotation (MethodDefinition method) =>
+			GetAnnotations (method.DeclaringType).TryGetAnnotation (method, out var annotation)
+				? annotation.ReturnParameterAnnotation
+				: DynamicallyAccessedMemberTypes.None;
 
-		public DynamicallyAccessedMemberTypes GetReturnParameterAnnotation (MethodDefinition method)
-		{
-			if (GetAnnotations (method.DeclaringType).TryGetAnnotation (method, out var annotation)) {
-				return annotation.ReturnParameterAnnotation;
-			}
+		public DynamicallyAccessedMemberTypes GetFieldAnnotation (FieldDefinition field) =>
+			GetAnnotations (field.DeclaringType).TryGetAnnotation (field, out var annotation)
+				? annotation.Annotation
+				: DynamicallyAccessedMemberTypes.None;
 
-			return DynamicallyAccessedMemberTypes.None;
-		}
-
-		public DynamicallyAccessedMemberTypes GetFieldAnnotation (FieldDefinition field)
-		{
-			if (GetAnnotations (field.DeclaringType).TryGetAnnotation (field, out var annotation)) {
-				return annotation.Annotation;
-			}
-
-			return DynamicallyAccessedMemberTypes.None;
-		}
-
-		public DynamicallyAccessedMemberTypes GetTypeAnnotation (TypeDefinition type)
-		{
-			return GetAnnotations (type).TypeAnnotation;
-		}
+		public DynamicallyAccessedMemberTypes GetTypeAnnotation (TypeDefinition type) =>
+			GetAnnotations (type).TypeAnnotation;
 
 		public DynamicallyAccessedMemberTypes GetGenericParameterAnnotation (GenericParameter genericParameter)
 		{
@@ -92,6 +72,13 @@ namespace Mono.Linker.Dataflow
 
 			return DynamicallyAccessedMemberTypes.None;
 		}
+
+		public bool ShouldWarnWhenAccessedForReflection (MethodDefinition method) =>
+			GetAnnotations (method.DeclaringType).TryGetAnnotation (method, out var annotation) &&
+				(annotation.ParameterAnnotations != null || annotation.ReturnParameterAnnotation != DynamicallyAccessedMemberTypes.None);
+
+		public bool ShouldWarnWhenAccessedForReflection (FieldDefinition field) =>
+			GetAnnotations (field.DeclaringType).TryGetAnnotation (field, out _);
 
 		TypeAnnotations GetAnnotations (TypeDefinition type)
 		{

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2820,6 +2820,14 @@ namespace Mono.Linker.Steps
 					break;
 				}
 
+				// If the method only has annotation on the return value and it's not virtual avoid warning.
+				// Return value annotations are "consumed" by the caller of a method, and as such there is nothing
+				// wrong calling these dynamically. The only problem can happen if something overrides a virtual
+				// method with annotated return value at runtime - in this case the trimmer can't validate
+				// that the method will return only types which fulfill the annotation's requirements.
+				if (!method.IsVirtual && _context.Annotations.FlowAnnotations.MethodHasNoAnnotatedParameters (method))
+					return;
+
 				_context.LogWarning (
 					$"Method '{method.GetDisplayName ()}' with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.",
 					2111,

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2871,10 +2871,6 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		Type _typeField;
-
-		private ref Type GetRefType () { Type type = null; return ref _typeField; }
-
 		internal bool ShouldSuppressAnalysisWarningsForRequiresUnreferencedCode ()
 		{
 			// Check if the current scope method has RequiresUnreferencedCode on it

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2826,6 +2826,40 @@ namespace Mono.Linker.Steps
 				// wrong calling these dynamically. The only problem can happen if something overrides a virtual
 				// method with annotated return value at runtime - in this case the trimmer can't validate
 				// that the method will return only types which fulfill the annotation's requirements.
+				// For example:
+				//   class BaseWithAnnotation
+				//   {
+				//       [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
+				//       public abstract Type GetTypeWithFields();
+				//   }
+				//
+				//   class UsingTheBase
+				//   {
+				//       public void PrintFields(Base base)
+				//       {
+				//            // No warning here - GetTypeWithFields is correctly annotated to allow GetFields on the return value.
+				//            Console.WriteLine(string.Join(" ", base.GetTypeWithFields().GetFields().Select(f => f.Name)));
+				//       }
+				//   }
+				//
+				// If at runtime (through ref emit) something generates code like this:
+				//   class DerivedAtRuntimeFromBase
+				//   {
+				//       // No point in adding annotation on the return value - nothing will look at it anyway
+				//       // Linker will not see this code, so there are no checks
+				//       public override Type GetTypeWithFields() { return typeof(TestType); }
+				//   }
+				//
+				// If TestType from above is trimmed, it may note have all its fields, and there would be no warnings generated.
+				// But there has to be code like this somewhere in the app, in order to generate the override:
+				//   class RuntimeTypeGenerator
+				//   {
+				//       public MethodInfo GetBaseMethod()
+				//       {
+				//            // This must warn - that the GetTypeWithFields has annotation on the return value
+				//            return typeof(BaseWithAnnotation).GetMethod("GetTypeWithFields");
+				//       }
+				//   }
 				if (!method.IsVirtual && _context.Annotations.FlowAnnotations.MethodHasNoAnnotatedParameters (method))
 					return;
 

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1562,7 +1562,8 @@ namespace Mono.Linker.Steps
 			case DependencyKind.DynamicDependency:
 			case DependencyKind.DynamicallyAccessedMember:
 			case DependencyKind.InteropMethodDependency:
-				if (_context.Annotations.FlowAnnotations.ShouldWarnWhenAccessedForReflection (field))
+				if (_context.Annotations.FlowAnnotations.ShouldWarnWhenAccessedForReflection (field) &&
+					!ShouldSuppressAnalysisWarningsForRequiresUnreferencedCode ())
 					_context.LogWarning (
 						$"Field '{field.GetDisplayName ()}' with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.",
 						2110,
@@ -2835,6 +2836,10 @@ namespace Mono.Linker.Steps
 					MessageSubCategory.TrimAnalysis);
 			}
 		}
+
+		Type _typeField;
+
+		private ref Type GetRefType () { Type type = null; return ref _typeField; }
 
 		internal bool ShouldSuppressAnalysisWarningsForRequiresUnreferencedCode ()
 		{

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1571,7 +1571,7 @@ namespace Mono.Linker.Steps
 
 				break;
 			}
-				
+
 
 			if (CheckProcessed (field))
 				return;

--- a/test/Mono.Linker.Tests.Cases/DataFlow/AnnotatedMembersAccessedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/AnnotatedMembersAccessedViaReflection.cs
@@ -1,0 +1,409 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
+
+namespace Mono.Linker.Tests.Cases.DataFlow
+{
+	[SkipKeptItemsValidation]
+	[ExpectedNoWarnings]
+	class AnnotatedMembersAccessedViaReflection
+	{
+		public static void Main ()
+		{
+			AnnotatedField.Test ();
+			AnnotatedMethodParameters.Test ();
+			AnnotatedMethodReturnValue.Test ();
+			AnnotatedProperty.Test ();
+			AnnotatedGenerics.Test ();
+			AnnotationOnGenerics.Test ();
+			AnnotationOnInteropMethod.Test ();
+			AccessThroughLdToken.Test ();
+		}
+
+		class AnnotatedField
+		{
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+			public static Type _annotatedField;
+
+			[ExpectedWarning ("IL2110", nameof (_annotatedField))]
+			static void Reflection ()
+			{
+				typeof (AnnotatedField).GetField ("_annotatedField").SetValue (null, typeof (TestType));
+			}
+
+			[ExpectedWarning ("IL2110", nameof (_annotatedField))]
+			static void ReflectionReadOnly ()
+			{
+				typeof (AnnotatedField).GetField ("_annotatedField").GetValue (null);
+			}
+
+			[ExpectedWarning ("IL2110", nameof (_annotatedField))]
+			[DynamicDependency (DynamicallyAccessedMemberTypes.PublicFields, typeof (AnnotatedField))]
+			static void DynamicDependency ()
+			{
+			}
+
+			[ExpectedWarning ("IL2110", nameof (_annotatedField))]
+			[DynamicDependency (nameof (_annotatedField), typeof (AnnotatedField))]
+			static void DynamicDependencyByName ()
+			{
+			}
+
+			[ExpectedWarning ("IL2110", nameof (_annotatedField))]
+			static void DynamicallyAccessedMembers ()
+			{
+				typeof (AnnotatedField).RequiresPublicFields ();
+			}
+
+			public static void Test ()
+			{
+				Reflection ();
+				ReflectionReadOnly ();
+				DynamicDependency ();
+				DynamicDependencyByName ();
+				DynamicallyAccessedMembers ();
+			}
+		}
+
+		class AnnotatedMethodParameters
+		{
+			public static void MethodWithSingleAnnotatedParameter (
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] Type type)
+			{ }
+
+			class AttributeWithConstructorWithAnnotation : Attribute
+			{
+				public AttributeWithConstructorWithAnnotation (
+					[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] Type type) { }
+			}
+
+			[ExpectedWarning ("IL2111", nameof (MethodWithSingleAnnotatedParameter))]
+			static void Reflection ()
+			{
+				typeof (AnnotatedMethodParameters).GetMethod (nameof (MethodWithSingleAnnotatedParameter)).Invoke (null, null);
+			}
+
+			// Should not warn, there's nothing wrong about this
+			[AttributeWithConstructorWithAnnotation(typeof (TestType))]
+			static void AnnotatedAttributeConstructor ()
+			{
+			}
+
+			[ExpectedWarning ("IL2111", nameof (MethodWithSingleAnnotatedParameter))]
+			[DynamicDependency (DynamicallyAccessedMemberTypes.PublicMethods, typeof (AnnotatedMethodParameters))]
+			static void DynamicDependency ()
+			{
+			}
+
+			[ExpectedWarning ("IL2111", nameof (MethodWithSingleAnnotatedParameter))]
+			[DynamicDependency (nameof (MethodWithSingleAnnotatedParameter), typeof (AnnotatedMethodParameters))]
+			static void DynamicDependencyByName ()
+			{
+			}
+
+			[ExpectedWarning ("IL2111", nameof (MethodWithSingleAnnotatedParameter))]
+			static void DynamicallyAccessedMembers ()
+			{
+				typeof (AnnotatedMethodParameters).RequiresPublicMethods ();
+			}
+
+			[ExpectedWarning ("IL2111", nameof (MethodWithSingleAnnotatedParameter))]
+			static void Ldftn ()
+			{
+				var _ = new Action<Type> (AnnotatedMethodParameters.MethodWithSingleAnnotatedParameter);
+			}
+
+			interface IWithAnnotatedMethod
+			{
+				public void AnnotatedMethod ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)] Type type);
+			}
+
+			[ExpectedWarning ("IL2111", nameof (IWithAnnotatedMethod.AnnotatedMethod))]
+			static void Ldvirtftn ()
+			{
+				IWithAnnotatedMethod instance = null;
+				var _ = new Action<Type> (instance.AnnotatedMethod);
+			}
+
+			public static void Test ()
+			{
+				Reflection ();
+				DynamicDependency ();
+				DynamicDependencyByName ();
+				DynamicallyAccessedMembers ();
+				Ldftn ();
+				Ldvirtftn ();
+			}
+		}
+
+		class AnnotatedMethodReturnValue
+		{
+			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+			public static Type MethodWithAnnotatedReturnValue () => null;
+
+			[ExpectedWarning ("IL2111", nameof (MethodWithAnnotatedReturnValue))]
+			static void Reflection ()
+			{
+				typeof (AnnotatedMethodReturnValue).GetMethod (nameof (MethodWithAnnotatedReturnValue)).Invoke (null, null);
+			}
+
+			[ExpectedWarning ("IL2111", nameof (MethodWithAnnotatedReturnValue))]
+			[DynamicDependency (DynamicallyAccessedMemberTypes.PublicMethods, typeof (AnnotatedMethodReturnValue))]
+			static void DynamicDependency ()
+			{
+			}
+
+			[ExpectedWarning ("IL2111", nameof (MethodWithAnnotatedReturnValue))]
+			[DynamicDependency (nameof (MethodWithAnnotatedReturnValue), typeof (AnnotatedMethodReturnValue))]
+			static void DynamicDependencyByName ()
+			{
+			}
+
+			[ExpectedWarning ("IL2111", nameof (MethodWithAnnotatedReturnValue))]
+			static void DynamicallyAccessedMembers ()
+			{
+				typeof (AnnotatedMethodReturnValue).RequiresPublicMethods ();
+			}
+
+			[ExpectedWarning ("IL2111", nameof (MethodWithAnnotatedReturnValue))]
+			static void Ldftn ()
+			{
+				var _ = new Func<Type> (AnnotatedMethodReturnValue.MethodWithAnnotatedReturnValue);
+			}
+
+			public static void Test ()
+			{
+				Reflection ();
+				DynamicDependency ();
+				DynamicDependencyByName ();
+				DynamicallyAccessedMembers ();
+				Ldftn ();
+			}
+		}
+
+		class AnnotatedProperty
+		{
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicNestedTypes)]
+			public static Type PropertyWithAnnotation { get; set; }
+
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicEvents)]
+			public static Type PropertyWithAnnotationGetterOnly { get => null; }
+
+			class AttributeWithPropertyWithAnnotation : Attribute
+			{
+				public AttributeWithPropertyWithAnnotation () { }
+
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicProperties)]
+				public Type PropertyWithAnnotation { get; set; }
+			}
+
+			[ExpectedWarning ("IL2111", nameof (PropertyWithAnnotation))]
+			static void ReflectionOnPropertyItself ()
+			{
+				// TODO: Technically this should warn if one of the setter is annotated since
+				// linker can't guarantee that it will not be used.
+				typeof (AnnotatedProperty).GetProperty (nameof (PropertyWithAnnotation));
+			}
+
+			[ExpectedWarning ("IL2111", nameof (PropertyWithAnnotationGetterOnly))]
+			static void ReflectionOnPropertyWithGetterOnly ()
+			{
+				// Following the rules we maintain on normal methods, just returning annotated value is considered dangerous
+				// (in theory one could use type builder to create an override for the method, and its body would not be validated
+				// and would need to fulfill the annotation on the return value anyway)
+				typeof (AnnotatedProperty).GetProperty (nameof (PropertyWithAnnotationGetterOnly));
+			}
+
+			[ExpectedWarning ("IL2111", nameof (PropertyWithAnnotation) + ".get")]
+			static void ReflectionOnGetter ()
+			{
+				typeof (AnnotatedProperty).GetMethod ("get_" + nameof (PropertyWithAnnotation));
+			}
+
+			[ExpectedWarning ("IL2111", nameof (PropertyWithAnnotation) + ".set")]
+			static void ReflectionOnSetter ()
+			{
+				typeof (AnnotatedProperty).GetMethod ("set_" + nameof (PropertyWithAnnotation));
+			}
+
+			// Should not warn - there's nothing wrong with this
+			[AttributeWithPropertyWithAnnotation (PropertyWithAnnotation = typeof (TestType))]
+			static void AnnotatedAttributeProperty ()
+			{
+			}
+
+			[ExpectedWarning ("IL2111", nameof (PropertyWithAnnotation) + ".get")]
+			[ExpectedWarning ("IL2111", nameof (PropertyWithAnnotation) + ".set")]
+			[ExpectedWarning ("IL2111", nameof (PropertyWithAnnotationGetterOnly) + ".get")]
+			[DynamicDependency (DynamicallyAccessedMemberTypes.PublicProperties, typeof (AnnotatedProperty))]
+			static void DynamicDependency ()
+			{
+			}
+
+			[ExpectedWarning ("IL2111", nameof (PropertyWithAnnotation) + ".get")]
+			[ExpectedWarning ("IL2111", nameof (PropertyWithAnnotation) + ".set")]
+			[ExpectedWarning ("IL2111", nameof (PropertyWithAnnotationGetterOnly) + ".get")]
+			static void DynamicallyAccessedMembers ()
+			{
+				typeof (AnnotatedProperty).RequiresPublicProperties ();
+			}
+
+			public static void Test ()
+			{
+				ReflectionOnPropertyItself ();
+				ReflectionOnPropertyWithGetterOnly ();
+				ReflectionOnGetter ();
+				ReflectionOnSetter ();
+				AnnotatedAttributeProperty ();
+				DynamicDependency ();
+				DynamicallyAccessedMembers ();
+			}
+		}
+
+		// Annotation on generic parameter
+		class AnnotatedGenerics
+		{
+			public static void GenericWithAnnotation<
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.Interfaces)] T> ()
+			{ }
+
+			static void ReflectionOnly()
+			{
+				// Should not warn - there's nothing wrong with asking for MethodInfo alone
+				typeof (AnnotatedGenerics).GetMethod (nameof (GenericWithAnnotation));
+			}
+
+			// Similarly to direct reflection - no warning expected
+			[DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, typeof(AnnotatedGenerics))]
+			static void DynamicDependency ()
+			{
+			}
+
+			// Similarly to direct reflection - no warning expected
+			static void DynamicallyAccessedMembers()
+			{
+				typeof (AnnotatedGenerics).RequiresPublicMethods ();
+			}
+
+			// This should produce IL2071 https://github.com/mono/linker/issues/2144
+			[ExpectedWarning ("IL2070", "MakeGenericMethod")]
+			static void InstantiateGeneric(Type type = null)
+			{
+				// This should warn due to MakeGenericMethod - in this case the generic parameter is unannotated type
+				typeof (AnnotatedGenerics).GetMethod (nameof (GenericWithAnnotation)).MakeGenericMethod (type);
+			}
+
+			public static void Test ()
+			{
+				ReflectionOnly ();
+				DynamicDependency ();
+				DynamicallyAccessedMembers ();
+				InstantiateGeneric ();
+			}
+		}
+
+		// Annotation on non-generic parameter but on generic methods
+		class AnnotationOnGenerics
+		{
+			class GenericWithAnnotatedMethod<T>
+			{
+				public static void AnnotatedMethod (
+					[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] Type type) { }
+			}
+
+			public static void GenericMethodWithAnnotation<T>(
+			   [DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] Type type) {}
+
+			[ExpectedWarning ("IL2111", nameof (GenericWithAnnotatedMethod<TestType>.AnnotatedMethod))]
+			public static void GenericTypeWithStaticMethodViaLdftn ()
+			{
+				var _ = new Action<Type> (GenericWithAnnotatedMethod<TestType>.AnnotatedMethod);
+			}
+
+			[ExpectedWarning ("IL2111", nameof (GenericMethodWithAnnotation))]
+			public static void GenericMethodWithAnnotationReflection ()
+			{
+				typeof (AnnotationOnGenerics).GetMethod (nameof (GenericMethodWithAnnotation));
+			}
+
+			public static void GenericMethodWithAnnotationDirectCall ()
+			{
+				// Should not warn, nothing wrong about this
+				GenericMethodWithAnnotation<TestType> (typeof (TestType));
+			}
+
+			[ExpectedWarning ("IL2111", nameof(GenericMethodWithAnnotation))]
+			public static void GenericMethodWithAnnotationViaLdftn ()
+			{
+				var _ = new Action<Type> (GenericMethodWithAnnotation<TestType>);
+			}
+
+			[ExpectedWarning ("IL2111", nameof (GenericMethodWithAnnotation))]
+			public static void GenericMethodDynamicallyAccessedMembers ()
+			{
+				typeof (AnnotationOnGenerics).RequiresPublicMethods ();
+			}
+
+			public static void Test ()
+			{
+				GenericTypeWithStaticMethodViaLdftn ();
+				GenericMethodWithAnnotationReflection ();
+				GenericMethodWithAnnotationDirectCall ();
+				GenericMethodWithAnnotationViaLdftn ();
+				GenericMethodDynamicallyAccessedMembers ();
+			}
+		}
+
+		class AnnotationOnInteropMethod
+		{
+			struct ValueWithAnnotatedField
+			{
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+				public Type _typeField;
+			}
+
+			[ExpectedWarning ("IL2110", nameof (ValueWithAnnotatedField._typeField))]
+			[DllImport ("nonexistent")]
+			static extern ValueWithAnnotatedField GetValueWithAnnotatedField ();
+
+			[ExpectedWarning ("IL2110", nameof (ValueWithAnnotatedField._typeField))]
+			[DllImport ("nonexistent")]
+			static extern void AcceptValueWithAnnotatedField (ValueWithAnnotatedField value);
+
+			public static void Test ()
+			{
+				GetValueWithAnnotatedField ();
+				AcceptValueWithAnnotatedField (default (ValueWithAnnotatedField));
+			}
+		}
+
+		class AccessThroughLdToken
+		{
+			static Type PropertyWithLdToken {
+				[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+				get {
+					return null;
+				}
+			}
+
+			[ExpectedWarning ("IL2111", nameof (PropertyWithLdToken))]
+			public static void Test ()
+			{
+				Expression<Func<Type>> getter = () => PropertyWithLdToken;
+			}
+		}
+
+		class TestType { }
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/AnnotatedMembersAccessedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/AnnotatedMembersAccessedViaReflection.cs
@@ -42,6 +42,12 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				typeof (AnnotatedField).GetField ("_annotatedField").SetValue (null, typeof (TestType));
 			}
 
+			[RequiresUnreferencedCode ("test")]
+			static void ReflectionSuppressedByRUC ()
+			{
+				typeof (AnnotatedField).GetField ("_annotatedField").SetValue (null, typeof (TestType));
+			}
+
 			[ExpectedWarning ("IL2110", nameof (_annotatedField))]
 			static void ReflectionReadOnly ()
 			{
@@ -51,6 +57,12 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[ExpectedWarning ("IL2110", nameof (_annotatedField))]
 			[DynamicDependency (DynamicallyAccessedMemberTypes.PublicFields, typeof (AnnotatedField))]
 			static void DynamicDependency ()
+			{
+			}
+
+			[RequiresUnreferencedCode ("test")]
+			[DynamicDependency (DynamicallyAccessedMemberTypes.PublicFields, typeof (AnnotatedField))]
+			static void DynamicDependencySuppressedByRUC ()
 			{
 			}
 
@@ -66,13 +78,23 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				typeof (AnnotatedField).RequiresPublicFields ();
 			}
 
+			[RequiresUnreferencedCode ("test")]
+			static void DynamicallyAccessedMembersSuppressedByRUC ()
+			{
+				typeof (AnnotatedField).RequiresPublicFields ();
+			}
+
+			[UnconditionalSuppressMessage ("test", "IL2026")]
 			public static void Test ()
 			{
 				Reflection ();
+				ReflectionSuppressedByRUC ();
 				ReflectionReadOnly ();
 				DynamicDependency ();
+				DynamicDependencySuppressedByRUC ();
 				DynamicDependencyByName ();
 				DynamicallyAccessedMembers ();
+				DynamicallyAccessedMembersSuppressedByRUC ();
 			}
 		}
 
@@ -95,6 +117,12 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				typeof (AnnotatedMethodParameters).GetMethod (nameof (MethodWithSingleAnnotatedParameter)).Invoke (null, null);
 			}
 
+			[RequiresUnreferencedCode ("test")]
+			static void ReflectionSuppressedByRUC ()
+			{
+				typeof (AnnotatedMethodParameters).GetMethod (nameof (MethodWithSingleAnnotatedParameter)).Invoke (null, null);
+			}
+
 			// Should not warn, there's nothing wrong about this
 			[AttributeWithConstructorWithAnnotation (typeof (TestType))]
 			static void AnnotatedAttributeConstructor ()
@@ -107,6 +135,12 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			{
 			}
 
+			[RequiresUnreferencedCode ("test")]
+			[DynamicDependency (DynamicallyAccessedMemberTypes.PublicMethods, typeof (AnnotatedMethodParameters))]
+			static void DynamicDependencySuppressedByRUC ()
+			{
+			}
+
 			[ExpectedWarning ("IL2111", nameof (MethodWithSingleAnnotatedParameter))]
 			[DynamicDependency (nameof (MethodWithSingleAnnotatedParameter), typeof (AnnotatedMethodParameters))]
 			static void DynamicDependencyByName ()
@@ -115,6 +149,12 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 			[ExpectedWarning ("IL2111", nameof (MethodWithSingleAnnotatedParameter))]
 			static void DynamicallyAccessedMembers ()
+			{
+				typeof (AnnotatedMethodParameters).RequiresPublicMethods ();
+			}
+
+			[RequiresUnreferencedCode ("test")]
+			static void DynamicallyAccessedMembersSuppressedByRUC ()
 			{
 				typeof (AnnotatedMethodParameters).RequiresPublicMethods ();
 			}
@@ -137,12 +177,16 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				var _ = new Action<Type> (instance.AnnotatedMethod);
 			}
 
+			[UnconditionalSuppressMessage ("test", "IL2026")]
 			public static void Test ()
 			{
 				Reflection ();
+				ReflectionSuppressedByRUC ();
 				DynamicDependency ();
+				DynamicDependencySuppressedByRUC ();
 				DynamicDependencyByName ();
 				DynamicallyAccessedMembers ();
+				DynamicallyAccessedMembersSuppressedByRUC ();
 				Ldftn ();
 				Ldvirtftn ();
 			}
@@ -178,9 +222,21 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				typeof (AnnotatedMethodReturnValue).GetMethod (nameof (VirtualMethodWithAnnotatedReturnValue)).Invoke (null, null);
 			}
 
+			[RequiresUnreferencedCode ("test")]
+			static void ReflectionOnVirtualSuppressedByRUC ()
+			{
+				typeof (AnnotatedMethodReturnValue).GetMethod (nameof (VirtualMethodWithAnnotatedReturnValue)).Invoke (null, null);
+			}
+
 			[ExpectedWarning ("IL2111", nameof (VirtualMethodWithAnnotatedReturnValue))]
 			[DynamicDependency (DynamicallyAccessedMemberTypes.PublicMethods, typeof (AnnotatedMethodReturnValue))]
 			static void DynamicDependency ()
+			{
+			}
+
+			[RequiresUnreferencedCode ("test")]
+			[DynamicDependency (DynamicallyAccessedMemberTypes.PublicMethods, typeof (AnnotatedMethodReturnValue))]
+			static void DynamicDependencySuppressedByRUC ()
 			{
 			}
 
@@ -206,6 +262,12 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				typeof (AnnotatedMethodReturnValue).RequiresPublicMethods ();
 			}
 
+			[RequiresUnreferencedCode ("test")]
+			static void DynamicallyAccessedMembersSuppressedByRUC ()
+			{
+				typeof (AnnotatedMethodReturnValue).RequiresPublicMethods ();
+			}
+
 			static void LdftnOnStatic ()
 			{
 				var _ = new Func<Type> (AnnotatedMethodReturnValue.StaticMethodWithAnnotatedReturnValue);
@@ -222,16 +284,20 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				var _ = new Func<Type> ((new AnnotatedMethodReturnValue ()).VirtualMethodWithAnnotatedReturnValue);
 			}
 
+			[UnconditionalSuppressMessage ("test", "IL2026")]
 			public static void Test ()
 			{
 				ReflectionOnStatic ();
 				ReflectionOnInstance ();
 				ReflectionOnVirtual ();
+				ReflectionOnVirtualSuppressedByRUC ();
 				DynamicDependency ();
+				DynamicDependencySuppressedByRUC ();
 				DynamicDependencyByNameOnStatic ();
 				DynamicDependencyByNameOnInstance ();
 				DynamicDependencyByNameOnVirtual ();
 				DynamicallyAccessedMembers ();
+				DynamicallyAccessedMembersSuppressedByRUC ();
 				LdftnOnStatic ();
 				LdftnOnInstance ();
 				LdftnOnVirtual ();
@@ -259,6 +325,12 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 			[ExpectedWarning ("IL2111", nameof (PropertyWithAnnotation))]
 			static void ReflectionOnPropertyItself ()
+			{
+				typeof (AnnotatedProperty).GetProperty (nameof (PropertyWithAnnotation));
+			}
+
+			[RequiresUnreferencedCode ("test")]
+			static void ReflectionOnPropertyItselfSuppressedByRUC ()
 			{
 				typeof (AnnotatedProperty).GetProperty (nameof (PropertyWithAnnotation));
 			}
@@ -304,6 +376,12 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			{
 			}
 
+			[RequiresUnreferencedCode ("test")]
+			[DynamicDependency (DynamicallyAccessedMemberTypes.PublicProperties, typeof (AnnotatedProperty))]
+			static void DynamicDependencySuppressedByRUC ()
+			{
+			}
+
 			[ExpectedWarning ("IL2111", nameof (PropertyWithAnnotation) + ".set")]
 			[ExpectedWarning ("IL2111", nameof (VirtualPropertyWithAnnotationGetterOnly) + ".get")]
 			static void DynamicallyAccessedMembers ()
@@ -311,9 +389,17 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				typeof (AnnotatedProperty).RequiresPublicProperties ();
 			}
 
+			[RequiresUnreferencedCode ("test")]
+			static void DynamicallyAccessedMembersSuppressedByRUC ()
+			{
+				typeof (AnnotatedProperty).RequiresPublicProperties ();
+			}
+
+			[UnconditionalSuppressMessage ("test", "IL2026")]
 			public static void Test ()
 			{
 				ReflectionOnPropertyItself ();
+				ReflectionOnPropertyItselfSuppressedByRUC ();
 				ReflectionOnPropertyWithGetterOnly ();
 				ReflectionOnPropertyWithGetterOnlyOnVirtual ();
 				ReflectionOnGetter ();
@@ -321,7 +407,9 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				ReflectionOnVirtualGetter ();
 				AnnotatedAttributeProperty ();
 				DynamicDependency ();
+				DynamicDependencySuppressedByRUC ();
 				DynamicallyAccessedMembers ();
+				DynamicallyAccessedMembersSuppressedByRUC ();
 			}
 		}
 

--- a/test/Mono.Linker.Tests.Cases/DataFlow/AnnotatedMembersAccessedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/AnnotatedMembersAccessedViaReflection.cs
@@ -85,7 +85,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			class AttributeWithConstructorWithAnnotation : Attribute
 			{
 				public AttributeWithConstructorWithAnnotation (
-					[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] Type type) { }
+					[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] Type type)
+				{ }
 			}
 
 			[ExpectedWarning ("IL2111", nameof (MethodWithSingleAnnotatedParameter))]
@@ -95,7 +96,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			}
 
 			// Should not warn, there's nothing wrong about this
-			[AttributeWithConstructorWithAnnotation(typeof (TestType))]
+			[AttributeWithConstructorWithAnnotation (typeof (TestType))]
 			static void AnnotatedAttributeConstructor ()
 			{
 			}
@@ -278,27 +279,27 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.Interfaces)] T> ()
 			{ }
 
-			static void ReflectionOnly()
+			static void ReflectionOnly ()
 			{
 				// Should not warn - there's nothing wrong with asking for MethodInfo alone
 				typeof (AnnotatedGenerics).GetMethod (nameof (GenericWithAnnotation));
 			}
 
 			// Similarly to direct reflection - no warning expected
-			[DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, typeof(AnnotatedGenerics))]
+			[DynamicDependency (DynamicallyAccessedMemberTypes.PublicMethods, typeof (AnnotatedGenerics))]
 			static void DynamicDependency ()
 			{
 			}
 
 			// Similarly to direct reflection - no warning expected
-			static void DynamicallyAccessedMembers()
+			static void DynamicallyAccessedMembers ()
 			{
 				typeof (AnnotatedGenerics).RequiresPublicMethods ();
 			}
 
 			// This should produce IL2071 https://github.com/mono/linker/issues/2144
 			[ExpectedWarning ("IL2070", "MakeGenericMethod")]
-			static void InstantiateGeneric(Type type = null)
+			static void InstantiateGeneric (Type type = null)
 			{
 				// This should warn due to MakeGenericMethod - in this case the generic parameter is unannotated type
 				typeof (AnnotatedGenerics).GetMethod (nameof (GenericWithAnnotation)).MakeGenericMethod (type);
@@ -319,11 +320,13 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			class GenericWithAnnotatedMethod<T>
 			{
 				public static void AnnotatedMethod (
-					[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] Type type) { }
+					[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] Type type)
+				{ }
 			}
 
-			public static void GenericMethodWithAnnotation<T>(
-			   [DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] Type type) {}
+			public static void GenericMethodWithAnnotation<T> (
+			   [DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] Type type)
+			{ }
 
 			[ExpectedWarning ("IL2111", nameof (GenericWithAnnotatedMethod<TestType>.AnnotatedMethod))]
 			public static void GenericTypeWithStaticMethodViaLdftn ()
@@ -343,7 +346,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				GenericMethodWithAnnotation<TestType> (typeof (TestType));
 			}
 
-			[ExpectedWarning ("IL2111", nameof(GenericMethodWithAnnotation))]
+			[ExpectedWarning ("IL2111", nameof (GenericMethodWithAnnotation))]
 			public static void GenericMethodWithAnnotationViaLdftn ()
 			{
 				var _ = new Action<Type> (GenericMethodWithAnnotation<TestType>);

--- a/test/Mono.Linker.Tests.Cases/DataFlow/VirtualMethodHierarchyDataflowAnnotationValidation.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/VirtualMethodHierarchyDataflowAnnotationValidation.cs
@@ -13,6 +13,9 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 {
 	[SkipKeptItemsValidation]
 	[SandboxDependency ("Dependencies/TestSystemTypeBase.cs")]
+
+	// Suppress warnings about accessing methods with annotations via reflection - the test below does that a LOT
+	[UnconditionalSuppressMessage("test", "IL2111")]
 	class VirtualMethodHierarchyDataflowAnnotationValidation
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/DataFlow/VirtualMethodHierarchyDataflowAnnotationValidation.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/VirtualMethodHierarchyDataflowAnnotationValidation.cs
@@ -15,7 +15,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 	[SandboxDependency ("Dependencies/TestSystemTypeBase.cs")]
 
 	// Suppress warnings about accessing methods with annotations via reflection - the test below does that a LOT
-	[UnconditionalSuppressMessage("test", "IL2111")]
+	// (The test accessed these methods through DynamicallyAccessedMembers annotations which is effectively the same reflection access)
+	[UnconditionalSuppressMessage ("test", "IL2111")]
 	class VirtualMethodHierarchyDataflowAnnotationValidation
 	{
 		public static void Main ()

--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallString.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallString.cs
@@ -213,13 +213,13 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[Kept]
 			public static void GenericMethodWithRequirements<
 				[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
-				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicProperties)] T> ()
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicProperties)] T> ()
 			{ }
 
 			[Kept]
 			public static void GenericMethodWithRequirementsNoArguments<
 				[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
-				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicProperties)] T> ()
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicProperties)] T> ()
 			{ }
 
 			[Kept]

--- a/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallString.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallString.cs
@@ -118,21 +118,6 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		class TestUnknownType
 		{
 			[Kept]
-			public static void PublicMethod ()
-			{
-			}
-
-			[Kept]
-			protected static void ProtectedMethod ()
-			{
-			}
-
-			[Kept]
-			private static void PrivateMethod ()
-			{
-			}
-
-			[Kept]
 			[UnrecognizedReflectionAccessPattern (typeof (Expression), nameof (Expression.Call),
 				new Type[] { typeof (Type), typeof (string), typeof (Type[]), typeof (Expression[]) }, messageCode: "IL2072")]
 			public static void Test ()
@@ -148,13 +133,13 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]
 			static Type GetUnknownType ()
 			{
-				return typeof (TestUnknownType);
+				return typeof (TestType);
 			}
 
 			[Kept]
 			static Type TriggerUnrecognizedPattern ()
 			{
-				return typeof (TestUnknownType);
+				return typeof (TestType);
 			}
 		}
 
@@ -228,13 +213,13 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[Kept]
 			public static void GenericMethodWithRequirements<
 				[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
-			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicProperties)] T> ()
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicProperties)] T> ()
 			{ }
 
 			[Kept]
 			public static void GenericMethodWithRequirementsNoArguments<
 				[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
-			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicProperties)] T> ()
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicProperties)] T> ()
 			{ }
 
 			[Kept]
@@ -355,5 +340,8 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicProperties)]
 			static Type GetUnknownTypeWithRequrements () { return null; }
 		}
+
+		[Kept]
+		class TestType { }
 	}
 }


### PR DESCRIPTION
Any access to DAM annotated method must be validated by the trimmer. Normal calls and such are handled already, but direct reflection access or other indirect accesses can lead to trimmer allowing potential invocation of DAM annotated method without validating the annotations. This change will warn whenever such potential "leak" happens.

This applies to method parameter, method return value and field annotations.
Uses the same infra as RUC already just adds additional checks.

Tests for the new cases.

Fixes https://github.com/mono/linker/issues/1764