### PR TITLE
Make ILCompiler more flexible.

### DIFF
--- a/test/Mono.Linker.Tests/TestCasesRunner/ILCompiler.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/ILCompiler.cs
@@ -12,18 +12,6 @@ namespace Mono.Linker.Tests.TestCasesRunner
 {
 	public class ILCompiler
 	{
-		private readonly string _ilasmExecutable;
-
-		public ILCompiler ()
-		{
-			_ilasmExecutable = LocateIlasm ().ToString ();
-		}
-
-		public ILCompiler (string ilasmExecutable)
-		{
-			_ilasmExecutable = ilasmExecutable;
-		}
-
 		public NPath Compile (CompilerOptions options)
 		{
 			var capturedOutput = new List<string> ();
@@ -44,7 +32,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 		protected virtual void SetupProcess (Process process, CompilerOptions options)
 		{
-			process.StartInfo.FileName = _ilasmExecutable;
+			process.StartInfo.FileName = LocateIlasm ().ToString ();
 			process.StartInfo.Arguments = BuildArguments (options);
 			process.StartInfo.UseShellExecute = false;
 			process.StartInfo.CreateNoWindow = true;
@@ -65,7 +53,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			return args.ToString ();
 		}
 
-		public static NPath LocateIlasm ()
+		protected virtual NPath LocateIlasm ()
 		{
 #if NETCOREAPP
 			var extension = RuntimeInformation.IsOSPlatform (OSPlatform.Windows) ? ".exe" : "";
@@ -89,6 +77,10 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				throw new InvalidOperationException ("This method should only be called on windows");
 
 			var possiblePath = RuntimeEnvironment.GetRuntimeDirectory ().ToNPath ().Combine ("ilasm.exe");
+			if (possiblePath.FileExists ())
+				return possiblePath;
+
+			possiblePath = Environment.CurrentDirectory.ToNPath ().Combine ("ilasm.exe");
 			if (possiblePath.FileExists ())
 				return possiblePath;
 


### PR DESCRIPTION
The ILCompiler class is giving me some grief.  These changes make it a little easier to deal with.

The first issue is that every test fails if ilasm cannot be located.  I think it would be better if only the tests that need ilasm fail when it cannot be found.  So instead of locating at construction time, locate ilasm when it is needed.

The next issue is that the `#if NETCOREAPP` logic for finding ilasm doesn't work when Mono.Linker.Tests is in our source tree, using our build process.  Currently, when we run the Mono.Linker.Tests in our source tree we are actually being routed down the `#else` path because our fork is fairly far behind and our version has `#if ILLINK` instead.  That causes us to call `LocateIlasmOnWindows` which doesn't find ilasm when targeting net5.  I think it's fairly harmless to check the current directory for ilasm.  This is one way I have managed to restore the ability to locate ilasm in our source tree.