### PR TITLE
[release/6.0] Update edited document before continuing code fixing

### DIFF
--- a/src/ILLink.CodeFix/RequiresAssemblyFilesCodeFixProvider.cs
+++ b/src/ILLink.CodeFix/RequiresAssemblyFilesCodeFixProvider.cs
@@ -12,7 +12,6 @@ using ILLink.RoslynAnalyzer;
 using ILLink.Shared;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Editing;
 
 namespace ILLink.CodeFix
@@ -35,15 +34,13 @@ namespace ILLink.CodeFix
 
 		public sealed override Task RegisterCodeFixesAsync (CodeFixContext context) => BaseRegisterCodeFixesAsync (context);
 
-		protected override SyntaxNode[] GetAttributeArguments (SemanticModel semanticModel, SyntaxNode targetNode, CSharpSyntaxNode containingDecl, SyntaxGenerator generator, Diagnostic diagnostic)
+		protected override SyntaxNode[] GetAttributeArguments (ISymbol attributableSymbol, ISymbol targetSymbol, SyntaxGenerator syntaxGenerator, Diagnostic diagnostic)
 		{
-			var containingSymbol = semanticModel.GetDeclaredSymbol (containingDecl);
-			var name = semanticModel.GetSymbolInfo (targetNode).Symbol?.Name;
-			if (string.IsNullOrEmpty (name) || HasPublicAccessibility (containingSymbol!)) {
+			var symbolDisplayName = targetSymbol.GetDisplayName ();
+			if (string.IsNullOrEmpty (symbolDisplayName) || HasPublicAccessibility (attributableSymbol))
 				return Array.Empty<SyntaxNode> ();
-			} else {
-				return new[] { generator.AttributeArgument (generator.LiteralExpression ($"Calls {name}")) };
-			}
+
+			return new[] { syntaxGenerator.AttributeArgument (syntaxGenerator.LiteralExpression ($"Calls {symbolDisplayName}")) };
 		}
 	}
 }

--- a/src/ILLink.CodeFix/RequiresUnreferencedCodeCodeFixProvider.cs
+++ b/src/ILLink.CodeFix/RequiresUnreferencedCodeCodeFixProvider.cs
@@ -12,7 +12,6 @@ using ILLink.RoslynAnalyzer;
 using ILLink.Shared;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Editing;
 
 namespace ILLink.CodeFix
@@ -32,15 +31,13 @@ namespace ILLink.CodeFix
 
 		public sealed override Task RegisterCodeFixesAsync (CodeFixContext context) => BaseRegisterCodeFixesAsync (context);
 
-		protected override SyntaxNode[] GetAttributeArguments (SemanticModel semanticModel, SyntaxNode targetNode, CSharpSyntaxNode containingDecl, SyntaxGenerator generator, Diagnostic diagnostic)
+		protected override SyntaxNode[] GetAttributeArguments (ISymbol attributableSymbol, ISymbol targetSymbol, SyntaxGenerator syntaxGenerator, Diagnostic diagnostic)
 		{
-			var containingSymbol = semanticModel.GetDeclaredSymbol (containingDecl);
-			var name = semanticModel.GetSymbolInfo (targetNode).Symbol?.Name;
-			if (string.IsNullOrEmpty (name) || HasPublicAccessibility (containingSymbol!)) {
+			var symbolDisplayName = targetSymbol.GetDisplayName ();
+			if (string.IsNullOrEmpty (symbolDisplayName) || HasPublicAccessibility (attributableSymbol))
 				return Array.Empty<SyntaxNode> ();
-			} else {
-				return new[] { generator.AttributeArgument (generator.LiteralExpression ($"Calls {name}")) };
-			}
+
+			return new[] { syntaxGenerator.AttributeArgument (syntaxGenerator.LiteralExpression ($"Calls {symbolDisplayName}")) };
 		}
 	}
 }

--- a/test/ILLink.RoslynAnalyzer.Tests/RequiresAssemblyFilesAnalyzerTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/RequiresAssemblyFilesAnalyzerTests.cs
@@ -474,16 +474,16 @@ public class C
 {
     [RequiresAssemblyFiles(""message"")]
     public int M1() => 0;
-    [RequiresAssemblyFiles(""Calls M1"")]
+    [RequiresAssemblyFiles(""Calls C.M1()"")]
     int M2() => M1();
 }
 class D
 {
-    [RequiresAssemblyFiles(""Calls M1"")]
+    [RequiresAssemblyFiles(""Calls C.M1()"")]
     public int M3(C c) => c.M1();
     public class E
     {
-        [RequiresAssemblyFiles(""Calls M1"")]
+        [RequiresAssemblyFiles(""Calls C.M1()"")]
         public int M4(C c) => c.M1();
     }
 }
@@ -578,7 +578,7 @@ public class C
     [RequiresAssemblyFiles(""message"")]
     public int M1() => 0;
 
-    [RequiresAssemblyFiles(""Calls M1"")]
+    [RequiresAssemblyFiles(""Calls C.M1()"")]
     int M2 => M1();
 }";
 			return VerifyRequiresAssemblyFilesCodeFix (
@@ -663,10 +663,10 @@ public class C
     [RequiresAssemblyFiles(""message"")]
     public int M1() => 0;
 
-    [RequiresAssemblyFiles(""Calls Wrapper"")]
+    [RequiresAssemblyFiles(""Calls Wrapper()"")]
     Action M2()
     {
-        [global::System.Diagnostics.CodeAnalysis.RequiresAssemblyFilesAttribute(""Calls M1"")] void Wrapper () => M1();
+        [global::System.Diagnostics.CodeAnalysis.RequiresAssemblyFilesAttribute(""Calls C.M1()"")] void Wrapper () => M1();
         return Wrapper;
     }
 }";

--- a/test/ILLink.RoslynAnalyzer.Tests/RequiresUnreferencedCodeAnalyzerTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/RequiresUnreferencedCodeAnalyzerTests.cs
@@ -111,17 +111,17 @@ public class C
     [RequiresUnreferencedCodeAttribute(""message"")]
     public int M1() => 0;
 
-    [RequiresUnreferencedCode(""Calls M1"")]
+    [RequiresUnreferencedCode(""Calls C.M1()"")]
     int M2() => M1();
 }
 class D
 {
-    [RequiresUnreferencedCode(""Calls M1"")]
+    [RequiresUnreferencedCode(""Calls C.M1()"")]
     public int M3(C c) => c.M1();
 
     public class E
     {
-        [RequiresUnreferencedCode(""Calls M1"")]
+        [RequiresUnreferencedCode(""Calls C.M1()"")]
         public int M4(C c) => c.M1();
     }
 }
@@ -221,10 +221,10 @@ public class C
     [RequiresUnreferencedCodeAttribute(""message"")]
     public int M1() => 0;
 
-    [RequiresUnreferencedCode(""Calls Wrapper"")]
+    [RequiresUnreferencedCode(""Calls Wrapper()"")]
     Action M2()
     {
-        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute(""Calls M1"")] void Wrapper () => M1();
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute(""Calls C.M1()"")] void Wrapper () => M1();
         return Wrapper;
     }
 }";


### PR DESCRIPTION
Backport of #2250 

Applying code fixes suggested by our fixer was causing multiple applications of the same fix (see [here](https://github.com/dotnet/roslyn/issues/54602)). This was caused by a race condition due to sharing the same instance of a `SyntaxEditor` across multiple invocations (see [comment](https://github.com/mono/linker/pull/2250#issuecomment-912926483)).