### PR TITLE
Add feature attributes design

### DIFF
--- a/docs/design/feature-attribute-semantics.md
+++ b/docs/design/feature-attribute-semantics.md
@@ -51,15 +51,18 @@ Access to members with a _feature requirement_ is always allowed from a _feature
 
 ## Feature available scope
 
-Methods and constructors (including static constructors) with a _feature requirement_ are in a _feature available_ scope.
+The following constructs with a _feature requirement_ are also in a _feature available_ scope:
+- Methods
+- Constructors (including static constructors)
 
-Methods, constructors (including static constructors), and fields declared in a class or struct with a _feature requirement_ are also in a _feature available_ scope.
+When a class or struct has a _feature requirement_, the following members are in a _feature available_ scope:
+- Methods
+- Constructors (including static constructors)
+- Fields
+- Properties
+- Events
 
-Properties and events declared in a class or struct with a _feature requirement_ are also in a _feature available_ scope.
-
-Lambdas and local functions with a _feature requirement_ are also in a _feature available_ scope.
-
-Note that the _feature available_ scope for a type does not extend to nested types.
+Note that the _feature available_ scope for a type does not extend to nested types or to members of base classes or interfaces implemented by the type.
 
 ## Feature requirement
 


### PR DESCRIPTION
This is an attempt to specify the behavior of the various `Requires`* attributes we have today. Unlike https://github.com/dotnet/linker/pull/2177, this is intended to specify the allowed and disallowed semantics for a generalized feature attribute, not the specific formatting of the warnings. I think https://github.com/dotnet/linker/pull/2177 would be helpful in addition to this spec to give more concrete examples, but I want this to be a concise summary of the rules.

See the motivation section for details.