### PR TITLE
[DAM analyzer] Track null values

### DIFF
--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
@@ -81,6 +81,11 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 			return TopValue;
 		}
 
+		public override MultiValue VisitLiteral (ILiteralOperation literalOperation, StateValue state)
+		{
+			return literalOperation.ConstantValue.Value == null ? NullValue.Instance : TopValue;
+		}
+
 		// Override handlers for situations where annotated locations may be involved in reflection access:
 		// - assignments
 		// - method calls

--- a/src/linker/Linker.Dataflow/MethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/MethodBodyScanner.cs
@@ -904,7 +904,7 @@ namespace Mono.Linker.Dataflow
 			if (!handledFunction) {
 				if (isNewObj) {
 					if (newObjValue == null)
-						PushUnknown (currentStack);
+						methodReturnValue = new MultiValue (UnknownValue.Instance);
 					else
 						methodReturnValue = newObjValue;
 				} else {
@@ -914,7 +914,7 @@ namespace Mono.Linker.Dataflow
 				}
 			}
 
-			if (!methodReturnValue.IsEmpty ())
+			if (isNewObj || GetReturnTypeWithoutModifiers (calledMethod.ReturnType).MetadataType != MetadataType.Void)
 				currentStack.Push (new StackSlot (methodReturnValue, calledMethod.ReturnType.IsByRefOrPointer ()));
 
 			foreach (var param in methodParams) {

--- a/test/Mono.Linker.Tests.Cases/DataFlow/AssemblyQualifiedNameDataflow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/AssemblyQualifiedNameDataflow.cs
@@ -63,8 +63,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			RequirePublicConstructors ("System.Invalid.TypeName");
 		}
 
-		// https://github.com/dotnet/linker/issues/2528
-		[ExpectedWarning ("IL2072", nameof (RequirePublicConstructors), ProducedBy = ProducedBy.Analyzer)]
 		static void TestNull ()
 		{
 			Type type = null;

--- a/test/Mono.Linker.Tests.Cases/DataFlow/TypeHandleDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/TypeHandleDataFlow.cs
@@ -64,8 +64,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			Type.GetTypeFromHandle (typeWithMethods.TypeHandle).RequiresPublicMethods ();
 		}
 
-		// https://github.com/dotnet/linker/issues/2528
-		[ExpectedWarning ("IL2072", nameof (Type.GetTypeFromHandle), nameof (DataFlowTypeExtensions.RequiresPublicMethods), ProducedBy = ProducedBy.Analyzer)]
 		static void TestNull ()
 		{
 			Type type = null;

--- a/test/Mono.Linker.Tests.Cases/Reflection/RunClassConstructorUsedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/Reflection/RunClassConstructorUsedViaReflection.cs
@@ -33,8 +33,6 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		}
 
 		[Kept]
-		// https://github.com/dotnet/linker/issues/2528
-		[ExpectedWarning ("IL2059", nameof (RuntimeHelpers) + "." + nameof (RuntimeHelpers.RunClassConstructor), ProducedBy = ProducedBy.Analyzer)]
 		static void TestNull ()
 		{
 			Type type = null;


### PR DESCRIPTION
This tracks null values and adjusts the handling of null values in a
few intrinsics which either take structs that can never be null, or
don't return when the input is null.

MethodBodyScanner needed a small adjustment to correctly deal with the
case where an intrinsic returns TopValue.

Fixes https://github.com/dotnet/linker/issues/2528