### PR TITLE
Special case `MakeGenericMethod/Type` in RUC analyzer

### DIFF
--- a/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
@@ -72,6 +72,9 @@ namespace ILLink.RoslynAnalyzer
 		{
 			if (member is IMethodSymbol method && ImmutableArrayOperations.Contains (specialIncompatibleMembers, member, SymbolEqualityComparer.Default) &&
 				(method.Name == "MakeGenericMethod" || method.Name == "MakeGenericType")) {
+				// These two RUC-annotated APIs are intrinsically handled by the trimmer, which will not produce any
+				// RUC warning related to them. For unrecognized reflection patterns realted to generic type/method
+				// creation IL2055/IL2060 should be used instead.
 				return true;
 			}
 

--- a/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
@@ -131,8 +131,8 @@ namespace ILLink.RoslynAnalyzer
 			return false;
 		}
 
-    private protected override ImmutableArray<(Action<OperationAnalysisContext> Action, OperationKind[] OperationKind)> ExtraOperationActions =>
-			ImmutableArray.Create ((s_dynamicTypeInvocation, new OperationKind[] { OperationKind.DynamicInvocation }));
+		private protected override ImmutableArray<(Action<OperationAnalysisContext> Action, OperationKind[] OperationKind)> ExtraOperationActions =>
+				ImmutableArray.Create ((s_dynamicTypeInvocation, new OperationKind[] { OperationKind.DynamicInvocation }));
 
 		private protected override ImmutableArray<(Action<SyntaxNodeAnalysisContext> Action, SyntaxKind[] SyntaxKind)> ExtraSyntaxNodeActions =>
 			ImmutableArray.Create ((s_constructorConstraint, new SyntaxKind[] { SyntaxKind.GenericName }));

--- a/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
@@ -70,13 +70,8 @@ namespace ILLink.RoslynAnalyzer
 
 		protected override bool ReportSpecialIncompatibleMembersDiagnostic (OperationAnalysisContext operationContext, ImmutableArray<ISymbol> specialIncompatibleMembers, ISymbol member)
 		{
-			if (member is IMethodSymbol method && ImmutableArrayOperations.Contains (specialIncompatibleMembers, member, SymbolEqualityComparer.Default)) {
-				if (method.Name == "MakeGenericType") {
-					operationContext.ReportDiagnostic (Diagnostic.Create (s_makeGenericTypeRule, operationContext.Operation.Syntax.GetLocation (), method.GetDisplayName ()));
-				} else if (method.Name == "MakeGenericMethod") {
-					operationContext.ReportDiagnostic (Diagnostic.Create (s_makeGenericMethodRule, operationContext.Operation.Syntax.GetLocation (), method.GetDisplayName ()));
-				}
-
+			if (member is IMethodSymbol method && ImmutableArrayOperations.Contains (specialIncompatibleMembers, member, SymbolEqualityComparer.Default) &&
+				(method.Name == "MakeGenericMethod" || method.Name == "MakeGenericType")) {
 				return true;
 			}
 

--- a/src/ILLink.Shared/DiagnosticId.cs
+++ b/src/ILLink.Shared/DiagnosticId.cs
@@ -5,6 +5,8 @@
 		// Linker diagnostic ids.
 		RequiresUnreferencedCode = 2026,
 		RequiresUnreferencedCodeAttributeMismatch = 2046,
+		MakeGenericType = 2055,
+		MakeGenericMethod = 2060,
 		RequiresUnreferencedCodeOnStaticConstructor = 2116,
 
 		// Single-file diagnostic ids.

--- a/src/ILLink.Shared/SharedStrings.resx
+++ b/src/ILLink.Shared/SharedStrings.resx
@@ -171,6 +171,12 @@
   <data name="DynamicTypeInvocationTitle" xml:space="preserve">
     <value>Using dynamic types might cause types or members to be removed by trimmer.</value>
   </data>
+  <data name="MakeGenericMethodMessage" xml:space="preserve">
+    <value>Call to '{0}' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.</value>
+  </data>
+  <data name="MakeGenericTypeMessage" xml:space="preserve">
+    <value>Call to '{0}' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic type.</value>
+  </data>
   <data name="RequiresUnreferencedCodeOnStaticConstructorMessage" xml:space="preserve">
     <value>'RequiresUnreferencedCodeAttribute' cannot be placed directly on static constructor '{0}', consider placing 'RequiresUnreferencedCodeAttribute' on the type declaration instead.</value>
   </data>

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using ILLink.Shared;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Mono.Linker.Steps;
@@ -745,10 +746,8 @@ namespace Mono.Linker.Dataflow
 										}
 									}
 									if (hasUncheckedAnnotation) {
-										reflectionContext.RecordUnrecognizedPattern (
-												2055,
-												$"Call to '{calledMethodDefinition.GetDisplayName ()}' can not be statically analyzed. " +
-												$"It's not possible to guarantee the availability of requirements of the generic type.");
+										reflectionContext.RecordUnrecognizedPattern ((int) DiagnosticId.MakeGenericType,
+											new DiagnosticString (DiagnosticId.MakeGenericType).GetMessage (calledMethodDefinition.GetDisplayName ()));
 									}
 								}
 
