### PR TITLE
Fix re-entrancy when marking nested functions

### DIFF
--- a/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/linker/Linker.Steps/MarkStep.cs
@@ -3467,6 +3467,16 @@ namespace Mono.Linker.Steps
 		// to avoid recursion.
 		bool MarkAndCheckRequiresReflectionMethodBodyScanner (MethodBody body)
 		{
+#if DEBUG
+			if (!Annotations.IsProcessed (body.Method)) {
+				Debug.Assert (CompilerGeneratedState.IsNestedFunctionOrStateMachineMember (body.Method));
+				MethodDefinition owningMethod = body.Method;
+				while (Context.CompilerGeneratedState.TryGetOwningMethodForCompilerGeneratedMember (owningMethod, out var owner))
+					owningMethod = owner;
+				Debug.Assert (owningMethod != body.Method);
+				Debug.Assert (Annotations.IsProcessed (owningMethod));
+			}
+#endif
 			// This may get called multiple times for compiler-generated code: once for
 			// reflection access, and once as part of the interprocedural scan of the user method.
 			// This check ensures that we only do the work and produce warnings once.
@@ -3493,6 +3503,7 @@ namespace Mono.Linker.Steps
 
 			PostMarkMethodBody (body);
 
+			Debug.Assert (requiresReflectionMethodBodyScanner == CheckRequiresReflectionMethodBodyScanner (body));
 			return requiresReflectionMethodBodyScanner;
 		}
 

--- a/test/Mono.Linker.Tests.Cases/DataFlow/CompilerGeneratedCodeAccessedViaReflection.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/CompilerGeneratedCodeAccessedViaReflection.cs
@@ -527,7 +527,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		{
 			static void RequiresAllOnT<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] T> () { }
 
-			static void RequiresNonPublicMethodsMethodsOnT<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicMethods)] T> () { }
+			static void RequiresNonPublicMethodsOnT<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicMethods)] T> () { }
 
 			class LambdaWhichMarksItself
 			{
@@ -603,7 +603,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 					ProducedBy = ProducedBy.Trimmer)]
 				public static void Test ()
 				{
-					RequiresNonPublicMethodsMethodsOnT<ClassWithLocalFunction> ();
+					RequiresNonPublicMethodsOnT<ClassWithLocalFunction> ();
 				}
 
 				public class ClassWithLocalFunction
@@ -614,7 +614,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 							ProducedBy = ProducedBy.Trimmer)]
 						static void LocalFunction ()
 						{
-							RequiresNonPublicMethodsMethodsOnT<ClassWithLocalFunction> ();
+							RequiresNonPublicMethodsOnT<ClassWithLocalFunction> ();
 						};
 
 						LocalFunction ();


### PR DESCRIPTION
Fixes https://github.com/dotnet/linker/issues/2903

I tried to actually fix the re-entrancy instead of putting a temporary value in the cache, because this will make it easier to fix the behavior of `CheckRequiresReflectionMethodBodyScanner` to not consider type parameter annotations.