### PR TITLE
Pin compiler version to fix build

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,6 +7,7 @@
     <PatchVersion>100</PatchVersion>
     <!-- Use an unchanging prerelease label so it doesn't need to be updated. -->
     <PreReleaseVersionLabel>1</PreReleaseVersionLabel>
+    <UsingToolMicrosoftNetCompilers>true</UsingToolMicrosoftNetCompilers>
   </PropertyGroup>
   <PropertyGroup>
     <!-- ilasm -->
@@ -21,6 +22,7 @@
     <MicrosoftDotNetCodeAnalysisVersion>6.0.0-beta.21271.1</MicrosoftDotNetCodeAnalysisVersion>
     <MicrosoftCodeAnalysisCSharpCodeStyleVersion>3.10.0-2.final</MicrosoftCodeAnalysisCSharpCodeStyleVersion>
     <MicrosoftCodeAnalysisVersion>4.4.0-2.22379.3</MicrosoftCodeAnalysisVersion>
+    <MicrosoftNetCompilersToolsetVersion>$(MicrosoftCodeAnalysisVersion)</MicrosoftNetCompilersToolsetVersion>
     <MicrosoftCodeAnalysisCSharpAnalyzerTestingXunitVersion>1.0.1-beta1.*</MicrosoftCodeAnalysisCSharpAnalyzerTestingXunitVersion>
     <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>3.3.2</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>
     <!-- This controls the version of the cecil package, or the version of cecil in the project graph


### PR DESCRIPTION
https://github.com/dotnet/linker/pull/2954 and https://github.com/dotnet/linker/pull/2952 together broke the build because we are referencing a version of the compiler package greater than that used to compile the project. This uses the same version for both.