@@ -758,10 +757,8 @@ namespace Mono.Linker.Dataflow
 								reflectionContext.RecordHandledPattern ();
 							else {
 								// We have no way to "include more" to fix this if we don't know, so we have to warn
-								reflectionContext.RecordUnrecognizedPattern (
-									2055,
-									$"Call to '{calledMethodDefinition.GetDisplayName ()}' can not be statically analyzed. " +
-									$"It's not possible to guarantee the availability of requirements of the generic type.");
+								reflectionContext.RecordUnrecognizedPattern ((int) DiagnosticId.MakeGenericType,
+											new DiagnosticString (DiagnosticId.MakeGenericType).GetMessage (calledMethodDefinition.GetDisplayName ()));
 							}
 						}
 
@@ -853,9 +850,8 @@ namespace Mono.Linker.Dataflow
 										if (hasTypeArguments) {
 											// We don't know what method the `MakeGenericMethod` was called on, so we have to assume
 											// that the method may have requirements which we can't fullfil -> warn.
-											reflectionContext.RecordUnrecognizedPattern (
-												2060, string.Format (Resources.Strings.IL2060,
-													DiagnosticUtilities.GetMethodSignatureDisplayName (calledMethod)));
+											reflectionContext.RecordUnrecognizedPattern ((int) DiagnosticId.MakeGenericMethod,
+												new DiagnosticString (DiagnosticId.MakeGenericMethod).GetMessage (DiagnosticUtilities.GetMethodSignatureDisplayName (calledMethod)));
 										}
 
 										RequireDynamicallyAccessedMembers (
@@ -869,9 +865,8 @@ namespace Mono.Linker.Dataflow
 								if (hasTypeArguments) {
 									// We don't know what method the `MakeGenericMethod` was called on, so we have to assume
 									// that the method may have requirements which we can't fullfil -> warn.
-									reflectionContext.RecordUnrecognizedPattern (
-										2060, string.Format (Resources.Strings.IL2060,
-											DiagnosticUtilities.GetMethodSignatureDisplayName (calledMethod)));
+									reflectionContext.RecordUnrecognizedPattern ((int) DiagnosticId.MakeGenericMethod,
+										new DiagnosticString (DiagnosticId.MakeGenericMethod).GetMessage (DiagnosticUtilities.GetMethodSignatureDisplayName (calledMethod)));
 								}
 
 								RequireDynamicallyAccessedMembers (
@@ -1718,9 +1713,8 @@ namespace Mono.Linker.Dataflow
 							} else {
 								// We don't know what method the `MakeGenericMethod` was called on, so we have to assume
 								// that the method may have requirements which we can't fullfil -> warn.
-								reflectionContext.RecordUnrecognizedPattern (
-									2060, string.Format (Resources.Strings.IL2060,
-										DiagnosticUtilities.GetMethodSignatureDisplayName (calledMethod)));
+								reflectionContext.RecordUnrecognizedPattern ((int) DiagnosticId.MakeGenericMethod,
+									new DiagnosticString (DiagnosticId.MakeGenericMethod).GetMessage (DiagnosticUtilities.GetMethodSignatureDisplayName (calledMethod)));
 							}
 						}
 
