### PR TITLE
Fix suppression check with assembly suppressions

### DIFF
--- a/src/linker/Linker/UnconditionalSuppressMessageAttributeState.cs
+++ b/src/linker/Linker/UnconditionalSuppressMessageAttributeState.cs
@@ -173,7 +173,7 @@ namespace Mono.Linker
 			}
 		}
 
-		public IEnumerable<SuppressMessageInfo> DecodeSuppressions (ICustomAttributeProvider provider)
+		IEnumerable<SuppressMessageInfo> DecodeSuppressions (ICustomAttributeProvider provider)
 		{
 			Debug.Assert (provider is not ModuleDefinition or AssemblyDefinition);
 
@@ -191,7 +191,7 @@ namespace Mono.Linker
 			}
 		}
 
-		public IEnumerable<(SuppressMessageInfo Info, ICustomAttributeProvider Target)> DecodeAssemblyAndModuleSuppressions (ModuleDefinition module)
+		IEnumerable<(SuppressMessageInfo Info, ICustomAttributeProvider Target)> DecodeAssemblyAndModuleSuppressions (ModuleDefinition module)
 		{
 			AssemblyDefinition assembly = module.Assembly;
 			foreach (var suppression in DecodeGlobalSuppressions (module, assembly))
@@ -203,7 +203,7 @@ namespace Mono.Linker
 			}
 		}
 
-		public IEnumerable<(SuppressMessageInfo Info, ICustomAttributeProvider Target)> DecodeGlobalSuppressions (ModuleDefinition module, ICustomAttributeProvider provider)
+		IEnumerable<(SuppressMessageInfo Info, ICustomAttributeProvider Target)> DecodeGlobalSuppressions (ModuleDefinition module, ICustomAttributeProvider provider)
 		{
 			var attributes = _context.CustomAttributes.GetCustomAttributes (provider).
 					Where (a => TypeRefHasUnconditionalSuppressions (a.AttributeType));

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInMembersAndTypes.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInMembersAndTypes.cs
@@ -111,6 +111,10 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			public TypeWithSuppression ()
 			{
 				MethodWithRUC ();
+
+				// Triggering the suppression check a second time
+				// still shouldn't warn about duplicate suppressions.
+				MethodWithRUC ();
 			}
 
 			int _field;

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInMembersAndTypesUsingTarget.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInMembersAndTypesUsingTarget.cs
@@ -9,6 +9,9 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 [module: UnconditionalSuppressMessage ("Test", "IL2072", Scope = "type", Target = "T:Mono.Linker.Tests.Cases.Warnings.WarningSuppression.WarningsInType")]
 [module: UnconditionalSuppressMessage ("Test", "IL2072", Scope = "member", Target = "M:Mono.Linker.Tests.Cases.Warnings.WarningSuppression.WarningsInMembers.Method")]
 [module: UnconditionalSuppressMessage ("Test", "IL2072", Scope = "member", Target = "M:Mono.Linker.Tests.Cases.Warnings.WarningSuppression.WarningsInMembers.get_Property")]
+[module: UnconditionalSuppressMessage ("Test", "IL2072", Scope = "member", Target = "M:Mono.Linker.Tests.Cases.Warnings.WarningSuppression..get_Property")]
+[module: UnconditionalSuppressMessage ("Test", "IL2072", Scope = "member", Target = "M:Mono.Linker.Tests.Cases.Warnings.WarningSuppression.WarningsInMembers.MultipleWarnings")]
+[module: UnconditionalSuppressMessage ("Test", "IL2026", Scope = "member", Target = "M:Mono.Linker.Tests.Cases.Warnings.WarningSuppression.WarningsInMembers.MultipleSuppressions")]
 
 namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 {
@@ -30,6 +33,9 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			var warningsInMembers = new WarningsInMembers ();
 			warningsInMembers.Method ();
 			int propertyThatTriggersWarning = warningsInMembers.Property;
+
+			WarningsInMembers.MultipleWarnings ();
+			WarningsInMembers.MultipleSuppressions ();
 		}
 
 		public static Type TriggerUnrecognizedPattern ()
@@ -73,6 +79,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 		}
 	}
 
+	[ExpectedNoWarnings]
 	public class WarningsInMembers
 	{
 		public void Method ()
@@ -85,6 +92,25 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 				Expression.Call (SuppressWarningsInMembersAndTypesUsingTarget.TriggerUnrecognizedPattern (), "", Type.EmptyTypes);
 				return 0;
 			}
+		}
+
+		[UnconditionalSuppressMessage ("Test", "IL2026")]
+		public static void MultipleWarnings ()
+		{
+			Expression.Call (SuppressWarningsInMembersAndTypesUsingTarget.TriggerUnrecognizedPattern (), "", Type.EmptyTypes);
+			RUCMethod ();
+		}
+
+		[LogContains (nameof (MultipleSuppressions) + "() has more than one unconditional suppression")]
+		[UnconditionalSuppressMessage ("Test", "IL2026")]
+		public static void MultipleSuppressions ()
+		{
+			RUCMethod ();
+		}
+
+		[RequiresUnreferencedCode ("--RUCMethod--")]
+		static void RUCMethod ()
+		{
 		}
 	}
 }


### PR DESCRIPTION
The change in https://github.com/mono/linker/pull/2171 was incorrect
because it didn't account for the possibility that the suppressions
cache already contains assembly or module suppressions for the provider.
(The same cache is used for both - the provider here is the suppression
target, not the attribute provider).

This fixes the check by re-using the cache to also track whether we have
scanned for suppression attributes on the provider. This caching is
necessary since we warn about duplicate suppressions.

Providers without any suppressions may still be scanned multiple times
since we don't cache the negative result.

I encountered this while investigating warnings in runtime, but it appears to
have been the result of an inconsistent state in my case - I don't believe
this change is necessary to fix runtime in response to the reflection warning
changes.