### PR TITLE
[release/6.0] Stop using git protocol for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cecil"]
 	path = external/cecil
-	url = git://github.com/mono/cecil.git
+	url = https://github.com/mono/cecil.git


### PR DESCRIPTION
GitHub is removing support for unencrypted git soon: https://github.blog/2021-09-01-improving-git-protocol-security-github/

Backport of #2248 