### PR TITLE
Remove preview branding

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,8 +7,6 @@
     <PatchVersion>100</PatchVersion>
     <!-- Use an unchanging prerelease label so it doesn't need to be updated. -->
     <PreReleaseVersionLabel>1</PreReleaseVersionLabel>
-    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
-    <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
   </PropertyGroup>
   <PropertyGroup>
     <UsingToolMicrosoftNetCompilers>true</UsingToolMicrosoftNetCompilers>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,8 +5,8 @@
     <MajorVersion>7</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>100</PatchVersion>
-    <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
+    <!-- Use an unchanging prerelease label so it doesn't need to be updated. -->
+    <PreReleaseVersionLabel>1</PreReleaseVersionLabel>
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
   </PropertyGroup>


### PR DESCRIPTION
Like https://github.com/mono/linker/pull/2258, uses an unchanging numerical prerelease label.

I also removed the `DotNetFinalVersionKind` setting since I don't think we use it. (I left it as-is in the 6.0 branch just in case - there I wanted to avoid breaking things as much as possible).