### PR TITLE
Skip peverify on CopyOfCoreLibrariesKeepsUnusedTypes

### DIFF
--- a/test/Mono.Linker.Tests.Cases/CoreLink/CopyOfCoreLibrariesKeepsUnusedTypes.cs
+++ b/test/Mono.Linker.Tests.Cases/CoreLink/CopyOfCoreLibrariesKeepsUnusedTypes.cs
@@ -13,8 +13,7 @@ namespace Mono.Linker.Tests.Cases.CoreLink
 	[KeptAssembly (PlatformAssemblies.CoreLib)]
 	[KeptAllTypesAndMembersInAssembly (PlatformAssemblies.CoreLib)]
 
-	// Can be removed once this bug is fixed https://bugzilla.xamarin.com/show_bug.cgi?id=58168
-	[SkipPeVerify (SkipPeVerifyForToolchian.Pedump)]
+	[SkipPeVerify]
 	class CopyOfCoreLibrariesKeepsUnusedTypes
 	{
 		public static void Main ()


### PR DESCRIPTION
We up dated our mono and new assemblies survive.  One of which is Mono.Security.  This test isn't really concerned with peverify so just disable it across the board