### PR TITLE
Add a test for #2260

### DIFF
--- a/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NoKeptCtor/OverrideRemoval/Dependencies/OverrideOfAbstractIsKeptNonEmptyLibrary.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NoKeptCtor/OverrideRemoval/Dependencies/OverrideOfAbstractIsKeptNonEmptyLibrary.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.NoKeptCtor.OverrideRemoval.Dependencies
+{
+	public class OverrideOfAbstractIsKeptNonEmpty_UnusedType
+	{
+	}
+
+	public abstract class OverrideOfAbstractIsKeptNonEmpty_BaseType
+	{
+		public abstract void Method ();
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NoKeptCtor/OverrideRemoval/Dependencies/OverrideOfAbstractIsKeptNonEmptyLibraryWithNonEmpty.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NoKeptCtor/OverrideRemoval/Dependencies/OverrideOfAbstractIsKeptNonEmptyLibraryWithNonEmpty.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.NoKeptCtor.OverrideRemoval.Dependencies
+{
+	public class OverrideOfAbstractIsKeptNonEmptyLibraryWithNonEmpty :
+		OverrideOfAbstractIsKeptNonEmpty_BaseType
+	{
+		Dependencies.OverrideOfAbstractIsKeptNonEmpty_UnusedType _field;
+
+		public override void Method ()
+		{
+			_field = null;
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NoKeptCtor/OverrideRemoval/OverrideOfAbstractIsKeptNonEmpty.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NoKeptCtor/OverrideRemoval/OverrideOfAbstractIsKeptNonEmpty.cs
@@ -14,7 +14,10 @@ namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.NoKeptCtor.Overrid
 
 	[KeptAssembly ("library.dll")]
 	[KeptAssembly ("librarywithnonempty.dll")]
-	[RemovedTypeInAssembly("library.dll", typeof(Dependencies.OverrideOfAbstractIsKeptNonEmpty_UnusedType))]
+
+	// Uncomment after this bug is fixed
+	// https://github.com/mono/linker/issues/2260
+	//[RemovedTypeInAssembly ("library.dll", typeof (Dependencies.OverrideOfAbstractIsKeptNonEmpty_UnusedType))]
 
 	public class OverrideOfAbstractIsKeptNonEmpty
 	{
@@ -25,6 +28,10 @@ namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.NoKeptCtor.Overrid
 
 			Dependencies.OverrideOfAbstractIsKeptNonEmpty_BaseType c = HelperToMarkLibraryAndRequireItsBase ();
 			c.Method ();
+
+			// Remove after this bug is fixed
+			// https://github.com/mono/linker/issues/2260
+			new Dependencies.OverrideOfAbstractIsKeptNonEmpty_UnusedType ();
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NoKeptCtor/OverrideRemoval/OverrideOfAbstractIsKeptNonEmpty.cs
+++ b/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NoKeptCtor/OverrideRemoval/OverrideOfAbstractIsKeptNonEmpty.cs
@@ -4,16 +4,37 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.NoKeptCtor.OverrideRemoval
 {
 	[SetupLinkerArgument ("--enable-opt", "unreachablebodies")]
+
+	// The order is important - since the bug this uncovers depends on order of processing of assemblies in the sweep step
+	[SetupCompileBefore ("library.dll", new[] { "Dependencies/OverrideOfAbstractIsKeptNonEmptyLibrary.cs" })]
+	[SetupCompileBefore (
+		"librarywithnonempty.dll",
+		new[] { "Dependencies/OverrideOfAbstractIsKeptNonEmptyLibraryWithNonEmpty.cs" },
+		new[] { "library.dll" })]
+
+	[KeptAssembly ("library.dll")]
+	[KeptAssembly ("librarywithnonempty.dll")]
+	[RemovedTypeInAssembly("library.dll", typeof(Dependencies.OverrideOfAbstractIsKeptNonEmpty_UnusedType))]
+
 	public class OverrideOfAbstractIsKeptNonEmpty
 	{
 		public static void Main ()
 		{
 			Base b = HelperToMarkFooAndRequireBase ();
 			b.Method ();
+
+			Dependencies.OverrideOfAbstractIsKeptNonEmpty_BaseType c = HelperToMarkLibraryAndRequireItsBase ();
+			c.Method ();
 		}
 
 		[Kept]
 		static Foo HelperToMarkFooAndRequireBase ()
+		{
+			return null;
+		}
+
+		[Kept]
+		static Dependencies.OverrideOfAbstractIsKeptNonEmptyLibraryWithNonEmpty HelperToMarkLibraryAndRequireItsBase ()
 		{
 			return null;
 		}
@@ -41,11 +62,14 @@ namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.NoKeptCtor.Overrid
 		[KeptBaseType (typeof (Base3))]
 		class Foo : Base3
 		{
+			Dependencies.OverrideOfAbstractIsKeptNonEmpty_UnusedType _field;
+
 			[Kept]
 			[ExpectBodyModified]
 			public override void Method ()
 			{
 				Other ();
+				_field = null;
 			}
 
 			static void Other ()


### PR DESCRIPTION
This uncovers a null ref in sweepstep.
The test is order dependent:
- Assembly (librarywithnonemtpy) has a virtual method which referes to type from second library (library). This processes the type reference.
- The type is removed from library
- The virtual method is re-processed again -> hits a type def which does not belong to any assembly/scope

For this to happen the virtual method must be processed after the type has been removed.
This also requires the method to be meant for removal later on (the body will be rewritten to throw), since otherwise the type would have been marked.
This also requires the library with the removed type to be kept (so something else in it must be kept).