### PR TITLE
Fix warnings for DAMT on interfaces

### DIFF
--- a/src/linker/Linker.Dataflow/DynamicallyAccessedMembersTypeHierarchy.cs
+++ b/src/linker/Linker.Dataflow/DynamicallyAccessedMembersTypeHierarchy.cs
@@ -227,9 +227,6 @@ namespace Mono.Linker.Dataflow
 		{
 			Debug.Assert (annotation != DynamicallyAccessedMemberTypes.None);
 
-			if (type.Name == "AnnotatedAll")
-				System.Console.WriteLine ("Hey");
-
 			reflectionPatternContext.AnalyzingPattern ();
 			// Handle cases where a type has no members but annotations are to be applied to derived type members
 			reflectionPatternContext.RecordHandledPattern ();

--- a/src/linker/Linker.Dataflow/DynamicallyAccessedMembersTypeHierarchy.cs
+++ b/src/linker/Linker.Dataflow/DynamicallyAccessedMembersTypeHierarchy.cs
@@ -120,7 +120,7 @@ namespace Mono.Linker.Dataflow
 				var reflectionMethodBodyScanner = new ReflectionMethodBodyScanner (_context, _markStep, _scopeStack);
 				// Set up a context to report warnings on access to annotated members, with the annotated type as the origin.
 				var reflectionPatternContext = new ReflectionPatternContext (_context, reportingEnabled: true, _scopeStack.CurrentScope.Origin, type);
-				reflectionMethodBodyScanner.ApplyDynamicallyAccessedMembersToType (ref reflectionPatternContext, type, annotation);
+				ApplyDynamicallyAccessedMembersToType (ref reflectionMethodBodyScanner, ref reflectionPatternContext, type, annotation);
 				reflectionPatternContext.Dispose ();
 			}
 
@@ -145,7 +145,7 @@ namespace Mono.Linker.Dataflow
 			using var _ = _scopeStack.PushScope (new MessageOrigin (type));
 			// Set up a context to report warnings on access to annotated members, with the annotated type as the origin.
 			var reflectionPatternContext = new ReflectionPatternContext (_context, reportingEnabled: true, _scopeStack.CurrentScope.Origin, type);
-			reflectionMethodBodyScanner.ApplyDynamicallyAccessedMembersToType (ref reflectionPatternContext, type, annotation);
+			ApplyDynamicallyAccessedMembersToType (ref reflectionMethodBodyScanner, ref reflectionPatternContext, type, annotation);
 
 			// Mark it as applied in the cache
 			_typesInDynamicallyAccessedMembersHierarchy[type] = (annotation, true);
@@ -216,11 +216,61 @@ namespace Mono.Linker.Dataflow
 				using var _ = _scopeStack.PushScope (new MessageOrigin (type));
 				// Set up a context to report warnings on access to annotated members, with the annotated type as the origin.
 				var reflectionPatternContext = new ReflectionPatternContext (_context, reportingEnabled: true, _scopeStack.CurrentScope.Origin, type);
-				reflectionMethodBodyScanner.ApplyDynamicallyAccessedMembersToType (ref reflectionPatternContext, type, annotation);
+				ApplyDynamicallyAccessedMembersToType (ref reflectionMethodBodyScanner, ref reflectionPatternContext, type, annotation);
 				_typesInDynamicallyAccessedMembersHierarchy[type] = (annotation, true);
 			}
 
 			return applied;
