### PR TITLE
Refactor PeVerifier

### DIFF
--- a/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -21,35 +21,27 @@ namespace Mono.Linker.Tests.TestCasesRunner
 		readonly BaseAssemblyResolver _linkedResolver;
 		readonly ReaderParameters _originalReaderParameters;
 		readonly ReaderParameters _linkedReaderParameters;
-#if !NETCOREAPP
 		readonly PeVerifier _peVerifier;
-#endif
 
 		public ResultChecker ()
 			: this (new TestCaseAssemblyResolver (), new TestCaseAssemblyResolver (),
-#if !NETCOREAPP
-					new PeVerifier (),
-#endif
-					new ReaderParameters {
-						SymbolReaderProvider = new DefaultSymbolReaderProvider (false)
-					},
-					new ReaderParameters {
-						SymbolReaderProvider = new DefaultSymbolReaderProvider (false)
-					})
+				new PeVerifier (),
+				new ReaderParameters {
+					SymbolReaderProvider = new DefaultSymbolReaderProvider (false)
+				},
+				new ReaderParameters {
+					SymbolReaderProvider = new DefaultSymbolReaderProvider (false)
+				})
 		{
 		}
 
 		public ResultChecker (BaseAssemblyResolver originalsResolver, BaseAssemblyResolver linkedResolver,
-#if !NETCOREAPP
 			PeVerifier peVerifier,
-#endif
 			ReaderParameters originalReaderParameters, ReaderParameters linkedReaderParameters)
 		{
 			_originalsResolver = originalsResolver;
 			_linkedResolver = linkedResolver;
-#if !NETCOREAPP
 			_peVerifier = peVerifier;
-#endif
 			_originalReaderParameters = originalReaderParameters;
 			_linkedReaderParameters = linkedReaderParameters;
 		}
@@ -206,10 +198,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 		protected virtual void InitialChecking (LinkedTestCaseResult linkResult, AssemblyDefinition original, AssemblyDefinition linked)
 		{
-#if !NETCOREAPP
-			// the PE Verifier does not know how to resolve .NET Core assemblies.
 			_peVerifier.Check (linkResult, original);
-#endif
 		}
 
 		void VerifyLinkingOfOtherAssemblies (AssemblyDefinition original)


### PR DESCRIPTION
We are migrating our unit test projects to run on net5.  However, we will continue to run our linker tests against a mono like profile (since that is what Unity is based on).

Eliminating PeVerifier entirely when building for net5 causes us problems.  We want to continue running it on the linker test executables.

This PR refactors how PeVerifier is made to do nothing when compiling with NETCOREAPP defined.  This approach lets the illink tests continue to operate as they do now.  While also giving us the ability to run our `Unity.Linker.Tests` project on net5, our test case assemblies compiled against a .NET Framework profile, and have our test framework continue to run PeVerifier