@@ -2403,9 +2397,8 @@ namespace Mono.Linker.Dataflow
 			}
 
 			if (!AnalyzeGenericInstatiationTypeArray (genericParametersArray, ref reflectionContext, reflectionMethod, genericMethod.GenericParameters)) {
-				reflectionContext.RecordUnrecognizedPattern (
-					2060,
-					string.Format (Resources.Strings.IL2060, DiagnosticUtilities.GetMethodSignatureDisplayName (reflectionMethod)));
+				reflectionContext.RecordUnrecognizedPattern ((int) DiagnosticId.MakeGenericMethod,
+					new DiagnosticString (DiagnosticId.MakeGenericMethod).GetMessage (DiagnosticUtilities.GetMethodSignatureDisplayName (reflectionMethod)));
 			} else {
 				reflectionContext.RecordHandledPattern ();
 			}

--- a/src/linker/Resources/Strings.Designer.cs
+++ b/src/linker/Resources/Strings.Designer.cs
@@ -61,15 +61,6 @@ namespace Mono.Linker.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Call to &apos;{0}&apos; can not be statically analyzed. It&apos;s not possible to guarantee the availability of requirements of the generic method..
-        /// </summary>
-        internal static string IL2060 {
-            get {
-                return ResourceManager.GetString("IL2060", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; argument does not satisfy {4} in call to &apos;{1}&apos;. The parameter &apos;{2}&apos; of method &apos;{3}&apos; does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to..
         /// </summary>
         internal static string IL2067 {

--- a/src/linker/Resources/Strings.resx
+++ b/src/linker/Resources/Strings.resx
@@ -117,9 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="IL2060" xml:space="preserve">
-    <value>Call to '{0}' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.</value>
-  </data>
   <data name="IL2067" xml:space="preserve">
     <value>'{0}' argument does not satisfy {4} in call to '{1}'. The parameter '{2}' of method '{3}' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.</value>
   </data>

--- a/test/ILLink.RoslynAnalyzer.Tests/RequiresUnreferencedCodeAnalyzerTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/RequiresUnreferencedCodeAnalyzerTests.cs
@@ -942,10 +942,7 @@ class C
 	}
 }";
 
-			return VerifyRequiresUnreferencedCodeAnalyzer (source,
-				// (9,3): warning IL2060: Call to 'System.Reflection.MethodInfo.MakeGenericMethod(params System.Type[])' can not be statically analyzed.
-				// It's not possible to guarantee the availability of requirements of the generic method.
-				VerifyCS.Diagnostic (DiagnosticId.MakeGenericMethod).WithSpan (9, 3, 9, 44).WithArguments ("System.Reflection.MethodInfo.MakeGenericMethod(params System.Type[])"));
+			return VerifyRequiresUnreferencedCodeAnalyzer (source);
 		}
 
 		[Fact]
@@ -969,10 +966,7 @@ class C
 	}
 }";
 
-			return VerifyRequiresUnreferencedCodeAnalyzer (source,
-				// (9,3): warning IL2055: Call to 'System.Type.MakeGenericType(params System.Type[])' can not be statically analyzed.
-				// It's not possible to guarantee the availability of requirements of the generic type.
-				VerifyCS.Diagnostic (DiagnosticId.MakeGenericType).WithSpan (9, 3, 9, 51).WithArguments ("System.Type.MakeGenericType(params System.Type[])"));
+			return VerifyRequiresUnreferencedCodeAnalyzer (source);
 		}
 	}
 }


### PR DESCRIPTION
Now that `MakeGenericMethod` and `MakeGenericType` methods were annotated in the runtime, we need to special case these in the analyzer to emit the right warning (IL2060 and IL2055, respectively).