### PR TITLE
Warn on TrimMode=copyused

### DIFF
--- a/src/ILLink.Tasks/build/Microsoft.NET.ILLink.targets
+++ b/src/ILLink.Tasks/build/Microsoft.NET.ILLink.targets
@@ -230,6 +230,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <!-- Set TrimmerDefaultAction for compat in < 7.0 -->
       <_TrimmerDefaultAction Condition="$([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '7.0'))">$(TrimmerDefaultAction)</_TrimmerDefaultAction>
       <_TrimmerDefaultAction Condition="'$(_TrimmerDefaultAction)' == '' And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '6.0'))">$(TrimMode)</_TrimmerDefaultAction>
+      <_TrimmerDefaultAction Condition="'$(_TrimmerDefaultAction)' == '' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '6.0'))">copy</_TrimmerDefaultAction>
     </PropertyGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/linker/issues/3039

Warns if using deprecated `TrimMode=copyused` in net7.0. Also sets the default action to `copy` as a fallback when not using `TrimMode` `full` or `partial` in 7.0.