### PR TITLE
Avoid the propagation of RequiresUnreferencedCode to nested classes

### DIFF
--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -40,7 +40,7 @@ namespace Mono.Linker.Dataflow
 			return GetIntrinsicIdForMethod (methodDefinition) > IntrinsicId.RequiresReflectionBodyScanner_Sentinel ||
 				context.Annotations.FlowAnnotations.RequiresDataFlowAnalysis (methodDefinition) ||
 				context.Annotations.HasLinkerAttribute<RequiresUnreferencedCodeAttribute> (methodDefinition) ||
-				context.Annotations.TryGetEffectiveRequiresUnreferencedCodeAttributeOnType (methodDefinition.DeclaringType, out RequiresUnreferencedCodeAttribute _) ||
+				context.Annotations.HasLinkerAttribute<RequiresUnreferencedCodeAttribute> (methodDefinition.DeclaringType) ||
 				methodDefinition.IsPInvokeImpl;
 		}
 

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -39,8 +39,7 @@ namespace Mono.Linker.Dataflow
 
 			return GetIntrinsicIdForMethod (methodDefinition) > IntrinsicId.RequiresReflectionBodyScanner_Sentinel ||
 				context.Annotations.FlowAnnotations.RequiresDataFlowAnalysis (methodDefinition) ||
-				context.Annotations.HasLinkerAttribute<RequiresUnreferencedCodeAttribute> (methodDefinition) ||
-				context.Annotations.HasLinkerAttribute<RequiresUnreferencedCodeAttribute> (methodDefinition.DeclaringType) ||
+				context.Annotations.DoesMethodRequireUnreferencedCode (methodDefinition, out _) ||
 				methodDefinition.IsPInvokeImpl;
 		}
 

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -1768,10 +1768,7 @@ namespace Mono.Linker.Steps
 				MarkType (type.DeclaringType, new DependencyInfo (DependencyKind.DeclaringType, type));
 			MarkSecurityDeclarations (type, new DependencyInfo (DependencyKind.CustomAttribute, type));
 
