### PR TITLE
Check attribute suppressions lazily

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -808,10 +808,6 @@ namespace Mono.Linker.Steps
 						continue;
 					}
 
-					if (UnconditionalSuppressMessageAttributeState.TypeRefHasUnconditionalSuppressions (ca.Constructor.DeclaringType) &&
-						provider is not ModuleDefinition && provider is not AssemblyDefinition)
-						_context.Suppressions.AddSuppression (ca, provider);
-
 					var resolvedAttributeType = _context.Resolve (ca.AttributeType);
 					if (resolvedAttributeType == null) {
 						continue;
@@ -1756,16 +1752,14 @@ namespace Mono.Linker.Steps
 
 			MarkType (type.BaseType, new DependencyInfo (DependencyKind.BaseType, type));
 
-			MarkCustomAttributes (type, new DependencyInfo (DependencyKind.CustomAttribute, type));
-
 			// The DynamicallyAccessedMembers hiearchy processing must be done after the base type was marked
-			// (to avoid inconsistencies in the cache), and after marking custom attributes (in case the attributes have
-			// warning suppressions for the type hierarchy marking) but before anything else as work done below
+			// (to avoid inconsistencies in the cache), but before anything else as work done below
 			// might need the results of the processing here.
 			_dynamicallyAccessedMembersTypeHierarchy.ProcessMarkedTypeForDynamicallyAccessedMembersHierarchy (type);
 
 			if (type.DeclaringType != null)
 				MarkType (type.DeclaringType, new DependencyInfo (DependencyKind.DeclaringType, type));
+			MarkCustomAttributes (type, new DependencyInfo (DependencyKind.CustomAttribute, type));
 			MarkSecurityDeclarations (type, new DependencyInfo (DependencyKind.CustomAttribute, type));
 
 			if (type.BaseType != null &&

--- a/src/linker/Linker/UnconditionalSuppressMessageAttributeState.cs
+++ b/src/linker/Linker/UnconditionalSuppressMessageAttributeState.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Mono.Cecil;
@@ -212,7 +212,7 @@ namespace Mono.Linker
 			}
 		}
 
-		public static bool TypeRefHasUnconditionalSuppressions (TypeReference typeRef)
+		static bool TypeRefHasUnconditionalSuppressions (TypeReference typeRef)
 		{
 			return typeRef.Name == "UnconditionalSuppressMessageAttribute" &&
 				typeRef.Namespace == "System.Diagnostics.CodeAnalysis";

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCopyAssembly.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCopyAssembly.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using System.Reflection;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
+{
+#if !NETCOREAPP
+	[Reference ("System.Core.dll")]
+#endif
+	[SetupLinkerAction ("copy", "test")]
+	[SkipKeptItemsValidation]
+	[ExpectedNoWarnings]
+	public class SuppressWarningsInCopyAssembly
+	{
+		public static void Main ()
+		{
+			// Regression test for https://github.com/dotnet/runtime/issues/56252
+			// where a compiler-generated method is marked before the source code with the suppression
+			foreach (var type in GetTypeNames ())
+				Console.WriteLine (type);
+		}
+
+		[UnconditionalSuppressMessage ("", "IL2026")]
+		public static IEnumerable<string> GetTypeNames ()
+		{
+			foreach (var type in Assembly.GetCallingAssembly ().GetTypes ())
+				yield return type.Name;
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInMembersAndTypes.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInMembersAndTypes.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
@@ -103,9 +103,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 
 	class SuppressOnTypeMarkedEntirely
 	{
-		// https://github.com/mono/linker/issues/2095
-		// [LogDoesNotContain (nameof(TypeWithSuppression) + " has more than one unconditional suppression")]
-		[LogContains (nameof (TypeWithSuppression) + " has more than one unconditional suppression")]
+		[LogDoesNotContain (nameof(TypeWithSuppression) + " has more than one unconditional suppression")]
 		[UnconditionalSuppressMessage ("Test", "IL2026")]
 		class TypeWithSuppression
 		{

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInMembersAndTypes.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInMembersAndTypes.cs
@@ -103,7 +103,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 
 	class SuppressOnTypeMarkedEntirely
 	{
-		[LogDoesNotContain (nameof(TypeWithSuppression) + " has more than one unconditional suppression")]
+		[LogDoesNotContain (nameof (TypeWithSuppression) + " has more than one unconditional suppression")]
 		[UnconditionalSuppressMessage ("Test", "IL2026")]
 		class TypeWithSuppression
 		{

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsViaXml.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsViaXml.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
+{
+	[SkipKeptItemsValidation]
+	[ExpectedNoWarnings]
+	[SetupLinkAttributesFile ("SuppressWarningsViaXml.xml")]
+	public class SuppressWarningsViaXml
+	{
+		public static void Main ()
+		{
+			SuppressedOnMethod ();
+			var t = typeof (SuppressedOnType);
+		}
+
+		static void SuppressedOnMethod () {
+			TriggerWarning ();
+		}
+
+		class SuppressedOnType : TriggerWarningType { }
+
+		[RequiresUnreferencedCode ("--TriggerWarning--")]
+		static void TriggerWarning () {}
+
+		[RequiresUnreferencedCode ("--TriggerWarningType--")]
+		class TriggerWarningType { }
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsViaXml.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsViaXml.cs
@@ -18,14 +18,15 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			var t = typeof (SuppressedOnType);
 		}
 
-		static void SuppressedOnMethod () {
+		static void SuppressedOnMethod ()
+		{
 			TriggerWarning ();
 		}
 
 		class SuppressedOnType : TriggerWarningType { }
 
 		[RequiresUnreferencedCode ("--TriggerWarning--")]
-		static void TriggerWarning () {}
+		static void TriggerWarning () { }
 
 		[RequiresUnreferencedCode ("--TriggerWarningType--")]
 		class TriggerWarningType { }

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsViaXml.xml
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsViaXml.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<linker>
+	<assembly fullname="test">
+		<type fullname="Mono.Linker.Tests.Cases.Warnings.WarningSuppression.SuppressWarningsViaXml">
+			<method name="SuppressedOnMethod">
+				<attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+					<argument>ILLink</argument>
+					<argument>IL2026</argument>
+				</attribute>
+			</method>
+			<attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+				<argument>ILLink</argument>
+				<argument>IL2109</argument>
+			</attribute>
+		</type>
+	</assembly>
+</linker>


### PR DESCRIPTION
Previously attribute suppressions were populated while marking
the attributes. This meant that any suppression checks before the
attributes got marked would not see the suppressions. Doing this
lazily fixes the problem, but may result in scanning the attributes
multiple times.

Fixes https://github.com/mono/linker/issues/2163
FIxes https://github.com/mono/linker/issues/2095
Fixes https://github.com/dotnet/runtime/issues/56252

This also fixes an issue where we were not respecting
UnconditionalSuppressMessageAttribute injected via
XML for anything other than assembly/module level attributes.