### PR TITLE
Update MSBuild version to fix official build

### DIFF
--- a/global.json
+++ b/global.json
@@ -5,7 +5,8 @@
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "7.0.100-preview.7.22377.5"
+    "dotnet": "7.0.100-preview.7.22377.5",
+    "xcopy-msbuild": "17.2.1"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "7.0.0-beta.22379.10",


### PR DESCRIPTION
I think this will fix the official build - see https://github.com/dotnet/arcade/issues/10280 for context.