### PR TITLE
Fix broken try/catch/filter offsets after isinst optimization

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -3468,12 +3468,6 @@ namespace Mono.Linker.Steps
 					if (type.IsInterface)
 						break;
 
-					if (type.Name == "QuicStreamAbortedException")
-						Debugger.Break ();
-
-					if (type.Name == "TypeToCheckException")
-						Debugger.Break ();
-
 					if (!Annotations.IsInstantiated (type)) {
 						_pending_isinst_instr.Add ((type, method.Body, instruction));
 						return;

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -532,6 +532,19 @@ namespace Mono.Linker.Steps
 						break;
 					}
 				}
+
+				foreach (var handler in body.ExceptionHandlers) {
+					if (handler.TryStart == oldTarget)
+						handler.TryStart = newTarget;
+					if (handler.TryEnd == oldTarget)
+						handler.TryEnd = newTarget;
+					if (handler.HandlerStart == oldTarget)
+						handler.HandlerStart = newTarget;
+					if (handler.HandlerEnd == oldTarget)
+						handler.HandlerEnd = newTarget;
+					if (handler.FilterStart == oldTarget)
+						handler.FilterStart = newTarget;
+				}
 			}
 		}
 
@@ -3454,6 +3467,12 @@ namespace Mono.Linker.Steps
 
 					if (type.IsInterface)
 						break;
+
+					if (type.Name == "QuicStreamAbortedException")
+						Debugger.Break ();
+
+					if (type.Name == "TypeToCheckException")
+						Debugger.Break ();
 
 					if (!Annotations.IsInstantiated (type)) {
 						_pending_isinst_instr.Add ((type, method.Body, instruction));

--- a/test/Mono.Linker.Tests.Cases/Advanced/TypeCheckRemoval.cs
+++ b/test/Mono.Linker.Tests.Cases/Advanced/TypeCheckRemoval.cs
@@ -238,36 +238,111 @@ namespace Mono.Linker.Tests.Cases.Advanced
 		{
 			[Kept]
 			[KeptBaseType(typeof(Exception))]
-			class TypeToCheckException : Exception { 
+			class TypeToCheckException : Exception {
 				[Kept]
-				public int Value { 
-					[Kept]
-					[ExpectedInstructionSequence (new string[] {
-						"ldstr",
-						"newobj",
-						"throw"
-					})]
-					get; } 
+				public int Value;
 			}
 
 			[Kept]
-			static void MethodWithFilter ()
+			[ExpectedInstructionSequence (new string[] {
+				".try",
+				"ldarg.0",
+				"pop",
+				"ldnull",
+				"pop",
+				"leave.s il_1f",
+				".endtry",
+				".filter",
+				"pop",
+				"ldnull",
+				"dup",
+				"brtrue.s il_f",
+				"pop",
+				"ldc.i4.0",
+				"br.s il_1a",
+				"ldfld",
+				"ldc.i4.0",
+				"ceq",
+				"ldc.i4.0",
+				"cgt.un",
+				"endfilter",
+				".catch",
+				"pop",
+				"leave.s il_1f",
+				".endcatch",
+				"ret"
+			})]
+			static void MethodWithFilterRemovalInTry (object o)
 			{
 				try {
-					new object (); // Do nothing
+					if (o is TypeToCheckException) {
+					}
 				}
 				catch (TypeToCheckException ex) when (ex.Value == 0) {
-					throw new ApplicationException ();
+				}
+			}
+
+			[Kept]
+			[ExpectedInstructionSequence (new string[] {
+				".try",
+				"newobj",
+				"pop",
+				"leave.s il_3a",
+				".endtry",
+				".filter",
+				"pop",
+				"ldnull",
+				"dup",
+				"brtrue.s il_11",
+				"pop",
+				"ldc.i4.0",
+				"br.s il_1c",
+				"ldfld",
+				"ldc.i4.0",
+				"ceq",
+				"ldc.i4.0",
+				"cgt.un",
+				"endfilter",
+				".catch",
+				"pop",
+				"leave.s il_3a",
+				".endcatch",
+				".filter",
+				"pop",
+				"ldnull",
+				"dup",
+				"brtrue.s il_2a",
+				"pop",
+				"ldc.i4.0",
+				"br.s il_35",
+				"ldfld",
+				"ldc.i4.1",
+				"ceq",
+				"ldc.i4.0",
+				"cgt.un",
+				"endfilter",
+				".catch",
+				"pop",
+				"leave.s il_3a",
+				".endcatch",
+				"ret",          
+			})]
+			static void MethodWithTwoFilters ()
+			{
+				try {
+					new object ();
+				}
+				catch (TypeToCheckException ex) when (ex.Value == 0) {
 				}
 				catch (TypeToCheckException ex) when (ex.Value == 1) {
-					throw new ApplicationException ();
 				}
 			}
 
 			[Kept]
 			public static void Test ()
 			{
-				MethodWithFilter ();
+				MethodWithFilterRemovalInTry (null);
+				MethodWithTwoFilters ();
 			}
 		}
 	}

--- a/test/Mono.Linker.Tests.Cases/Advanced/TypeCheckRemoval.cs
+++ b/test/Mono.Linker.Tests.Cases/Advanced/TypeCheckRemoval.cs
@@ -20,6 +20,8 @@ namespace Mono.Linker.Tests.Cases.Advanced
 			TestTypeCheckKept_2<string> (null);
 			TestTypeCheckKept_3 ();
 			TestTypeCheckKept_4 (null);
+
+			TypeCheckRemovalInExceptionFilter.Test ();
 		}
 
 		[Kept]
