### PR TITLE
[release/7.0] Ports fixes for not crashing/haning on recursive arrays

### DIFF
--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/ArrayValue.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/ArrayValue.cs
@@ -69,6 +69,15 @@ namespace ILLink.Shared.TrimAnalysis
 		{
 			var newArray = new ArrayValue (Size);
 			foreach (var kvp in IndexValues) {
+#if DEBUG
+				// Since it's possible to store a reference to array as one of its own elements
+				// simple deep copy could lead to endless recursion.
+				// So instead we simply disallow arrays as element values completely - and treat that case as "too complex to analyze".
+				foreach (SingleValue v in kvp.Value) {
+					System.Diagnostics.Debug.Assert (v is not ArrayValue);
+				}
+#endif
+
 				newArray.IndexValues.Add (kvp.Key, kvp.Value.DeepCopy ());
 			}
 

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
@@ -79,7 +79,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 			var elements = operation.Initializer?.ElementValues.Select (val => Visit (val, state)).ToArray () ?? System.Array.Empty<MultiValue> ();
 			foreach (var array in arrayValue.Cast<ArrayValue> ()) {
 				for (int i = 0; i < elements.Length; i++) {
-					array.IndexValues.Add (i, elements[i]);
+					array.IndexValues.Add (i, ArrayValue.SanitizeArrayElementValue(elements[i]));
 				}
 			}
 
@@ -229,9 +229,9 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 						arr.IndexValues.Clear ();
 					} else {
 						if (arr.IndexValues.TryGetValue (index.Value, out _)) {
-							arr.IndexValues[index.Value] = valueToWrite;
+							arr.IndexValues[index.Value] = ArrayValue.SanitizeArrayElementValue(valueToWrite);
 						} else if (arr.IndexValues.Count < MaxTrackedArrayValues) {
-							arr.IndexValues[index.Value] = valueToWrite;
+							arr.IndexValues[index.Value] = ArrayValue.SanitizeArrayElementValue (valueToWrite);
 						}
 					}
 				}

--- a/src/ILLink.Shared/TrimAnalysis/ArrayValue.cs
+++ b/src/ILLink.Shared/TrimAnalysis/ArrayValue.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Linq;
 using ILLink.Shared.DataFlow;
 using MultiValue = ILLink.Shared.DataFlow.ValueSet<ILLink.Shared.DataFlow.SingleValue>;
 
@@ -16,5 +17,32 @@ namespace ILLink.Shared.TrimAnalysis
 		public readonly SingleValue Size;
 
 		public partial bool TryGetValueByIndex (int index, out MultiValue value);
+
+		public static MultiValue SanitizeArrayElementValue (MultiValue input)
+		{
+			// We need to be careful about self-referencing arrays. It's easy to have an array which has one of the elements as itself:
+			// var arr = new object[1];
+			// arr[0] = arr;
+			//
+			// We can't deep copy this, as it's an infinite recursion. And we can't easily guard against it with checks to self-referencing
+			// arrays - as this could be two or more levels deep.
+			//
+			// We need to deep copy arrays because we don't have a good way to track references (we treat everything as a value type)
+			// and thus we could get bad results if the array is involved in multiple branches for example.
+			// That said, it only matters for us to track arrays to be able to get integers or Type values (and we really only need relatively simple cases)
+			//
+			// So we will simply treat array value as an element value as "too complex to analyze" and give up by storing Unknown instead
+
+			bool needSanitization = false;
+			foreach (var v in input) {
+				if (v is ArrayValue)
+					needSanitization = true;
+			}
+
+			if (!needSanitization)
+				return input;
+
+			return new (input.Select (v => v is ArrayValue ? UnknownValue.Instance : v));
+		}
 	}
 }

