### PR TITLE
Switch to ubuntu 20.04 agents

### DIFF
--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -105,7 +105,7 @@ stages:
         - job: Linux
           condition: eq(variables.officialBuild, 'false')
           pool:
-            name: Hosted Ubuntu 1604
+            vmImage: ubuntu-20.04
           steps:
           - checkout: self
             submodules: true
@@ -137,7 +137,7 @@ stages:
   - ${{ if eq(variables.officialBuild, 'false') }}:
     - job: Lint
       pool:
-          name: Hosted Ubuntu 1604
+        vmImage: ubuntu-20.04
       steps:
       - checkout: self
         submodules: true


### PR DESCRIPTION
The Ubuntu 16.04 agents were removed from Azure DevOps: https://github.com/actions/virtual-environments/issues/3287