### PR TITLE
Tag analyzer diagnostics as non configurable

### DIFF
--- a/src/ILLink.RoslynAnalyzer/DiagnosticDescriptors.cs
+++ b/src/ILLink.RoslynAnalyzer/DiagnosticDescriptors.cs
@@ -18,7 +18,8 @@ namespace ILLink.RoslynAnalyzer
 				diagnosticString.GetMessageFormat (),
 				GetDiagnosticCategory (diagnosticId),
 				DiagnosticSeverity.Warning,
-				true);
+				true,
+				customTags: WellKnownDiagnosticTags.NotConfigurable);
 		}
 
 		public static DiagnosticDescriptor GetDiagnosticDescriptor (DiagnosticId diagnosticId, DiagnosticString diagnosticString)
@@ -27,7 +28,8 @@ namespace ILLink.RoslynAnalyzer
 				diagnosticString.GetMessage (),
 				GetDiagnosticCategory (diagnosticId),
 				DiagnosticSeverity.Warning,
-				true);
+				true,
+				customTags: WellKnownDiagnosticTags.NotConfigurable);
 
 		public static DiagnosticDescriptor GetDiagnosticDescriptor (DiagnosticId diagnosticId,
 			LocalizableResourceString? lrsTitle = null,
@@ -45,7 +47,8 @@ namespace ILLink.RoslynAnalyzer
 					diagnosticCategory ?? GetDiagnosticCategory (diagnosticId),
 					diagnosticSeverity,
 					isEnabledByDefault,
-					helpLinkUri);
+					helpLinkUri,
+					customTags: WellKnownDiagnosticTags.NotConfigurable);
 			}
 
 			return new DiagnosticDescriptor (diagnosticId.AsString (),
@@ -54,7 +57,8 @@ namespace ILLink.RoslynAnalyzer
 				diagnosticCategory ?? GetDiagnosticCategory (diagnosticId),
 				diagnosticSeverity,
 				isEnabledByDefault,
-				helpLinkUri);
+				helpLinkUri,
+				customTags: WellKnownDiagnosticTags.NotConfigurable);
 		}
 
 		static string GetDiagnosticCategory (DiagnosticId diagnosticId)


### PR DESCRIPTION
This PR tags the set of diagnostics produced by the trimmer analyzer as non configurable so that the option to generate a global suppression file is not shown to the user (since this would not work for these diagnostics, see #2251).