### PR TITLE
[release/7.0] Fix endless loop in illink analyzer

### DIFF
--- a/src/ILLink.RoslynAnalyzer/DataFlow/InterproceduralState.cs
+++ b/src/ILLink.RoslynAnalyzer/DataFlow/InterproceduralState.cs
@@ -39,7 +39,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 			=> Methods.Equals (other.Methods) && HoistedLocals.Equals (other.HoistedLocals);
 
 		public InterproceduralState<TValue, TValueLattice> Clone ()
-			=> new (Methods.Clone (),
+			=> new (Methods.DeepCopy (),
 			HoistedLocals.Clone (), lattice);
 
 		public void TrackMethod (MethodBodyValue method)

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/ArrayValue.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/ArrayValue.cs
@@ -53,10 +53,15 @@ namespace ILLink.Shared.TrimAnalysis
 			if (!equals)
 				return false;
 
-			// If both sets T and O are the same size and "T intersect O" is empty, then T == O.
-			HashSet<KeyValuePair<int, MultiValue>> thisValueSet = new (IndexValues);
-			thisValueSet.ExceptWith (otherArr.IndexValues);
-			return thisValueSet.Count == 0;
+			// Here we rely on the assumption that we can't store mutable values in arrays. The only mutable value
+			// which we currently support are array values, but those are not allowed in an array (to avoid complexity).
+			// As such we can rely on the values to be immutable, and thus if the counts are equal
+			// then the arrays are equal if items from one can be directly found in the other.
+			foreach (var kvp in IndexValues)
+				if (!otherArr.IndexValues.TryGetValue (kvp.Key, out MultiValue value) || !kvp.Value.Equals (value))
+					return false;
+
+			return true;
 		}
 
 		// Lattice Meet() is supposed to copy values, so we need to make a deep copy since ArrayValue is mutable through IndexValues
