### PR TITLE
[release/6.0] Remove preview branding

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,8 +5,8 @@
     <MajorVersion>6</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>100</PatchVersion>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>6</PreReleaseVersionIteration>
+    <!-- Use an unchanging prerelease label so it doesn't need to be updated. -->
+    <PreReleaseVersionLabel>1</PreReleaseVersionLabel>
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
   </PropertyGroup>


### PR DESCRIPTION
As discussed, use an unchanging numerical prerelease label. This produces versions like `6.0.100-1.short_date.revision` for both the package and the AssemblyInformationalVersion. The package version isn't user-facing since it just flows into the SDK, but we wanted the informational version not to say "preview" or "rtm". This also prevents us from having to update the prerelease labels in the future (we have never been very consistent about it in the past).

The assembly versions should be unchanged (`6:0:100:0` for the linker, versions like `6:0:4:45308` for the MSBuild task and analyzers where the last two components are computed from the date).

I noticed that there's another way to remove prerelease labels - you can just not set one, which defines it to be a "release-only" package per Arcade. This produces package versions like `6.0.patch_number` where patch_number is computed from the date/revision - notice it doesn't include the `$(PatchVersion)`. I am not sure if it matters, but I went with the current approach so that we can use patch versions to differentiate between versions for servicing purposes.

Fixes https://github.com/mono/linker/issues/2157