### PR TITLE
Add BannedApiAnalyzer

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -25,6 +25,7 @@
     <MicrosoftCodeAnalysisCSharpCodeStyleVersion>3.10.0-2.final</MicrosoftCodeAnalysisCSharpCodeStyleVersion>
     <MicrosoftCodeAnalysisVersion>3.10.0-2.final</MicrosoftCodeAnalysisVersion>
     <MicrosoftCodeAnalysisCSharpAnalyzerTestingXunitVersion>1.0.1-beta1.*</MicrosoftCodeAnalysisCSharpAnalyzerTestingXunitVersion>
+    <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>3.3.2</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>
     <!-- This controls the version of the cecil package, or the version of cecil in the project graph
          when we build the cecil submodule. The reference assembly package will depend on this version of cecil.
          Keep this in sync with ProjectInfo.cs in the submodule. -->

--- a/src/linker/BannedSymbols.txt
+++ b/src/linker/BannedSymbols.txt
@@ -1,0 +1,2 @@
+T:Mono.Cecil.Cil.ILProcessor;Use LinkerILProcessor instead
+M:Mono.Cecil.TypeReference.Resolve();Use LinkContext.Resolve and LinkContext.TryResolve helpers instead

--- a/src/linker/Linker.Dataflow/DynamicallyAccessedMembersTypeHierarchy.cs
+++ b/src/linker/Linker.Dataflow/DynamicallyAccessedMembersTypeHierarchy.cs
@@ -66,7 +66,7 @@ namespace Mono.Linker.Dataflow
 
 			// Base should already be marked (since we're marking its derived type now)
 			// so we should already have its cached values filled.
