### PR TITLE
Use new build images

### DIFF
--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -56,7 +56,7 @@ stages:
             vmImage: windows-latest
           ${{ if eq(variables.officialBuild, 'true') }}:
             name: NetCore1ESPool-Internal
-            demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
+            demands: ImageOverride -equals 1es-windows-2019
         variables:
           - ${{ if eq(variables.officialBuild, 'false') }}:
             - _SignType: test


### PR DESCRIPTION
Following eng guidance at https://github.com/dotnet/arcade/blob/0213f8ad31ac8c63ad41760f02a929998abf69bb/Documentation/NativeToolsOnMachine.md. The windows images we are using for official builds are going away. We aren't using native tool bootstrapping, so I picked the 1es image.