@@ -229,6 +231,44 @@ namespace Mono.Linker.Tests.Cases.Advanced
 		{
 			[Kept]
 			public object Instance;
+		}
+
+		[Kept]
+		class TypeCheckRemovalInExceptionFilter
+		{
+			[Kept]
+			[KeptBaseType(typeof(Exception))]
+			class TypeToCheckException : Exception { 
+				[Kept]
+				public int Value { 
+					[Kept]
+					[ExpectedInstructionSequence (new string[] {
+						"ldstr",
+						"newobj",
+						"throw"
+					})]
+					get; } 
+			}
+
+			[Kept]
+			static void MethodWithFilter ()
+			{
+				try {
+					new object (); // Do nothing
+				}
+				catch (TypeToCheckException ex) when (ex.Value == 0) {
+					throw new ApplicationException ();
+				}
+				catch (TypeToCheckException ex) when (ex.Value == 1) {
+					throw new ApplicationException ();
+				}
+			}
+
+			[Kept]
+			public static void Test ()
+			{
+				MethodWithFilter ();
+			}
 		}
 	}
 }

--- a/test/Mono.Linker.Tests.Cases/Advanced/TypeCheckRemoval.cs
+++ b/test/Mono.Linker.Tests.Cases/Advanced/TypeCheckRemoval.cs
@@ -237,8 +237,9 @@ namespace Mono.Linker.Tests.Cases.Advanced
 		class TypeCheckRemovalInExceptionFilter
 		{
 			[Kept]
-			[KeptBaseType(typeof(Exception))]
-			class TypeToCheckException : Exception {
+			[KeptBaseType (typeof (Exception))]
+			class TypeToCheckException : Exception
+			{
 				[Kept]
 				public int Value;
 			}
@@ -277,8 +278,7 @@ namespace Mono.Linker.Tests.Cases.Advanced
 				try {
 					if (o is TypeToCheckException) {
 					}
-				}
-				catch (TypeToCheckException ex) when (ex.Value == 0) {
+				} catch (TypeToCheckException ex) when (ex.Value == 0) {
 				}
 			}
 
@@ -325,16 +325,14 @@ namespace Mono.Linker.Tests.Cases.Advanced
 				"pop",
 				"leave.s il_3a",
 				".endcatch",
-				"ret",          
+				"ret",
 			})]
 			static void MethodWithTwoFilters ()
 			{
 				try {
 					new object ();
-				}
-				catch (TypeToCheckException ex) when (ex.Value == 0) {
-				}
-				catch (TypeToCheckException ex) when (ex.Value == 1) {
+				} catch (TypeToCheckException ex) when (ex.Value == 0) {
+				} catch (TypeToCheckException ex) when (ex.Value == 1) {
 				}
 			}
 

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/ReplacedReturns.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/ReplacedReturns.cs
@@ -133,16 +133,20 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 
 		[Kept]
 		[ExpectedInstructionSequence (new[] {
+			".try",
 			"call",
 			"pop",
 			"call",
 			"leave.s il_16",
+			".endtry",
+			".catch",
 			"pop",
 			"call",
 			"leave.s il_15",
+			".endcatch",
 			"ret",
-			"ret"
-			})]
+			"ret",
+		})]
 		static void Test5 ()
 		{
 			try {
@@ -162,6 +166,7 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 
 		[Kept]
 		[ExpectedInstructionSequence (new[] {
+			".try",
 			"call",
 			"pop",
 			"call",
@@ -169,14 +174,17 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 			"conv.i8",
 			"stloc.0",
 			"leave.s il_16",
+			".endtry",
+			".catch",
 			"pop",
 			"ldc.i4.2",
 			"conv.i8",
 			"stloc.0",
 			"leave.s il_16",
+			".endcatch",
 			"ldloc.0",
-			"ret"
-			})]
+			"ret",
+		})]
 		static long Test6 ()
 		{
 			try {
@@ -195,21 +203,25 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 		[ExpectedInstructionSequence (new[] {
 			"ldc.i4.0",
 			"stloc.0",
+			".try",
 			"call",
 			"pop",
 			"call",
 			"ldc.i4.1",
 			"stloc.1",
 			"leave.s il_1c",
+			".endtry",
+			".catch",
 			"pop",
 			"ldloc.0",
 			"call",
 			"leave.s il_1a",
+			".endcatch",
 			"ldc.i4.3",
 			"ret",
 			"ldloc.1",
-			"ret"
-			})]
+			"ret",
+		})]
 		static byte Test7 ()
 		{
 			int i = 0;
@@ -251,13 +263,17 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 
 		[Kept]
 		[ExpectedInstructionSequence (new[] {
+			".try",
 			"call",
 			"pop",
 			"call",
 			"leave.s il_10",
+			".endtry",
+			".catch",
 			"pop",
 			"leave.s il_10",
-			"ret"
+			".endcatch",
+			"ret",
 		})]
 		static void Test9 ()
 		{

--- a/test/Mono.Linker.Tests.Cases/UnreachableBlock/TryFilterBlocks.cs
+++ b/test/Mono.Linker.Tests.Cases/UnreachableBlock/TryFilterBlocks.cs
@@ -16,19 +16,24 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 
 		[Kept]
 		[ExpectedInstructionSequence (new[] {
+			".try",
 			"call",
 			"brfalse.s il_7",
 			"call",
 			"leave.s il_1c",
+			".endtry",
+			".filter",
 			"pop",
 			"call",
 			"ldc.i4.0",
 			"cgt.un",
 			"endfilter",
+			".catch",
 			"pop",
 			"leave.s il_1c",
+			".endcatch",
 			"ldc.i4.2",
-			"ret"
+			"ret",
 		})]
 		[ExpectedExceptionHandlerSequence (new string[] { "filter" })]
 		static int TestUnreachableInsideTry ()
@@ -46,8 +51,11 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 
 		[Kept]
 		[ExpectedInstructionSequence (new[] {
+			".try",
 			"call",
 			"leave.s il_18",
+			".endtry",
+			".filter",
 			"pop",
 			"call",
 			"brfalse.s il_f",
@@ -55,10 +63,12 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 			"ldc.i4.0",
 			"cgt.un",
 			"endfilter",
+			".catch",
 			"pop",
 			"leave.s il_18",
+			".endcatch",
 			"ldc.i4.3",
-			"ret"
+			"ret",
 		})]
 		[ExpectedExceptionHandlerSequence (new string[] { "filter" })]
 		static int TestUnreachableInsideFilterCondition ()

--- a/test/Mono.Linker.Tests/TestCasesRunner/AssemblyChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/AssemblyChecker.cs
@@ -404,7 +404,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 			HashSet<(Instruction, Instruction)> existingTryBlocks = new HashSet<(Instruction, Instruction)> ();
 			foreach (var exHandler in body.ExceptionHandlers) {
-				if (!existingTryBlocks.Contains ((exHandler.TryStart, exHandler.TryEnd))) {
+				if (existingTryBlocks.Add ((exHandler.TryStart, exHandler.TryEnd))) {
 					InsertBeforeInstruction (exHandler.TryStart, ".try");
 					InsertBeforeInstruction (exHandler.TryEnd, ".endtry");
 				}
@@ -417,8 +417,6 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 				if (exHandler.FilterStart != null)
 					InsertBeforeInstruction (exHandler.FilterStart, ".filter");
-
-				existingTryBlocks.Add ((exHandler.TryStart, exHandler.TryEnd));
 			}
 
 			return result.Select (i => i.Item2).ToArray ();

--- a/test/Mono.Linker.Tests/TestCasesRunner/AssemblyChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/AssemblyChecker.cs
@@ -399,7 +399,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			List<(Instruction, string)> result = new List<(Instruction, string)> (body.Instructions.Count);
 			for (int index = 0; index < body.Instructions.Count; index++) {
 				var instruction = body.Instructions[index];
-				result.Add ((instruction, FormatInstruction (instruction)));
+				result.Add ((instruction, FormatInstruction (instruction).ToLowerInvariant ()));
 			}
 
 			HashSet<(Instruction, Instruction)> existingTryBlocks = new HashSet<(Instruction, Instruction)> ();
@@ -507,18 +507,18 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			if (src.CustomAttributes.Any (attr => attr.AttributeType.Name == expectModifiedAttributeName)) {
 				Assert.That (
 					linkedValues,
-					Is.Not.EquivalentTo (srcValues),
+					Is.Not.EqualTo (srcValues),
 					$"Expected method `{src} to have {propertyDescription} modified, however, the {propertyDescription} were the same as the original\n{FormattingUtils.FormatSequenceCompareFailureMessage (linkedValues, srcValues)}");
 			} else if (expectedSequenceAttribute != null) {
 				var expected = getExpectFromSequenceAttribute (expectedSequenceAttribute).ToArray ();
 				Assert.That (
 					linkedValues,
-					Is.EquivalentTo (expected),
+					Is.EqualTo (expected),
 					$"Expected method `{src} to have it's {propertyDescription} modified, however, the sequence of {propertyDescription} does not match the expected value\n{FormattingUtils.FormatSequenceCompareFailureMessage2 (linkedValues, expected, srcValues)}");
 			} else {
 				Assert.That (
 					linkedValues,
-					Is.EquivalentTo (srcValues),
+					Is.EqualTo (srcValues),
 					$"Expected method `{src} to have it's {propertyDescription} unchanged, however, the {propertyDescription} differ from the original\n{FormattingUtils.FormatSequenceCompareFailureMessage (linkedValues, srcValues)}");
 			}
 		}

--- a/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -1075,7 +1075,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			var memberName = (string) inAssemblyAttribute.ConstructorArguments[2].Value;
 
 			if (TryVerifyKeptMemberInAssemblyAsMethod (memberName, originalType, linkedType, out MethodDefinition originalMethod, out MethodDefinition linkedMethod)) {
-				static string[] valueCollector (MethodDefinition m) => m.Body.Instructions.Select (ins => AssemblyChecker.FormatInstruction (ins).ToLower ()).ToArray ();
+				static string[] valueCollector (MethodDefinition m) => AssemblyChecker.FormatMethodBody (m.Body);
 				var linkedValues = valueCollector (linkedMethod);
 				var srcValues = valueCollector (originalMethod);
 


### PR DESCRIPTION
The isinst optimization replaces that instruction with a `pop, ldnull` when the type is not instantiated. This changes the instruction and also changes the length of the instruction in that position. Cecil unfortunately doesn't update try/catch/filter references and they keep pointing to the old `isinst` instruction which not part of the method body anymore. When saving the assembly the offsets stores in the try/catch/filter records end up effective random and corrupted.

This is a short-term fix to unblock failures in runtime due to this problem. 

Medium term fix would be to carefully handle all IL replacements in the linker with regard to try/catch/filter records.

Ideally the long term fix would be to do this in Cecil in such a way that IL replacements would be correctly handled on their own.

This fixes the `Http3RequestStream` failures mentioned in https://github.com/mono/linker/issues/2181, but I was not able to confirm if this fixes the CoreLib ArrayPool issues as well (I think it will not).