### PR TITLE
Nullable annotations part 1

### DIFF
--- a/src/linker/Linker.Dataflow/MethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/MethodBodyScanner.cs
@@ -791,7 +791,7 @@ namespace Mono.Linker.Dataflow
 
 			bool isByRef = code == Code.Ldflda || code == Code.Ldsflda;
 
-			FieldDefinition field = _context.TryResolve (operation.Operand as FieldReference);
+			FieldDefinition field = _context.TryResolve ((FieldReference) operation.Operand);
 			if (field != null) {
 				StackSlot slot = new StackSlot (GetFieldValue (thisMethod, field), isByRef);
 				currentStack.Push (slot);
@@ -819,7 +819,7 @@ namespace Mono.Linker.Dataflow
 			if (operation.OpCode.Code == Code.Stfld)
 				PopUnknown (currentStack, 1, methodBody, operation.Offset);
 
-			FieldDefinition field = _context.TryResolve (operation.Operand as FieldReference);
+			FieldDefinition field = _context.TryResolve ((FieldReference) operation.Operand);
 			if (field != null) {
 				HandleStoreField (thisMethod, field, operation, valueToStoreSlot.Value);
 			}

--- a/src/linker/Linker.Steps/BodySubstitutionParser.cs
+++ b/src/linker/Linker.Steps/BodySubstitutionParser.cs
@@ -46,7 +46,8 @@ namespace Mono.Linker.Steps
 			ProcessTypeChildren (type, nav);
 		}
 
