### PR TITLE
Add `dynamic` analyzer

### DIFF
--- a/src/ILLink.RoslynAnalyzer/AnalyzerOptionsExtensions.cs
+++ b/src/ILLink.RoslynAnalyzer/AnalyzerOptionsExtensions.cs
@@ -27,5 +27,17 @@ namespace ILLink.RoslynAnalyzer
 				? value
 				: null;
 		}
+
+		public static bool IsMSBuildPropertyValueTrue (
+			this AnalyzerOptions options,
+			string propertyName,
+			Compilation compilation)
+		{
+			var propertyValue = GetMSBuildPropertyValue (options, propertyName, compilation);
+			if (!string.Equals (propertyValue?.Trim (), "true", System.StringComparison.OrdinalIgnoreCase))
+				return false;
+
+			return true;
+		}
 	}
 }

--- a/src/ILLink.RoslynAnalyzer/DiagnosticDescriptors.cs
+++ b/src/ILLink.RoslynAnalyzer/DiagnosticDescriptors.cs
@@ -21,6 +21,14 @@ namespace ILLink.RoslynAnalyzer
 				true);
 		}
 
+		public static DiagnosticDescriptor GetDiagnosticDescriptor (DiagnosticId diagnosticId, DiagnosticString diagnosticString)
+			=> new DiagnosticDescriptor (diagnosticId.AsString (),
+				diagnosticString.GetTitle (),
+				diagnosticString.GetMessage (),
+				GetDiagnosticCategory (diagnosticId),
+				DiagnosticSeverity.Warning,
+				true);
+
 		public static DiagnosticDescriptor GetDiagnosticDescriptor (DiagnosticId diagnosticId,
 			LocalizableResourceString? lrsTitle = null,
 			LocalizableResourceString? lrsMessage = null,

--- a/src/ILLink.RoslynAnalyzer/IOperationExtensions.cs
+++ b/src/ILLink.RoslynAnalyzer/IOperationExtensions.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.Operations;
 namespace ILLink.RoslynAnalyzer
 {
 	// Copied from https://github.com/dotnet/roslyn/blob/9c6d864baca08d7572871701ab583cec18279426/src/Compilers/Core/Portable/Operations/OperationExtensions.cs
-	internal static partial class OperationExtensions
+	internal static partial class IOperationExtensions
 	{
 		/// <summary>
 		/// Returns the <see cref="ValueUsageInfo"/> for the given operation.

--- a/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
@@ -216,13 +216,13 @@ namespace ILLink.RoslynAnalyzer
 
 				case ILocalFunctionOperation local when targets.HasFlag (DiagnosticTargets.MethodOrConstructor):
 					return local.Symbol;
-				
+
 				case IMethodBodyBaseOperation when targets.HasFlag (DiagnosticTargets.MethodOrConstructor):
 				case IPropertyReferenceOperation when targets.HasFlag (DiagnosticTargets.Property):
 				case IFieldReferenceOperation when targets.HasFlag (DiagnosticTargets.Field):
 				case IEventReferenceOperation when targets.HasFlag (DiagnosticTargets.Event):
 					return operationContext.ContainingSymbol;
-				
+
 				default:
 					parent = parent.Parent;
 					break;

--- a/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
@@ -25,6 +25,8 @@ namespace ILLink.RoslynAnalyzer
 
 		private protected abstract DiagnosticDescriptor RequiresAttributeMismatch { get; }
 
+		private protected virtual ImmutableArray<(Action<OperationAnalysisContext> Action, OperationKind[] OperationKind)> ExtraOperationActions { get; } = ImmutableArray<(Action<OperationAnalysisContext> Action, OperationKind[] OperationKind)>.Empty;
+
 		public override void Initialize (AnalysisContext context)
 		{
 			context.EnableConcurrentExecution ();
@@ -113,6 +115,10 @@ namespace ILLink.RoslynAnalyzer
 					CheckCalledMember (operationContext, methodSymbol, incompatibleMembers);
 				}, OperationKind.DelegateCreation);
 
+				// Register any extra operation actions supported by the analyzer.
+				foreach (var extraOperationAction in ExtraOperationActions)
+					context.RegisterOperationAction (extraOperationAction.Action, extraOperationAction.OperationKind);
+
 				void CheckStaticConstructors (OperationAnalysisContext operationContext,
 					ImmutableArray<IMethodSymbol> staticConstructors)
 				{
@@ -200,25 +206,29 @@ namespace ILLink.RoslynAnalyzer
 		/// <param name="operationContext">Analyzer operation context to retrieve the current operation.</param>
 		/// <param name="targets">Scope of the attribute to search for callers.</param>
 		/// <returns>The symbol of the caller to the operation</returns>
-		private static ISymbol FindContainingSymbol (OperationAnalysisContext operationContext, DiagnosticTargets targets)
+		protected static ISymbol FindContainingSymbol (OperationAnalysisContext operationContext, DiagnosticTargets targets)
 		{
 			var parent = operationContext.Operation.Parent;
 			while (parent is not null) {
 				switch (parent) {
 				case IAnonymousFunctionOperation lambda:
 					return lambda.Symbol;
+
 				case ILocalFunctionOperation local when targets.HasFlag (DiagnosticTargets.MethodOrConstructor):
 					return local.Symbol;
+				
 				case IMethodBodyBaseOperation when targets.HasFlag (DiagnosticTargets.MethodOrConstructor):
 				case IPropertyReferenceOperation when targets.HasFlag (DiagnosticTargets.Property):
 				case IFieldReferenceOperation when targets.HasFlag (DiagnosticTargets.Field):
 				case IEventReferenceOperation when targets.HasFlag (DiagnosticTargets.Event):
 					return operationContext.ContainingSymbol;
+				
 				default:
 					parent = parent.Parent;
 					break;
 				}
 			}
+
 			return operationContext.ContainingSymbol;
 		}
 

--- a/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
@@ -18,8 +18,21 @@ namespace ILLink.RoslynAnalyzer
 
 		static readonly DiagnosticDescriptor s_requiresUnreferencedCodeRule = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.RequiresUnreferencedCode);
 		static readonly DiagnosticDescriptor s_requiresUnreferencedCodeAttributeMismatch = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.RequiresUnreferencedCodeAttributeMismatch);
+		static readonly DiagnosticDescriptor s_dynamicTypeInvocationRule = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.RequiresUnreferencedCode,
+			new LocalizableResourceString (nameof (SharedStrings.DynamicTypeInvocationTitle), SharedStrings.ResourceManager, typeof (SharedStrings)),
+			new LocalizableResourceString (nameof (SharedStrings.DynamicTypeInvocationMessage), SharedStrings.ResourceManager, typeof (SharedStrings)));
 