+		}
+
+		public void ApplyDynamicallyAccessedMembersToType (ref ReflectionMethodBodyScanner reflectionMethodBodyScanner, ref ReflectionPatternContext reflectionPatternContext, TypeDefinition type, DynamicallyAccessedMemberTypes annotation)
+		{
+			Debug.Assert (annotation != DynamicallyAccessedMemberTypes.None);
+
+			if (type.Name == "AnnotatedAll")
+				System.Console.WriteLine ("Hey");
+
+			reflectionPatternContext.AnalyzingPattern ();
+			// Handle cases where a type has no members but annotations are to be applied to derived type members
+			reflectionPatternContext.RecordHandledPattern ();
+
+			// We need to apply annotations to this type, and its base/interface types (recursively)
+			// But the annotations on base/interfaces are already applied so we don't need to apply those
+			// again (and should avoid doing so as it would produce extra warnings).
+			var baseType = _context.TryResolve (type.BaseType);
+			if (baseType != null) {
+				var baseAnnotation = GetCachedInfoForTypeInHierarchy (baseType);
+				var annotationToApplyToBase = ReflectionMethodBodyScanner.GetMissingMemberTypes (annotation, baseAnnotation.annotation);
+
+				// Apply any annotations that didn't exist on the base type to the base type.
+				// This may produce redundant warnings when the annotation is DAMT.All or DAMT.PublicConstructors and the base already has a
+				// subset of those annotations.
+				reflectionMethodBodyScanner.MarkTypeForDynamicallyAccessedMembers (ref reflectionPatternContext, baseType, annotationToApplyToBase, DependencyKind.DynamicallyAccessedMemberOnType, declaredOnly: false);
+			}
+
+			// Most of the DynamicallyAccessedMemberTypes don't select members on interfaces. We only need to apply
+			// annotations to interfaces separately if dealing with DAMT.All or DAMT.Interfaces.
+			if (annotation.HasFlag (DynamicallyAccessedMemberTypesOverlay.Interfaces) && type.HasInterfaces) {
+				var annotationToApplyToInterfaces = annotation == DynamicallyAccessedMemberTypes.All ? annotation : DynamicallyAccessedMemberTypesOverlay.Interfaces;
+				foreach (var iface in type.Interfaces) {
+					var interfaceType = _context.TryResolve (iface.InterfaceType);
+					if (interfaceType == null)
+						continue;
+
+					var interfaceAnnotation = GetCachedInfoForTypeInHierarchy (interfaceType);
+					if (interfaceAnnotation.annotation.HasFlag (annotationToApplyToInterfaces))
+						continue;
+
+					// Apply All or Interfaces to the interface type.
+					// DAMT.All may produce redundant warnings from implementing types, when the interface type already had some annotations.
+					reflectionMethodBodyScanner.MarkTypeForDynamicallyAccessedMembers (ref reflectionPatternContext, interfaceType, annotationToApplyToInterfaces, DependencyKind.DynamicallyAccessedMemberOnType, declaredOnly: false);
+				}
+			}
+
+			// The annotations this type inherited from its base types or interfaces should not produce
+			// warnings on the respective base/interface members, since those are already covered by applying
+			// the annotations to those types.
+			reflectionMethodBodyScanner.MarkTypeForDynamicallyAccessedMembers (ref reflectionPatternContext, type, annotation, DependencyKind.DynamicallyAccessedMemberOnType, declaredOnly: true);
 		}
 
 		(DynamicallyAccessedMemberTypes annotation, bool applied) GetCachedInfoForTypeInHierarchy (TypeDefinition type)

--- a/src/linker/Linker.Dataflow/DynamicallyAccessedMembersTypeHierarchy.cs
+++ b/src/linker/Linker.Dataflow/DynamicallyAccessedMembersTypeHierarchy.cs
@@ -228,7 +228,7 @@ namespace Mono.Linker.Dataflow
 			Debug.Assert (annotation != DynamicallyAccessedMemberTypes.None);
 
 			reflectionPatternContext.AnalyzingPattern ();
-			// Handle cases where a type has no members but annotations are to be applied to derived type members
+			// There are no cases where we don't handle the pattern - the method will always "deal with it"
 			reflectionPatternContext.RecordHandledPattern ();
 
 			// We need to apply annotations to this type, and its base/interface types (recursively)
@@ -266,7 +266,7 @@ namespace Mono.Linker.Dataflow
 
 			// The annotations this type inherited from its base types or interfaces should not produce
 			// warnings on the respective base/interface members, since those are already covered by applying
-			// the annotations to those types.
+			// the annotations to those types. So we only need to handle the members directly declared on this type.
 			reflectionMethodBodyScanner.MarkTypeForDynamicallyAccessedMembers (ref reflectionPatternContext, type, annotation, DependencyKind.DynamicallyAccessedMemberOnType, declaredOnly: true);
 		}
 

--- a/test/Mono.Linker.Tests.Cases/Reflection/ObjectGetType.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/ObjectGetType.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1347,6 +1347,22 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			}
 
 			[Kept]
+			interface InterfaceImplementedByDerived
+			{
+				[Kept]
+				void Method ();
+			}
+
+			[KeptMember (".ctor()")]
+			[KeptBaseType (typeof (AnnotatedBase))]
+			[KeptInterface (typeof (InterfaceImplementedByDerived))]
+			class DerivedWithInterface : AnnotatedBase, InterfaceImplementedByDerived
+			{
+				[Kept]
+				public void Method () { }
+			}
+
+			[Kept]
 			static AnnotatedBase GetInstance () => new Derived ();
 
 			[Kept]
@@ -1354,6 +1370,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			{
 				Type t = GetInstance ().GetType ();
 				t.RequiresAll ();
+				var t2 = typeof (DerivedWithInterface);
 			}
 		}
 


### PR DESCRIPTION
https://github.com/mono/linker/pull/2191 addressed issues with redundant
warnings from base types, but interfaces need to be handled specially.

There were a few issues with the interface handling in that change:
- The binding logic didn't include interfaces for DAM.All when
  declaredOnly was specified, as @vitek-karas pointed out in
   https://github.com/mono/linker/pull/2206#discussion_r687573854.
   This could have led to us not marking interfaces for types derived
   from a DAMT.All-annotated type. Either way, the binding logic
   should not select interface _members_ when declaredOnly is specified.
- The DAMT-on-type logic had special handling for base types, but
  didn't separately mark interface members, which is needed when
  applying annotations DAMT.All or DAMT.Interfaces. This could have led
  to missing interface impls or interface members for types which have
  (explicit or inherited) DAMT.All or DAMT.Interfaces annotations.

Separately, the bit operations on DAMT also didn't correctly handle cases
where there are bits shared by different enum members.