### PR TITLE
Remove hard coded case directory name

### DIFF
--- a/test/Mono.Linker.Tests/TestCases/TestCase.cs
+++ b/test/Mono.Linker.Tests/TestCases/TestCase.cs
@@ -9,6 +9,7 @@ namespace Mono.Linker.Tests.TestCases
 		public TestCase (NPath sourceFile, NPath rootCasesDirectory, NPath originalTestCaseAssemblyPath)
 		{
 			SourceFile = sourceFile;
+			RootCasesDirectory = rootCasesDirectory;
 			OriginalTestCaseAssemblyPath = originalTestCaseAssemblyPath;
 			Name = sourceFile.FileNameWithoutExtension;
 			DisplayName = $"{sourceFile.RelativeTo (rootCasesDirectory).Parent.ToString (SlashMode.Forward).Replace ('/', '.')}.{sourceFile.FileNameWithoutExtension}";
@@ -20,6 +21,8 @@ namespace Mono.Linker.Tests.TestCases
 			var firstParentRelativeToRoot = SourceFile.RelativeTo (rootCasesDirectory).Elements.First ();
 			TestSuiteDirectory = rootCasesDirectory.Combine (firstParentRelativeToRoot);
 		}
+
+		public NPath RootCasesDirectory { get; }
 
 		public string Name { get; }
 

--- a/test/Mono.Linker.Tests/TestCasesRunner/TestCaseSandbox.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestCaseSandbox.cs
@@ -42,16 +42,11 @@ namespace Mono.Linker.Tests.TestCasesRunner
 		{
 			_testCase = testCase;
 
-			_directory = rootTemporaryDirectory.Combine (string.IsNullOrEmpty (namePrefix) ? "linker_tests" : namePrefix);
+			var rootDirectory = rootTemporaryDirectory.Combine (string.IsNullOrEmpty (namePrefix) ? "linker_tests" : namePrefix);
 
-			const string tcases_name = "Mono.Linker.Tests.Cases";
-			var location = testCase.SourceFile.Parent.ToString ();
-			int idx = location.IndexOf (tcases_name + Path.DirectorySeparatorChar);
-			if (idx < 0)
-				throw new ArgumentException ("Unknown test cases location");
-
-			_directory = _directory.Combine (location.Substring (idx + tcases_name.Length + 1));
-			_directory = _directory.Combine (testCase.SourceFile.FileNameWithoutExtension);
+			var locationRelativeToRoot = testCase.SourceFile.Parent.RelativeTo (testCase.RootCasesDirectory);
+			var suiteDirectory = rootDirectory.Combine (locationRelativeToRoot);
+			_directory = suiteDirectory.Combine (testCase.SourceFile.FileNameWithoutExtension);
 
 			_directory.DeleteContents ();
 


### PR DESCRIPTION
This causes us problems with our test framework since our assembly containing additional test cases is called Unity.Linker.Tests.Cases.