### PR TITLE
[release/7.0] Don't crash trim analyzer on unrecognized input

### DIFF
--- a/src/ILLink.RoslynAnalyzer/DataFlow/CapturedReferenceValue.cs
+++ b/src/ILLink.RoslynAnalyzer/DataFlow/CapturedReferenceValue.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics;
 using ILLink.Shared.DataFlow;
 using Microsoft.CodeAnalysis;
 
@@ -29,7 +30,12 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 				// These will just be ignored when referenced later.
 				break;
 			default:
-				throw new NotImplementedException (operation.Kind.ToString ());
+				// Assert on anything else as it means we need to implement support for it
+				// but do not throw here as it means new Roslyn version could cause the analyzer to crash
+				// which is not fixable by the user. The analyzer is not going to be 100% correct no matter what we do
+				// so effectively ignoring constructs it doesn't understand is OK.
+				Debug.Fail ($"{operation.GetType ()}: {operation.Syntax.GetLocation ().GetLineSpan ()}");
+				break;
 			}
 			Reference = operation;
 		}

--- a/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -275,7 +275,13 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 				// (don't have specific I*Operation types), such as pointer dereferences.
 				if (targetOperation.Kind is OperationKind.None)
 					break;
-				throw new NotImplementedException ($"{targetOperation.GetType ().ToString ()}: {targetOperation.Syntax.GetLocation ().GetLineSpan ()}");
+
+				// Assert on anything else as it means we need to implement support for it
+				// but do not throw here as it means new Roslyn version could cause the analyzer to crash
+				// which is not fixable by the user. The analyzer is not going to be 100% correct no matter what we do
+				// so effectively ignoring constructs it doesn't understand is OK.
+				Debug.Fail ($"{targetOperation.GetType ()}: {targetOperation.Syntax.GetLocation ().GetLineSpan ()}");
+				break;
 			}
 			return Visit (operation.Value, state);
 		}


### PR DESCRIPTION
This is a port of https://github.com/dotnet/runtime/pull/88836.

Note: The `ParameterProxy` change from the original PR doesn't apply - the code used lived in MethodProxy and didn't have the "default throw" case in the switch.