-			TypeDefinition baseType = type.BaseType?.Resolve ();
+			TypeDefinition baseType = _context.TryResolve (type.BaseType);
 			Debug.Assert (baseType == null || _context.Annotations.IsMarked (baseType));
 			if (baseType != null && _typesInDynamicallyAccessedMembersHierarchy.TryGetValue (baseType, out var baseValue)) {
 				annotation |= baseValue.annotation;
@@ -80,7 +80,7 @@ namespace Mono.Linker.Dataflow
 			// relatively low. In the future it could be possibly optimized.
 			if (type.HasInterfaces) {
 				foreach (InterfaceImplementation iface in type.Interfaces) {
-					var interfaceType = iface.InterfaceType.Resolve ();
+					var interfaceType = _context.TryResolve (iface.InterfaceType);
 					if (interfaceType != null) {
 						var interfaceValue = ProcessMarkedTypeForDynamicallyAccessedMembersHierarchy (interfaceType);
 						annotation |= interfaceValue.annotation;
@@ -196,13 +196,13 @@ namespace Mono.Linker.Dataflow
 			if (applied)
 				return true;
 
-			TypeDefinition baseType = type.BaseType?.Resolve ();
+			TypeDefinition baseType = _context.TryResolve (type.BaseType);
 			if (baseType != null)
 				applied = ApplyDynamicallyAccessedMembersToTypeHierarchyInner (reflectionMethodBodyScanner, baseType);
 
 			if (!applied && type.HasInterfaces) {
 				foreach (InterfaceImplementation iface in type.Interfaces) {
-					var interfaceType = iface.InterfaceType.Resolve ();
+					var interfaceType = _context.TryResolve (iface.InterfaceType);
 					if (interfaceType != null) {
 						if (ApplyDynamicallyAccessedMembersToTypeHierarchyInner (reflectionMethodBodyScanner, interfaceType)) {
 							applied = true;

--- a/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -1851,10 +1851,10 @@ namespace Mono.Linker.Dataflow
 					} else if (parameterTypeDef.IsMulticastDelegate ()) {
 						// Delegates are special cased by interop
 						return false;
-					} else if (parameterTypeDef.IsSubclassOf ("System.Runtime.InteropServices", "CriticalHandle")) {
+					} else if (parameterTypeDef.IsSubclassOf ("System.Runtime.InteropServices", "CriticalHandle", _context)) {
 						// Subclasses of CriticalHandle are special cased by interop
 						return false;
-					} else if (parameterTypeDef.IsSubclassOf ("System.Runtime.InteropServices", "SafeHandle")) {
+					} else if (parameterTypeDef.IsSubclassOf ("System.Runtime.InteropServices", "SafeHandle", _context)) {
 						// Subclasses of SafeHandle are special cased by interop
 						return false;
 					} else if (!parameterTypeDef.IsSequentialLayout && !parameterTypeDef.IsExplicitLayout) {

--- a/src/linker/Linker.Steps/LinkAttributesParser.cs
+++ b/src/linker/Linker.Steps/LinkAttributesParser.cs
@@ -170,7 +170,8 @@ namespace Mono.Linker.Steps
 					//
 					// No candidates betterness, only exact matches are supported
 					//
-					if (_context.TryResolve (p[ii].ParameterType) != _context.TryResolve (args[ii].Type))
+					var parameterType = _context.TryResolve (p[ii].ParameterType);
+					if (parameterType == null || parameterType != _context.TryResolve (args[ii].Type))
 						match = false;
 				}
 

--- a/src/linker/Linker.Steps/LinkAttributesParser.cs
+++ b/src/linker/Linker.Steps/LinkAttributesParser.cs
@@ -153,7 +153,7 @@ namespace Mono.Linker.Steps
 			return customAttribute;
 		}
 
-		static MethodDefinition FindBestMatchingConstructor (TypeDefinition attributeType, CustomAttributeArgument[] args)
+		MethodDefinition FindBestMatchingConstructor (TypeDefinition attributeType, CustomAttributeArgument[] args)
 		{
 			var methods = attributeType.Methods;
 			for (int i = 0; i < attributeType.Methods.Count; ++i) {
@@ -170,7 +170,7 @@ namespace Mono.Linker.Steps
 					//
 					// No candidates betterness, only exact matches are supported
 					//
-					if (p[ii].ParameterType.Resolve () != args[ii].Type.Resolve ())
+					if (_context.TryResolve (p[ii].ParameterType) != _context.TryResolve (args[ii].Type))
 						match = false;
 				}
 
@@ -240,7 +240,7 @@ namespace Mono.Linker.Steps
 					return null;
 				}
 
-				var boxedValue = ReadCustomAttributeArgument (iterator, typeref.Resolve ());
+				var boxedValue = ReadCustomAttributeArgument (iterator, _context.TryResolve (typeref));
 				if (boxedValue is null)
 					return null;
 

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -877,7 +877,7 @@ namespace Mono.Linker.Steps
 
 			TypeDefinition type;
 			if (dynamicDependency.TypeName is string typeName) {
-				type = DocumentationSignatureParser.GetTypeByDocumentationSignature (assembly, typeName);
+				type = DocumentationSignatureParser.GetTypeByDocumentationSignature (assembly, typeName, _context);
 				if (type == null) {
 					_context.LogWarning ($"Unresolved type '{typeName}' in DynamicDependencyAttribute", 2036, _scopeStack.CurrentScope.Origin);
 					return;
@@ -900,7 +900,7 @@ namespace Mono.Linker.Steps
 
 			IEnumerable<IMetadataTokenProvider> members;
 			if (dynamicDependency.MemberSignature is string memberSignature) {
-				members = DocumentationSignatureParser.GetMembersByDocumentationSignature (type, memberSignature, acceptName: true);
+				members = DocumentationSignatureParser.GetMembersByDocumentationSignature (type, memberSignature, _context, acceptName: true);
 				if (!members.Any ()) {
 					_context.LogWarning ($"No members were resolved for '{memberSignature}'.", 2037, _scopeStack.CurrentScope.Origin);
 					return;
@@ -2037,7 +2037,7 @@ namespace Mono.Linker.Steps
 			TypeDefinition typeDefinition = null;
 			switch (attribute.ConstructorArguments[0].Value) {
 			case string s:
-				typeDefinition = _context.TypeNameResolver.ResolveTypeName (s, _scopeStack.CurrentScope.Origin.Provider, out AssemblyDefinition assemblyDefinition)?.Resolve ();
+				typeDefinition = _context.TryResolve (_context.TypeNameResolver.ResolveTypeName (s, _scopeStack.CurrentScope.Origin.Provider, out AssemblyDefinition assemblyDefinition));
 				if (typeDefinition != null)
 					MarkingHelpers.MarkMatchingExportedType (typeDefinition, assemblyDefinition, new DependencyInfo (DependencyKind.CustomAttribute, provider));
 

--- a/src/linker/Linker.Steps/ProcessLinkerXmlBase.cs
+++ b/src/linker/Linker.Steps/ProcessLinkerXmlBase.cs
@@ -581,7 +581,7 @@ namespace Mono.Linker.Steps
 
 			case MetadataType.ValueType:
 				if (value is string &&
-					_context.TryResolve (target) is var typeDefinition &&
+					_context.TryResolve (target) is TypeDefinition typeDefinition &&
 					typeDefinition.IsEnum) {
 					var enumField = typeDefinition.Fields.Where (f => f.IsStatic && f.Name == value).FirstOrDefault ();
 					if (enumField != null) {

--- a/src/linker/Linker.Steps/ProcessLinkerXmlBase.cs
+++ b/src/linker/Linker.Steps/ProcessLinkerXmlBase.cs
@@ -483,7 +483,7 @@ namespace Mono.Linker.Steps
 
 		public override string ToString () => GetType ().Name + ": " + _xmlDocumentLocation;
 
-		public static bool TryConvertValue (string value, TypeReference target, out object result)
+		public bool TryConvertValue (string value, TypeReference target, out object result)
 		{
 			switch (target.MetadataType) {
 			case MetadataType.Boolean:
@@ -581,7 +581,7 @@ namespace Mono.Linker.Steps
 
 			case MetadataType.ValueType:
 				if (value is string &&
-					target.Resolve () is var typeDefinition &&
+					_context.TryResolve (target) is var typeDefinition &&
 					typeDefinition.IsEnum) {
 					var enumField = typeDefinition.Fields.Where (f => f.IsStatic && f.Name == value).FirstOrDefault ();
 					if (enumField != null) {

--- a/src/linker/Linker.Steps/SweepStep.cs
+++ b/src/linker/Linker.Steps/SweepStep.cs
@@ -256,7 +256,7 @@ namespace Mono.Linker.Steps
 				SweepAssemblyReferences (assembly);
 		}
 
-		static bool SweepAssemblyReferences (AssemblyDefinition assembly)
+		bool SweepAssemblyReferences (AssemblyDefinition assembly)
 		{
 			//
 			// We used to run over list returned by GetTypeReferences but
@@ -266,7 +266,7 @@ namespace Mono.Linker.Steps
 			//
 			assembly.MainModule.AssemblyReferences.Clear ();
 
-			var ars = new AssemblyReferencesCorrector (assembly);
+			var ars = new AssemblyReferencesCorrector (assembly, Context);
 			return ars.Process ();
 		}
 
@@ -568,14 +568,16 @@ namespace Mono.Linker.Steps
 		{
 			readonly AssemblyDefinition assembly;
 			readonly DefaultMetadataImporter importer;
+			readonly ITryResolveMetadata resolver;
 
 			HashSet<TypeReference> updated;
 			bool changedAnyScopes;
 
-			public AssemblyReferencesCorrector (AssemblyDefinition assembly)
+			public AssemblyReferencesCorrector (AssemblyDefinition assembly, ITryResolveMetadata resolver)
 			{
 				this.assembly = assembly;
 				this.importer = new DefaultMetadataImporter (assembly.MainModule);
+				this.resolver = resolver;
 
 				updated = null;
 				changedAnyScopes = false;
@@ -923,7 +925,7 @@ namespace Mono.Linker.Steps
 				//
 				// Resolve to type definition to remove any type forwarding imports
 				//
-				TypeDefinition td = type.Resolve ();
+				TypeDefinition td = resolver.TryResolve (type);
 				if (td == null) {
 					//
 					// This can happen when not all assembly refences were provided and we

--- a/src/linker/Linker/DocumentationSignatureGenerator.cs
+++ b/src/linker/Linker/DocumentationSignatureGenerator.cs
@@ -25,57 +25,57 @@ namespace Mono.Linker
 		{
 		}
 
-		public static void VisitMember (IMemberDefinition member, StringBuilder builder)
+		public static void VisitMember (IMemberDefinition member, StringBuilder builder, ITryResolveMetadata resolver)
 		{
 			switch (member.MetadataToken.TokenType) {
 			case TokenType.TypeDef:
-				VisitTypeDefinition (member as TypeDefinition, builder);
+				VisitTypeDefinition (member as TypeDefinition, builder, resolver);
 				break;
 			case TokenType.Method:
-				VisitMethod (member as MethodDefinition, builder);
+				VisitMethod (member as MethodDefinition, builder, resolver);
 				break;
 			case TokenType.Property:
-				VisitProperty (member as PropertyDefinition, builder);
+				VisitProperty (member as PropertyDefinition, builder, resolver);
 				break;
 			case TokenType.Field:
-				VisitField (member as FieldDefinition, builder);
+				VisitField (member as FieldDefinition, builder, resolver);
 				break;
 			case TokenType.Event:
-				VisitEvent (member as EventDefinition, builder);
+				VisitEvent (member as EventDefinition, builder, resolver);
 				break;
 			default:
 				break;
 			}
 		}
 
-		private static void VisitMethod (MethodDefinition method, StringBuilder builder)
+		private static void VisitMethod (MethodDefinition method, StringBuilder builder, ITryResolveMetadata resolver)
 		{
 			builder.Append (MethodPrefix);
-			PartVisitor.Instance.VisitMethodDefinition (method, builder);
+			PartVisitor.Instance.VisitMethodDefinition (method, builder, resolver);
 		}
 
-		private static void VisitField (FieldDefinition field, StringBuilder builder)
+		private static void VisitField (FieldDefinition field, StringBuilder builder, ITryResolveMetadata resolver)
 		{
 			builder.Append (FieldPrefix);
-			PartVisitor.Instance.VisitField (field, builder);
+			PartVisitor.Instance.VisitField (field, builder, resolver);
 		}
 
-		private static void VisitEvent (EventDefinition evt, StringBuilder builder)
+		private static void VisitEvent (EventDefinition evt, StringBuilder builder, ITryResolveMetadata resolver)
 		{
 			builder.Append (EventPrefix);
-			PartVisitor.Instance.VisitEvent (evt, builder);
+			PartVisitor.Instance.VisitEvent (evt, builder, resolver);
 		}
 
-		private static void VisitProperty (PropertyDefinition property, StringBuilder builder)
+		private static void VisitProperty (PropertyDefinition property, StringBuilder builder, ITryResolveMetadata resolver)
 		{
 			builder.Append (PropertyPrefix);
-			PartVisitor.Instance.VisitProperty (property, builder);
+			PartVisitor.Instance.VisitProperty (property, builder, resolver);
 		}
 
-		private static void VisitTypeDefinition (TypeDefinition type, StringBuilder builder)
+		private static void VisitTypeDefinition (TypeDefinition type, StringBuilder builder, ITryResolveMetadata resolver)
 		{
 			builder.Append (TypePrefix);
-			PartVisitor.Instance.VisitTypeReference (type, builder);
+			PartVisitor.Instance.VisitTypeReference (type, builder, resolver);
 		}
 	}
 }

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -475,7 +475,7 @@ namespace Mono.Linker
 							return -1;
 						}
 
-						context.WarningSuppressionWriter = new WarningSuppressionWriter (fileOutputKind);
+						context.WarningSuppressionWriter = new WarningSuppressionWriter (context, fileOutputKind);
 						continue;
 
 					case "--nowarn":

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -50,7 +50,13 @@ namespace Mono.Linker
 		NET6 = 6,
 	}
 
-	public class LinkContext : IMetadataResolver, IDisposable
+	public interface ITryResolveMetadata
+	{
+		MethodDefinition TryResolve (MethodReference methodReference);
+		TypeDefinition TryResolve (TypeReference typeReference);
+	}
+
+	public class LinkContext : IMetadataResolver, ITryResolveMetadata, IDisposable
 	{
 
 		readonly Pipeline _pipeline;
@@ -813,7 +819,9 @@ namespace Mono.Linker
 			if (typeReference is GenericParameter || (typeReference is TypeSpecification && typeReference is not GenericInstanceType))
 				throw new NotSupportedException ($"TypeDefinition cannot be resolved from '{typeReference.GetType ()}' type");
 
+#pragma warning disable RS0030
 			td = typeReference.Resolve ();
+#pragma warning restore RS0030
 			if (td == null && !IgnoreUnresolved) {
 				ReportUnresolved (typeReference);
 			}
@@ -843,7 +851,9 @@ namespace Mono.Linker
 					td = TryResolve (ts.GetElementType ());
 				}
 			} else {
+#pragma warning disable RS0030
 				td = typeReference.Resolve ();
+#pragma warning restore RS0030
 			}
 
 			typeresolveCache.Add (typeReference, td);

--- a/src/linker/Linker/LinkerILProcessor.cs
+++ b/src/linker/Linker/LinkerILProcessor.cs
@@ -8,6 +8,7 @@ using Mono.Cecil.Cil;
 
 namespace Mono.Linker
 {
+#pragma warning disable RS0030
 	class LinkerILProcessor
 	{
 		readonly ILProcessor _ilProcessor;
@@ -115,6 +116,7 @@ namespace Mono.Linker
 				}
 			}
 		}
+#pragma warning disable RS0030
 	}
 
 	static class ILProcessorExtensions

--- a/src/linker/Linker/MethodReferenceExtensions.cs
+++ b/src/linker/Linker/MethodReferenceExtensions.cs
@@ -53,18 +53,18 @@ namespace Mono.Linker
 			return sb.ToString ();
 		}
 
-		public static TypeReference GetReturnType (this MethodReference method)
+		public static TypeReference GetReturnType (this MethodReference method, LinkContext context)
 		{
 			if (method.DeclaringType is GenericInstanceType genericInstance)
-				return TypeReferenceExtensions.InflateGenericType (genericInstance, method.ReturnType);
+				return TypeReferenceExtensions.InflateGenericType (genericInstance, method.ReturnType, context);
 
 			return method.ReturnType;
 		}
 
-		public static TypeReference GetParameterType (this MethodReference method, int parameterIndex)
+		public static TypeReference GetParameterType (this MethodReference method, int parameterIndex, LinkContext context)
 		{
 			if (method.DeclaringType is GenericInstanceType genericInstance)
-				return TypeReferenceExtensions.InflateGenericType (genericInstance, method.Parameters[parameterIndex].ParameterType);
+				return TypeReferenceExtensions.InflateGenericType (genericInstance, method.Parameters[parameterIndex].ParameterType, context);
 
 			return method.Parameters[parameterIndex].ParameterType;
 		}

--- a/src/linker/Linker/ModuleDefinitionExtensions.cs
+++ b/src/linker/Linker/ModuleDefinitionExtensions.cs
@@ -26,7 +26,7 @@ namespace Mono.Linker
 			return false;
 		}
 
-		public static TypeDefinition ResolveType (this ModuleDefinition module, string typeFullName)
+		public static TypeDefinition ResolveType (this ModuleDefinition module, string typeFullName, ITryResolveMetadata resolver)
 		{
 			if (typeFullName == null)
 				return null;
@@ -44,7 +44,7 @@ namespace Mono.Linker
 				(string.Empty, typeFullName);
 
 			TypeReference typeReference = new TypeReference (typeNamespace, typeName, module, module);
-			return typeReference.Resolve ();
+			return resolver.TryResolve (typeReference);
 		}
 	}
 }

--- a/src/linker/Linker/OverrideInformation.cs
+++ b/src/linker/Linker/OverrideInformation.cs
@@ -6,11 +6,14 @@ namespace Mono.Linker
 	[DebuggerDisplay ("{Override}")]
 	public class OverrideInformation
 	{
-		public OverrideInformation (MethodDefinition @base, MethodDefinition @override, InterfaceImplementation matchingInterfaceImplementation = null)
+		readonly ITryResolveMetadata resolver;
+
+		public OverrideInformation (MethodDefinition @base, MethodDefinition @override, ITryResolveMetadata resolver, InterfaceImplementation matchingInterfaceImplementation = null)
 		{
 			Base = @base;
 			Override = @override;
 			MatchingInterfaceImplementation = matchingInterfaceImplementation;
+			this.resolver = resolver;
 		}
 
 		public MethodDefinition Base { get; }
@@ -32,7 +35,7 @@ namespace Mono.Linker
 					return null;
 
 				if (MatchingInterfaceImplementation != null)
-					return MatchingInterfaceImplementation.InterfaceType.Resolve ();
+					return resolver.TryResolve (MatchingInterfaceImplementation.InterfaceType);
 
 				return Base.DeclaringType;
 			}

--- a/src/linker/Linker/SerializationMarker.cs
+++ b/src/linker/Linker/SerializationMarker.cs
@@ -186,7 +186,7 @@ namespace Mono.Linker
 			// This doesn't handle other TypeSpecs. We are only matching what xamarin-android used to do.
 			// Arrays will still work because Resolve returns the array element type.
 
-			TypeDefinition type = typeRef.Resolve ();
+			TypeDefinition type = _context.TryResolve (typeRef);
 			if (type == null)
 				return;
 

--- a/src/linker/Linker/TypeMapInfo.cs
+++ b/src/linker/Linker/TypeMapInfo.cs
@@ -91,7 +91,7 @@ namespace Mono.Linker
 				override_methods.Add (@base, methods);
 			}
 
-			methods.Add (new OverrideInformation (@base, @override, matchingInterfaceImplementation));
+			methods.Add (new OverrideInformation (@base, @override, context, matchingInterfaceImplementation));
 		}
 
 		public void AddDefaultInterfaceImplementation (MethodDefinition @base, TypeDefinition implementingType, InterfaceImplementation matchingInterfaceImplementation)
@@ -123,7 +123,7 @@ namespace Mono.Linker
 
 			// Foreach interface and for each newslot virtual method on the interface, try
 			// to find the method implementation and record it.
-			foreach (var interfaceImpl in type.GetInflatedInterfaces ()) {
+			foreach (var interfaceImpl in type.GetInflatedInterfaces (context)) {
 				foreach (MethodReference interfaceMethod in interfaceImpl.InflatedInterface.GetMethods (context)) {
 					MethodDefinition resolvedInterfaceMethod = context.TryResolve (interfaceMethod);
 					if (resolvedInterfaceMethod == null)
@@ -245,7 +245,7 @@ namespace Mono.Linker
 				var baseType = context.TryResolve (type)?.BaseType;
 
 				if (baseType is GenericInstanceType)
-					return TypeReferenceExtensions.InflateGenericType (genericInstance, baseType);
+					return TypeReferenceExtensions.InflateGenericType (genericInstance, baseType, context);
 
 				return baseType;
 			}
@@ -314,7 +314,7 @@ namespace Mono.Linker
 			return null;
 		}
 
-		static bool MethodMatch (MethodReference candidate, MethodReference method)
+		bool MethodMatch (MethodReference candidate, MethodReference method)
 		{
 			if (candidate.HasParameters != method.HasParameters)
 				return false;
@@ -327,7 +327,7 @@ namespace Mono.Linker
 
 			// we need to track what the generic parameter represent - as we cannot allow it to
 			// differ between the return type or any parameter
-			if (!TypeMatch (candidate.GetReturnType (), method.GetReturnType ()))
+			if (!TypeMatch (candidate.GetReturnType (context), method.GetReturnType (context)))
 				return false;
 
 			if (!candidate.HasParameters)
@@ -342,7 +342,7 @@ namespace Mono.Linker
 				return false;
 
 			for (int i = 0; i < cp.Count; i++) {
-				if (!TypeMatch (candidate.GetParameterType (i), method.GetParameterType (i)))
+				if (!TypeMatch (candidate.GetParameterType (i, context), method.GetParameterType (i, context)))
 					return false;
 			}
 

--- a/src/linker/Linker/TypeNameResolver.cs
+++ b/src/linker/Linker/TypeNameResolver.cs
@@ -98,7 +98,7 @@ namespace Mono.Linker
 				if (genericTypeRef == null)
 					return null;
 
-				TypeDefinition genericType = genericTypeRef.Resolve ();
+				TypeDefinition genericType = _context.TryResolve (genericTypeRef);
 				var genericInstanceType = new GenericInstanceType (genericType);
 				foreach (var arg in constructedGenericTypeName.GenericArguments) {
 					var genericArgument = ResolveTypeName (assembly, arg);
@@ -123,7 +123,7 @@ namespace Mono.Linker
 				};
 			}
 
-			return assembly.MainModule.ResolveType (typeName.ToString ());
+			return assembly.MainModule.ResolveType (typeName.ToString (), _context);
 		}
 	}
 }

--- a/src/linker/Linker/UnconditionalSuppressMessageAttributeState.cs
+++ b/src/linker/Linker/UnconditionalSuppressMessageAttributeState.cs
@@ -228,7 +228,7 @@ namespace Mono.Linker
 
 				case "type":
 				case "member":
-					foreach (var result in DocumentationSignatureParser.GetMembersForDocumentationSignature (info.Target, module))
+					foreach (var result in DocumentationSignatureParser.GetMembersForDocumentationSignature (info.Target, module, _context))
 						yield return (info, result);
 
 					break;

--- a/src/linker/Linker/WarningSuppressionWriter.cs
+++ b/src/linker/Linker/WarningSuppressionWriter.cs
@@ -16,11 +16,13 @@ namespace Mono.Linker
 	{
 		private readonly Dictionary<AssemblyNameDefinition, HashSet<(int Code, IMemberDefinition Member)>> _warnings;
 		private readonly FileOutputKind _fileOutputKind;
+		readonly LinkContext _context;
 
-		public WarningSuppressionWriter (FileOutputKind fileOutputKind = FileOutputKind.CSharp)
+		public WarningSuppressionWriter (LinkContext context, FileOutputKind fileOutputKind = FileOutputKind.CSharp)
 		{
 			_warnings = new Dictionary<AssemblyNameDefinition, HashSet<(int, IMemberDefinition)>> ();
 			_fileOutputKind = fileOutputKind;
+			_context = context;
 		}
 
 		public bool IsEmpty => _warnings.Count == 0;
@@ -99,7 +101,7 @@ namespace Mono.Linker
 			List<(int Code, string MemberDocumentationSignature)> listOfWarnings = new List<(int Code, string MemberDocumentationSignature)> ();
 			StringBuilder sb = new StringBuilder ();
 			foreach (var warning in _warnings[assemblyName].ToList ()) {
-				DocumentationSignatureGenerator.VisitMember (warning.Member, sb);
+				DocumentationSignatureGenerator.VisitMember (warning.Member, sb, _context);
 				listOfWarnings.Add ((warning.Code, sb.ToString ()));
 				sb.Clear ();
 			}

--- a/src/linker/Linker/XmlDependencyRecorder.cs
+++ b/src/linker/Linker/XmlDependencyRecorder.cs
@@ -136,14 +136,14 @@ namespace Mono.Linker
 			return false;
 		}
 
-		static string TokenString (object o)
+		string TokenString (object o)
 		{
 			if (o == null)
 				return "N:null";
 
 			if (o is TypeReference t) {
 				bool addAssembly = true;
-				var td = t as TypeDefinition ?? t.Resolve ();
+				var td = context.TryResolve (t);
 
 				if (td != null) {
 					addAssembly = td.IsNotPublic || IsAssemblyBound (td);
@@ -185,7 +185,7 @@ namespace Mono.Linker
 				return WillAssemblyBeModified (m.DeclaringType.Module.Assembly);
 
 			if (o is TypeReference typeRef) {
-				var resolved = typeRef.Resolve ();
+				var resolved = context.TryResolve (typeRef);
 
 				// Err on the side of caution if we can't resolve
 				if (resolved == null)

--- a/src/linker/Mono.Linker.csproj
+++ b/src/linker/Mono.Linker.csproj
@@ -20,6 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AdditionalFiles Include="BannedSymbols.txt" />
     <Compile Remove="ref\**\*.cs" />
     <Compile Include="..\..\external\corert\**\*.cs" />
   </ItemGroup>
@@ -28,6 +29,13 @@
     <PackageReference Condition="'$(UseCecilPackage)' == 'true'" Include="Mono.Cecil" Version="$(MonoCecilVersion)" />
     <ProjectReference Condition="'$(UseCecilPackage)' != 'true'" Include="..\..\external\cecil\Mono.Cecil.csproj" />
     <ProjectReference Condition="'$(UseCecilPackage)' != 'true'" Include="..\..\external\cecil\symbols\pdb\Mono.Cecil.Pdb.csproj" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="$(MicrosoftCodeAnalysisBannedApiAnalyzersVersion)">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Mono.Linker.Tests/Tests/DocumentationSignatureParserTests.cs
+++ b/test/Mono.Linker.Tests/Tests/DocumentationSignatureParserTests.cs
@@ -3,12 +3,21 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Mono.Cecil;
+using Mono.Linker;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.TestCasesRunner;
 using NUnit.Framework;
 
 namespace Mono.Linker.Tests
 {
+	class TestResolver : ITryResolveMetadata
+	{
+		public static TestResolver Instance => new TestResolver ();
+
+		public MethodDefinition TryResolve (MethodReference methodReference) => methodReference.Resolve ();
+		public TypeDefinition TryResolve (TypeReference typeReference) => typeReference.Resolve ();
+	}
+
 	[TestFixture]
 	public class DocumentationSignatureParserTests
 	{
@@ -40,7 +49,7 @@ namespace Mono.Linker.Tests
 		{
 			var module = (member as TypeDefinition)?.Module ?? member.DeclaringType?.Module;
 			Assert.NotNull (module);
-			var parseResults = DocumentationSignatureParser.GetMembersForDocumentationSignature (input, module);
+			var parseResults = DocumentationSignatureParser.GetMembersForDocumentationSignature (input, module, TestResolver.Instance);
 			Assert.AreEqual (1, parseResults.Count ());
 			Assert.AreEqual (member, parseResults.First ());
 		}
@@ -48,7 +57,7 @@ namespace Mono.Linker.Tests
 		public static void CheckGeneratedString (IMemberDefinition member, string expected)
 		{
 			var builder = new StringBuilder ();
-			DocumentationSignatureGenerator.VisitMember (member, builder);
+			DocumentationSignatureGenerator.VisitMember (member, builder, TestResolver.Instance);
 			Assert.AreEqual (expected, builder.ToString ());
 		}
 
@@ -56,7 +65,7 @@ namespace Mono.Linker.Tests
 		{
 			var module = (member as TypeDefinition)?.Module ?? member.DeclaringType?.Module;
 			Assert.NotNull (module);
-			var parseResults = DocumentationSignatureParser.GetMembersForDocumentationSignature (input, module);
+			var parseResults = DocumentationSignatureParser.GetMembersForDocumentationSignature (input, module, TestResolver.Instance);
 			CollectionAssert.Contains (parseResults, member);
 		}
 
@@ -64,7 +73,7 @@ namespace Mono.Linker.Tests
 		{
 			var module = (member as TypeDefinition)?.Module ?? member.DeclaringType?.Module;
 			Assert.NotNull (module);
-			var parseResults = DocumentationSignatureParser.GetMembersForDocumentationSignature (input, module);
+			var parseResults = DocumentationSignatureParser.GetMembersForDocumentationSignature (input, module, TestResolver.Instance);
 			CollectionAssert.DoesNotContain (parseResults, member);
 		}
 


### PR DESCRIPTION
- Prevent usage of Cecil's Resolve
- Prevent usage of Cecil's ILProcessor

This adds an `ITryResolveMetadata` to let the test infrastructure use the `TryResolve` helpers without creating a `LinkContext`.