### PR TITLE
Fix nullref in operator handling

### DIFF
--- a/src/linker/Linker.Steps/DiscoverCustomOperatorsHandler.cs
+++ b/src/linker/Linker.Steps/DiscoverCustomOperatorsHandler.cs
@@ -130,7 +130,18 @@ namespace Mono.Linker.Steps
 			// Unwrap Nullable<T>
 			Debug.Assert (typeDef.HasGenericParameters);
 			var nullableType = type as GenericInstanceType;
-			Debug.Assert (nullableType != null && nullableType.HasGenericArguments && nullableType.GenericArguments.Count == 1);
+			// The original type reference might be a TypeSpecification like array of Nullable<T>
+			// that we need to unwrap until we get to the Nullable<T>
+			while (nullableType == null) {
+				var typeSpec = type as TypeSpecification;
+				Debug.Assert (typeSpec != null);
+				if (typeSpec == null)
+					return null;
+
+				type = typeSpec.ElementType;
+				nullableType = type as GenericInstanceType;
+			}
+			Debug.Assert (nullableType.HasGenericArguments && nullableType.GenericArguments.Count == 1);
 			return _context.TryResolve (nullableType.GenericArguments[0]);
 		}
 

--- a/src/linker/Linker.Steps/DiscoverCustomOperatorsHandler.cs
+++ b/src/linker/Linker.Steps/DiscoverCustomOperatorsHandler.cs
@@ -129,19 +129,14 @@ namespace Mono.Linker.Steps
 
 			// Unwrap Nullable<T>
 			Debug.Assert (typeDef.HasGenericParameters);
-			var nullableType = type as GenericInstanceType;
 			// The original type reference might be a TypeSpecification like array of Nullable<T>
 			// that we need to unwrap until we get to the Nullable<T>
-			while (nullableType == null) {
-				var typeSpec = type as TypeSpecification;
-				Debug.Assert (typeSpec != null);
-				if (typeSpec == null)
-					return null;
-
-				type = typeSpec.ElementType;
-				nullableType = type as GenericInstanceType;
+			while (!type.IsGenericInstance) {
+				Debug.Assert (type is TypeSpecification);
+				type = (type as TypeSpecification).ElementType;
 			}
-			Debug.Assert (nullableType.HasGenericArguments && nullableType.GenericArguments.Count == 1);
+			var nullableType = type as GenericInstanceType;
+			Debug.Assert (nullableType != null && nullableType.HasGenericArguments && nullableType.GenericArguments.Count == 1);
 			return _context.TryResolve (nullableType.GenericArguments[0]);
 		}
 

--- a/test/Mono.Linker.Tests.Cases/LinqExpressions/CanPreserveCustomOperators.cs
+++ b/test/Mono.Linker.Tests.Cases/LinqExpressions/CanPreserveCustomOperators.cs
@@ -14,6 +14,9 @@ namespace Mono.Linker.Tests.Cases.LinqExpressions
 			var t4 = typeof (SourceTypeImplicit);
 			var t5 = typeof (TargetTypeExplicit);
 			var t6 = typeof (SourceTypeExplicit);
+
+			var t7 = typeof (GenericCustomOperators<>);
+			var t8 = typeof (GenericTypeArgument);
 		}
 
 		class CustomOperators
@@ -89,5 +92,23 @@ namespace Mono.Linker.Tests.Cases.LinqExpressions
 		class TargetTypeExplicit { }
 		[Kept]
 		class SourceTypeExplicit { }
+
+		class GenericCustomOperators<T>
+		{
+			[Kept]
+			public static explicit operator GenericCustomOperators<T> (int i) => null;
+
+			[Kept]
+			public static explicit operator GenericCustomOperators<T> (T t) => null;
+
+			[Kept]
+			public static explicit operator GenericCustomOperators<T> (int[] i) => null;
+
+			[Kept]
+			public static explicit operator GenericCustomOperators<T> (T[] ts) => null;
+		}
+
+		[Kept]
+		class GenericTypeArgument { }
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/LinqExpressions/CanPreserveNullableCustomOperators.cs
+++ b/test/Mono.Linker.Tests.Cases/LinqExpressions/CanPreserveNullableCustomOperators.cs
@@ -20,6 +20,8 @@ namespace Mono.Linker.Tests.Cases.LinqExpressions
 			var t5 = typeof (SourceValueType);
 
 			var s2 = typeof (ValueTypeUnusedOperators);
