### PR TITLE
Fix package props for older SDKs

### DIFF
--- a/src/ILLink.Tasks/build/Microsoft.NET.ILLink.Tasks.props
+++ b/src/ILLink.Tasks/build/Microsoft.NET.ILLink.Tasks.props
@@ -15,6 +15,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- N.B. The ILLinkTargetsPath is used as a sentinel to indicate a version of this file has already been imported. It will also be the path
          used to import the targets later in the SDK. -->
     <ILLinkTargetsPath>$(MSBuildThisFileDirectory)Microsoft.NET.ILLink.targets</ILLinkTargetsPath>
+    <!-- Older SDKs used this property as a sentinel instead, to control the import of this file 
+         (but not the targets, which were included with the SDK). -->
+    <UsingILLinkTasksSdk>true</UsingILLinkTasksSdk>
     <ILLinkTasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\net6.0\ILLink.Tasks.dll</ILLinkTasksAssembly>
     <ILLinkTasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\ILLink.Tasks.dll</ILLinkTasksAssembly>
   </PropertyGroup>


### PR DESCRIPTION
This should keep the existing package override logic working, since
the current SDK will only import the in-box ILLink.Tasks.props if
this is not already set.

We could probably remove this once runtime is updated to use an SDK
with https://github.com/dotnet/sdk/pull/25993. Or, we might want to
keep it as long as any SDKs using the old override logic are still in support.
This would let them reference newer ILLink.Tasks packages as long as
the task surface doesn't contain breaking changes (like new required parameters).