### PR TITLE
Fix typo

### DIFF
--- a/src/ILLink.Shared/SharedStrings.resx
+++ b/src/ILLink.Shared/SharedStrings.resx
@@ -166,7 +166,7 @@
     <value>Types that derive from a base class with 'RequiresUnreferencedCodeAttribute' need to explicitly use the 'RequiresUnreferencedCodeAttribute' or suppress this warning</value>
   </data>
   <data name="DynamicTypeInvocationMessage" xml:space="preserve">
-    <value>Invoking members on dynamic types is not trimming-compatible. Types or member might have been removed by the trimmer.</value>
+    <value>Invoking members on dynamic types is not trimming-compatible. Types or members might have been removed by the trimmer.</value>
   </data>
   <data name="DynamicTypeInvocationTitle" xml:space="preserve">
     <value>Using dynamic types might cause types or members to be removed by trimmer.</value>

--- a/test/ILLink.RoslynAnalyzer.Tests/RequiresUnreferencedCodeAnalyzerTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/RequiresUnreferencedCodeAnalyzerTests.cs
@@ -896,9 +896,9 @@ class C
 }";
 
 			return VerifyRequiresUnreferencedCodeAnalyzer (source,
-				// (8,3): warning IL2026: Invoking members on dynamic types is not trimming safe. Types or member might have been removed by the trimmer.
+				// (8,3): warning IL2026: Invoking members on dynamic types is not trimming safe. Types or members might have been removed by the trimmer.
 				VerifyCS.Diagnostic (dynamicInvocationDiagnosticDescriptor).WithSpan (8, 3, 8, 35),
-				// (24,3): warning IL2026: Invoking members on dynamic types is not trimming safe. Types or member might have been removed by the trimmer.
+				// (24,3): warning IL2026: Invoking members on dynamic types is not trimming safe. Types or members might have been removed by the trimmer.
 				VerifyCS.Diagnostic (dynamicInvocationDiagnosticDescriptor).WithSpan (24, 3, 24, 33));
 		}
 


### PR DESCRIPTION
Typo on a resource string of the dynamic analyzer.