### PR TITLE
Fix assignment to captured invalid operation

### DIFF
--- a/src/ILLink.RoslynAnalyzer/DataFlow/CapturedReferenceValue.cs
+++ b/src/ILLink.RoslynAnalyzer/DataFlow/CapturedReferenceValue.cs
@@ -25,6 +25,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 			case OperationKind.InstanceReference:
 			case OperationKind.Invocation:
 			case OperationKind.EventReference:
+			case OperationKind.Invalid:
 				// These will just be ignored when referenced later.
 				break;
 			default:

--- a/test/ILLink.RoslynAnalyzer.Tests/DynamicallyAccessedMembersAnalyzerTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/DynamicallyAccessedMembersAnalyzerTests.cs
@@ -1206,5 +1206,119 @@ class C
 
 			return VerifyDynamicallyAccessedMembersAnalyzer (TargetMethodWithAnnotations);
 		}
+
+		[Fact]
+		public Task MethodArgumentIsInvalidOperation ()
+		{
+			var Source = """
+			using System;
+			using System.Diagnostics.CodeAnalysis;
+
+			class C
+			{
+				public static void Main()
+				{
+					RequireAll(type);
+				}
+
+				static void RequireAll([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type t) {}
+			}
+			""";
+
+			return VerifyDynamicallyAccessedMembersAnalyzer (Source,
+				DiagnosticResult.CompilerError ("CS0103").WithSpan (8, 14, 8, 18).WithArguments ("type"));
+		}
+
+		[Fact]
+		public Task MethodReturnIsInvalidOperation ()
+		{
+			var Source = """
+			using System;
+			using System.Diagnostics.CodeAnalysis;
+
+			class C
+			{
+				public static void Main()
+				{
+					GetTypeWithAll ();
+				}
+				
+				[return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+				static Type GetTypeWithAll() => type;
+			}
+			""";
+
+			return VerifyDynamicallyAccessedMembersAnalyzer (Source,
+				DiagnosticResult.CompilerError ("CS0103").WithSpan (12, 34, 12, 38).WithArguments ("type"));
+		}
+
+		[Fact]
+		public Task AssignmentSourceIsInvalidOperation ()
+		{
+			var Source = """
+			using System;
+			using System.Diagnostics.CodeAnalysis;
+
+			class C
+			{
+				public static void Main()
+				{
+					fieldRequiresAll = type;
+				}
+				
+				[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+				static Type fieldRequiresAll;
+			}
+			""";
+
+			return VerifyDynamicallyAccessedMembersAnalyzer (Source,
+				DiagnosticResult.CompilerError ("CS0103").WithSpan (8, 22, 8, 26).WithArguments ("type"));
+		}
+
+		[Fact]
+		public Task AssignmentTargetIsInvalidOperation ()
+		{
+			var Source = """
+			using System;
+			using System.Diagnostics.CodeAnalysis;
+
+			class C
+			{
+				public static void Main()
+				{
+					type = GetTypeWithAll();
+				}
+				
+				[return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+				static Type GetTypeWithAll() => null;
+			}
+			""";
+
+			return VerifyDynamicallyAccessedMembersAnalyzer (Source,
+				DiagnosticResult.CompilerError ("CS0103").WithSpan (8, 3, 8, 7).WithArguments ("type"));
+		}
+
+		[Fact]
+		public Task AssignmentTargetIsCapturedInvalidOperation ()
+		{
+			var Source = """
+			using System;
+			using System.Diagnostics.CodeAnalysis;
+
+			class C
+			{
+				public static void Main()
+				{
+					type ??= GetTypeWithAll();
+				}
+				
+				[return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+				static Type GetTypeWithAll() => null;
+			}
+			""";
+
+			return VerifyDynamicallyAccessedMembersAnalyzer (Source,
+				DiagnosticResult.CompilerError ("CS0103").WithSpan (8, 3, 8, 7).WithArguments ("type"));
+		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/linker/issues/2847

I added a few basic tests for sources that have invalid syntax (to generate IInvalidOperation). Only the `AssignmentTargetIsCapturedInvalidOperation` testcase was actually hitting the failure in `CapturedReferenceValue` but I think it's good to have a little more coverage.