### PR TITLE
Fix warning origin for DAM on types

### DIFF
--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -1753,6 +1753,68 @@ void TestMethod()
 }
 ```
 
+#### `IL2112` Trim analysis: 'DynamicallyAccessedMembers' on 'type' or one of its base types references 'member' which requires unreferenced code. [message]. [url]
+
+- A type is annotated with `DynamicallyAccessedMembers` indicating that the type may dynamically access some members declared on the type or its derived types. This instructs the trimmer to keep the specified members, but one of them is annotated with `RequiresUnreferencedCode` which can break functionality when trimming. The `DynamicallyAccessedMembers` annotation may be directly on the type, or implied by an annotation on one of its base or interface types. This warning originates from the member with `RequiresUnreferencedCode`.
+
+  ```C#
+  [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+  public class AnnotatedType {
+      // Trim analysis warning IL2112: AnnotatedType.Method(): 'DynamicallyAccessedMembers' on 'AnnotatedType' or one of its
+      // base types references 'AnnotatedType.Method()' which requires unreferenced code. Using this member is trim unsafe.
+      [RequiresUnreferencedCode("Using this member is trim unsafe")]
+      public static void Method() { }
+  }
+  ```
+
+#### `IL2113` Trim analysis: 'DynamicallyAccessedMembers' on 'type' or one of its base types references 'member' which requires unreferenced code. [message]. [url]
+
+- A type is annotated with `DynamicallyAccessedMembers` indicating that the type may dynamically access some members declared on the type or its derived types. This instructs the trimmer to keep the specified members, but a member of one of the base or interface types is annotated with `RequiresUnreferencedCode` which can break functionality when trimming. The `DynamicallyAccessedMembers` annotation may be directly on the type, or implied by an annotation on one of its base or interface types. This warning originates from the type which has `DynamicallyAccessedMembers` requirements.
+
+  ```C#
+  public class BaseType {
+      [RequiresUnreferencedCode("Using this member is trim unsafe")]
+      public static void Method() { }
+  }
+
+  // Trim analysis warning IL2113: AnnotatedType: 'DynamicallyAccessedMembers' on 'AnnotatedType' or one of its
+  // base types references 'BaseType.Method()' which requires unreferenced code. Using this member is trim unsafe.
+  [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+  public class AnnotatedType : BaseType {
+  }
+  ```
+
+#### `IL2114 ` Trim analysis: 'DynamicallyAccessedMembers' on 'type' or one of its base types references 'member' which has 'DynamicallyAccessedMembers' requirements.
+
+- A type is annotated with `DynamicallyAccessedMembers` indicating that the type may dynamically access some members declared on the type or its derived types. This instructs the trimmer to keep the specified members, but one of them is annotated with `DynamicallyAccessedMembersAttribute` which can not be statically verified. The `DynamicallyAccessedMembers` annotation may be directly on the type, or implied by an annotation on one of its base or interface types. This warning originates from the member with `DynamicallyAccessedMembers` requirements.
+
+  ```C#
+  [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
+  public class AnnotatedType {
+      // Trim analysis warning IL2114: System.Type AnnotatedType::Field: 'DynamicallyAccessedMembers' on 'AnnotatedType' or one of its
+      // base types references 'System.Type AnnotatedType::Field' which has 'DynamicallyAccessedMembers' requirements .
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
+      public static Type Field;
+  }
+  ```
+
+#### `IL2115 ` Trim analysis: 'DynamicallyAccessedMembers' on 'type' or one of its base types references 'member' which has 'DynamicallyAccessedMembers' requirements.
+
+- A type is annotated with `DynamicallyAccessedMembers` indicating that the type may dynamically access some members declared on the type or its derived types. This instructs the trimmer to keep the specified members, but a member of one of the base or interface types is annotated with `DynamicallyAccessedMembersAttribute` which can not be statically verified. The `DynamicallyAccessedMembers` annotation may be directly on the type, or implied by an annotation on one of its base or interface types. This warning originates from the type which has `DynamicallyAccessedMembers` requirements.
+
+  ```C#
+  public class BaseType {
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
+      public static Type Field;
+  }
+
+  // Trim analysis warning IL2115: AnnotatedType: 'DynamicallyAccessedMembers' on 'AnnotatedType' or one of its
+  // base types references 'System.Type BaseType::Field' which has 'DynamicallyAccessedMembers' requirements .
+  [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
+  public class AnnotatedType : BaseType {
+  }
+  ```
+
 ## Single-File Warning Codes
 
 #### `IL3000`: 'member' always returns an empty string for assemblies embedded in a single-file app. If the path to the app directory is needed, consider calling 'System.AppContext.BaseDirectory'

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -1753,23 +1753,23 @@ void TestMethod()
 }
 ```
 
-#### `IL2112` Trim analysis: 'DynamicallyAccessedMembers' on 'type' or one of its base types references 'member' which requires unreferenced code. [message]. [url]
+#### `IL2112` Trim analysis: 'DynamicallyAccessedMembersAttribute' on 'type' or one of its base types references 'member' which requires unreferenced code. [message]. [url]
 
-- A type is annotated with `DynamicallyAccessedMembers` indicating that the type may dynamically access some members declared on the type or its derived types. This instructs the trimmer to keep the specified members, but one of them is annotated with `RequiresUnreferencedCode` which can break functionality when trimming. The `DynamicallyAccessedMembers` annotation may be directly on the type, or implied by an annotation on one of its base or interface types. This warning originates from the member with `RequiresUnreferencedCode`.
+- A type is annotated with `DynamicallyAccessedMembersAttribute` indicating that the type may dynamically access some members declared on the type or its derived types. This instructs the trimmer to keep the specified members, but one of them is annotated with `RequiresUnreferencedCodeAttribute` which can break functionality when trimming. The `DynamicallyAccessedMembersAttribute` annotation may be directly on the type, or implied by an annotation on one of its base or interface types. This warning originates from the member with `RequiresUnreferencedCodeAttribute`.
 
   ```C#
   [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
   public class AnnotatedType {
-      // Trim analysis warning IL2112: AnnotatedType.Method(): 'DynamicallyAccessedMembers' on 'AnnotatedType' or one of its
+      // Trim analysis warning IL2112: AnnotatedType.Method(): 'DynamicallyAccessedMembersAttribute' on 'AnnotatedType' or one of its
       // base types references 'AnnotatedType.Method()' which requires unreferenced code. Using this member is trim unsafe.
       [RequiresUnreferencedCode("Using this member is trim unsafe")]
       public static void Method() { }
   }
   ```
 
-#### `IL2113` Trim analysis: 'DynamicallyAccessedMembers' on 'type' or one of its base types references 'member' which requires unreferenced code. [message]. [url]
+#### `IL2113` Trim analysis: 'DynamicallyAccessedMembersAttribute' on 'type' or one of its base types references 'member' which requires unreferenced code. [message]. [url]
 
-- A type is annotated with `DynamicallyAccessedMembers` indicating that the type may dynamically access some members declared on the type or its derived types. This instructs the trimmer to keep the specified members, but a member of one of the base or interface types is annotated with `RequiresUnreferencedCode` which can break functionality when trimming. The `DynamicallyAccessedMembers` annotation may be directly on the type, or implied by an annotation on one of its base or interface types. This warning originates from the type which has `DynamicallyAccessedMembers` requirements.
+- A type is annotated with `DynamicallyAccessedMembersAttribute` indicating that the type may dynamically access some members declared on the type or its derived types. This instructs the trimmer to keep the specified members, but a member of one of the base or interface types is annotated with `RequiresUnreferencedCodeAttribute` which can break functionality when trimming. The `DynamicallyAccessedMembersAttribute` annotation may be directly on the type, or implied by an annotation on one of its base or interface types. This warning originates from the type which has `DynamicallyAccessedMembersAttribute` requirements.
 
   ```C#
   public class BaseType {
@@ -1777,30 +1777,30 @@ void TestMethod()
       public static void Method() { }
   }
 
-  // Trim analysis warning IL2113: AnnotatedType: 'DynamicallyAccessedMembers' on 'AnnotatedType' or one of its
+  // Trim analysis warning IL2113: AnnotatedType: 'DynamicallyAccessedMembersAttribute' on 'AnnotatedType' or one of its
   // base types references 'BaseType.Method()' which requires unreferenced code. Using this member is trim unsafe.
   [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
   public class AnnotatedType : BaseType {
   }
   ```
 
-#### `IL2114 ` Trim analysis: 'DynamicallyAccessedMembers' on 'type' or one of its base types references 'member' which has 'DynamicallyAccessedMembers' requirements.
+#### `IL2114 ` Trim analysis: 'DynamicallyAccessedMembersAttribute' on 'type' or one of its base types references 'member' which has 'DynamicallyAccessedMembersAttribute' requirements.
 
-- A type is annotated with `DynamicallyAccessedMembers` indicating that the type may dynamically access some members declared on the type or its derived types. This instructs the trimmer to keep the specified members, but one of them is annotated with `DynamicallyAccessedMembersAttribute` which can not be statically verified. The `DynamicallyAccessedMembers` annotation may be directly on the type, or implied by an annotation on one of its base or interface types. This warning originates from the member with `DynamicallyAccessedMembers` requirements.
+- A type is annotated with `DynamicallyAccessedMembersAttribute` indicating that the type may dynamically access some members declared on the type or its derived types. This instructs the trimmer to keep the specified members, but one of them is annotated with `DynamicallyAccessedMembersAttribute` which can not be statically verified. The `DynamicallyAccessedMembersAttribute` annotation may be directly on the type, or implied by an annotation on one of its base or interface types. This warning originates from the member with `DynamicallyAccessedMembersAttribute` requirements.
 
   ```C#
   [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
   public class AnnotatedType {
-      // Trim analysis warning IL2114: System.Type AnnotatedType::Field: 'DynamicallyAccessedMembers' on 'AnnotatedType' or one of its
-      // base types references 'System.Type AnnotatedType::Field' which has 'DynamicallyAccessedMembers' requirements .
+      // Trim analysis warning IL2114: System.Type AnnotatedType::Field: 'DynamicallyAccessedMembersAttribute' on 'AnnotatedType' or one of its
+      // base types references 'System.Type AnnotatedType::Field' which has 'DynamicallyAccessedMembersAttribute' requirements .
       [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
       public static Type Field;
   }
   ```
 
-#### `IL2115 ` Trim analysis: 'DynamicallyAccessedMembers' on 'type' or one of its base types references 'member' which has 'DynamicallyAccessedMembers' requirements.
+#### `IL2115 ` Trim analysis: 'DynamicallyAccessedMembersAttribute' on 'type' or one of its base types references 'member' which has 'DynamicallyAccessedMembersAttribute' requirements.
 
-- A type is annotated with `DynamicallyAccessedMembers` indicating that the type may dynamically access some members declared on the type or its derived types. This instructs the trimmer to keep the specified members, but a member of one of the base or interface types is annotated with `DynamicallyAccessedMembersAttribute` which can not be statically verified. The `DynamicallyAccessedMembers` annotation may be directly on the type, or implied by an annotation on one of its base or interface types. This warning originates from the type which has `DynamicallyAccessedMembers` requirements.
+- A type is annotated with `DynamicallyAccessedMembersAttribute` indicating that the type may dynamically access some members declared on the type or its derived types. This instructs the trimmer to keep the specified members, but a member of one of the base or interface types is annotated with `DynamicallyAccessedMembersAttribute` which can not be statically verified. The `DynamicallyAccessedMembersAttribute` annotation may be directly on the type, or implied by an annotation on one of its base or interface types. This warning originates from the type which has `DynamicallyAccessedMembersAttribute` requirements.
 
   ```C#
   public class BaseType {
@@ -1808,8 +1808,8 @@ void TestMethod()
       public static Type Field;
   }
 
-  // Trim analysis warning IL2115: AnnotatedType: 'DynamicallyAccessedMembers' on 'AnnotatedType' or one of its
-  // base types references 'System.Type BaseType::Field' which has 'DynamicallyAccessedMembers' requirements .
+  // Trim analysis warning IL2115: AnnotatedType: 'DynamicallyAccessedMembersAttribute' on 'AnnotatedType' or one of its
+  // base types references 'System.Type BaseType::Field' which has 'DynamicallyAccessedMembersAttribute' requirements .
   [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
   public class AnnotatedType : BaseType {
   }

--- a/src/linker/Linker.Dataflow/DynamicallyAccessedMembersTypeHierarchy.cs
+++ b/src/linker/Linker.Dataflow/DynamicallyAccessedMembersTypeHierarchy.cs
@@ -118,7 +118,8 @@ namespace Mono.Linker.Dataflow
 				// so we need to apply the annotation to this type as well
 				using var _ = _scopeStack.PushScope (new MessageOrigin (type));
 				var reflectionMethodBodyScanner = new ReflectionMethodBodyScanner (_context, _markStep, _scopeStack);
-				var reflectionPatternContext = new ReflectionPatternContext (_context, true, _scopeStack.CurrentScope.Origin, type);
+				// Set up a context to report warnings on access to annotated members, with the annotated type as the origin.
+				var reflectionPatternContext = new ReflectionPatternContext (_context, reportingEnabled: true, _scopeStack.CurrentScope.Origin, type);
 				reflectionMethodBodyScanner.ApplyDynamicallyAccessedMembersToType (ref reflectionPatternContext, type, annotation);
 				reflectionPatternContext.Dispose ();
 			}
@@ -142,7 +143,8 @@ namespace Mono.Linker.Dataflow
 
 			// Apply the effective annotation for the type
 			using var _ = _scopeStack.PushScope (new MessageOrigin (type));
-			var reflectionPatternContext = new ReflectionPatternContext (_context, true, _scopeStack.CurrentScope.Origin, type);
+			// Set up a context to report warnings on access to annotated members, with the annotated type as the origin.
+			var reflectionPatternContext = new ReflectionPatternContext (_context, reportingEnabled: true, _scopeStack.CurrentScope.Origin, type);
 			reflectionMethodBodyScanner.ApplyDynamicallyAccessedMembersToType (ref reflectionPatternContext, type, annotation);
 
 			// Mark it as applied in the cache
@@ -212,7 +214,8 @@ namespace Mono.Linker.Dataflow
 
 			if (applied) {
 				using var _ = _scopeStack.PushScope (new MessageOrigin (type));
-				var reflectionPatternContext = new ReflectionPatternContext (_context, true, _scopeStack.CurrentScope.Origin, type);
+				// Set up a context to report warnings on access to annotated members, with the annotated type as the origin.
+				var reflectionPatternContext = new ReflectionPatternContext (_context, reportingEnabled: true, _scopeStack.CurrentScope.Origin, type);
 				reflectionMethodBodyScanner.ApplyDynamicallyAccessedMembersToType (ref reflectionPatternContext, type, annotation);
 				_typesInDynamicallyAccessedMembersHierarchy[type] = (annotation, true);
 			}

--- a/src/linker/Linker.Dataflow/FlowAnnotations.cs
+++ b/src/linker/Linker.Dataflow/FlowAnnotations.cs
@@ -65,13 +65,10 @@ namespace Mono.Linker.Dataflow
 		public DynamicallyAccessedMemberTypes GetTypeAnnotation (TypeDefinition type) =>
 			GetAnnotations (type).TypeAnnotation;
 
-		public bool DoesMemberAccessRequireDynamicallyAccessedMembers (IMemberDefinition provider) =>
+		public bool ShouldWarnWhenAccessedForReflection (IMemberDefinition provider) =>
 			provider switch {
-				MethodDefinition method =>
-					GetAnnotations (method.DeclaringType).TryGetAnnotation (method, out var annotation) &&
-					(annotation.ParameterAnnotations != null || annotation.ReturnParameterAnnotation != DynamicallyAccessedMemberTypes.None),
-				FieldDefinition field =>
-					GetAnnotations (field.DeclaringType).TryGetAnnotation (field, out _),
+				MethodDefinition method => ShouldWarnWhenAccessedForReflection (method),
+				FieldDefinition field => ShouldWarnWhenAccessedForReflection (field),
 				_ => false
 			};
 
@@ -93,13 +90,55 @@ namespace Mono.Linker.Dataflow
 			return DynamicallyAccessedMemberTypes.None;
 		}
 
-		public bool ShouldWarnWhenAccessedForReflection (MethodDefinition method) =>
-			GetAnnotations (method.DeclaringType).TryGetAnnotation (method, out var annotation) &&
-			(annotation.ParameterAnnotations != null || annotation.ReturnParameterAnnotation != DynamicallyAccessedMemberTypes.None);
+		public bool ShouldWarnWhenAccessedForReflection (MethodDefinition method)
+		{
+			if (!GetAnnotations (method.DeclaringType).TryGetAnnotation (method, out var annotation))
+				return false;
 
-		public bool MethodHasNoAnnotatedParameters (MethodDefinition method) =>
-			GetAnnotations (method.DeclaringType).TryGetAnnotation (method, out var annotation) &&
-			annotation.ParameterAnnotations == null;
+			if (annotation.ParameterAnnotations == null && annotation.ReturnParameterAnnotation == DynamicallyAccessedMemberTypes.None)
+				return false;
+
+			// If the method only has annotation on the return value and it's not virtual avoid warning.
+			// Return value annotations are "consumed" by the caller of a method, and as such there is nothing
+			// wrong calling these dynamically. The only problem can happen if something overrides a virtual
+			// method with annotated return value at runtime - in this case the trimmer can't validate
+			// that the method will return only types which fulfill the annotation's requirements.
+			// For example:
+			//   class BaseWithAnnotation
+			//   {
+			//       [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
+			//       public abstract Type GetTypeWithFields();
+			//   }
+			//
+			//   class UsingTheBase
+			//   {
+			//       public void PrintFields(Base base)
+			//       {
+			//            // No warning here - GetTypeWithFields is correctly annotated to allow GetFields on the return value.
+			//            Console.WriteLine(string.Join(" ", base.GetTypeWithFields().GetFields().Select(f => f.Name)));
+			//       }
+			//   }
+			//
+			// If at runtime (through ref emit) something generates code like this:
+			//   class DerivedAtRuntimeFromBase
+			//   {
+			//       // No point in adding annotation on the return value - nothing will look at it anyway
+			//       // Linker will not see this code, so there are no checks
+			//       public override Type GetTypeWithFields() { return typeof(TestType); }
+			//   }
+			//
+			// If TestType from above is trimmed, it may note have all its fields, and there would be no warnings generated.
+			// But there has to be code like this somewhere in the app, in order to generate the override:
+			//   class RuntimeTypeGenerator
+			//   {
+			//       public MethodInfo GetBaseMethod()
+			//       {
+			//            // This must warn - that the GetTypeWithFields has annotation on the return value
+			//            return typeof(BaseWithAnnotation).GetMethod("GetTypeWithFields");
+			//       }
+			//   }
+			return method.IsVirtual || annotation.ParameterAnnotations != null;
+		}
 
 		public bool ShouldWarnWhenAccessedForReflection (FieldDefinition field) =>
 			GetAnnotations (field.DeclaringType).TryGetAnnotation (field, out _);

--- a/src/linker/Linker.Dataflow/FlowAnnotations.cs
+++ b/src/linker/Linker.Dataflow/FlowAnnotations.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -64,6 +64,16 @@ namespace Mono.Linker.Dataflow
 
 		public DynamicallyAccessedMemberTypes GetTypeAnnotation (TypeDefinition type) =>
 			GetAnnotations (type).TypeAnnotation;
+
+		public bool DoesMemberAccessRequireDynamicallyAccessedMembers (IMemberDefinition provider) =>
+			provider switch {
+				MethodDefinition method =>
+					GetAnnotations (method.DeclaringType).TryGetAnnotation (method, out var annotation) &&
+					(annotation.ParameterAnnotations != null || annotation.ReturnParameterAnnotation != DynamicallyAccessedMemberTypes.None),
+				FieldDefinition field =>
+					GetAnnotations (field.DeclaringType).TryGetAnnotation (field, out _),
+				_ => false
+			};
 
 		public DynamicallyAccessedMemberTypes GetGenericParameterAnnotation (GenericParameter genericParameter)
 		{

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -72,6 +72,7 @@ namespace Mono.Linker.Steps
 			DependencyKind.AccessedViaReflection,
 			DependencyKind.BaseType,
 			DependencyKind.DynamicallyAccessedMember,
+			DependencyKind.DynamicallyAccessedMemberOnType,
 			DependencyKind.DynamicDependency,
 			DependencyKind.NestedType,
 			DependencyKind.TypeInAssembly,
@@ -85,6 +86,7 @@ namespace Mono.Linker.Steps
 			DependencyKind.Custom,
 			DependencyKind.CustomAttributeField,
 			DependencyKind.DynamicallyAccessedMember,
+			DependencyKind.DynamicallyAccessedMemberOnType,
 			DependencyKind.EventSourceProviderField,
 			DependencyKind.FieldAccess,
 			DependencyKind.FieldOnGenericInstance,
@@ -110,6 +112,7 @@ namespace Mono.Linker.Steps
 			DependencyKind.DeclaringType,
 			DependencyKind.DeclaringTypeOfCalledMethod,
 			DependencyKind.DynamicallyAccessedMember,
+			DependencyKind.DynamicallyAccessedMemberOnType,
 			DependencyKind.DynamicDependency,
 			DependencyKind.ElementType,
 			DependencyKind.FieldType,
@@ -146,6 +149,7 @@ namespace Mono.Linker.Steps
 			DependencyKind.DefaultCtorForNewConstrainedGenericArgument,
 			DependencyKind.DirectCall,
 			DependencyKind.DynamicallyAccessedMember,
+			DependencyKind.DynamicallyAccessedMemberOnType,
 			DependencyKind.DynamicDependency,
 			DependencyKind.ElementMethod,
 			DependencyKind.EventMethod,
@@ -329,7 +333,7 @@ namespace Mono.Linker.Steps
 
 			_entireTypesMarked[type] = includeBaseAndInterfaceTypes;
 
-			bool isDynamicDependencyReason = reason.Kind == DependencyKind.DynamicallyAccessedMember || reason.Kind == DependencyKind.DynamicDependency;
+			bool isDynamicDependencyReason = reason.Kind == DependencyKind.DynamicallyAccessedMember || reason.Kind == DependencyKind.DynamicDependency || reason.Kind == DependencyKind.DynamicallyAccessedMemberOnType;
 
 			if (type.HasNestedTypes) {
 				foreach (TypeDefinition nested in type.NestedTypes)
@@ -1540,6 +1544,52 @@ namespace Mono.Linker.Steps
 			MarkField (field, reason);
 		}
 
+		void ReportWarningsForTypeHierarchyReflectionAccess (IMemberDefinition member)
+		{
+			Debug.Assert (member is MethodDefinition or FieldDefinition);
+
+			var type = _scopeStack.CurrentScope.Origin.MemberDefinition as TypeDefinition;
+			Debug.Assert (type != null);
+
+			static bool IsDeclaredWithinType (IMemberDefinition member, TypeDefinition type)
+			{
+				while ((member = member.DeclaringType) != null) {
+					if (member == type)
+						return true;
+				}
+				return false;
+			}
+
+			var reportOnMember = IsDeclaredWithinType (member, type);
+			var memberScope = reportOnMember ? _scopeStack.PushScope (new MessageOrigin (member)) : null;
+
+			try {
+				var origin = _scopeStack.CurrentScope.Origin;
+
+				if (member is MethodDefinition method && DoesMethodRequireUnreferencedCode (method, out RequiresUnreferencedCodeAttribute attribute)) {
+					var message = string.Format (
+						"'DynamicallyAccessedMembers' on '{0}' or one of its base types references '{1}' which requires unreferenced code.{2}{3}",
+						type.GetDisplayName (),
+						method.GetDisplayName (),
+						MessageFormat.FormatRequiresAttributeMessageArg (attribute.Message),
+						MessageFormat.FormatRequiresAttributeMessageArg (attribute.Url));
+					var code = reportOnMember ? 2112 : 2113;
+					_context.LogWarning (message, code, origin, MessageSubCategory.TrimAnalysis);
+				}
+
+				if (_context.Annotations.FlowAnnotations.DoesMemberAccessRequireDynamicallyAccessedMembers (member)) {
+					var message = string.Format (
+						"'DynamicallyAccessedMembers' on '{0}' or one of its base types references '{1}' which has 'DynamicallyAccessedMembers' requirements.",
+						type.GetDisplayName (),
+						(member as MemberReference).GetDisplayName ());
+					var code = reportOnMember ? 2114 : 2115;
+					_context.LogWarning (message, code, origin, MessageSubCategory.TrimAnalysis);
+				}
+			} finally {
+				memberScope?.Dispose ();
+			}
+		}
+
 		void MarkField (FieldDefinition field, in DependencyInfo reason)
 		{
 #if DEBUG
@@ -1567,8 +1617,10 @@ namespace Mono.Linker.Steps
 						MessageSubCategory.TrimAnalysis);
 
 				break;
+			case DependencyKind.DynamicallyAccessedMemberOnType:
+				ReportWarningsForTypeHierarchyReflectionAccess (field);
+				break;
 			}
-
 
 			if (CheckProcessed (field))
 				return;
@@ -1688,8 +1740,13 @@ namespace Mono.Linker.Steps
 
 		internal void MarkEventVisibleToReflection (EventDefinition @event, in DependencyInfo reason)
 		{
-			// MarkEvent actually marks the add/remove/invoke methods as well, so no need to mark those explicitly
 			MarkEvent (@event, reason);
+			// MarkEvent already marks the add/remove/invoke methods, but we need to mark them with the
+			// DependencyInfo used to access the event from reflection, to produce warnings for annotated
+			// event methods.
+			MarkMethodIfNotNull (@event.AddMethod, reason);
+			MarkMethodIfNotNull (@event.InvokeMethod, reason);
+			MarkMethodIfNotNull (@event.InvokeMethod, reason);
 			MarkMethodsIf (@event.OtherMethods, m => true, reason);
 		}
 
@@ -2783,19 +2840,27 @@ namespace Mono.Linker.Steps
 			case DependencyKind.KeptForSpecialAttribute:
 				return;
 
+			case DependencyKind.DynamicallyAccessedMember:
+			case DependencyKind.DynamicallyAccessedMemberOnType:
+				// All override methods should have the same annotations as their base methods
+				// (else we will produce warning IL2046 or IL2092 or some other warning).
+				// When marking override methods via DynamicallyAccessedMembers, we should only issue a warning for the base method.
+				if (method.IsVirtual && Annotations.GetBaseMethods (method) != null)
+					return;
+				break;
+
 			default:
 				// All other cases have the potential of us missing a warning if we don't report it
 				// It is possible that in some cases we may report the same warning twice, but that's better than not reporting it.
 				break;
 			}
 
-			// All override methods should have the same annotations as their base methods
-			// (else we will produce warning IL2046 or IL2092 or some other warning).
-			// When marking override methods via DynamicallyAccessedMembers, we should only issue a warning for the base method.
-			if (dependencyKind == DependencyKind.DynamicallyAccessedMember &&
-				method.IsVirtual &&
-				Annotations.GetBaseMethods (method) != null)
+			if (dependencyKind == DependencyKind.DynamicallyAccessedMemberOnType) {
+				// DynamicallyAccessedMembers on type gets special treatment so that the warning origin
+				// is the type or the annotated member.
+				ReportWarningsForTypeHierarchyReflectionAccess (method);
 				return;
+			}
 
 			CheckAndReportRequiresUnreferencedCode (method);
 
@@ -2890,24 +2955,29 @@ namespace Mono.Linker.Steps
 			return false;
 		}
 
+		bool DoesMethodRequireUnreferencedCode (MethodDefinition method, out RequiresUnreferencedCodeAttribute attribute)
+		{
+			if (Annotations.TryGetLinkerAttribute (method, out attribute))
+				return true;
+
+			if ((method.IsStatic || method.IsConstructor) &&
+				Annotations.TryGetEffectiveRequiresUnreferencedCodeAttributeOnType (method.DeclaringType, out attribute))
+				return true;
+
+			return false;
+		}
+
 		internal void CheckAndReportRequiresUnreferencedCode (MethodDefinition method)
 		{
-			var currentOrigin = _scopeStack.CurrentScope.Origin;
-
 			// If the caller of a method is already marked with `RequiresUnreferencedCodeAttribute` a new warning should not
 			// be produced for the callee.
 			if (ShouldSuppressAnalysisWarningsForRequiresUnreferencedCode ())
 				return;
 
-			if (method.IsStatic || method.IsConstructor) {
-				if (Annotations.TryGetEffectiveRequiresUnreferencedCodeAttributeOnType (method.DeclaringType, out RequiresUnreferencedCodeAttribute requiresUnreferencedCodeOnTypeHierarchy)) {
-					ReportRequiresUnreferencedCode (method.GetDisplayName (), requiresUnreferencedCodeOnTypeHierarchy, currentOrigin);
-					return;
-				}
-			}
+			if (!DoesMethodRequireUnreferencedCode (method, out RequiresUnreferencedCodeAttribute requiresUnreferencedCode))
+				return;
 
-			if (Annotations.TryGetLinkerAttribute (method, out RequiresUnreferencedCodeAttribute requiresUnreferencedCode))
-				ReportRequiresUnreferencedCode (method.GetDisplayName (), requiresUnreferencedCode, currentOrigin);
+			ReportRequiresUnreferencedCode (method.GetDisplayName (), requiresUnreferencedCode, _scopeStack.CurrentScope.Origin);
 		}
 
 		private void ReportRequiresUnreferencedCode (string displayName, RequiresUnreferencedCodeAttribute requiresUnreferencedCode, MessageOrigin currentOrigin)

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1548,6 +1548,11 @@ namespace Mono.Linker.Steps
 		{
 			Debug.Assert (member is MethodDefinition or FieldDefinition);
 
+			// Don't check whether the current scope is a RUC type or RUC method because these warnings
+			// are not suppressed in RUC scopes. Here the scope represents the DynamicallyAccessedMembers
+			// annotation on a type, not a callsite which uses the annotation. We always want to warn about
+			// possible reflection access indicated by these annotations.
+
 			var type = _scopeStack.CurrentScope.Origin.MemberDefinition as TypeDefinition;
 			Debug.Assert (type != null);
 
@@ -1568,7 +1573,7 @@ namespace Mono.Linker.Steps
 
 				if (member is MethodDefinition method && DoesMethodRequireUnreferencedCode (method, out RequiresUnreferencedCodeAttribute attribute)) {
 					var message = string.Format (
-						"'DynamicallyAccessedMembers' on '{0}' or one of its base types references '{1}' which requires unreferenced code.{2}{3}",
+						"'DynamicallyAccessedMembersAttribute' on '{0}' or one of its base types references '{1}' which requires unreferenced code.{2}{3}",
 						type.GetDisplayName (),
 						method.GetDisplayName (),
 						MessageFormat.FormatRequiresAttributeMessageArg (attribute.Message),
@@ -1579,7 +1584,7 @@ namespace Mono.Linker.Steps
 
 				if (_context.Annotations.FlowAnnotations.DoesMemberAccessRequireDynamicallyAccessedMembers (member)) {
 					var message = string.Format (
-						"'DynamicallyAccessedMembers' on '{0}' or one of its base types references '{1}' which has 'DynamicallyAccessedMembers' requirements.",
+						"'DynamicallyAccessedMembersAttribute' on '{0}' or one of its base types references '{1}' which has 'DynamicallyAccessedMembersAttribute' requirements.",
 						type.GetDisplayName (),
 						(member as MemberReference).GetDisplayName ());
 					var code = reportOnMember ? 2114 : 2115;

--- a/src/linker/Linker/DependencyInfo.cs
+++ b/src/linker/Linker/DependencyInfo.cs
@@ -137,7 +137,9 @@ namespace Mono.Linker
 		SerializedRecursiveType = 85, // recursive type kept due to serialization handling
 		SerializedMember = 86, // field or property kept on a type for serialization
 
-		PreservedOperator = 87 // operator method preserved on a type
+		PreservedOperator = 87, // operator method preserved on a type
+
+		DynamicallyAccessedMemberOnType = 88, // type with DynamicallyAccessedMembers annotations (including those inherited from base types and interfaces)
 	}
 
 	public readonly struct DependencyInfo : IEquatable<DependencyInfo>

--- a/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchyLibraryModeSuppressions.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchyLibraryModeSuppressions.cs
@@ -38,7 +38,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		[Kept]
 		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 		[KeptAttributeAttribute (typeof (UnconditionalSuppressMessageAttribute))]
-		// TODO: it should be possible to suppress this on the method instead
+		// It should be possible to suppress this on the method instead: https://github.com/mono/linker/issues/2163
 		[UnconditionalSuppressMessage ("TrimAnalysis", "IL2112")]
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
 		class Suppressed

--- a/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchyLibraryModeSuppressions.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchyLibraryModeSuppressions.cs
@@ -26,11 +26,11 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		[Kept]
 		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
-		[ExpectedWarning ("IL2026", nameof (Unsuppressed))]
 		class Unsuppressed
 		{
 			[Kept]
 			[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+			[ExpectedWarning ("IL2112", "--RUC on Unsuppressed--")]
 			[RequiresUnreferencedCode ("--RUC on Unsuppressed--")]
 			public void RUCMethod () { }
 		}
@@ -38,7 +38,8 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		[Kept]
 		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 		[KeptAttributeAttribute (typeof (UnconditionalSuppressMessageAttribute))]
-		[UnconditionalSuppressMessage ("TrimAnalysis", "IL2026")]
+		// TODO: it should be possible to suppress this on the method instead
+		[UnconditionalSuppressMessage ("TrimAnalysis", "IL2112")]
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
 		class Suppressed
 		{

--- a/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchyLibraryModeSuppressions.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchyLibraryModeSuppressions.cs
@@ -37,14 +37,13 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
 		[Kept]
 		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
-		[KeptAttributeAttribute (typeof (UnconditionalSuppressMessageAttribute))]
-		// It should be possible to suppress this on the method instead: https://github.com/mono/linker/issues/2163
-		[UnconditionalSuppressMessage ("TrimAnalysis", "IL2112")]
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
 		class Suppressed
 		{
 			[Kept]
 			[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+			[KeptAttributeAttribute (typeof (UnconditionalSuppressMessageAttribute))]
+			[UnconditionalSuppressMessage ("TrimAnalysis", "IL2112")]
 			[RequiresUnreferencedCode ("--RUC on Suppressed--")]
 			public void RUCMethod () { }
 		}

--- a/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchyReflectionWarnings.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchyReflectionWarnings.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -130,12 +130,12 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[Kept]
 			[KeptBackingField]
 			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
-			// TODO: This can't currently be suppressed on the property. requires a type-level suppression.
-			// [KeptAttributeAttribute (typeof (UnconditionalSuppressMessageAttribute))]
-			// [UnconditionalSuppressMessage ("TrimAnalysis", "IL2114")]
-			[ExpectedWarning ("IL2114", nameof (AnnotatedPublicProperties), nameof (DAMTProperty) + ".get", CompilerGeneratedCode = true)]
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
-			public static string DAMTProperty { get; }
+			public static string DAMTProperty {
+				// Property access reports warnings on getter/setter
+				[ExpectedWarning ("IL2114", nameof (AnnotatedPublicProperties), nameof (DAMTProperty) + ".get")]
+				get;
+			}
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchyReflectionWarnings.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchyReflectionWarnings.cs
@@ -167,7 +167,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
 			public static string DAMProperty {
 				[Kept]
-				// No warning for getter since return value is not annotated
+				// No warning for non-virtual getter since return value is not annotated
 				get;
 				[Kept]
 				// Property access reports warnings on getter/setter

--- a/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchyReflectionWarnings.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchyReflectionWarnings.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -359,6 +359,14 @@ namespace Mono.Linker.Tests.Cases.Reflection
 				[Kept]
 				[ExpectedWarning ("IL2112", "--RUC on NestedRUCType--")]
 				static void StaticMethod () { }
+			}
+
+			[KeptMember (".ctor()")]
+			[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+			[ExpectedWarning ("IL2112", nameof (NestedRUCTypeWithDefaultConstructor) + "()", "--RUC on NestedRUCTypeWithDefaultConstructor--", CompilerGeneratedCode = true)]
+			[RequiresUnreferencedCode ("--RUC on NestedRUCTypeWithDefaultConstructor--")]
+			public class NestedRUCTypeWithDefaultConstructor
+			{
 			}
 		}
 

--- a/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchyReflectionWarnings.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchyReflectionWarnings.cs
@@ -1,0 +1,436 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Reflection
+{
+	[ExpectedNoWarnings]
+	public class TypeHierarchyReflectionWarnings
+	{
+		public static void Main ()
+		{
+			RequirePublicMethods (annotatedBase.GetType ());
+			// Reference to the derived type should apply base annotations
+			var t = typeof (DerivedFromAnnotatedBase);
+			RequirePublicMethods (annotatedDerivedFromBase.GetType ());
+			RequirePublicNestedTypes (annotatedPublicNestedTypes.GetType ());
+			RequirePublicFields (derivedFromAnnotatedDerivedFromBase.GetType ());
+			RequirePublicMethods (annotatedPublicMethods.GetType ());
+			RequirePublicFields (annotatedPublicFields.GetType ());
+			RequirePublicProperties (annotatedPublicProperties.GetType ());
+			RequirePublicEvents (annotatedPublicEvents.GetType ());
+			RequirePublicNestedTypes (annotatedPublicNestedTypes.GetType ());
+			RequireInterfaces (annotatedInterfaces.GetType ());
+			RequireAll (annotatedAll.GetType ());
+			RequirePublicMethods (annotatedRUCPublicMethods.GetType ());
+
+			// Instantiate this type just so its property getters are considered reachable
+			var b = new DerivedFromAnnotatedDerivedFromBase ();
+		}
+
+		[Kept]
+		static AnnotatedAll annotatedAll;
+		[Kept]
+		static AnnotatedPublicMethods annotatedPublicMethods;
+		[Kept]
+		static AnnotatedPublicFields annotatedPublicFields;
+		[Kept]
+		static AnnotatedPublicProperties annotatedPublicProperties;
+		[Kept]
+		static AnnotatedPublicEvents annotatedPublicEvents;
+		[Kept]
+		static AnnotatedInterfaces annotatedInterfaces;
+		[Kept]
+		static AnnotatedBase annotatedBase;
+		[Kept]
+		static AnnotatedDerivedFromBase annotatedDerivedFromBase;
+		[Kept]
+		static AnnotatedPublicNestedTypes annotatedPublicNestedTypes;
+		[Kept]
+		static DerivedFromAnnotatedDerivedFromBase derivedFromAnnotatedDerivedFromBase;
+		[Kept]
+		static AnnotatedRUCPublicMethods annotatedRUCPublicMethods;
+
+		[Kept]
+		[KeptMember (".ctor()")]
+		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+		class AnnotatedAll
+		{
+			[Kept]
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+			[ExpectedWarning ("IL2114", nameof (AnnotatedAll), nameof (DAMTField))]
+			public Type DAMTField;
+
+			[Kept]
+			[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+			[ExpectedWarning ("IL2112", "--RUC on AnnotatedAll.RUCMethod--")]
+			[RequiresUnreferencedCode ("--RUC on AnnotatedAll.RUCMethod--")]
+			public void RUCMethod () { }
+
+			[Kept]
+			[ExpectedWarning ("IL2114", nameof (AnnotatedAll), nameof (DAMTMethod))]
+			public void DAMTMethod (
+				[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+				Type t
+			)
+			{ }
+		}
+
+		[Kept]
+		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+		class AnnotatedPublicMethods
+		{
+			[Kept]
+			[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+			[ExpectedWarning ("IL2112", "--RUC on AnnotatedPublicMethods.RUCMethod--")]
+			[RequiresUnreferencedCode ("--RUC on AnnotatedPublicMethods.RUCMethod--")]
+			public void RUCMethod () { }
+
+			[Kept]
+			[ExpectedWarning ("IL2114", nameof (AnnotatedPublicMethods), nameof (DAMTMethod))]
+			public void DAMTMethod (
+				[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+				Type t
+			)
+			{ }
+		}
+
+		[Kept]
+		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)]
+		class AnnotatedPublicFields
+		{
+			[Kept]
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+			[ExpectedWarning ("IL2114", nameof (AnnotatedPublicFields), nameof (DAMTField))]
+			public Type DAMTField;
+
+		}
+
+		[Kept]
+		[KeptMember ("get_DAMTProperty()")]
+		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicProperties)]
+		class AnnotatedPublicProperties
+		{
+			[Kept]
+			[KeptBackingField]
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			// TODO: This can't currently be suppressed on the property. requires a type-level suppression.
+			// [KeptAttributeAttribute (typeof (UnconditionalSuppressMessageAttribute))]
+			// [UnconditionalSuppressMessage ("TrimAnalysis", "IL2114")]
+			[ExpectedWarning ("IL2114", nameof (AnnotatedPublicProperties), nameof (DAMTProperty) + ".get", CompilerGeneratedCode = true)]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+			public static string DAMTProperty { get; }
+		}
+
+		[Kept]
+		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicEvents)]
+		class AnnotatedPublicEvents
+		{
+			[Kept]
+			[KeptMember (".ctor(System.Object,System.IntPtr)")]
+			[KeptMember ("Invoke(System.Object,System.Int32)")]
+			[KeptBaseType (typeof (MulticastDelegate))]
+			public delegate void MyEventHandler (object sender, int i);
+
+			[Kept]
+			// We always keep event methods when an event is kept, so this generates warnings
+			// on the event itself (since an event access is considered to reference the annotated add method),
+			// and on the add method (if it is accessed through reflection).
+			[ExpectedWarning ("IL2026", "--RUC on add_RUCEvent--")]
+			public event MyEventHandler RUCEvent {
+				[Kept]
+				[ExpectedWarning ("IL2112", nameof (AnnotatedPublicEvents), "--RUC on add_RUCEvent--")]
+				[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+				[RequiresUnreferencedCode ("--RUC on add_RUCEvent--")]
+				add { }
+				[Kept]
+				remove { }
+			}
+		}
+
+		[Kept]
+		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+		interface RequiredInterface
+		{
+			// Removed, because keeping the interface on its own
+			// doesn't apply its type annotations
+			[RequiresUnreferencedCode ("--RUC on RequiredInterface.UnusedMethod--")]
+			void RUCMethod ();
+		}
+
+		[Kept]
+		[KeptInterface (typeof (RequiredInterface))]
+		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.Interfaces)]
+		class AnnotatedInterfaces : RequiredInterface
+		{
+			[Kept]
+			[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+			// This should produce a warning: https://github.com/mono/linker/issues/2161
+			[RequiresUnreferencedCode ("--RUC on AnnotatedInterfaces.UnusedMethod--")]
+			public void RUCMethod () { }
+		}
+
+		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+		class AnnotatedBase
+		{
+			[Kept]
+			[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+			[ExpectedWarning ("IL2112", "--RUC on AnnotatedBase--")]
+			[RequiresUnreferencedCode ("--RUC on AnnotatedBase--")]
+			public void RUCMethod () { }
+		}
+
+		[KeptBaseType (typeof (AnnotatedBase))]
+		[ExpectedWarning ("IL2113", "--RUC on AnnotatedBase--")]
+		class DerivedFromAnnotatedBase : AnnotatedBase
+		{
+			[Kept]
+			[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+			[ExpectedWarning ("IL2112", "--RUC on DerivedFromAnnotatedBase--")]
+			[RequiresUnreferencedCode ("--RUC on DerivedFromAnnotatedBase--")]
+			public void RUCMethod () { }
+		}
+
+		[KeptMember (".ctor()")]
+		[KeptMember ("get_DAMTVirtualProperty()")]
+		class Base
+		{
+			[Kept]
+			[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+			[RequiresUnreferencedCode ("--RUCBaseMethod--")]
+			public void RUCBaseMethod () { }
+
+			[Kept]
+			[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+			[RequiresUnreferencedCode ("--Base.RUCVirtualMethod--")]
+			public virtual void RUCVirtualMethod () { }
+
+			[Kept]
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicMethods)]
+			public string DAMTField1;
+
+			[Kept]
+			[KeptBackingField]
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicMethods)]
+			public virtual string DAMTVirtualProperty { get; }
+		}
+
+		[KeptBaseType (typeof (Base))]
+		[KeptMember (".ctor()")]
+		[KeptMember ("get_DAMTVirtualProperty()")]
+		[ExpectedWarning ("IL2113", "--RUCBaseMethod--")]
+		[ExpectedWarning ("IL2113", "--Base.RUCVirtualMethod--")]
+		[ExpectedWarning ("IL2115", nameof (Base), nameof (Base.DAMTVirtualProperty) + ".get")]
+		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+		class AnnotatedDerivedFromBase : Base
+		{
+			[Kept]
+			[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+			[ExpectedWarning ("IL2112", "--RUC on AnnotatedDerivedFromBase--")]
+			[RequiresUnreferencedCode ("--RUC on AnnotatedDerivedFromBase--")]
+			public void RUCMethod () { }
+
+			[Kept]
+			[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+			// shouldn't warn because we warn on the base method instead
+			[RequiresUnreferencedCode ("--AnnotatedDerivedFromBase.RUCVirtualMethod--")]
+			public override void RUCVirtualMethod () { }
+
+			[Kept]
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicMethods)]
+			public string DAMTField2;
+
+			[Kept]
+			[KeptBackingField]
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			// shouldn't warn because we warn on the base getter instead
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicMethods)]
+			public override string DAMTVirtualProperty { get; }
+
+		}
+
+		[KeptBaseType (typeof (AnnotatedDerivedFromBase))]
+		[KeptMember (".ctor()")]
+		[KeptMember ("get_DAMTVirtualProperty()")]
+		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)]
+		[ExpectedWarning ("IL2115", nameof (Base), nameof (DAMTField1))]
+		[ExpectedWarning ("IL2115", nameof (AnnotatedDerivedFromBase), nameof (DAMTField2))]
+		[ExpectedWarning ("IL2113", "--RUCBaseMethod--")]
+		[ExpectedWarning ("IL2113", "--Base.RUCVirtualMethod--")]
+		[ExpectedWarning ("IL2113", "--RUC on AnnotatedDerivedFromBase--")]
+		[ExpectedWarning ("IL2115", nameof (Base), nameof (Base.DAMTVirtualProperty) + ".get")]
+		class DerivedFromAnnotatedDerivedFromBase : AnnotatedDerivedFromBase
+		{
+			[Kept]
+			[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+			[ExpectedWarning ("IL2112", "--RUC on AnnotatedDerivedFromBase--")]
+			[RequiresUnreferencedCode ("--RUC on AnnotatedDerivedFromBase--")]
+			public void RUCMethod () { }
+
+			[Kept]
+			[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+			// shouldn't warn because we warn on the base method instead
+			[RequiresUnreferencedCode ("--DerivedFromAnnotatedDerivedFromBase.RUCVirtualMethod--")]
+			public override void RUCVirtualMethod () { }
+
+			[Kept]
+			[ExpectedWarning ("IL2114", nameof (DerivedFromAnnotatedDerivedFromBase), nameof (DAMTField3))]
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicMethods)]
+			public string DAMTField3;
+
+			[Kept]
+			[KeptBackingField]
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			// shouldn't warn because we warn on the base getter instead
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicMethods)]
+			public override string DAMTVirtualProperty { get; }
+		}
+
+		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicNestedTypes)]
+		class AnnotatedPublicNestedTypes
+		{
+			[KeptMember (".ctor()")]
+			public class NestedType
+			{
+				[Kept]
+				[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+				[ExpectedWarning ("IL2112", "--RUC on NestedType.RUCMethod--")]
+				[RequiresUnreferencedCode ("--RUC on NestedType.RUCMethod--")]
+				void RUCMethod () { }
+			}
+
+			[KeptMember (".ctor()")]
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+			public class NestedAnnotatedType
+			{
+				[Kept]
+				[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+				[ExpectedWarning ("IL2112", "--RUC on NestedAnnotatedType.RUCMethod--")]
+				[RequiresUnreferencedCode ("--RUC on NestedAnnotatedType.RUCMethod--")]
+				void RUCMethod () { }
+			}
+
+			[KeptMember (".ctor()")]
+			[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+			[RequiresUnreferencedCode ("--RUC on NestedRUCType--")]
+			public class NestedRUCType
+			{
+				[Kept]
+				[ExpectedWarning ("IL2112", "--RUC on NestedRUCType--")]
+				public NestedRUCType () { }
+
+				[Kept]
+				[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+				[ExpectedWarning ("IL2112", "--RUC on NestedRUCType.RUCMethod--")]
+				[RequiresUnreferencedCode ("--RUC on NestedRUCType.RUCMethod--")]
+				void RUCMethod () { }
+
+				[Kept]
+				void Method () { }
+
+				[Kept]
+				[ExpectedWarning ("IL2112", "--RUC on NestedRUCType--")]
+				static void StaticMethod () { }
+			}
+		}
+
+		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+		[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+		[RequiresUnreferencedCode ("--AnnotatedRUCPublicMethods--")]
+		public class AnnotatedRUCPublicMethods
+		{
+			public AnnotatedRUCPublicMethods () { }
+
+			[Kept]
+			[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+			[ExpectedWarning ("IL2112", "--RUC on AnnotatedRUCPublicMethods.RUCMethod--")]
+			[RequiresUnreferencedCode ("--RUC on AnnotatedRUCPublicMethods.RUCMethod--")]
+			public void RUCMethod () { }
+
+			[Kept]
+			public void Method () { }
+
+			[Kept]
+			[ExpectedWarning ("IL2112", "--AnnotatedRUCPublicMethods--")]
+			public static void StaticMethod () { }
+		}
+
+		[Kept]
+		static void RequirePublicMethods (
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+			Type type)
+		{ }
+
+		[Kept]
+		static void RequirePublicFields (
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)]
+			Type type)
+		{ }
+
+		[Kept]
+		static void RequirePublicProperties (
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicProperties)]
+			Type type)
+		{ }
+
+		[Kept]
+		static void RequirePublicEvents (
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicEvents)]
+			Type type)
+		{ }
+
+		[Kept]
+		static void RequireAll (
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+			Type type)
+		{ }
+
+		[Kept]
+		static void RequirePublicNestedTypes (
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicNestedTypes)]
+			Type type)
+		{ }
+
+		[Kept]
+		static void RequireInterfaces (
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.Interfaces)]
+			Type type)
+		{ }
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchyReflectionWarnings.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchyReflectionWarnings.cs
@@ -120,6 +120,27 @@ namespace Mono.Linker.Tests.Cases.Reflection
 				Type t
 			)
 			{ }
+
+			[Kept]
+			// No warning for non-virtual method which only has DAM on return parameter
+			[return: KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[return: DynamicallyAccessedMembersAttribute (DynamicallyAccessedMemberTypes.PublicMethods)]
+			public Type DAMReturnMethod () => null;
+
+			[Kept]
+			[ExpectedWarning ("IL2114", nameof (AnnotatedPublicMethods), nameof (DAMVirtualMethod))]
+			public virtual void DAMVirtualMethod (
+				[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+				Type type
+			)
+			{ }
+
+			[Kept]
+			[ExpectedWarning ("IL2114", nameof (AnnotatedPublicMethods), nameof (DAMReturnVirtualMethod))]
+			[return: KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[return: DynamicallyAccessedMembersAttribute (DynamicallyAccessedMemberTypes.PublicMethods)]
+			public virtual Type DAMReturnVirtualMethod () => null;
 		}
 
 		[Kept]
@@ -136,7 +157,6 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		}
 
 		[Kept]
-		[KeptMember ("get_DAMProperty()")]
 		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicProperties)]
 		class AnnotatedPublicProperties
@@ -146,9 +166,13 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
 			public static string DAMProperty {
-				// Property access reports warnings on getter/setter
-				[ExpectedWarning ("IL2114", nameof (AnnotatedPublicProperties), nameof (DAMProperty) + ".get")]
+				[Kept]
+				// No warning for getter since return value is not annotated
 				get;
+				[Kept]
+				// Property access reports warnings on getter/setter
+				[ExpectedWarning ("IL2114", nameof (AnnotatedPublicProperties), nameof (DAMProperty) + ".set")]
+				set;
 			}
 		}
 
@@ -253,7 +277,6 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
 		[KeptBaseType (typeof (Base))]
 		[KeptMember (".ctor()")]
-		[KeptMember ("get_DAMVirtualProperty()")]
 		[ExpectedWarning ("IL2113", "--RUCBaseMethod--")]
 		[ExpectedWarning ("IL2113", "--Base.RUCVirtualMethod--")]
 		[ExpectedWarning ("IL2115", nameof (Base), nameof (Base.DAMVirtualProperty) + ".get")]
@@ -283,13 +306,12 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 			// shouldn't warn because we warn on the base getter instead
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicMethods)]
-			public override string DAMVirtualProperty { get; }
+			public override string DAMVirtualProperty { [Kept] get; }
 
 		}
 
 		[KeptBaseType (typeof (AnnotatedDerivedFromBase))]
 		[KeptMember (".ctor()")]
-		[KeptMember ("get_DAMVirtualProperty()")]
 		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)]
 		// Warnings about base members could go away with https://github.com/mono/linker/issues/2175
@@ -324,7 +346,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 			// shouldn't warn because we warn on the base getter instead
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicMethods)]
-			public override string DAMVirtualProperty { get; }
+			public override string DAMVirtualProperty { [Kept] get; }
 		}
 
 		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]

--- a/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchySuppressions.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchySuppressions.cs
@@ -142,28 +142,26 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
 		[Kept]
 		[KeptBaseType (typeof (Unsuppressed))]
-		[KeptAttributeAttribute (typeof (UnconditionalSuppressMessageAttribute))]
-		// It should be possible to suppress this on the method instead: https://github.com/mono/linker/issues/2163
-		[UnconditionalSuppressMessage ("TrimAnalysis", "IL2112")]
 		[ExpectedWarning ("IL2113", "--RUC on Unsuppressed--")]
 		class SuppressedOnDerived1 : Unsuppressed
 		{
 			[Kept]
 			[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+			[KeptAttributeAttribute (typeof (UnconditionalSuppressMessageAttribute))]
+			[UnconditionalSuppressMessage ("TrimAnalysis", "IL2112")]
 			[RequiresUnreferencedCode ("--RUC on SuppressedOnDerived1--")]
 			public void DerivedRUCMethod () { }
 		}
 
 		[Kept]
 		[KeptBaseType (typeof (Unsuppressed))]
-		[KeptAttributeAttribute (typeof (UnconditionalSuppressMessageAttribute))]
-		// It should be possible to suppress this on the method instead: https://github.com/mono/linker/issues/2163
-		[UnconditionalSuppressMessage ("TrimAnalysis", "IL2112")]
 		[ExpectedWarning ("IL2113", "--RUC on Unsuppressed--")]
 		class SuppressedOnDerived2 : Unsuppressed
 		{
 			[Kept]
 			[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+			[KeptAttributeAttribute (typeof (UnconditionalSuppressMessageAttribute))]
+			[UnconditionalSuppressMessage ("TrimAnalysis", "IL2112")]
 			[RequiresUnreferencedCode ("--RUC on SuppressedOnDerived2--")]
 			public void DerivedRUCMethod () { }
 		}
@@ -185,25 +183,26 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		[Kept]
 		[KeptMember (".ctor()")]
 		[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
-		[KeptAttributeAttribute (typeof (UnconditionalSuppressMessageAttribute))]
-		[KeptAttributeAttribute (typeof (UnconditionalSuppressMessageAttribute))]
-		// It should be possible to suppress this on the method instead: https://github.com/mono/linker/issues/2163
-		[UnconditionalSuppressMessage ("TrimAnalysis", "IL2112")]
-		[UnconditionalSuppressMessage ("TrimAnalysis", "IL2114")]
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
 		class AnnotatedAllSuppressed
 		{
 			[Kept]
 			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[KeptAttributeAttribute (typeof (UnconditionalSuppressMessageAttribute))]
+			[UnconditionalSuppressMessage ("TrimAnalysis", "IL2114")]
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
 			public Type DAMTField;
 
 			[Kept]
 			[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+			[KeptAttributeAttribute (typeof (UnconditionalSuppressMessageAttribute))]
+			[UnconditionalSuppressMessage ("TrimAnalysis", "IL2112")]
 			[RequiresUnreferencedCode ("--RUC on AnnotatedAllSuppresed.RUCMethod--")]
 			public static void RUCMethod () { }
 
 			[Kept]
+			[KeptAttributeAttribute (typeof (UnconditionalSuppressMessageAttribute))]
+			[UnconditionalSuppressMessage ("TrimAnalysis", "IL2114")]
 			public void DAMTMethod (
 				[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]

--- a/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -759,17 +759,9 @@ namespace Mono.Linker.Tests.TestCasesRunner
 										MethodDefinition methodDefinition = mc.Origin?.MemberDefinition as MethodDefinition;
 										if (methodDefinition != null) {
 											string actualName = methodDefinition.DeclaringType.FullName + "." + methodDefinition.Name;
-											if (actualName.StartsWith (attrProvider.DeclaringType.FullName)) {
-												if (actualName.Contains ("<" + attrProvider.Name + ">"))
-													return true;
-
-												if ((actualName.Contains ("get_" + attrProvider.Name) || actualName.Contains ("set_" + attrProvider.Name)) && methodDefinition.HasCustomAttributes) {
-													foreach (var attr in methodDefinition.CustomAttributes) {
-														if (attr.AttributeType.Resolve ()?.Name == nameof (CompilerGeneratedAttribute))
-															return true;
-													}
-												}
-											}
+											if (actualName.StartsWith (attrProvider.DeclaringType.FullName) &&
+												actualName.Contains ("<" + attrProvider.Name + ">"))
+												return true;
 										}
 
 										return false;

--- a/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -762,6 +762,9 @@ namespace Mono.Linker.Tests.TestCasesRunner
 											if (actualName.StartsWith (attrProvider.DeclaringType.FullName) &&
 												actualName.Contains ("<" + attrProvider.Name + ">"))
 												return true;
+											if (methodDefinition.Name == ".ctor" &&
+												methodDefinition.DeclaringType.FullName == attrProvider.FullName)
+												return true;
 										}
 
 										return false;

--- a/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using Mono.Cecil;
@@ -758,9 +759,17 @@ namespace Mono.Linker.Tests.TestCasesRunner
 										MethodDefinition methodDefinition = mc.Origin?.MemberDefinition as MethodDefinition;
 										if (methodDefinition != null) {
 											string actualName = methodDefinition.DeclaringType.FullName + "." + methodDefinition.Name;
-											if (actualName.StartsWith (attrProvider.DeclaringType.FullName) &&
-												actualName.Contains ("<" + attrProvider.Name + ">"))
-												return true;
+											if (actualName.StartsWith (attrProvider.DeclaringType.FullName)) {
+												if (actualName.Contains ("<" + attrProvider.Name + ">"))
+													return true;
+
+												if ((actualName.Contains ("get_" + attrProvider.Name) || actualName.Contains ("set_" + attrProvider.Name)) && methodDefinition.HasCustomAttributes) {
+													foreach (var attr in methodDefinition.CustomAttributes) {
+														if (attr.AttributeType.Resolve ()?.Name == nameof (CompilerGeneratedAttribute))
+															return true;
+													}
+												}
+											}
 										}
 
 										return false;


### PR DESCRIPTION
Fixes https://github.com/mono/linker/issues/2136.

The warnings pretty much work as described in https://github.com/mono/linker/issues/2136#issuecomment-879146153, and the scenario from https://github.com/mono/linker/issues/2136#issuecomment-881681867 will warn on the derived type. There's still an issue where the member warnings can't be suppressed on the member because we haven't marked custom attributes at that point.