+
+			var e = typeof (ArrayElementValueType);
 		}
 
 		class ReferenceTypeOperators
@@ -61,6 +63,12 @@ namespace Mono.Linker.Tests.Cases.LinqExpressions
 			public static explicit operator TargetValueType? (ValueTypeOperators? self) => null;
 			[Kept]
 			public static explicit operator ValueTypeOperators? (SourceValueType? other) => null;
+
+			[Kept]
+			public static ValueTypeOperators? operator + (ArrayElementValueType?[] left, ValueTypeOperators? right) => null;
+
+			[Kept]
+			public static ValueTypeOperators? operator + (ArrayElementValueType?[][][] left, ValueTypeOperators? right) => null;
 		}
 
 		[Kept]
@@ -81,5 +89,8 @@ namespace Mono.Linker.Tests.Cases.LinqExpressions
 		struct AdditionValueTypeUnused { }
 		struct TargetValueTypeUnused { }
 		struct SourceValueTypeUnused { }
+
+		[Kept]
+		struct ArrayElementValueType { }
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/LinqExpressions/CanPreserveNullableCustomOperators.cs
+++ b/test/Mono.Linker.Tests.Cases/LinqExpressions/CanPreserveNullableCustomOperators.cs
@@ -3,6 +3,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.LinqExpressions
 {
+	[SetupCompileArgument ("/unsafe")]
 	[SetupLinkerArgument ("--used-attrs-only")]
 	public class CanPreserveNullableCustomOperators
 	{
@@ -22,6 +23,8 @@ namespace Mono.Linker.Tests.Cases.LinqExpressions
 			var s2 = typeof (ValueTypeUnusedOperators);
 
 			var e = typeof (ArrayElementValueType);
+			var p = typeof (PointerElementValueType);
+			var f = typeof (FunctionPointerArgumentValueType);
 		}
 
 		class ReferenceTypeOperators
@@ -69,6 +72,12 @@ namespace Mono.Linker.Tests.Cases.LinqExpressions
 
 			[Kept]
 			public static ValueTypeOperators? operator + (ArrayElementValueType?[][][] left, ValueTypeOperators? right) => null;
+
+			[Kept]
+			public static unsafe explicit operator ValueTypeOperators? (PointerElementValueType?* other) => null;
+
+			[Kept]
+			public static unsafe explicit operator ValueTypeOperators? (delegate*<FunctionPointerArgumentValueType?, void> other) => null;
 		}
 
 		[Kept]
@@ -92,5 +101,11 @@ namespace Mono.Linker.Tests.Cases.LinqExpressions
 
 		[Kept]
 		struct ArrayElementValueType { }
+
+		[Kept]
+		struct PointerElementValueType { }
+
+		[Kept]
+		struct FunctionPointerArgumentValueType { }
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/56819

The issue occurs when preserving an operator method with an argument like `Foo?[]`. We need to preserve the operator if `Foo` was marked. This was done by checking if the argument resolves to `Nullable<T>`, and if so, extracting the generic argument from the unresolved typeref. Cecil resolves `Foo?[]` to `Nullable<T>`, but we weren't prepared to handle this case because `Foo?[]` doesn't have generic arguments.

The fix unwraps the typereference until we get to the `Nullable<Foo>` so that we can extract the generic argument `Foo`.

I wasn't sure how to reproduce the original failing test in https://github.com/dotnet/runtime/issues/56819, but I see that the tests use this pattern. I did confirm that a local testcase reproduced the stacktrace from that issue.