@@ -64,7 +69,7 @@ namespace ILLink.Shared.TrimAnalysis
 		{
 			var newArray = new ArrayValue (Size);
 			foreach (var kvp in IndexValues) {
-				newArray.IndexValues.Add (kvp.Key, kvp.Value.Clone ());
+				newArray.IndexValues.Add (kvp.Key, kvp.Value.DeepCopy ());
 			}
 
 			return newArray;

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisAssignmentPattern.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisAssignmentPattern.cs
@@ -20,8 +20,8 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 
 		public TrimAnalysisAssignmentPattern (MultiValue source, MultiValue target, IOperation operation)
 		{
-			Source = source.Clone ();
-			Target = target.Clone ();
+			Source = source.DeepCopy ();
+			Target = target.DeepCopy ();
 			Operation = operation;
 		}
 

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisMethodCallPattern.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisMethodCallPattern.cs
@@ -29,13 +29,13 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 			ISymbol owningSymbol)
 		{
 			CalledMethod = calledMethod;
-			Instance = instance.Clone ();
+			Instance = instance.DeepCopy ();
 			if (arguments.IsEmpty) {
 				Arguments = ImmutableArray<MultiValue>.Empty;
 			} else {
 				var builder = ImmutableArray.CreateBuilder<MultiValue> ();
 				foreach (var argument in arguments) {
-					builder.Add (argument.Clone ());
+					builder.Add (argument.DeepCopy ());
 				}
 				Arguments = builder.ToImmutableArray ();
 			}

--- a/src/ILLink.Shared/DataFlow/MaybeLattice.cs
+++ b/src/ILLink.Shared/DataFlow/MaybeLattice.cs
@@ -10,7 +10,7 @@ namespace ILLink.Shared.DataFlow
 	// Wrapper for Nullable<T> which implements IEquatable so that this may
 	// be used as a lattice value. Nullable types can't satisfy interface constraints;
 	// see for example https://docs.microsoft.com/dotnet/csharp/misc/cs0313.
-	public struct Maybe<T> : IEquatable<Maybe<T>>
+	public struct Maybe<T> : IEquatable<Maybe<T>>, IDeepCopyValue<Maybe<T>>
 		where T : struct, IEquatable<T>
 	{
 		public T? MaybeValue;
@@ -18,7 +18,7 @@ namespace ILLink.Shared.DataFlow
 		public bool Equals (Maybe<T> other) => MaybeValue?.Equals (other.MaybeValue) ?? other.MaybeValue == null;
 		public override bool Equals (object? obj) => obj is Maybe<T> other && Equals (other);
 		public override int GetHashCode () => MaybeValue?.GetHashCode () ?? 0;
-		public Maybe<T> Clone ()
+		public Maybe<T> DeepCopy ()
 		{
 			if (MaybeValue is not T value)
 				return default;
@@ -42,9 +42,9 @@ namespace ILLink.Shared.DataFlow
 		public Maybe<T> Meet (Maybe<T> left, Maybe<T> right)
 		{
 			if (left.MaybeValue is not T leftValue)
-				return right.Clone ();
+				return right.DeepCopy ();
 			if (right.MaybeValue is not T rightValue)
-				return left.Clone ();
+				return left.DeepCopy ();
 			return new Maybe<T> (ValueLattice.Meet (leftValue, rightValue));
 		}
 	}

--- a/src/ILLink.Shared/DataFlow/ValueSet.cs
+++ b/src/ILLink.Shared/DataFlow/ValueSet.cs
@@ -12,7 +12,7 @@ using System.Text;
 
 namespace ILLink.Shared.DataFlow
 {
-	public readonly struct ValueSet<TValue> : IEquatable<ValueSet<TValue>>, IEnumerable<TValue>
+	public readonly struct ValueSet<TValue> : IEquatable<ValueSet<TValue>>, IEnumerable<TValue>, IDeepCopyValue<ValueSet<TValue>>
 		where TValue : notnull
 	{
 		// Since we're going to do lot of type checks for this class a lot, it is much more efficient
@@ -28,12 +28,45 @@ namespace ILLink.Shared.DataFlow
 					hashCode = HashUtils.Combine (hashCode, item);
 				return hashCode;
 			}
+
+			public bool Equals (EnumerableValues other)
+			{
+				// Unfortunately if some of the values are ArrayValues then they can mutate
+				// after being added to the set, in which case their "hashing" is broken
+				// The set will self-heal on every Meet since we recreate the HashSet
+				// but equality is not guaranteed in the interim state.
+				// So to workaround this for now, iterate over both sets and check
+				// that the item can be found in the other set.
+				foreach (TValue item in this)
+					if (!other.Contains (item))
+						return false;
+
+				foreach (TValue item in other)
+					if (!Contains (item))
+						return false;
+
+				return true;
+			}
+
+			public bool Equals (TValue other)
+			{
+				// As described above, it's possible to end up with a hashset which has multiple
+				// values which are equal (due to mutability). So we can't rely on item count.
+				bool found = false;
+				foreach (TValue item in this) {
+					if (!item.Equals (other))
+						return false;
+					found = true;
+				}
+
+				return found;
+			}
 		}
 
 		public struct Enumerator : IEnumerator<TValue>, IDisposable, IEnumerator
 		{
 			readonly object? _value;
-			int _state;  // 0 before begining, 1 at item, 2 after end
+			int _state;  // 0 before beginning, 1 at item, 2 after end
 			readonly IEnumerator<TValue>? _enumerator;
 
 			internal Enumerator (object? values)
@@ -108,12 +141,12 @@ namespace ILLink.Shared.DataFlow
 
 			if (_values is EnumerableValues enumerableValues) {
 				if (other._values is EnumerableValues otherValuesSet) {
-					return enumerableValues.SetEquals (otherValuesSet);
+					return enumerableValues.Equals (otherValuesSet);
 				} else
-					return false;
+					return enumerableValues.Equals ((TValue) other._values);
 			} else {
-				if (other._values is EnumerableValues) {
-					return false;
+				if (other._values is EnumerableValues otherEnumerableValues) {
+					return otherEnumerableValues.Equals ((TValue) _values);
 				}
 
 				return EqualityComparer<TValue>.Default.Equals ((TValue) _values, (TValue) other._values);
@@ -146,18 +179,18 @@ namespace ILLink.Shared.DataFlow
 		internal static ValueSet<TValue> Meet (ValueSet<TValue> left, ValueSet<TValue> right)
 		{
 			if (left._values == null)
-				return right.Clone ();
+				return right.DeepCopy ();
 			if (right._values == null)
-				return left.Clone ();
+				return left.DeepCopy ();
 
 			if (left._values is not EnumerableValues && right.Contains ((TValue) left._values))
-				return right.Clone ();
+				return right.DeepCopy ();
 
 			if (right._values is not EnumerableValues && left.Contains ((TValue) right._values))
-				return left.Clone ();
+				return left.DeepCopy ();
 
-			var values = new EnumerableValues (left.Clone ());
-			values.UnionWith (right.Clone ());
+			var values = new EnumerableValues (left.DeepCopy ());
+			values.UnionWith (right.DeepCopy ());
 			return new ValueSet<TValue> (values);
 		}
 
@@ -174,7 +207,7 @@ namespace ILLink.Shared.DataFlow
 
 		// Meet should copy the values, but most SingleValues are immutable.
 		// Clone returns `this` if there are no mutable SingleValues (SingleValues that implement IDeepCopyValue), otherwise creates a new ValueSet with copies of the copiable Values
-		public ValueSet<TValue> Clone ()
+		public ValueSet<TValue> DeepCopy ()
 		{
 			if (_values is null)
 				return this;

--- a/src/linker/Linker.Dataflow/ArrayValue.cs
+++ b/src/linker/Linker.Dataflow/ArrayValue.cs
@@ -68,18 +68,22 @@ namespace ILLink.Shared.TrimAnalysis
 			if (!equals)
 				return false;
 
-			// If both sets T and O are the same size and "T intersect O" is empty, then T == O.
-			HashSet<KeyValuePair<int, ValueBasicBlockPair>> thisValueSet = new (IndexValues);
-			HashSet<KeyValuePair<int, ValueBasicBlockPair>> otherValueSet = new (otherArr.IndexValues);
-			thisValueSet.ExceptWith (otherValueSet);
-			return thisValueSet.Count == 0;
+			// Here we rely on the assumption that we can't store mutable values in arrays. The only mutable value
+			// which we currently support are array values, but those are not allowed in an array (to avoid complexity).
+			// As such we can rely on the values to be immutable, and thus if the counts are equal
+			// then the arrays are equal if items from one can be directly found in the other.
+			foreach (var kvp in IndexValues)
+				if (!otherArr.IndexValues.TryGetValue (kvp.Key, out ValueBasicBlockPair value) || !kvp.Value.Equals (value))
+					return false;
+
+			return true;
 		}
 
 		public override SingleValue DeepCopy ()
 		{
 			var newValue = new ArrayValue (Size.DeepCopy (), ElementType);
 			foreach (var kvp in IndexValues) {
-				newValue.IndexValues.Add (kvp.Key, new ValueBasicBlockPair (kvp.Value.Value.Clone (), kvp.Value.BasicBlockIndex));
+				newValue.IndexValues.Add (kvp.Key, new ValueBasicBlockPair (kvp.Value.Value.DeepCopy (), kvp.Value.BasicBlockIndex));
 			}
 
 			return newValue;

--- a/src/linker/Linker.Dataflow/InterproceduralState.cs
+++ b/src/linker/Linker.Dataflow/InterproceduralState.cs
@@ -35,7 +35,7 @@ namespace Mono.Linker.Dataflow
 		public override int GetHashCode () => HashUtils.Combine(MethodBodies.GetHashCode (), HoistedLocals.GetHashCode ());
 
 		public InterproceduralState Clone ()
-			=> new (MethodBodies.Clone (), HoistedLocals.Clone (), lattice);
+			=> new (MethodBodies.DeepCopy (), HoistedLocals.Clone (), lattice);
 
 		public void TrackMethod (MethodDefinition method)
 		{

--- a/src/linker/Linker.Dataflow/TrimAnalysisAssignmentPattern.cs
+++ b/src/linker/Linker.Dataflow/TrimAnalysisAssignmentPattern.cs
@@ -17,8 +17,8 @@ namespace Mono.Linker.Dataflow
 
 		public TrimAnalysisAssignmentPattern (MultiValue source, MultiValue target, MessageOrigin origin)
 		{
-			Source = source.Clone ();
-			Target = target.Clone ();
+			Source = source.DeepCopy ();
+			Target = target.DeepCopy ();
 			Origin = origin;
 		}
 

--- a/src/linker/Linker.Dataflow/TrimAnalysisMethodCallPattern.cs
+++ b/src/linker/Linker.Dataflow/TrimAnalysisMethodCallPattern.cs
@@ -30,13 +30,13 @@ namespace Mono.Linker.Dataflow
 			Debug.Assert (origin.Provider is MethodDefinition);
 			Operation = operation;
 			CalledMethod = calledMethod;
-			Instance = instance.Clone ();
+			Instance = instance.DeepCopy ();
 			if (arguments.IsEmpty) {
 				Arguments = ImmutableArray<MultiValue>.Empty;
 			} else {
 				var builder = ImmutableArray.CreateBuilder<MultiValue> ();
 				foreach (var argument in arguments)
-					builder.Add (argument.Clone ());
+					builder.Add (argument.DeepCopy ());
 				Arguments = builder.ToImmutableArray ();
 			}
 			Origin = origin;

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ArrayDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ArrayDataFlow.cs
@@ -45,6 +45,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			WriteCapturedArrayElement.Test ();
 
 			ConstantFieldValuesAsIndex.Test ();
+
+			HoistedArrayMutation.Test ();
 		}
 
 		[ExpectedWarning ("IL2062", nameof (DataFlowTypeExtensions.RequiresPublicMethods))]
@@ -620,6 +622,38 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				types[ConstUShort].RequiresPublicMethods ();
 				types[ConstInt].RequiresPublicMethods ();
 				types[ConstUInt].RequiresPublicMethods ();
+			}
+		}
+
+		class HoistedArrayMutation
+		{
+			static void LoopAssignmentWithInitAfter ()
+			{
+				// This is a repro for https://github.com/dotnet/runtime/issues/86379
+				// The array value is a hoisted local
+				// It's first used in the main method (in the for loop)
+				// this doesn't get a deep clone of the value, it takes the value from
+				// the hoisted locals dictionary - and modifies it.
+				// The local function Initialize then creates a deep copy and uses that.
+				// Because of a bug, the changes done in the main body method are also
+				// visible in the "old" interprocedural state. So the state never settles
+				// and this causes an endless loop in the analyzer.
+				int[] arr;
+
+				Initialize ();
+				for (int i = 0; i < arr.Length; i++) {
+					arr[i] = 0;
+				}
+
+				void Initialize ()
+				{
+					arr = new int[10];
+				}
+			}
+
+			public static void Test ()
+			{
+				LoopAssignmentWithInitAfter ();
 			}
 		}
 

--- a/test/Mono.Linker.Tests/Tests/GetDisplayNameTests.cs
+++ b/test/Mono.Linker.Tests/Tests/GetDisplayNameTests.cs
@@ -191,18 +191,18 @@ namespace Mono.Linker.Tests
 		}
 
 		[DisplayName ("Mono.Linker.Tests.GetDisplayNameTests.MethodWithGenericTypeArgument(IList<GetDisplayNameTests.GenericClassOneParameter<Byte*[]>>)")]
-		public static void MethodWithGenericTypeArgument (IList<GenericClassOneParameter<byte*[]>> p)
+		public unsafe static void MethodWithGenericTypeArgument (IList<GenericClassOneParameter<byte*[]>> p)
 		{
 		}
 
 		[DisplayName ("Mono.Linker.Tests.GetDisplayNameTests.MethodWithGenericTypeArguments(GetDisplayNameTests.GenericClassMultipleParameters<Char*[],Int32[,][]>)")]
-		public static void MethodWithGenericTypeArguments (GenericClassMultipleParameters<char*[], int[,][]> p)
+		public unsafe static void MethodWithGenericTypeArguments (GenericClassMultipleParameters<char*[], int[,][]> p)
 		{
 		}
 
 		[DisplayName ("Mono.Linker.Tests.GetDisplayNameTests.MethodWithNestedGenericTypeArguments" +
 			"(GetDisplayNameTests.GenericClassMultipleParameters<Char*[],Int32[,][]>.NestedGenericClassMultipleParameters<Char*[],Int32[,][]>)")]
-		public static void MethodWithNestedGenericTypeArguments (GenericClassMultipleParameters<char*[], int[,][]>.NestedGenericClassMultipleParameters<char*[], int[,][]> p)
+		public unsafe static void MethodWithNestedGenericTypeArguments (GenericClassMultipleParameters<char*[], int[,][]>.NestedGenericClassMultipleParameters<char*[], int[,][]> p)
 		{
 		}
 


### PR DESCRIPTION
This is a port of the 8.0 change: https://github.com/dotnet/runtime/pull/86449

I verified that the repro from https://github.com/dotnet/runtime/issues/86379 is fixed with this change.

This is a 7.0 fix of https://github.com/dotnet/runtime/issues/86379

## Impact

If the right pattern occurs in the analyzed code, the analyzer will hang. This leads to hanging the build as well as causing problems with IDEs relying on a language service with the analyzer.

## Workaround

The only workaround is to disable the trim analyzer on the affected project - which means losing all of the diagnostics it provides.

## Risk

The fix is slightly risky in that it changes how some internal state of the analyzer is maintained (makes more things immutable). The fix has been merged into .NET 8 main for about 2 weeks now and we haven't seen any problems with it.

/cc @agocke