### PR TITLE
[release/5.0] Stop using git protocol for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "cecil"]
 	path = external/cecil
-	url = git://github.com/mono/cecil.git
+	url = https://github.com/mono/cecil.git
 	branch = release/5.0


### PR DESCRIPTION
GitHub is removing support for unencrypted git soon: https://github.blog/2021-09-01-improving-git-protocol-security-github/

Backport of #2248