### PR TITLE
[release/6.0.x] Use new build images

### DIFF
--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -56,7 +56,7 @@ stages:
             vmImage: windows-latest
           ${{ if eq(variables.officialBuild, 'true') }}:
             name: NetCore1ESPool-Svc-Internal
-            demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
+            demands: ImageOverride -equals 1es-windows-2019
         variables:
           - ${{ if eq(variables.officialBuild, 'false') }}:
             - _SignType: test


### PR DESCRIPTION
~~This uses a different image than https://github.com/dotnet/linker/pull/3051 because there weren't any 1es images listed with vs2017. I followed the email guidance which recommended windows.vs2017.amd64.~~

Never mind, I think I was using the wrong base branch. Changed to 6.0.x where we were using vs2019 images, so this is a simple port of https://github.com/dotnet/linker/pull/3051.