-		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create (s_requiresUnreferencedCodeRule, s_requiresUnreferencedCodeAttributeMismatch);
+		static readonly Action<OperationAnalysisContext> s_dynamicTypeInvocation = operationContext => {
+			if (FindContainingSymbol (operationContext, DiagnosticTargets.All) is ISymbol containingSymbol &&
+				containingSymbol.HasAttribute (RequiresUnreferencedCodeAttribute))
+					return;
+
+			operationContext.ReportDiagnostic (Diagnostic.Create (s_dynamicTypeInvocationRule,
+				operationContext.Operation.Syntax.GetLocation ()));
+		};
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+			ImmutableArray.Create (s_dynamicTypeInvocationRule, s_requiresUnreferencedCodeRule, s_requiresUnreferencedCodeAttributeMismatch);
 
 		private protected override string RequiresAttributeName => RequiresUnreferencedCodeAttribute;
 
@@ -31,13 +44,11 @@ namespace ILLink.RoslynAnalyzer
 
 		private protected override DiagnosticDescriptor RequiresAttributeMismatch => s_requiresUnreferencedCodeAttributeMismatch;
 
-		protected override bool IsAnalyzerEnabled (AnalyzerOptions options, Compilation compilation)
-		{
-			var isTrimAnalyzerEnabled = options.GetMSBuildPropertyValue (MSBuildPropertyOptionNames.EnableTrimAnalyzer, compilation);
-			if (!string.Equals (isTrimAnalyzerEnabled?.Trim (), "true", StringComparison.OrdinalIgnoreCase))
-				return false;
-			return true;
-		}
+		protected override bool IsAnalyzerEnabled (AnalyzerOptions options, Compilation compilation) =>
+			options.IsMSBuildPropertyValueTrue (MSBuildPropertyOptionNames.EnableTrimAnalyzer, compilation);
+
+		private protected override ImmutableArray<(Action<OperationAnalysisContext> Action, OperationKind[] OperationKind)> ExtraOperationActions =>
+			ImmutableArray.Create ((s_dynamicTypeInvocation, new OperationKind[] { OperationKind.DynamicInvocation }));
 
 		protected override bool VerifyAttributeArguments (AttributeData attribute) =>
 			attribute.ConstructorArguments.Length >= 1 && attribute.ConstructorArguments[0] is { Type: { SpecialType: SpecialType.System_String } } ctorArg;

--- a/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
@@ -25,7 +25,7 @@ namespace ILLink.RoslynAnalyzer
 		static readonly Action<OperationAnalysisContext> s_dynamicTypeInvocation = operationContext => {
 			if (FindContainingSymbol (operationContext, DiagnosticTargets.All) is ISymbol containingSymbol &&
 				containingSymbol.HasAttribute (RequiresUnreferencedCodeAttribute))
-					return;
+				return;
 
 			operationContext.ReportDiagnostic (Diagnostic.Create (s_dynamicTypeInvocationRule,
 				operationContext.Operation.Syntax.GetLocation ()));

--- a/src/ILLink.Shared/DiagnosticString.cs
+++ b/src/ILLink.Shared/DiagnosticString.cs
@@ -12,6 +12,13 @@
 			_messageFormat = resourceManager.GetString ($"{diagnosticId}Message");
 		}
 
+		public DiagnosticString (string diagnosticResourceStringName)
+		{
+			var resourceManager = SharedStrings.ResourceManager;
+			_titleFormat = resourceManager.GetString ($"{diagnosticResourceStringName}Title");
+			_messageFormat = resourceManager.GetString ($"{diagnosticResourceStringName}Message");
+		}
+
 		public string GetMessage (params string[] args) =>
 			string.Format (_messageFormat, args);
 

