### PR TITLE
Warn on RUC annotated ctors invoked through `new()` constraint in analyzer

### DIFF
--- a/src/ILLink.RoslynAnalyzer/ISymbolExtensions.cs
+++ b/src/ILLink.RoslynAnalyzer/ISymbolExtensions.cs
@@ -22,6 +22,19 @@ namespace ILLink.RoslynAnalyzer
 			return false;
 		}
 
+		internal static bool TryGetAttribute (this ISymbol member, string attributeName, [NotNullWhen (returnValue: true)] out AttributeData? attribute)
+		{
+			attribute = null;
+			foreach (var attr in member.GetAttributes ()) {
+				if (attr.AttributeClass is { } attrClass && attrClass.HasName (attributeName)) {
+					attribute = attr;
+					return true;
+				}
+			}
+
+			return false;
+		}
+
 		internal static bool TryGetOverriddenMember (this ISymbol? symbol, [NotNullWhen (returnValue: true)] out ISymbol? overridenMember)
 		{
 			overridenMember = symbol switch {

--- a/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using ILLink.Shared;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
 
@@ -26,6 +27,8 @@ namespace ILLink.RoslynAnalyzer
 		private protected abstract DiagnosticDescriptor RequiresAttributeMismatch { get; }
 
 		private protected virtual ImmutableArray<(Action<OperationAnalysisContext> Action, OperationKind[] OperationKind)> ExtraOperationActions { get; } = ImmutableArray<(Action<OperationAnalysisContext> Action, OperationKind[] OperationKind)>.Empty;
+
+		private protected virtual ImmutableArray<(Action<SyntaxNodeAnalysisContext> Action, SyntaxKind[] SyntaxKind)> ExtraSyntaxNodeActions { get; } = ImmutableArray<(Action<SyntaxNodeAnalysisContext> Action, SyntaxKind[] SyntaxKind)>.Empty;
 
 		public override void Initialize (AnalysisContext context)
 		{
@@ -118,6 +121,9 @@ namespace ILLink.RoslynAnalyzer
 				// Register any extra operation actions supported by the analyzer.
 				foreach (var extraOperationAction in ExtraOperationActions)
 					context.RegisterOperationAction (extraOperationAction.Action, extraOperationAction.OperationKind);
+
+				foreach (var extraSyntaxNodeAction in ExtraSyntaxNodeActions)
+					context.RegisterSyntaxNodeAction (extraSyntaxNodeAction.Action, extraSyntaxNodeAction.SyntaxKind);
 
 				void CheckStaticConstructors (OperationAnalysisContext operationContext,
 					ImmutableArray<IMethodSymbol> staticConstructors)

--- a/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
@@ -35,8 +35,8 @@ namespace ILLink.RoslynAnalyzer
 				var compilation = context.Compilation;
 				if (!IsAnalyzerEnabled (context.Options, compilation))
 					return;
-				var incompatibleMembers = GetSpecialIncompatibleMembers (compilation);
 
+				var incompatibleMembers = GetSpecialIncompatibleMembers (compilation);
 				context.RegisterSymbolAction (symbolAnalysisContext => {
 					var methodSymbol = (IMethodSymbol) symbolAnalysisContext.Symbol;
 					CheckMatchingAttributesInOverrides (symbolAnalysisContext, methodSymbol);

--- a/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
@@ -263,7 +263,7 @@ namespace ILLink.RoslynAnalyzer
 
 		protected abstract string GetMessageFromAttribute (AttributeData requiresAttribute);
 
-		private string GetUrlFromAttribute (AttributeData? requiresAttribute)
+		public static string GetUrlFromAttribute (AttributeData? requiresAttribute)
 		{
 			var url = requiresAttribute?.NamedArguments.FirstOrDefault (na => na.Key == "Url").Value.Value?.ToString ();
 			return MessageFormat.FormatRequiresAttributeUrlArg (url);

--- a/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
@@ -35,9 +35,10 @@ namespace ILLink.RoslynAnalyzer
 		};
 
 		[SuppressMessage ("MicrosoftCodeAnalysisPerformance", "RS1008",
-			Justification = "This action is registered through a compilation start action, so that the instances which " +
-			"can register this operation action will not outlive a compilation's lifetime, avoiding the possibility of " +
-			"this data causing stale compilations to remain in memory.")]
+			Justification = "Storing per-compilation data inside a diagnostic analyzer might cause stale compilations to remain alive." +
+				"This action is registered through a compilation start action, so that instances that register this syntax" +
+				" node action will not outlive a compilation's lifetime, avoiding the possibility of the locals stored in" +
+				" this function to cause for any stale compilations to remain in memory.")]
 		static readonly Action<SyntaxNodeAnalysisContext> s_constructorConstraint = syntaxNodeAnalysisContext => {
 			var model = syntaxNodeAnalysisContext.SemanticModel;
 			if (syntaxNodeAnalysisContext.ContainingSymbol is not ISymbol containingSymbol || containingSymbol.HasAttribute (RequiresUnreferencedCodeAttribute))

--- a/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
+++ b/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
@@ -62,8 +62,8 @@ namespace ILLink.RoslynAnalyzer
 			}
 
 			for (int i = 0; i < typeParams.Length; i++) {
-				var typeParam = typeParams [i];
-				var typeArg = typeArgs [i];
+				var typeParam = typeParams[i];
+				var typeArg = typeArgs[i];
 				if (!typeParam.HasConstructorConstraint)
 					continue;
 

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
@@ -81,6 +81,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			OnEventMethod.Test ();
 			AccessThroughNewConstraint.Test ();
 			AccessThroughNewConstraint.TestNewConstraintOnTypeParameter ();
+			AccessThroughNewConstraint.TestNewConstraintOnTypeParameterOfStaticType ();
 			AccessThroughLdToken.Test ();
 			RequiresOnClass.Test ();
 		}
@@ -785,6 +786,11 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				GenericMethod<NewConstraintTestType> ();
 			}
 
+			static class NewConstraintOnTypeParameterOfStaticType<T> where T : new()
+			{
+				public static void DoNothing () { }
+			}
+
 			class NewConstaintOnTypeParameter<T> where T : new()
 			{
 			}
@@ -793,6 +799,12 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			public static void TestNewConstraintOnTypeParameter ()
 			{
 				_ = new NewConstaintOnTypeParameter<NewConstraintTestType> ();
+			}
+
+			[ExpectedWarning ("IL2026", "--NewConstraintTestType.ctor--")]
+			public static void TestNewConstraintOnTypeParameterOfStaticType ()
+			{
+				NewConstraintOnTypeParameterOfStaticType<NewConstraintTestType>.DoNothing ();
 			}
 		}
 

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
@@ -80,6 +80,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			AccessThroughPInvoke.Test ();
 			OnEventMethod.Test ();
 			AccessThroughNewConstraint.Test ();
+			AccessThroughNewConstraint.TestNewConstraintOnTypeParameter ();
 			AccessThroughLdToken.Test ();
 			RequiresOnClass.Test ();
 		}