-			if (((type.DeclaringType is not null &&
-				!_context.Annotations.HasLinkerAttribute<RequiresUnreferencedCodeAttribute> (type.DeclaringType)) ||
-				type.DeclaringType is null) &&
-				type.BaseType is not null &&
+			if (type.BaseType is not null &&
 				!_context.Annotations.HasLinkerAttribute<RequiresUnreferencedCodeAttribute> (type) &&
 				_context.Annotations.TryGetLinkerAttribute (_context.TryResolve (type.BaseType), out RequiresUnreferencedCodeAttribute effectiveRequiresUnreferencedCode)) {
 

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2909,7 +2909,7 @@ namespace Mono.Linker.Steps
 
 			IMemberDefinition originMember = currentOrigin.MemberDefinition;
 			if (suppressionContextMember != originMember && originMember != null &&
-				Annotations.DoesMethodRequireUnreferencedCode (originMember.DeclaringType, out _))
+				Annotations.DoesMethodRequireUnreferencedCode (originMember, out _))
 				return true;
 
 			return false;

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2903,13 +2903,13 @@ namespace Mono.Linker.Steps
 			var currentOrigin = _scopeStack.CurrentScope.Origin;
 
 			IMemberDefinition suppressionContextMember = currentOrigin.SuppressionContextMember;
-			if (suppressionContextMember != null &&
-				Annotations.DoesMethodRequireUnreferencedCode (suppressionContextMember, out _))
+			if (suppressionContextMember is not null && suppressionContextMember is MethodDefinition &&
+				Annotations.DoesMethodRequireUnreferencedCode ((MethodDefinition) suppressionContextMember, out _))
 				return true;
 
 			IMemberDefinition originMember = currentOrigin.MemberDefinition;
-			if (suppressionContextMember != originMember && originMember != null &&
-				Annotations.DoesMethodRequireUnreferencedCode (originMember, out _))
+			if (originMember is not null && originMember is MethodDefinition && suppressionContextMember != originMember && 
+				Annotations.DoesMethodRequireUnreferencedCode ((MethodDefinition) originMember, out _))
 				return true;
 
 			return false;

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2903,12 +2903,12 @@ namespace Mono.Linker.Steps
 			var currentOrigin = _scopeStack.CurrentScope.Origin;
 
 			IMemberDefinition suppressionContextMember = currentOrigin.SuppressionContextMember;
-			if (suppressionContextMember is not null && suppressionContextMember is MethodDefinition &&
+			if (suppressionContextMember is MethodDefinition &&
 				Annotations.DoesMethodRequireUnreferencedCode ((MethodDefinition) suppressionContextMember, out _))
 				return true;
 
 			IMemberDefinition originMember = currentOrigin.MemberDefinition;
-			if (originMember is not null && originMember is MethodDefinition && suppressionContextMember != originMember &&
+			if (originMember is MethodDefinition && suppressionContextMember != originMember &&
 				Annotations.DoesMethodRequireUnreferencedCode ((MethodDefinition) originMember, out _))
 				return true;
 

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -2908,7 +2908,7 @@ namespace Mono.Linker.Steps
 				return true;
 
 			IMemberDefinition originMember = currentOrigin.MemberDefinition;
-			if (originMember is not null && originMember is MethodDefinition && suppressionContextMember != originMember && 
+			if (originMember is not null && originMember is MethodDefinition && suppressionContextMember != originMember &&
 				Annotations.DoesMethodRequireUnreferencedCode ((MethodDefinition) originMember, out _))
 				return true;
 

--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -552,27 +552,6 @@ namespace Mono.Linker
 			return marked_types_with_cctor.Add (type);
 		}
 
-		/// <summary>
-		/// Looks if there is a RequiresUnreferencedCodeAttribute on the <paramref name="type"/> or any of its declaring types and returns the attribute information
-		/// on <paramref name="attribute"/>
-		/// </summary>
-		/// <param name="type">Type to start the search of the attribute</param>
-		/// <param name="attribute">Information about the found RequiresUnreferencedCode Attribute</param>
-		/// <returns>Returns true along with the RequiresUnreferencedCodeAttribute if found, otherwise returns false</returns>
-		public bool TryGetEffectiveRequiresUnreferencedCodeAttributeOnType (TypeDefinition type, out RequiresUnreferencedCodeAttribute attribute)
-		{
-			while (type != null) {
-				if (TryGetLinkerAttribute (type, out RequiresUnreferencedCodeAttribute declaringTypeAttribute)) {
-					attribute = declaringTypeAttribute;
-					return true;
-				}
-				type = type.DeclaringType;
-			}
-
-			attribute = null;
-			return false;
-		}
-
 		public bool HasLinkerAttribute<T> (IMemberDefinition member) where T : Attribute
 		{
 			// Avoid setting up and inserting LinkerAttributesInformation for members without attributes.

--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -591,6 +591,18 @@ namespace Mono.Linker
 			return attribute != null;
 		}
 
+		internal bool DoesMethodRequireUnreferencedCode (IMemberDefinition member, out RequiresUnreferencedCodeAttribute attribute)
+		{
+			if (TryGetLinkerAttribute (member, out attribute))
+				return true;
+
+			if (member is MethodDefinition method && (method.IsStatic || method.IsConstructor) && method.DeclaringType is not null &&
+				TryGetLinkerAttribute (method.DeclaringType, out attribute))
+				return true;
+
+			return false;
+		}
+
 		public void EnqueueVirtualMethod (MethodDefinition method)
 		{
 			if (!method.IsVirtual)

--- a/src/linker/Linker/Annotations.cs
+++ b/src/linker/Linker/Annotations.cs
@@ -591,12 +591,12 @@ namespace Mono.Linker
 			return attribute != null;
 		}
 
-		internal bool DoesMethodRequireUnreferencedCode (IMemberDefinition member, out RequiresUnreferencedCodeAttribute attribute)
+		internal bool DoesMethodRequireUnreferencedCode (MethodDefinition method, out RequiresUnreferencedCodeAttribute attribute)
 		{
-			if (TryGetLinkerAttribute (member, out attribute))
+			if (TryGetLinkerAttribute (method, out attribute))
 				return true;
 
-			if (member is MethodDefinition method && (method.IsStatic || method.IsConstructor) && method.DeclaringType is not null &&
+			if ((method.IsStatic || method.IsConstructor) && method.DeclaringType is not null &&
 				TryGetLinkerAttribute (method.DeclaringType, out attribute))
 				return true;
 

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
@@ -898,7 +898,9 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			{
 				public static void StaticMethodInInheritedClass () { }
 
-				// The requires attribute in the declaring type suppresses IL2109 here
+				// A nested class is not considered a static method nor constructor therefore RequiresUnreferencedCode doesnt apply
+				// and this warning is not suppressed
+				[ExpectedWarning ("IL2109", "RequiresOnClass/DerivedWithRequires2/DerivedNestedClass", "--ClassWithRequiresUnreferencedCode--")]
 				public class DerivedNestedClass : ClassWithRequiresUnreferencedCode
 				{
 					public static void NestedStaticMethod () { }

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
@@ -798,10 +798,15 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 				public void NonStaticMethod () { }
 
+				// RequiresOnMethod.MethodWithRUC generates a warning that gets suppressed because the declaring type has RUC
+				public static void CallRUCMethod () => RequiresOnMethod.MethodWithRUC ();
+
 				public class NestedClass
 				{
 					public static void NestedStaticMethod () { }
-					// RequiresOnMethod.MethodWithRUC generates a warning that gets suppressed because the declaring type has RUC
+
+					// This warning doesn't get suppressed since the declaring type NestedClass is not annotated with RequiresUnreferencedCode
+					[ExpectedWarning ("IL2026", "RequiresOnClass.RequiresOnMethod.MethodWithRUC()", "MethodWithRUC")]
 					public static void CallRUCMethod () => RequiresOnMethod.MethodWithRUC ();
 				}
 
@@ -850,7 +855,8 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				}
 			}
 
-			[ExpectedWarning ("IL2109", "RequiresOnClass/DerivedWithoutRequires2", "RequiresOnClass.ClassWithRequiresUnreferencedCode.NestedClass", "--ClassWithRequiresUnreferencedCode--")]
+			// In order to generate IL2109 the nested class would also need to be annotated with RequiresUnreferencedCode
+			// otherwise we threat the nested class as safe
 			private class DerivedWithoutRequires2 : ClassWithRequiresUnreferencedCode.NestedClass
 			{
 				public static void StaticMethod () { }
@@ -910,19 +916,20 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			{
 				var classObject = new ClassWithRequiresUnreferencedCode ();
 			}
-			[ExpectedWarning ("IL2026", "RequiresOnClass.ClassWithRequiresUnreferencedCode.NestedClass.NestedStaticMethod()", "--ClassWithRequiresUnreferencedCode--", GlobalAnalysisOnly = true)]
+
 			static void TestRequiresInParentClassAccesedByStaticMethod ()
 			{
 				ClassWithRequiresUnreferencedCode.NestedClass.NestedStaticMethod ();
 			}
 
 			[ExpectedWarning ("IL2026", "RequiresOnClass.ClassWithRequiresUnreferencedCode.StaticMethod()", "--ClassWithRequiresUnreferencedCode--", GlobalAnalysisOnly = true)]
-			[ExpectedWarning ("IL2026", "RequiresOnClass.ClassWithRequiresUnreferencedCode.NestedClass.NestedStaticMethod()", "--ClassWithRequiresUnreferencedCode--", GlobalAnalysisOnly = true)]
-			[ExpectedWarning ("IL2026", "RequiresOnClass.ClassWithRequiresUnreferencedCode.NestedClass.CallRUCMethod()", "Message for --ClassWithRequiresUnreferencedCode--", GlobalAnalysisOnly = true)]
+			// Although we suppress the warning from RequiresOnMethod.MethodWithRUC () we still get a warning because we call CallRUCMethod() which is an static method on a type with RUC
+			[ExpectedWarning ("IL2026", "RequiresOnClass.ClassWithRequiresUnreferencedCode.CallRUCMethod()", "--ClassWithRequiresUnreferencedCode--", GlobalAnalysisOnly = true)]
 			static void TestRequiresOnBaseButNotOnDerived ()
 			{
 				DerivedWithoutRequires.StaticMethodInInheritedClass ();
 				DerivedWithoutRequires.StaticMethod ();
+				DerivedWithoutRequires.CallRUCMethod ();
 				DerivedWithoutRequires.DerivedNestedClass.NestedStaticMethod ();
 				DerivedWithoutRequires.NestedClass.NestedStaticMethod ();
 				DerivedWithoutRequires.NestedClass.CallRUCMethod ();
@@ -932,7 +939,6 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			}
 
 			[ExpectedWarning ("IL2026", "RequiresOnClass.DerivedWithRequires.StaticMethodInInheritedClass()", "--DerivedWithRequires--", GlobalAnalysisOnly = true)]
-			[ExpectedWarning ("IL2026", "RequiresOnClass.DerivedWithRequires.DerivedNestedClass.NestedStaticMethod()", "--DerivedWithRequires--", GlobalAnalysisOnly = true)]
 			static void TestRequiresOnDerivedButNotOnBase ()
 			{
 				DerivedWithRequires.StaticMethodInInheritedClass ();
@@ -942,9 +948,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			}
 
 			[ExpectedWarning ("IL2026", "RequiresOnClass.DerivedWithRequires2.StaticMethodInInheritedClass()", "--DerivedWithRequires2--", GlobalAnalysisOnly = true)]
-			[ExpectedWarning ("IL2026", "RequiresOnClass.DerivedWithRequires2.DerivedNestedClass.NestedStaticMethod()", "--DerivedWithRequires2--", GlobalAnalysisOnly = true)]
 			[ExpectedWarning ("IL2026", "RequiresOnClass.ClassWithRequiresUnreferencedCode.StaticMethod()", "--ClassWithRequiresUnreferencedCode--", GlobalAnalysisOnly = true)]
-			[ExpectedWarning ("IL2026", "RequiresOnClass.ClassWithRequiresUnreferencedCode.NestedClass.NestedStaticMethod()", "--ClassWithRequiresUnreferencedCode--", GlobalAnalysisOnly = true)]
 			static void TestRequiresOnBaseAndDerived ()
 			{
 				DerivedWithRequires2.StaticMethodInInheritedClass ();


### PR DESCRIPTION
Avoid the propagation of RequiresUnreferencedCode to nested classes
When suppressing warnings only ask the declaring type instead of the effective type
Fixes #2151