--- a/src/linker/Linker.Dataflow/ArrayValue.cs
+++ b/src/linker/Linker.Dataflow/ArrayValue.cs
@@ -83,6 +83,14 @@ namespace ILLink.Shared.TrimAnalysis
 		{
 			var newValue = new ArrayValue (Size.DeepCopy (), ElementType);
 			foreach (var kvp in IndexValues) {
+#if DEBUG
+				// Since it's possible to store a reference to array as one of its own elements
+				// simple deep copy could lead to endless recursion.
+				// So instead we simply disallow arrays as element values completely - and treat that case as "too complex to analyze".
+				foreach (SingleValue v in kvp.Value.Value) {
+					System.Diagnostics.Debug.Assert (v is not ArrayValue);
+				}
+#endif
 				newValue.IndexValues.Add (kvp.Key, new ValueBasicBlockPair (kvp.Value.Value.DeepCopy (), kvp.Value.BasicBlockIndex));
 			}
 

--- a/src/linker/Linker.Dataflow/MethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/MethodBodyScanner.cs
@@ -1198,7 +1198,7 @@ namespace Mono.Linker.Dataflow
 						MarkArrayValuesAsUnknown (arrValue, curBasicBlock);
 					} else {
 						// When we know the index, we can record the value at that index.
-						StoreMethodLocalValue (arrValue.IndexValues, valueToStore.Value, indexToStoreAtInt.Value, curBasicBlock, MaxTrackedArrayValues);
+						StoreMethodLocalValue (arrValue.IndexValues, ArrayValue.SanitizeArrayElementValue(valueToStore.Value), indexToStoreAtInt.Value, curBasicBlock, MaxTrackedArrayValues);
 					}
 				}
 			}

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ArrayDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ArrayDataFlow.cs
@@ -40,6 +40,9 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			TestArrayResetGetElementOnByRefArray ();
 			TestArrayResetAfterCall ();
 			TestArrayResetAfterAssignment ();
+
+			TestArrayRecursion ();
+
 			TestMultiDimensionalArray.Test ();
 
 			WriteCapturedArrayElement.Test ();
@@ -273,6 +276,18 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			_externalArray = arr;
 
 			arr[0].RequiresPublicFields (); // Should warn
+		}
+
+		static void TestArrayRecursion ()
+		{
+			typeof (TestType).RequiresAll (); // Force data flow on this method
+
+			object[] arr = new object[3];
+			arr[0] = arr; // Recursive reference
+
+			ConsumeArray (arr);
+
+			static void ConsumeArray (object[] a) { }
 		}
 
 		static Type[] _externalArray;

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ExponentialDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ExponentialDataFlow.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading.Tasks;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
+
+namespace Mono.Linker.Tests.Cases.DataFlow
+{
+	[ExpectedNoWarnings]
+	[SkipKeptItemsValidation]
+	public class ExponentialDataFlow
+	{
+		public static void Main ()
+		{
+			ExponentialArrayInStateMachine.Test ();
+		}
+
+		class ExponentialArrayInStateMachine
+		{
+			// Force state machine
+			static async Task RecursiveReassignment ()
+			{
+				typeof (TestType).RequiresAll (); // Force data flow analysis
+
+				object[] args = null;
+				args = new[] { args };
+			}
+
+			public static void Test ()
+			{
+				RecursiveReassignment ().Wait ();
+			}
+		}
+
+		class TestType { }
+	}
+}

--- a/test/Mono.Linker.Tests/TestCasesRunner/TestCaseCompilationMetadataProvider.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestCaseCompilationMetadataProvider.cs
@@ -144,6 +144,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				yield return Path.Combine (referenceDir, "System.Collections.dll");
 				yield return Path.Combine (referenceDir, "System.ComponentModel.TypeConverter.dll");
 				yield return Path.Combine (referenceDir, "System.Console.dll");
+				yield return Path.Combine (referenceDir, "System.Linq.dll");
 				yield return Path.Combine (referenceDir, "System.Linq.Expressions.dll");
 				yield return Path.Combine (referenceDir, "System.ObjectModel.dll");
 				yield return Path.Combine (referenceDir, "System.Runtime.dll");


### PR DESCRIPTION
This is a port of the trimmer/analyzer changes from https://github.com/dotnet/runtime/pull/82818.

The main changes is to disallow array values in arrays - if we find an array element which is itself an array we replace it with unknown value.

This stops all kinds of weird recursion behavior in the analysis and fixes cases where the tool would either crash with stack overflow or hang (exponential explosion of states).

Adds the related tests as well.