--- a/src/ILLink.Shared/SharedStrings.resx
+++ b/src/ILLink.Shared/SharedStrings.resx
@@ -165,4 +165,10 @@
   <data name="RequiresOnBaseClassTitle" xml:space="preserve">
     <value>Types that derive from a base class with 'RequiresUnreferencedCodeAttribute' need to explicitly use the 'RequiresUnreferencedCodeAttribute' or suppress this warning</value>
   </data>
+  <data name="DynamicTypeInvocationMessage" xml:space="preserve">
+    <value>Invoking members on dynamic types is not trimming-compatible. Types or member might have been removed by the trimmer.</value>
+  </data>
+  <data name="DynamicTypeInvocationTitle" xml:space="preserve">
+    <value>Using dynamic types might cause types or members to be removed by trimmer.</value>
+  </data>
 </root>

--- a/test/ILLink.RoslynAnalyzer.Tests/RequiresUnreferencedCodeAnalyzerTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/RequiresUnreferencedCodeAnalyzerTests.cs
@@ -19,6 +19,8 @@ namespace ILLink.RoslynAnalyzer.Tests
 {
 	public class RequiresUnreferencedCodeAnalyzerTests
 	{
+		static DiagnosticDescriptor dynamicInvocationDiagnosticDescriptor = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.RequiresUnreferencedCode, new DiagnosticString ("DynamicTypeInvocation"));
+
 		static Task VerifyRequiresUnreferencedCodeAnalyzer (string source, params DiagnosticResult[] expected) =>
 			VerifyRequiresUnreferencedCodeAnalyzer (source, null, expected);
 
@@ -861,6 +863,62 @@ class AnotherImplementation : IRAF
 				VerifyCS.Diagnostic (DiagnosticId.RequiresUnreferencedCodeAttributeMismatch).WithSpan (7, 14, 7, 20).WithArguments ("Member 'Implementation.Method()' with 'RequiresUnreferencedCodeAttribute' implements interface member 'IRAF.Method()' without 'RequiresUnreferencedCodeAttribute'"),
 				// (13,3): warning IL2046: Member 'Implementation.StringProperty.get' with 'RequiresUnreferencedCodeAttribute' implements interface member 'IRAF.StringProperty.get' without 'RequiresUnreferencedCodeAttribute'. Attributes must match across all interface implementations or overrides.
 				VerifyCS.Diagnostic (DiagnosticId.RequiresUnreferencedCodeAttributeMismatch).WithSpan (13, 3, 13, 6).WithArguments ("Member 'Implementation.StringProperty.get' with 'RequiresUnreferencedCodeAttribute' implements interface member 'IRAF.StringProperty.get' without 'RequiresUnreferencedCodeAttribute'"));
+		}
+
+		[Fact]
+		public Task InvocationOnDynamicType ()
+		{
+			var source = @"
+using System;
+class C
+{
+	static void M0 ()
+	{
+		dynamic dynamicField = ""Some string"";
+		Console.WriteLine (dynamicField);
+	}
+
+	static void M1 ()
+	{
+		MethodWithDynamicArgDoNothing (0);
+		MethodWithDynamicArgDoNothing (""Some string"");
+		MethodWithDynamicArg(-1);
+	}
+
+	static void MethodWithDynamicArgDoNothing (dynamic arg)
+	{
+	}
+
+	static void MethodWithDynamicArg (dynamic arg)
+	{
+		arg.MethodWithDynamicArg (arg);
+	}
+}";
+
+			return VerifyRequiresUnreferencedCodeAnalyzer (source,
+				// (8,3): warning IL2026: Invoking members on dynamic types is not trimming safe. Types or member might have been removed by the trimmer.
+				VerifyCS.Diagnostic (dynamicInvocationDiagnosticDescriptor).WithSpan (8, 3, 8, 35),
+				// (24,3): warning IL2026: Invoking members on dynamic types is not trimming safe. Types or member might have been removed by the trimmer.
+				VerifyCS.Diagnostic (dynamicInvocationDiagnosticDescriptor).WithSpan (24, 3, 24, 33));
+		}
+
+		[Fact]
+		public Task InvocationOnDynamicTypeInMethodWithRUCDoesNotWarnTwoTimes ()
+		{
+			var source = @"
+using System;
+using System.Diagnostics.CodeAnalysis;
+class C
+{
+	[RequiresUnreferencedCode (""We should only see the warning related to this annotation, and none about the dynamic type."")]
+	static void M0 ()
+	{
+		dynamic dynamicField = ""Some string"";
+		Console.WriteLine (dynamicField);
+	}
+}";
+
+			return VerifyRequiresUnreferencedCodeAnalyzer (source);
 		}
 	}
 }


### PR DESCRIPTION
A `dynamic` type causes reflection to be performed on the runtime type, making it trimmer-incompatible. This analyzer will warn on any invocation on a dynamic type with `IL2026`.

Happy to read any suggestion(s) on interesting testing scenarios.