### PR TITLE
Don't depend on marking order in DAM type hierarchy

### DIFF
--- a/src/linker/Linker.Dataflow/DynamicallyAccessedMembersTypeHierarchy.cs
+++ b/src/linker/Linker.Dataflow/DynamicallyAccessedMembersTypeHierarchy.cs
@@ -47,14 +47,13 @@ namespace Mono.Linker.Dataflow
 
 		public (DynamicallyAccessedMemberTypes annotation, bool applied) ProcessMarkedTypeForDynamicallyAccessedMembersHierarchy (TypeDefinition type)
 		{
+			// We'll use the cache also as a way to detect and avoid recursion for interfaces and annotated base types
 			if (_typesInDynamicallyAccessedMembersHierarchy.TryGetValue (type, out var existingValue))
 				return existingValue;
 
 			DynamicallyAccessedMemberTypes annotation = _context.Annotations.FlowAnnotations.GetTypeAnnotation (type);
 			bool apply = false;
 
-			// We'll use the cache also as a way to detect and avoid recursion
-			// There's no possiblity to have recursion among base types, so only do this for interfaces
 			if (type.IsInterface)
 				_typesInDynamicallyAccessedMembersHierarchy.Add (type, (annotation, false));
 


### PR DESCRIPTION
This will allow `ApplyDynamicallyAccessedMembersToTypeHierarchy` to be called from the scanner when it sees `object.GetType` to get annotations on the type, without requiring that the type has been marked yet. (It will be marked during the final pass after the flow analysis has converged.)