### PR TITLE
Bump cecil package version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -28,7 +28,7 @@
     <!-- This controls the version of the cecil package, or the version of cecil in the project graph
          when we build the cecil submodule. The reference assembly package will depend on this version of cecil.
          Keep this in sync with ProjectInfo.cs in the submodule. -->
-    <MonoCecilVersion>0.11.3</MonoCecilVersion>
+    <MonoCecilVersion>0.11.4</MonoCecilVersion>
     <UseVSTestRunner>true</UseVSTestRunner>
   </PropertyGroup>
 </Project>

--- a/test/Mono.Linker.Tests/Mono.Linker.Tests.csproj
+++ b/test/Mono.Linker.Tests/Mono.Linker.Tests.csproj
@@ -9,6 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Used in testcase to check the cecil package version. -->
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadata">
+      <_Parameter1>CecilPackageVersion</_Parameter1>
+      <_Parameter2>$(MonoCecilVersion)</_Parameter2>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <Folder Include="Properties\" />
     <Folder Include="TestCasesRunner\" />
     <Folder Include="Extensions\" />

--- a/test/Mono.Linker.Tests/Tests/CecilVersionCheck.cs
+++ b/test/Mono.Linker.Tests/Tests/CecilVersionCheck.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+
+namespace Mono.Linker.Tests
+{
+	[TestFixture]
+	public class CecilVersionCheck
+	{
+		[TestCase]
+		public void CecilPackageVersionMatchesAssemblyVersion ()
+		{
+			var thisAssembly = Assembly.GetExecutingAssembly ();
+			var cecilPackageVersion = thisAssembly
+				.GetCustomAttributes<AssemblyMetadataAttribute> ()
+				.Where (ca => (ca as AssemblyMetadataAttribute).Key == "CecilPackageVersion")
+				.Single ().Value;
+			// Assume that the test assembly builds against the same cecil as the linker.
+			var cecilAssemblyVersion = thisAssembly
+				.GetReferencedAssemblies ()
+				.Where (an => an.Name == "Mono.Cecil")
+				.Single ().Version;
+			Assert.AreEqual (cecilPackageVersion, cecilAssemblyVersion.ToString (3));
+		}
+	}
+}


### PR DESCRIPTION
The submodule update in https://github.com/mono/linker/pull/2156
incremented the cecil version, but we were still using 0.11.3 as the version
in our package graph. See https://github.com/mono/linker/pull/1515 for more
context on how this is set up.

Fixes https://github.com/mono/linker/issues/2173