### PR TITLE
Use preview 5 framework version in runtimeconfig

### DIFF
--- a/src/linker/Mono.Linker.csproj
+++ b/src/linker/Mono.Linker.csproj
@@ -3,6 +3,11 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <ServerGarbageCollection>true</ServerGarbageCollection>
+    <!-- Pick a RuntimeFrameworkVersion at least as low as the DefaultRuntimeFrameworkVersion
+         of the SDK used by dotnet/runtime and dotnet/sdk, to ensure that the runtimeconfig.json
+         specifies a version available in those repos. This can be removed once they catch up to
+         the SDK version in our global.json. -->
+    <RuntimeFrameworkVersion>7.0.0-preview.5.22301.12</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
I am hoping this will help unblock dependency flow into runtime and SDK, which is failing with errors like the below. As a result of targeting .NET 7 in https://github.com/dotnet/linker/pull/2919, and updating to a preview 7 SDK in https://github.com/dotnet/linker/pull/2884, we are currently depending on a runtime version larger than what's available in runtime:

```xml
  Framework: 'Microsoft.NETCore.App', version '7.0.0-preview.7.22375.6' (x64)
  .NET location: /__w/1/s/.dotnet/
  
  The following frameworks were found:
    7.0.0-preview.5.22301.12 at [/__w/1/s/.dotnet/shared/Microsoft.NETCore.App]
  
  Learn about framework resolution:
  https://aka.ms/dotnet/app-launch-failed
  
  To install missing framework, download:
  https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=7.0.0-preview.7.22375.6&arch=x64&rid=debian.11-x64
/__w/1/s/eng/illink.targets(300,5): error MSB6006: "dotnet" exited with code 150. [/__w/1/s/src/coreclr/System.Private.CoreLib/System.Private.CoreLib.csproj]
```

This was tricky to test locally because MSBuild was giving very inconsistent results when I changed the RuntimeFrameworkVersion, I think because of https://github.com/dotnet/sdk/blob/b4220abd68bc1ad638936c754b46d024064ca93b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs#L73-L77. But this should fix the issue to the best of my knowledge.