### PR TITLE
Root entire assembly for non-exe projects

### DIFF
--- a/src/ILLink.Tasks/build/Microsoft.NET.ILLink.targets
+++ b/src/ILLink.Tasks/build/Microsoft.NET.ILLink.targets
@@ -279,9 +279,11 @@ Copyright (c) .NET Foundation. All rights reserved.
       <ManagedAssemblyToLink Include="@(_TrimmableManagedAssemblyToLink)" IsTrimmable="true" />
     </ItemGroup>
 
-    <!-- Root the main assembly entry point. -->
     <ItemGroup>
-      <TrimmerRootAssembly Include="@(IntermediateAssembly)" RootMode="EntryPoint" />
+      <!-- Root the main assembly entry point. -->
+      <TrimmerRootAssembly Condition="'$(OutputType)' == 'Exe'" Include="@(IntermediateAssembly)" RootMode="EntryPoint" />
+      <!-- Or the entire assembly, for non-exe projects. -->
+      <TrimmerRootAssembly Condition="'$(OutputType)' != 'Exe'" Include="@(IntermediateAssembly)" RootMode="All" />
     </ItemGroup>
 
     <!-- For .NET < 6, root and copy assemblies without IsTrimmable=true MSBuild metadata. -->


### PR DESCRIPTION
After fixing the root behavior in https://github.com/dotnet/linker/pull/3124, the linker update https://github.com/dotnet/runtime/pull/78020 is failing to build wasm test projects because they `PublishTrimmed` non-exe test projects which don't have an entry point:
```
ILLink : error IL1034: Root assembly 'System.Runtime.Tests, Version=7.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' does not have entry point.
```

This isn't really a supported scenario so we could work around it in dotnet/runtime, but in this case I think it makes sense to put the logic in the official targets here. This will root the entire assembly for non-exe projects, which is what the "default" root mode did (for non-exes) before https://github.com/dotnet/linker/pull/3124.