### PR TITLE
Don't drop suite name from test name.

### DIFF
--- a/test/Mono.Linker.Tests/TestCases/TestDatabase.cs
+++ b/test/Mono.Linker.Tests/TestCases/TestDatabase.cs
@@ -254,7 +254,7 @@ namespace Mono.Linker.Tests.TestCases
 		{
 			return AllCases ()
 				.Where (c => c.TestSuiteDirectory.FileName == suiteName)
-				.Select (c => CreateNUnitTestCase (c, c.DisplayName.Substring (suiteName.Length + 1)))
+				.Select (c => CreateNUnitTestCase (c, c.DisplayName))
 				.OrderBy (c => c.TestName);
 		}
 


### PR DESCRIPTION
This confuses IDE tests runners in different ways.

1) In Rider, if two folders contain a test with the same name, only 1 will ever run.  Rider silently drops the other and never runs it.

2) In Visual Studio 2022 Preview the tests a grouped oddly in the UI.  For example, tests under `Attributes.Csc.*` will appear as having their own top level grouping rather than nested under `Attributes`.  I did not test if VS suffered from (1) the above.  It may also.


This change is important for additional changes I have coming.  I'm trying to take the parallel test running changes into our fork's active branch and I'm hitting all sorts of path length problems.  I'm doing what I can to bring lengths down.  One of the things I will do is dropping the redundant file name prefix from files in `PreserveDependencies` and `DynamicDependencies`.  When I do this, some files between these two folders now have the same name.  This change is necessary to ensure that tests from both folders will run.