### PR TITLE
Add hook into SDK targets

### DIFF
--- a/src/ILLink.Tasks/build/Microsoft.NET.ILLink.targets
+++ b/src/ILLink.Tasks/build/Microsoft.NET.ILLink.targets
@@ -81,6 +81,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           Condition=" '$(PublishTrimmed)' == 'true' And
                       '$(RunILLink)' != 'false' And
                       '$(_TargetFrameworkVersionWithoutV)' >= '3.0' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' "
+          AfterTargets="ComputeResolvedFilesToPublishList"
           DependsOnTargets="_RunILLink">
 
     <NETSdkError Condition="'$(_ILLinkExitCode)' != '' And '$(_ILLinkExitCode)' != '0'" ResourceName="ILLinkFailed" />


### PR DESCRIPTION
Necessary for https://github.com/dotnet/sdk/pull/29441, which is using the implicit PackageReference approach for ILLink.Tasks. The PackageReference will only be added when PublishTrimmed is true, so this will replace https://github.com/dotnet/sdk/blob/3a12a4c2a731ea5963a8161ded6b62282d1323df/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets#L355.

This will need to go into the 7.0 branch too, so that the 7.0 package can be used when targeting net7.0 with a .NET 8 SDK.