### PR TITLE
Fix Activator.CreateInstance case

### DIFF
--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -1596,10 +1596,10 @@ namespace Mono.Linker.Dataflow
 								var requiredMemberTypes = GetDynamicallyAccessedMemberTypesFromBindingFlagsForConstructors (bindingFlags);
 
 								// Special case the public parameterless constructor if we know that there are 0 args passed in
-								if (ctorParameterCount == 0 &&
-									requiredMemberTypes.HasFlag (DynamicallyAccessedMemberTypes.PublicConstructors) &&
-									!requiredMemberTypes.HasFlag (DynamicallyAccessedMemberTypes.NonPublicConstructors))
-									requiredMemberTypes = DynamicallyAccessedMemberTypes.PublicParameterlessConstructor;
+								if (ctorParameterCount == 0 && requiredMemberTypes.HasFlag (DynamicallyAccessedMemberTypes.PublicConstructors)) {
+									requiredMemberTypes &= ~DynamicallyAccessedMemberTypes.PublicConstructors;
+									requiredMemberTypes |= DynamicallyAccessedMemberTypes.PublicParameterlessConstructor;
+								}
 
 								RequireDynamicallyAccessedMembers (ref reflectionContext, requiredMemberTypes, value, calledMethod.Parameters[0]);
 							}

--- a/test/Mono.Linker.Tests.Cases/Reflection/ActivatorCreateInstance.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ActivatorCreateInstance.cs
@@ -55,6 +55,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			TestNullArgsOnKnownType ();
 			TestNullArgsOnAnnotatedType (typeof (TestType));
 			TestNullArgsNonPublicOnly (typeof (TestType));
+			TestNullArgsNonPublicWithNonPublicAnnotation (typeof (TestType));
 
 			CreateInstanceWithGetTypeFromHierarchy.Test ();
 		}
@@ -530,6 +531,15 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))] Type type)
 		{
 			Activator.CreateInstance (type, BindingFlags.NonPublic | BindingFlags.Instance, null, null, CultureInfo.InvariantCulture);
+		}
+
+		[Kept]
+		[ExpectedNoWarnings]
+		private static void TestNullArgsNonPublicWithNonPublicAnnotation (
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.NonPublicConstructors),
+			KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))] Type type)
+		{
+			Activator.CreateInstance (type, nonPublic: true);
 		}
 
 		[Kept]


### PR DESCRIPTION
When no ctor parameters are passed, and non-public binding flags are
used, we only need to require parameterless public constructors. Fixes one of the issues in https://github.com/dotnet/runtime/pull/55636.