-		protected override void ProcessMethod (TypeDefinition type, XPathNavigator methodNav, object? _customData) {
+		protected override void ProcessMethod (TypeDefinition type, XPathNavigator methodNav, object? _customData)
+		{
 			Debug.Assert (_substitutionInfo != null);
 			string signature = GetSignature (methodNav);
 			if (string.IsNullOrEmpty (signature))

--- a/src/linker/Linker.Steps/BodySubstitutionParser.cs
+++ b/src/linker/Linker.Steps/BodySubstitutionParser.cs
@@ -5,11 +5,13 @@ using System.Linq;
 using System.Xml.XPath;
 using Mono.Cecil;
 
+#nullable enable
+
 namespace Mono.Linker.Steps
 {
 	public class BodySubstitutionParser : ProcessLinkerXmlBase
 	{
-		SubstitutionInfo _substitutionInfo;
+		SubstitutionInfo? _substitutionInfo;
 
 		public BodySubstitutionParser (LinkContext context, Stream documentStream, string xmlDocumentLocation)
 			: base (context, documentStream, xmlDocumentLocation)
@@ -24,74 +26,48 @@ namespace Mono.Linker.Steps
 		public void Parse (SubstitutionInfo xmlInfo)
 		{
 			_substitutionInfo = xmlInfo;
-			bool stripSubstitutions = _context.IsOptimizationEnabled (CodeOptimizations.RemoveSubstitutions, _resourceAssembly);
+			bool stripSubstitutions = _context.IsOptimizationEnabled (CodeOptimizations.RemoveSubstitutions, _resource?.Assembly);
 			ProcessXml (stripSubstitutions, _context.IgnoreSubstitutions);
 		}
 
 		protected override void ProcessAssembly (AssemblyDefinition assembly, XPathNavigator nav, bool warnOnUnresolvedTypes)
 		{
 			ProcessTypes (assembly, nav, warnOnUnresolvedTypes);
-			ProcessResources (assembly, nav.SelectChildren ("resource", ""));
+			ProcessResources (assembly, nav);
 		}
 
-		protected override TypeDefinition ProcessExportedType (ExportedType exported, AssemblyDefinition assembly) => null;
+		protected override TypeDefinition? ProcessExportedType (ExportedType exported, AssemblyDefinition assembly) => null;
 
 		protected override bool ProcessTypePattern (string fullname, AssemblyDefinition assembly, XPathNavigator nav) => false;
 
 		protected override void ProcessType (TypeDefinition type, XPathNavigator nav)
 		{
 			Debug.Assert (ShouldProcessElement (nav));
-
-			if (!nav.HasChildren)
-				return;
-
-			XPathNodeIterator methods = nav.SelectChildren ("method", "");
-			if (methods.Count > 0)
-				ProcessMethods (type, methods);
-
-			var fields = nav.SelectChildren ("field", "");
-			if (fields.Count > 0) {
-				while (fields.MoveNext ()) {
-					if (!ShouldProcessElement (fields.Current))
-						continue;
-
-					ProcessField (type, fields);
-				}
-			}
+			ProcessTypeChildren (type, nav);
 		}
 
-		void ProcessMethods (TypeDefinition type, XPathNodeIterator iterator)
-		{
-			while (iterator.MoveNext ()) {
-				if (!ShouldProcessElement (iterator.Current))
-					continue;
-
-				ProcessMethod (type, iterator);
-			}
-		}
-
-		void ProcessMethod (TypeDefinition type, XPathNodeIterator iterator)
-		{
-			string signature = GetAttribute (iterator.Current, "signature");
+		protected override void ProcessMethod (TypeDefinition type, XPathNavigator methodNav, object? _customData) {
+			Debug.Assert (_substitutionInfo != null);
+			string signature = GetSignature (methodNav);
 			if (string.IsNullOrEmpty (signature))
 				return;
 
-			MethodDefinition method = FindMethod (type, signature);
+			MethodDefinition? method = FindMethod (type, signature);
 			if (method == null) {
-				LogWarning ($"Could not find method '{signature}' on type '{type.GetDisplayName ()}'.", 2009, iterator.Current);
+				LogWarning ($"Could not find method '{signature}' on type '{type.GetDisplayName ()}'.", 2009, methodNav);
 				return;
 			}
 
-			string action = GetAttribute (iterator.Current, "body");
+			string action = GetAttribute (methodNav, "body");
 			switch (action) {
 			case "remove":
 				_substitutionInfo.SetMethodAction (method, MethodAction.ConvertToThrow);
 				return;
 			case "stub":
-				string value = GetAttribute (iterator.Current, "value");
+				string value = GetAttribute (methodNav, "value");
 				if (!string.IsNullOrEmpty (value)) {
-					if (!TryConvertValue (value, method.ReturnType, out object res)) {
-						LogWarning ($"Invalid value for '{method.GetDisplayName ()}' stub.", 2010, iterator.Current);
+					if (!TryConvertValue (value, method.ReturnType, out object? res)) {
+						LogWarning ($"Invalid value for '{method.GetDisplayName ()}' stub.", 2010, methodNav);
 						return;
 					}
 
@@ -101,69 +77,68 @@ namespace Mono.Linker.Steps
 				_substitutionInfo.SetMethodAction (method, MethodAction.ConvertToStub);
 				return;
 			default:
-				LogWarning ($"Unknown body modification '{action}' for '{method.GetDisplayName ()}'.", 2011, iterator.Current);
+				LogWarning ($"Unknown body modification '{action}' for '{method.GetDisplayName ()}'.", 2011, methodNav);
 				return;
 			}
 		}
 
-		void ProcessField (TypeDefinition type, XPathNodeIterator iterator)
+		protected override void ProcessField (TypeDefinition type, XPathNavigator fieldNav)
 		{
-			string name = GetAttribute (iterator.Current, "name");
+			Debug.Assert (_substitutionInfo != null);
+			string name = GetAttribute (fieldNav, "name");
 			if (string.IsNullOrEmpty (name))
 				return;
 
 			var field = type.Fields.FirstOrDefault (f => f.Name == name);
 			if (field == null) {
-				LogWarning ($"Could not find field '{name}' on type '{type.GetDisplayName ()}'.", 2012, iterator.Current);
+				LogWarning ($"Could not find field '{name}' on type '{type.GetDisplayName ()}'.", 2012, fieldNav);
 				return;
 			}
 
 			if (!field.IsStatic || field.IsLiteral) {
-				LogWarning ($"Substituted field '{field.GetDisplayName ()}' needs to be static field.", 2013, iterator.Current);
+				LogWarning ($"Substituted field '{field.GetDisplayName ()}' needs to be static field.", 2013, fieldNav);
 				return;
 			}
 
-			string value = GetAttribute (iterator.Current, "value");
+			string value = GetAttribute (fieldNav, "value");
 			if (string.IsNullOrEmpty (value)) {
-				LogWarning ($"Missing 'value' attribute for field '{field.GetDisplayName ()}'.", 2014, iterator.Current);
+				LogWarning ($"Missing 'value' attribute for field '{field.GetDisplayName ()}'.", 2014, fieldNav);
 				return;
 			}
-			if (!TryConvertValue (value, field.FieldType, out object res)) {
-				LogWarning ($"Invalid value '{value}' for '{field.GetDisplayName ()}'.", 2015, iterator.Current);
+			if (!TryConvertValue (value, field.FieldType, out object? res)) {
+				LogWarning ($"Invalid value '{value}' for '{field.GetDisplayName ()}'.", 2015, fieldNav);
 				return;
 			}
 
 			_substitutionInfo.SetFieldValue (field, res);
 
-			string init = GetAttribute (iterator.Current, "initialize");
+			string init = GetAttribute (fieldNav, "initialize");
 			if (init?.ToLowerInvariant () == "true") {
 				_substitutionInfo.SetFieldInit (field);
 			}
 		}
 
-		void ProcessResources (AssemblyDefinition assembly, XPathNodeIterator iterator)
+		void ProcessResources (AssemblyDefinition assembly, XPathNavigator nav)
 		{
-			while (iterator.MoveNext ()) {
-				XPathNavigator nav = iterator.Current;
-
-				if (!ShouldProcessElement (nav))
+			foreach (XPathNavigator resourceNav in nav.SelectChildren ("resource", "")) {
+				if (!ShouldProcessElement (resourceNav))
 					continue;
 
-				string name = GetAttribute (nav, "name");
+				string name = GetAttribute (resourceNav, "name");
 				if (String.IsNullOrEmpty (name)) {
-					LogWarning ($"Missing 'name' attribute for resource.", 2038, iterator.Current);
+					LogWarning ($"Missing 'name' attribute for resource.", 2038, resourceNav);
 					continue;
 				}
 
-				string action = GetAttribute (nav, "action");
+				string action = GetAttribute (resourceNav, "action");
 				if (action != "remove") {
-					LogWarning ($"Invalid value '{action}' for attribute 'action' for resource '{name}'.", 2039, iterator.Current);
+					LogWarning ($"Invalid value '{action}' for attribute 'action' for resource '{name}'.", 2039, resourceNav);
 					continue;
 				}
 
 				EmbeddedResource resource = assembly.FindEmbeddedResource (name);
 				if (resource == null) {
-					LogWarning ($"Could not find embedded resource '{name}' to remove in assembly '{assembly.Name.Name}'.", 2040, iterator.Current);
+					LogWarning ($"Could not find embedded resource '{name}' to remove in assembly '{assembly.Name.Name}'.", 2040, resourceNav);
 					continue;
 				}
 
@@ -171,7 +146,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		static MethodDefinition FindMethod (TypeDefinition type, string signature)
+		static MethodDefinition? FindMethod (TypeDefinition type, string signature)
 		{
 			if (!type.HasMethods)
 				return null;

--- a/src/linker/Linker.Steps/CodeRewriterStep.cs
+++ b/src/linker/Linker.Steps/CodeRewriterStep.cs
@@ -229,6 +229,9 @@ namespace Mono.Linker.Steps
 				break;
 			}
 
+			if (rtype == null)
+				return null;
+
 			switch (rtype.MetadataType) {
 			case MetadataType.Boolean:
 				if (value is int bintValue && bintValue == 1)

--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -277,7 +277,7 @@ namespace Mono.Linker.Steps
 					return false;
 				}
 
-				var assembly = _context.GetLoadedAssembly (an.Name);
+				var assembly = _context.GetLoadedAssembly (an.Name!);
 				if (assembly == null)
 					return false;
 

--- a/src/linker/Linker.Steps/OutputStep.cs
+++ b/src/linker/Linker.Steps/OutputStep.cs
@@ -211,10 +211,7 @@ namespace Mono.Linker.Steps
 			if (Environment.OSVersion.Platform != PlatformID.Win32NT && assembly.MainModule.SymbolReader.GetType ().FullName == "Mono.Cecil.Pdb.NativePdbReader")
 				return parameters;
 
-			if (Context.SymbolWriterProvider != null)
-				parameters.SymbolWriterProvider = Context.SymbolWriterProvider;
-			else
-				parameters.WriteSymbols = true;
+			parameters.WriteSymbols = true;
 			return parameters;
 		}
 

--- a/src/linker/Linker.Steps/OutputWarningSuppressions.cs
+++ b/src/linker/Linker.Steps/OutputWarningSuppressions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
 using System.IO;
 
 namespace Mono.Linker.Steps

--- a/src/linker/Linker.Steps/OutputWarningSuppressions.cs
+++ b/src/linker/Linker.Steps/OutputWarningSuppressions.cs
@@ -16,9 +16,8 @@ namespace Mono.Linker.Steps
 
 		protected override void Process ()
 		{
-			Debug.Assert (Context.WarningSuppressionWriter != null);
 			CheckOutputDirectory ();
-			Context.WarningSuppressionWriter.OutputSuppressions (Context.OutputDirectory);
+			Context.WarningSuppressionWriter?.OutputSuppressions (Context.OutputDirectory);
 		}
 
 		void CheckOutputDirectory ()

--- a/src/linker/Linker.Steps/OutputWarningSuppressions.cs
+++ b/src/linker/Linker.Steps/OutputWarningSuppressions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.IO;
 
 namespace Mono.Linker.Steps
@@ -15,6 +16,7 @@ namespace Mono.Linker.Steps
 
 		protected override void Process ()
 		{
+			Debug.Assert (Context.WarningSuppressionWriter != null);
 			CheckOutputDirectory ();
 			Context.WarningSuppressionWriter.OutputSuppressions (Context.OutputDirectory);
 		}

--- a/src/linker/Linker.Steps/ProcessLinkerXmlBase.cs
+++ b/src/linker/Linker.Steps/ProcessLinkerXmlBase.cs
@@ -297,8 +297,7 @@ namespace Mono.Linker.Steps
 
 		void ProcessSelectedMethods (XPathNavigator nav, TypeDefinition type, object? customData)
 		{
-			foreach (XPathNavigator methodNav in nav.SelectChildren (MethodElementName, XmlNamespace))
-			{
+			foreach (XPathNavigator methodNav in nav.SelectChildren (MethodElementName, XmlNamespace)) {
 				if (!ShouldProcessElement (methodNav))
 					continue;
 				ProcessMethod (type, methodNav, customData);

--- a/src/linker/Linker.Steps/ProcessLinkerXmlBase.cs
+++ b/src/linker/Linker.Steps/ProcessLinkerXmlBase.cs
@@ -14,6 +14,8 @@ using System.Xml.Linq;
 using System.Xml.XPath;
 using Mono.Cecil;
 
+#nullable enable
+
 namespace Mono.Linker.Steps
 {
 	[Flags]
@@ -40,8 +42,7 @@ namespace Mono.Linker.Steps
 
 		protected readonly string _xmlDocumentLocation;
 		readonly XPathNavigator _document;
-		readonly EmbeddedResource _resource;
-		protected readonly AssemblyDefinition _resourceAssembly;
+		protected readonly (EmbeddedResource Resource, AssemblyDefinition Assembly)? _resource;
 		protected readonly LinkContext _context;
 
 		protected ProcessLinkerXmlBase (LinkContext context, Stream documentStream, string xmlDocumentLocation)
@@ -56,15 +57,17 @@ namespace Mono.Linker.Steps
 		protected ProcessLinkerXmlBase (LinkContext context, Stream documentStream, EmbeddedResource resource, AssemblyDefinition resourceAssembly, string xmlDocumentLocation)
 			: this (context, documentStream, xmlDocumentLocation)
 		{
-			_resource = resource ?? throw new ArgumentNullException (nameof (resource));
-			_resourceAssembly = resourceAssembly ?? throw new ArgumentNullException (nameof (resourceAssembly));
+			_resource = (
+				resource ?? throw new ArgumentNullException (nameof (resource)),
+				resourceAssembly ?? throw new ArgumentNullException (nameof (resourceAssembly))
+			);
 		}
 
 		protected virtual bool ShouldProcessElement (XPathNavigator nav) => FeatureSettings.ShouldProcessElement (nav, _context, _xmlDocumentLocation);
 
 		protected virtual void ProcessXml (bool stripResource, bool ignoreResource)
 		{
-			if (!AllowedAssemblySelector.HasFlag (AllowedAssemblies.AnyAssembly) && _resourceAssembly == null)
+			if (!AllowedAssemblySelector.HasFlag (AllowedAssemblies.AnyAssembly) && _resource == null)
 				throw new InvalidOperationException ("The containing assembly must be specified for XML which is restricted to modifying that assembly only.");
 
 			try {
@@ -76,7 +79,7 @@ namespace Mono.Linker.Steps
 
 				if (_resource != null) {
 					if (stripResource)
-						_context.Annotations.AddResourceToRemove (_resourceAssembly, _resource);
+						_context.Annotations.AddResourceToRemove (_resource.Value.Assembly, _resource.Value.Resource);
 					if (ignoreResource)
 						return;
 				}
@@ -87,17 +90,17 @@ namespace Mono.Linker.Steps
 				ProcessAssemblies (nav);
 
 				// For embedded XML, allow not specifying the assembly explicitly in XML.
-				if (_resourceAssembly != null)
-					ProcessAssembly (_resourceAssembly, nav, warnOnUnresolvedTypes: true);
+				if (_resource != null)
+					ProcessAssembly (_resource.Value.Assembly, nav, warnOnUnresolvedTypes: true);
 
 			} catch (Exception ex) when (!(ex is LinkerFatalErrorException)) {
 				throw new LinkerFatalErrorException (MessageContainer.CreateErrorMessage ($"Error processing '{_xmlDocumentLocation}'", 1013), ex);
 			}
 		}
 
-		protected virtual AllowedAssemblies AllowedAssemblySelector { get => _resourceAssembly != null ? AllowedAssemblies.ContainingAssembly : AllowedAssemblies.AnyAssembly; }
+		protected virtual AllowedAssemblies AllowedAssemblySelector { get => _resource != null ? AllowedAssemblies.ContainingAssembly : AllowedAssemblies.AnyAssembly; }
 
-		bool ShouldProcessAllAssemblies (XPathNavigator nav, [NotNullWhen (false)] out AssemblyNameReference assemblyName)
+		bool ShouldProcessAllAssemblies (XPathNavigator nav, [NotNullWhen (false)] out AssemblyNameReference? assemblyName)
 		{
 			assemblyName = null;
 			if (GetFullName (nav) == AllAssembliesFullName)
@@ -112,20 +115,21 @@ namespace Mono.Linker.Steps
 			foreach (XPathNavigator assemblyNav in nav.SelectChildren ("assembly", "")) {
 				// Errors for invalid assembly names should show up even if this element will be
 				// skipped due to feature conditions.
-				bool processAllAssemblies = ShouldProcessAllAssemblies (assemblyNav, out AssemblyNameReference name);
+				bool processAllAssemblies = ShouldProcessAllAssemblies (assemblyNav, out AssemblyNameReference? name);
 				if (processAllAssemblies && AllowedAssemblySelector != AllowedAssemblies.AllAssemblies) {
 					LogWarning ($"XML contains unsupported wildcard for assembly 'fullname' attribute.", 2100, assemblyNav);
 					continue;
 				}
 
-				AssemblyDefinition assemblyToProcess = null;
+				AssemblyDefinition? assemblyToProcess = null;
 				if (!AllowedAssemblySelector.HasFlag (AllowedAssemblies.AnyAssembly)) {
 					Debug.Assert (!processAllAssemblies);
-					if (_resourceAssembly.Name.Name != name.Name) {
-						LogWarning ($"Embedded XML in assembly '{_resourceAssembly.Name.Name}' contains assembly 'fullname' attribute for another assembly '{name}'.", 2101, assemblyNav);
+					Debug.Assert (_resource != null);
+					if (_resource.Value.Assembly.Name.Name != name!.Name) {
+						LogWarning ($"Embedded XML in assembly '{_resource.Value.Assembly.Name.Name}' contains assembly 'fullname' attribute for another assembly '{name}'.", 2101, assemblyNav);
 						continue;
 					}
-					assemblyToProcess = _resourceAssembly;
+					assemblyToProcess = _resource.Value.Assembly;
 				}
 
 				if (!ShouldProcessElement (assemblyNav))
@@ -136,10 +140,11 @@ namespace Mono.Linker.Steps
 					foreach (AssemblyDefinition assembly in _context.GetReferencedAssemblies ())
 						ProcessAssembly (assembly, assemblyNav, warnOnUnresolvedTypes: false);
 				} else {
-					AssemblyDefinition assembly = assemblyToProcess ?? _context.TryResolve (name);
+					Debug.Assert (!processAllAssemblies);
+					AssemblyDefinition assembly = assemblyToProcess ?? _context.TryResolve (name!);
 
 					if (assembly == null) {
-						LogWarning ($"Could not resolve assembly '{name.Name}'.", 2007, assemblyNav);
+						LogWarning ($"Could not resolve assembly '{name!.Name}'.", 2007, assemblyNav);
 						continue;
 					}
 
@@ -188,7 +193,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		protected virtual TypeDefinition ProcessExportedType (ExportedType exported, AssemblyDefinition assembly) => exported.Resolve ();
+		protected virtual TypeDefinition? ProcessExportedType (ExportedType exported, AssemblyDefinition assembly) => exported.Resolve ();
 
 		void MatchType (TypeDefinition type, Regex regex, XPathNavigator nav)
 		{
@@ -226,7 +231,7 @@ namespace Mono.Linker.Steps
 
 		protected abstract void ProcessType (TypeDefinition type, XPathNavigator nav);
 
-		protected void ProcessTypeChildren (TypeDefinition type, XPathNavigator nav, object customData = null)
+		protected void ProcessTypeChildren (TypeDefinition type, XPathNavigator nav, object? customData = null)
 		{
 			if (nav.HasChildren) {
 				ProcessSelectedFields (nav, type);
@@ -238,14 +243,10 @@ namespace Mono.Linker.Steps
 
 		void ProcessSelectedFields (XPathNavigator nav, TypeDefinition type)
 		{
-			XPathNodeIterator fields = nav.SelectChildren (FieldElementName, XmlNamespace);
-			if (fields.Count == 0)
-				return;
-
-			while (fields.MoveNext ()) {
-				if (!ShouldProcessElement (fields.Current))
+			foreach (XPathNavigator fieldNav in nav.SelectChildren (FieldElementName, XmlNamespace)) {
+				if (!ShouldProcessElement (fieldNav))
 					continue;
-				ProcessField (type, fields.Current);
+				ProcessField (type, fieldNav);
 			}
 		}
 
@@ -253,7 +254,7 @@ namespace Mono.Linker.Steps
 		{
 			string signature = GetSignature (nav);
 			if (!String.IsNullOrEmpty (signature)) {
-				FieldDefinition field = GetField (type, signature);
+				FieldDefinition? field = GetField (type, signature);
 				if (field == null) {
 					LogWarning ($"Could not find field '{signature}' on type '{type.GetDisplayName ()}'.", 2012, nav);
 					return;
@@ -262,7 +263,7 @@ namespace Mono.Linker.Steps
 				ProcessField (type, field, nav);
 			}
 
-			string name = GetAttribute (nav, NameAttributeName);
+			string name = GetName (nav);
 			if (!String.IsNullOrEmpty (name)) {
 				bool foundMatch = false;
 				if (type.HasFields) {
@@ -280,7 +281,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		protected static FieldDefinition GetField (TypeDefinition type, string signature)
+		protected static FieldDefinition? GetField (TypeDefinition type, string signature)
 		{
 			if (!type.HasFields)
 				return null;
@@ -294,24 +295,21 @@ namespace Mono.Linker.Steps
 
 		protected virtual void ProcessField (TypeDefinition type, FieldDefinition field, XPathNavigator nav) { }
 
-		void ProcessSelectedMethods (XPathNavigator nav, TypeDefinition type, object customData)
+		void ProcessSelectedMethods (XPathNavigator nav, TypeDefinition type, object? customData)
 		{
-			XPathNodeIterator methods = nav.SelectChildren (MethodElementName, XmlNamespace);
-			if (methods.Count == 0)
-				return;
-
-			while (methods.MoveNext ()) {
-				if (!ShouldProcessElement (methods.Current))
+			foreach (XPathNavigator methodNav in nav.SelectChildren (MethodElementName, XmlNamespace))
+			{
+				if (!ShouldProcessElement (methodNav))
 					continue;
-				ProcessMethod (type, methods.Current, customData);
+				ProcessMethod (type, methodNav, customData);
 			}
 		}
 
-		protected virtual void ProcessMethod (TypeDefinition type, XPathNavigator nav, object customData)
+		protected virtual void ProcessMethod (TypeDefinition type, XPathNavigator nav, object? customData)
 		{
 			string signature = GetSignature (nav);
 			if (!String.IsNullOrEmpty (signature)) {
-				MethodDefinition method = GetMethod (type, signature);
+				MethodDefinition? method = GetMethod (type, signature);
 				if (method == null) {
 					LogWarning ($"Could not find method '{signature}' on type '{type.GetDisplayName ()}'.", 2009, nav);
 					return;
@@ -338,28 +336,24 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		protected virtual MethodDefinition GetMethod (TypeDefinition type, string signature) => null;
+		protected virtual MethodDefinition? GetMethod (TypeDefinition type, string signature) => null;
 
-		protected virtual void ProcessMethod (TypeDefinition type, MethodDefinition method, XPathNavigator nav, object customData) { }
+		protected virtual void ProcessMethod (TypeDefinition type, MethodDefinition method, XPathNavigator nav, object? customData) { }
 
-		void ProcessSelectedEvents (XPathNavigator nav, TypeDefinition type, object customData)
+		void ProcessSelectedEvents (XPathNavigator nav, TypeDefinition type, object? customData)
 		{
-			XPathNodeIterator events = nav.SelectChildren (EventElementName, XmlNamespace);
-			if (events.Count == 0)
-				return;
-
-			while (events.MoveNext ()) {
-				if (!ShouldProcessElement (events.Current))
+			foreach (XPathNavigator eventNav in nav.SelectChildren (EventElementName, XmlNamespace)) {
+				if (!ShouldProcessElement (eventNav))
 					continue;
-				ProcessEvent (type, events.Current, customData);
+				ProcessEvent (type, eventNav, customData);
 			}
 		}
 
-		protected virtual void ProcessEvent (TypeDefinition type, XPathNavigator nav, object customData)
+		protected virtual void ProcessEvent (TypeDefinition type, XPathNavigator nav, object? customData)
 		{
 			string signature = GetSignature (nav);
 			if (!String.IsNullOrEmpty (signature)) {
-				EventDefinition @event = GetEvent (type, signature);
+				EventDefinition? @event = GetEvent (type, signature);
 				if (@event == null) {
 					LogWarning ($"Could not find event '{signature}' on type '{type.GetDisplayName ()}'.", 2016, nav);
 					return;
@@ -384,7 +378,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		protected static EventDefinition GetEvent (TypeDefinition type, string signature)
+		protected static EventDefinition? GetEvent (TypeDefinition type, string signature)
 		{
 			if (!type.HasEvents)
 				return null;
@@ -396,26 +390,22 @@ namespace Mono.Linker.Steps
 			return null;
 		}
 
-		protected virtual void ProcessEvent (TypeDefinition type, EventDefinition @event, XPathNavigator nav, object customData) { }
+		protected virtual void ProcessEvent (TypeDefinition type, EventDefinition @event, XPathNavigator nav, object? customData) { }
 
-		void ProcessSelectedProperties (XPathNavigator nav, TypeDefinition type, object customData)
+		void ProcessSelectedProperties (XPathNavigator nav, TypeDefinition type, object? customData)
 		{
-			XPathNodeIterator properties = nav.SelectChildren (PropertyElementName, XmlNamespace);
-			if (properties.Count == 0)
-				return;
-
-			while (properties.MoveNext ()) {
-				if (!ShouldProcessElement (properties.Current))
+			foreach (XPathNavigator propertyNav in nav.SelectChildren (PropertyElementName, XmlNamespace)) {
+				if (!ShouldProcessElement (propertyNav))
 					continue;
-				ProcessProperty (type, properties.Current, customData);
+				ProcessProperty (type, propertyNav, customData);
 			}
 		}
 
-		protected virtual void ProcessProperty (TypeDefinition type, XPathNavigator nav, object customData)
+		protected virtual void ProcessProperty (TypeDefinition type, XPathNavigator nav, object? customData)
 		{
 			string signature = GetSignature (nav);
 			if (!String.IsNullOrEmpty (signature)) {
-				PropertyDefinition property = GetProperty (type, signature);
+				PropertyDefinition? property = GetProperty (type, signature);
 				if (property == null) {
 					LogWarning ($"Could not find property '{signature}' on type '{type.GetDisplayName ()}'.", 2017, nav);
 					return;
@@ -440,7 +430,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		protected static PropertyDefinition GetProperty (TypeDefinition type, string signature)
+		protected static PropertyDefinition? GetProperty (TypeDefinition type, string signature)
 		{
 			if (!type.HasProperties)
 				return null;
@@ -452,7 +442,7 @@ namespace Mono.Linker.Steps
 			return null;
 		}
 
-		protected virtual void ProcessProperty (TypeDefinition type, PropertyDefinition property, XPathNavigator nav, object customData, bool fromSignature) { }
+		protected virtual void ProcessProperty (TypeDefinition type, PropertyDefinition property, XPathNavigator nav, object? customData, bool fromSignature) { }
 
 		protected virtual AssemblyNameReference GetAssemblyName (XPathNavigator nav)
 		{
@@ -492,7 +482,7 @@ namespace Mono.Linker.Steps
 
 		public override string ToString () => GetType ().Name + ": " + _xmlDocumentLocation;
 
-		public bool TryConvertValue (string value, TypeReference target, out object result)
+		public bool TryConvertValue (string value, TypeReference target, out object? result)
 		{
 			switch (target.MetadataType) {
 			case MetadataType.Boolean:

--- a/src/linker/Linker/Driver.cs
+++ b/src/linker/Linker/Driver.cs
@@ -1208,10 +1208,9 @@ namespace Mono.Linker
 
 		protected virtual LinkContext GetDefaultContext (Pipeline pipeline, ILogger logger)
 		{
-			return new LinkContext (pipeline, logger ?? new ConsoleLogger ()) {
+			return new LinkContext (pipeline, logger ?? new ConsoleLogger (), "output") {
 				TrimAction = AssemblyAction.Link,
 				DefaultAction = AssemblyAction.Link,
-				OutputDirectory = "output",
 			};
 		}
 

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -31,6 +31,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
@@ -488,7 +489,7 @@ namespace Mono.Linker
 			return _parameters.ContainsKey (key);
 		}
 
-		public bool TryGetCustomData (string key, out string? value)
+		public bool TryGetCustomData (string key, [NotNullWhen (true)] out string? value)
 		{
 			return _parameters.TryGetValue (key, out value);
 		}

--- a/src/linker/Linker/SubstitutionInfo.cs
+++ b/src/linker/Linker/SubstitutionInfo.cs
@@ -5,20 +5,22 @@
 using System.Collections.Generic;
 using Mono.Cecil;
 
+#nullable enable
+
 namespace Mono.Linker
 {
 	public class SubstitutionInfo
 	{
 		public Dictionary<MethodDefinition, MethodAction> MethodActions { get; }
-		public Dictionary<MethodDefinition, object> MethodStubValues { get; }
-		public Dictionary<FieldDefinition, object> FieldValues { get; }
+		public Dictionary<MethodDefinition, object?> MethodStubValues { get; }
+		public Dictionary<FieldDefinition, object?> FieldValues { get; }
 		public HashSet<FieldDefinition> FieldInit { get; }
 
 		public SubstitutionInfo ()
 		{
 			MethodActions = new Dictionary<MethodDefinition, MethodAction> ();
-			MethodStubValues = new Dictionary<MethodDefinition, object> ();
-			FieldValues = new Dictionary<FieldDefinition, object> ();
+			MethodStubValues = new Dictionary<MethodDefinition, object?> ();
+			FieldValues = new Dictionary<FieldDefinition, object?> ();
 			FieldInit = new HashSet<FieldDefinition> ();
 		}
 
@@ -27,12 +29,12 @@ namespace Mono.Linker
 			MethodActions[method] = action;
 		}
 
-		public void SetMethodStubValue (MethodDefinition method, object value)
+		public void SetMethodStubValue (MethodDefinition method, object? value)
 		{
 			MethodStubValues[method] = value;
 		}
 
-		public void SetFieldValue (FieldDefinition field, object value)
+		public void SetFieldValue (FieldDefinition field, object? value)
 		{
 			FieldValues[field] = value;
 		}

--- a/src/linker/Linker/TypeReferenceExtensions.cs
+++ b/src/linker/Linker/TypeReferenceExtensions.cs
@@ -180,6 +180,8 @@ namespace Mono.Linker
 					return genericParameter;
 
 				var elementType = resolver.TryResolve (genericInstanceProvider.ElementType);
+				if (elementType == null)
+					return null;
 				var parameter = elementType.GenericParameters.Single (p => p == genericParameter);
 				return genericInstanceProvider.GenericArguments[parameter.Position];
 			}

--- a/test/Mono.Linker.Tests/Tests/AnnotationStoreTest.cs
+++ b/test/Mono.Linker.Tests/Tests/AnnotationStoreTest.cs
@@ -10,7 +10,7 @@ namespace Mono.Linker.Tests.Tests
 		[SetUp]
 		public void Setup ()
 		{
-			var ctx = new LinkContext (null, new ConsoleLogger ());
+			var ctx = new LinkContext (null, new ConsoleLogger (), string.Empty);
 			store = new AnnotationStore (ctx);
 		}
 

--- a/test/Mono.Linker.Tests/Tests/MessageContainerTests.cs
+++ b/test/Mono.Linker.Tests/Tests/MessageContainerTests.cs
@@ -8,7 +8,7 @@ namespace Mono.Linker.Tests
 		[Test]
 		public void MSBuildFormat ()
 		{
-			LinkContext context = new LinkContext (new Pipeline (), new ConsoleLogger ());
+			LinkContext context = new LinkContext (new Pipeline (), new ConsoleLogger (), string.Empty);
 
 			var msg = MessageContainer.CreateCustomErrorMessage ("text", 6001);
 			Assert.AreEqual ("ILLink: error IL6001: text", msg.ToMSBuildString ());


### PR DESCRIPTION
Enable nullable annotations for LinkContext and the XML processing classes. I chose these as a starting point for no reason in particular, except that they produced a lot of warnings. Also includes other small fixes for things I noticed. In particular PTAL at the removed `ReportUnresolved` calls in `LinkContext.Resolve` - those looked like they were producing redundant warnings for cached `null` results.