@@ -770,18 +771,28 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 		class AccessThroughNewConstraint
 		{
-			class NewConstrainTestType
+			class NewConstraintTestType
 			{
-				[RequiresUnreferencedCode ("Message for --NewConstrainTestType.ctor--")]
-				public NewConstrainTestType () { }
+				[RequiresUnreferencedCode ("Message for --NewConstraintTestType.ctor--")]
+				public NewConstraintTestType () { }
 			}
 
 			static void GenericMethod<T> () where T : new() { }
 
-			[ExpectedWarning ("IL2026", "--NewConstrainTestType.ctor--")]
+			[ExpectedWarning ("IL2026", "--NewConstraintTestType.ctor--")]
 			public static void Test ()
 			{
-				GenericMethod<NewConstrainTestType> ();
+				GenericMethod<NewConstraintTestType> ();
+			}
+
+			class NewConstaintOnTypeParameter<T> where T : new()
+			{
+			}
+
+			[ExpectedWarning ("IL2026", "--NewConstraintTestType.ctor--")]
+			public static void TestNewConstraintOnTypeParameter ()
+			{
+				_ = new NewConstaintOnTypeParameter<NewConstraintTestType> ();
 			}
 		}
 

--- a/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
+++ b/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresUnreferencedCodeCapability.cs
@@ -778,8 +778,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 			static void GenericMethod<T> () where T : new() { }
 
-			// https://github.com/mono/linker/issues/2117
-			[ExpectedWarning ("IL2026", "--NewConstrainTestType.ctor--", GlobalAnalysisOnly = true)]
+			[ExpectedWarning ("IL2026", "--NewConstrainTestType.ctor--")]
 			public static void Test ()
 			{
 				GenericMethod<NewConstrainTestType> ();


### PR DESCRIPTION
Fixes #2165.