### PR TITLE
Fix warning suppressions on types for type hierarchy

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1756,14 +1756,16 @@ namespace Mono.Linker.Steps
 
 			MarkType (type.BaseType, new DependencyInfo (DependencyKind.BaseType, type));
 
+			MarkCustomAttributes (type, new DependencyInfo (DependencyKind.CustomAttribute, type));
+
 			// The DynamicallyAccessedMembers hiearchy processing must be done after the base type was marked
-			// (to avoid inconsistencies in the cache), but before anything else as work done below
+			// (to avoid inconsistencies in the cache), and after marking custom attributes (in case the attributes have
+			// warning suppressions for the type hierarchy marking) but before anything else as work done below
 			// might need the results of the processing here.
 			_dynamicallyAccessedMembersTypeHierarchy.ProcessMarkedTypeForDynamicallyAccessedMembersHierarchy (type);
 
 			if (type.DeclaringType != null)
 				MarkType (type.DeclaringType, new DependencyInfo (DependencyKind.DeclaringType, type));
-			MarkCustomAttributes (type, new DependencyInfo (DependencyKind.CustomAttribute, type));
 			MarkSecurityDeclarations (type, new DependencyInfo (DependencyKind.CustomAttribute, type));
 
 			if (type.IsMulticastDelegate ()) {

--- a/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchyLibraryModeSuppressions.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchyLibraryModeSuppressions.cs
@@ -1,0 +1,51 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Reflection
+{
+	[SetupLinkerArgument ("-a", "test.exe", "library")]
+	[ExpectedNoWarnings]
+	[KeptMember (".ctor()")]
+	public class TypeHierarchyLibraryModeSuppressions
+	{
+		public static void Main ()
+		{
+			var t1 = typeof (Unsuppressed);
+			var t2 = typeof (Suppressed);
+		}
+
+		[Kept]
+		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+		[ExpectedWarning ("IL2026", nameof (Unsuppressed))]
+		class Unsuppressed
+		{
+			[Kept]
+			[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+			[RequiresUnreferencedCode ("--RUC on Unsuppressed--")]
+			public void RUCMethod () { }
+		}
+
+		[Kept]
+		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+		[KeptAttributeAttribute (typeof (UnconditionalSuppressMessageAttribute))]
+		[UnconditionalSuppressMessage ("TrimAnalysis", "IL2026")]
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+		class Suppressed
+		{
+			[Kept]
+			[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+			[RequiresUnreferencedCode ("--RUC on Suppressed--")]
+			public void RUCMethod () { }
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchySuppressions.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchySuppressions.cs
@@ -1,0 +1,167 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Reflection
+{
+	[ExpectedNoWarnings]
+	public class TypeHierarchySuppressions
+	{
+		// https://github.com/mono/linker/issues/2136
+		// Warnings should originate from the types (or rather their members, with the
+		// proposed behavior), and the type suppressions should silence the relevant
+		// warnings.
+
+		// Should originate from types instead
+		[ExpectedWarning ("IL2026", "--RUC on Unsuppressed--")]
+		[ExpectedWarning ("IL2026", "--RUC on DerivedFromUnsuppressed1--")]
+
+		// Should be suppressed by type-level suppression
+		[ExpectedWarning ("IL2026", "--RUC on Suppressed--")]
+		[ExpectedWarning ("IL2026", "--RUC on SuppressedOnDerived1--")]
+		[ExpectedWarning ("IL2026", "--RUC on DerivedFromSuppressed1--")]
+		public static void Main ()
+		{
+			RequireMethods (unsuppressed.GetType ());
+			RequireMethods (suppressed.GetType ());
+
+			var t = typeof (DerivedFromSuppressed1);
+			var t2 = typeof (DerivedFromUnsuppressed1);
+			var t3 = typeof (SuppressedOnDerived1);
+
+			UseDerivedTypes ();
+		}
+
+		// Referencing these types in a separate method ensures that they get
+		// marked after applying annotations on the base type.
+		[Kept]
+		static void UseDerivedTypes ()
+		{
+			var t = typeof (DerivedFromUnsuppressed2);
+			var t2 = typeof (DerivedFromSuppressed2);
+			var t3 = typeof (SuppressedOnDerived2);
+		}
+
+		[Kept]
+		static Unsuppressed unsuppressed;
+
+		[Kept]
+		static Suppressed suppressed;
+
+		[Kept]
+		static void RequireMethods (
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+			Type type)
+		{ }
+
+		[Kept]
+		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+		// https://github.com/mono/linker/issues/2136
+		// [ExpectedWarning ("IL2026", "--RUC on Unsuppressed--")]
+		class Unsuppressed
+		{
+			[Kept]
+			[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+			[RequiresUnreferencedCode ("--RUC on Unsuppressed--")]
+			public void RUCMethod () { }
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (Unsuppressed))]
+		// https://github.com/mono/linker/issues/2136
+		// [ExpectedWarning ("IL2026", "--RUC on DerivedFromUnsuppressed1--")]
+		class DerivedFromUnsuppressed1 : Unsuppressed
+		{
+			[Kept]
+			[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+			[RequiresUnreferencedCode ("--RUC on DerivedFromUnsuppressed1--")]
+			public void DerivedRUCMethod () { }
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (Unsuppressed))]
+		[ExpectedWarning ("IL2026", "--RUC on DerivedFromUnsuppressed2")]
+		// https://github.com/mono/linker/issues/2136
+		// Should originate from the base type instead
+		[ExpectedWarning ("IL2026", "--RUC on Unsuppressed--")]
+		class DerivedFromUnsuppressed2 : Unsuppressed
+		{
+			[Kept]
+			[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+			[RequiresUnreferencedCode ("--RUC on DerivedFromUnsuppressed2--")]
+			public void DerivedRUCMethod () { }
+		}
+
+		[Kept]
+		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+		[KeptAttributeAttribute (typeof (UnconditionalSuppressMessageAttribute))]
+		[UnconditionalSuppressMessage ("TrimAnalysis", "IL2026")]
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+		class Suppressed
+		{
+			[Kept]
+			[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+			[RequiresUnreferencedCode ("--RUC on Suppressed--")]
+			public void RUCMethod () { }
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (Suppressed))]
+		// https://github.com/mono/linker/issues/2136
+		// [ExpectedWarning ("IL2026", "--RUC on DerivedFromSuppressed1--")]
+		class DerivedFromSuppressed1 : Suppressed
+		{
+			[Kept]
+			[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+			[RequiresUnreferencedCode ("--RUC on DerivedFromSuppressed1--")]
+			public void RUCDerivedMethod () { }
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (Suppressed))]
+		[ExpectedWarning ("IL2026", "--RUC on DerivedFromSuppressed2--")]
+		// https://github.com/mono/linker/issues/2136
+		[ExpectedWarning ("IL2026", "--RUC on Suppressed--")]
+		class DerivedFromSuppressed2 : Suppressed
+		{
+			[Kept]
+			[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+			[RequiresUnreferencedCode ("--RUC on DerivedFromSuppressed2--")]
+			public void RUCDerivedMethod () { }
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (Unsuppressed))]
+		[KeptAttributeAttribute (typeof (UnconditionalSuppressMessageAttribute))]
+		[UnconditionalSuppressMessage ("TrimAnalysis", "IL2026")]
+		class SuppressedOnDerived1 : Unsuppressed
+		{
+			[Kept]
+			[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+			[RequiresUnreferencedCode ("--RUC on SuppressedOnDerived1--")]
+			public void DerivedRUCMethod () { }
+		}
+
+		[Kept]
+		[KeptBaseType (typeof (Unsuppressed))]
+		[KeptAttributeAttribute (typeof (UnconditionalSuppressMessageAttribute))]
+		[UnconditionalSuppressMessage ("TrimAnalysis", "IL2026")]
+		class SuppressedOnDerived2 : Unsuppressed
+		{
+			[Kept]
+			[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+			[RequiresUnreferencedCode ("--RUC on SuppressedOnDerived2--")]
+			public void DerivedRUCMethod () { }
+		}
+	}
+}


### PR DESCRIPTION
Currently it's not possible to suppress warnings that originate from types in most cases, because we don't process the suppression attributes until after we've processed the type for type hierarchy related warnings.

https://github.com/mono/linker/pull/2114 changes the library-mode behavior of type hierarchy marking to apply the DAMT annotation when the type with the annotation is first seen. So far we have been reporting an inconsistent warning origin for these (sometimes the GetType call, sometimes the type - see https://github.com/mono/linker/issues/2136). But by applying the annotations when the type is first marked, we are now reporting warnings from the type, which is introducing some of the additional warnings in https://github.com/dotnet/runtime/pull/55636 that were previously suppressed on the GetType call.

This change makes it possible to suppress the warnings on the originating type. I don't think it's complete since there might be cases where the type is derived from an attribute type and also has attribute instances of that attribute - which would mark the declaring type before processing type hierarchy annotations. But this workaround should be good enough in the meantime, in case we want to use type-level suppressions to unblock runtime dependency flow.