### PR TITLE
Fixes a null reference when trying to get RUC on a type

### DIFF
--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -561,17 +561,15 @@ namespace Mono.Linker
 		/// <returns>Returns true along with the RequiresUnreferencedCodeAttribute if found, otherwise returns false</returns>
 		public bool TryGetEffectiveRequiresUnreferencedCodeAttributeOnType (TypeDefinition type, out RequiresUnreferencedCodeAttribute attribute)
 		{
-			attribute = null;
-			if (type == null)
-				return false;
-
-			do {
+			while (type != null) {
 				if (TryGetLinkerAttribute (type, out RequiresUnreferencedCodeAttribute declaringTypeAttribute)) {
 					attribute = declaringTypeAttribute;
 					return true;
 				}
 				type = type.DeclaringType;
-			} while (type != null);
+			}
+
+			attribute = null;
 			return false;
 		}
 

--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -561,6 +561,10 @@ namespace Mono.Linker
 		/// <returns>Returns true along with the RequiresUnreferencedCodeAttribute if found, otherwise returns false</returns>
 		public bool TryGetEffectiveRequiresUnreferencedCodeAttributeOnType (TypeDefinition type, out RequiresUnreferencedCodeAttribute attribute)
 		{
+			attribute = null;
+			if (type == null)
+				return false;
+
 			do {
 				if (TryGetLinkerAttribute (type, out RequiresUnreferencedCodeAttribute declaringTypeAttribute)) {
 					attribute = declaringTypeAttribute;
@@ -568,7 +572,6 @@ namespace Mono.Linker
 				}
 				type = type.DeclaringType;
 			} while (type != null);
-			attribute = null;
 			return false;
 		}
 


### PR DESCRIPTION
If the type in question has unresolvable base type, we null ref.