### PR TITLE
Revert "Tag analyzer diagnostics as non configurable"

### DIFF
--- a/src/ILLink.RoslynAnalyzer/DiagnosticDescriptors.cs
+++ b/src/ILLink.RoslynAnalyzer/DiagnosticDescriptors.cs
@@ -18,8 +18,7 @@ namespace ILLink.RoslynAnalyzer
 				diagnosticString.GetMessageFormat (),
 				GetDiagnosticCategory (diagnosticId),
 				DiagnosticSeverity.Warning,
-				true,
-				customTags: WellKnownDiagnosticTags.NotConfigurable);
+				true);
 		}
 
 		public static DiagnosticDescriptor GetDiagnosticDescriptor (DiagnosticId diagnosticId, DiagnosticString diagnosticString)
@@ -28,8 +27,7 @@ namespace ILLink.RoslynAnalyzer
 				diagnosticString.GetMessage (),
 				GetDiagnosticCategory (diagnosticId),
 				DiagnosticSeverity.Warning,
-				true,
-				customTags: WellKnownDiagnosticTags.NotConfigurable);
+				true);
 
 		public static DiagnosticDescriptor GetDiagnosticDescriptor (DiagnosticId diagnosticId,
 			LocalizableResourceString? lrsTitle = null,
@@ -47,8 +45,7 @@ namespace ILLink.RoslynAnalyzer
 					diagnosticCategory ?? GetDiagnosticCategory (diagnosticId),
 					diagnosticSeverity,
 					isEnabledByDefault,
-					helpLinkUri,
-					customTags: WellKnownDiagnosticTags.NotConfigurable);
+					helpLinkUri);
 			}
 
 			return new DiagnosticDescriptor (diagnosticId.AsString (),
@@ -57,8 +54,7 @@ namespace ILLink.RoslynAnalyzer
 				diagnosticCategory ?? GetDiagnosticCategory (diagnosticId),
 				diagnosticSeverity,
 				isEnabledByDefault,
-				helpLinkUri,
-				customTags: WellKnownDiagnosticTags.NotConfigurable);
+				helpLinkUri);
 		}
 
 		static string GetDiagnosticCategory (DiagnosticId diagnosticId)


### PR DESCRIPTION
Reverts mono/linker#2252. Unfortunately, this not only stops showing the "suppress this warning" message in the IDE, but will make `NoWarn` unusable on these diagnostics.