### PR TITLE
[release/7.0] Port of stability fixes for trimmer and anlyzer

### DIFF
--- a/src/ILLink.RoslynAnalyzer/DataFlow/CapturedReferenceValue.cs
+++ b/src/ILLink.RoslynAnalyzer/DataFlow/CapturedReferenceValue.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics;
 using ILLink.Shared.DataFlow;
 using Microsoft.CodeAnalysis;
 
@@ -29,7 +30,12 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 				// These will just be ignored when referenced later.
 				break;
 			default:
-				throw new NotImplementedException (operation.Kind.ToString ());
+				// Assert on anything else as it means we need to implement support for it
+				// but do not throw here as it means new Roslyn version could cause the analyzer to crash
+				// which is not fixable by the user. The analyzer is not going to be 100% correct no matter what we do
+				// so effectively ignoring constructs it doesn't understand is OK.
+				Debug.Fail ($"{operation.GetType ()}: {operation.Syntax.GetLocation ().GetLineSpan ()}");
+				break;
 			}
 			Reference = operation;
 		}

--- a/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -275,7 +275,13 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 				// (don't have specific I*Operation types), such as pointer dereferences.
 				if (targetOperation.Kind is OperationKind.None)
 					break;
-				throw new NotImplementedException ($"{targetOperation.GetType ().ToString ()}: {targetOperation.Syntax.GetLocation ().GetLineSpan ()}");
+
+				// Assert on anything else as it means we need to implement support for it
+				// but do not throw here as it means new Roslyn version could cause the analyzer to crash
+				// which is not fixable by the user. The analyzer is not going to be 100% correct no matter what we do
+				// so effectively ignoring constructs it doesn't understand is OK.
+				Debug.Fail ($"{targetOperation.GetType ()}: {targetOperation.Syntax.GetLocation ().GetLineSpan ()}");
+				break;
 			}
 			return Visit (operation.Value, state);
 		}

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/ArrayValue.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/ArrayValue.cs
@@ -69,6 +69,15 @@ namespace ILLink.Shared.TrimAnalysis
 		{
 			var newArray = new ArrayValue (Size);
 			foreach (var kvp in IndexValues) {
+#if DEBUG
+				// Since it's possible to store a reference to array as one of its own elements
+				// simple deep copy could lead to endless recursion.
+				// So instead we simply disallow arrays as element values completely - and treat that case as "too complex to analyze".
+				foreach (SingleValue v in kvp.Value) {
+					System.Diagnostics.Debug.Assert (v is not ArrayValue);
+				}
+#endif
+
 				newArray.IndexValues.Add (kvp.Key, kvp.Value.DeepCopy ());
 			}
 

--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
@@ -79,7 +79,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 			var elements = operation.Initializer?.ElementValues.Select (val => Visit (val, state)).ToArray () ?? System.Array.Empty<MultiValue> ();
 			foreach (var array in arrayValue.Cast<ArrayValue> ()) {
 				for (int i = 0; i < elements.Length; i++) {
-					array.IndexValues.Add (i, elements[i]);
+					array.IndexValues.Add (i, ArrayValue.SanitizeArrayElementValue(elements[i]));
 				}
 			}
 
@@ -229,9 +229,9 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 						arr.IndexValues.Clear ();
 					} else {
 						if (arr.IndexValues.TryGetValue (index.Value, out _)) {
-							arr.IndexValues[index.Value] = valueToWrite;
+							arr.IndexValues[index.Value] = ArrayValue.SanitizeArrayElementValue(valueToWrite);
 						} else if (arr.IndexValues.Count < MaxTrackedArrayValues) {
-							arr.IndexValues[index.Value] = valueToWrite;
+							arr.IndexValues[index.Value] = ArrayValue.SanitizeArrayElementValue (valueToWrite);
 						}
 					}
 				}

--- a/src/ILLink.Shared/DataFlow/ValueSet.cs
+++ b/src/ILLink.Shared/DataFlow/ValueSet.cs
@@ -15,6 +15,8 @@ namespace ILLink.Shared.DataFlow
 	public readonly struct ValueSet<TValue> : IEquatable<ValueSet<TValue>>, IEnumerable<TValue>, IDeepCopyValue<ValueSet<TValue>>
 		where TValue : notnull
 	{
+		const int MaxValuesInSet = 256;
+
 		// Since we're going to do lot of type checks for this class a lot, it is much more efficient
 		// if the class is sealed (as then the runtime can do a simple method table pointer comparison)
 		sealed class EnumerableValues : HashSet<TValue>
@@ -191,6 +193,10 @@ namespace ILLink.Shared.DataFlow
 
 			var values = new EnumerableValues (left.DeepCopy ());
 			values.UnionWith (right.DeepCopy ());
+			// Limit the number of values we track, to prevent hangs in case of patterns that
+			// create exponentially many possible values. This will result in analysis holes.
+			if (values.Count > MaxValuesInSet)
+				return default; 
 			return new ValueSet<TValue> (values);
 		}
 

--- a/src/ILLink.Shared/TrimAnalysis/ArrayValue.cs
+++ b/src/ILLink.Shared/TrimAnalysis/ArrayValue.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Linq;
 using ILLink.Shared.DataFlow;
 using MultiValue = ILLink.Shared.DataFlow.ValueSet<ILLink.Shared.DataFlow.SingleValue>;
 
@@ -16,5 +17,32 @@ namespace ILLink.Shared.TrimAnalysis
 		public readonly SingleValue Size;
 
 		public partial bool TryGetValueByIndex (int index, out MultiValue value);
+
+		public static MultiValue SanitizeArrayElementValue (MultiValue input)
+		{
+			// We need to be careful about self-referencing arrays. It's easy to have an array which has one of the elements as itself:
+			// var arr = new object[1];
+			// arr[0] = arr;
+			//
+			// We can't deep copy this, as it's an infinite recursion. And we can't easily guard against it with checks to self-referencing
+			// arrays - as this could be two or more levels deep.
+			//
+			// We need to deep copy arrays because we don't have a good way to track references (we treat everything as a value type)
+			// and thus we could get bad results if the array is involved in multiple branches for example.
+			// That said, it only matters for us to track arrays to be able to get integers or Type values (and we really only need relatively simple cases)
+			//
+			// So we will simply treat array value as an element value as "too complex to analyze" and give up by storing Unknown instead
+
+			bool needSanitization = false;
+			foreach (var v in input) {
+				if (v is ArrayValue)
+					needSanitization = true;
+			}
+
+			if (!needSanitization)
+				return input;
+
+			return new (input.Select (v => v is ArrayValue ? UnknownValue.Instance : v));
+		}
 	}
 }

--- a/src/linker/Linker.Dataflow/ArrayValue.cs
+++ b/src/linker/Linker.Dataflow/ArrayValue.cs
@@ -83,6 +83,14 @@ namespace ILLink.Shared.TrimAnalysis
 		{
 			var newValue = new ArrayValue (Size.DeepCopy (), ElementType);
 			foreach (var kvp in IndexValues) {
+#if DEBUG
+				// Since it's possible to store a reference to array as one of its own elements
+				// simple deep copy could lead to endless recursion.
+				// So instead we simply disallow arrays as element values completely - and treat that case as "too complex to analyze".
+				foreach (SingleValue v in kvp.Value.Value) {
+					System.Diagnostics.Debug.Assert (v is not ArrayValue);
+				}
+#endif
 				newValue.IndexValues.Add (kvp.Key, new ValueBasicBlockPair (kvp.Value.Value.DeepCopy (), kvp.Value.BasicBlockIndex));
 			}
 

--- a/src/linker/Linker.Dataflow/MethodBodyScanner.cs
+++ b/src/linker/Linker.Dataflow/MethodBodyScanner.cs
@@ -1198,7 +1198,7 @@ namespace Mono.Linker.Dataflow
 						MarkArrayValuesAsUnknown (arrValue, curBasicBlock);
 					} else {
 						// When we know the index, we can record the value at that index.
-						StoreMethodLocalValue (arrValue.IndexValues, valueToStore.Value, indexToStoreAtInt.Value, curBasicBlock, MaxTrackedArrayValues);
+						StoreMethodLocalValue (arrValue.IndexValues, ArrayValue.SanitizeArrayElementValue(valueToStore.Value), indexToStoreAtInt.Value, curBasicBlock, MaxTrackedArrayValues);
 					}
 				}
 			}

--- a/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
+++ b/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
@@ -120,6 +120,12 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
+		public Task ExponentialDataFlow()
+		{
+			return RunTest ();
+		}
+
+		[Fact]
 		public Task FieldDataFlow ()
 		{
 			return RunTest (nameof (FieldDataFlow));

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ArrayDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ArrayDataFlow.cs
@@ -40,6 +40,9 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			TestArrayResetGetElementOnByRefArray ();
 			TestArrayResetAfterCall ();
 			TestArrayResetAfterAssignment ();
+
+			TestArrayRecursion ();
+
 			TestMultiDimensionalArray.Test ();
 
 			WriteCapturedArrayElement.Test ();
@@ -273,6 +276,18 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			_externalArray = arr;
 
 			arr[0].RequiresPublicFields (); // Should warn
+		}
+
+		static void TestArrayRecursion ()
+		{
+			typeof (TestType).RequiresAll (); // Force data flow on this method
+
+			object[] arr = new object[3];
+			arr[0] = arr; // Recursive reference
+
+			ConsumeArray (arr);
+
+			static void ConsumeArray (object[] a) { }
 		}
 
 		static Type[] _externalArray;

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ExponentialDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ExponentialDataFlow.cs
@@ -16,23 +16,174 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 	{
 		public static void Main ()
 		{
+			ExponentialArrayStates.Test ();
+			ExponentialArrayStatesDataFlow.Test<int> ();
+			ArrayStatesDataFlow.Test<int> ();
 			ExponentialArrayInStateMachine.Test ();
 		}
 
+		class ExponentialArrayStates
+		{
+			public static void Test ()
+			{
+				typeof(TestType).RequiresAll(); // Force data flow analysis
+
+				object[] data = new object[20];
+				if (true) data[0] = new object ();
+				if (true) data[1] = new object ();
+				if (true) data[2] = new object ();
+				if (true) data[3] = new object ();
+				if (true) data[4] = new object ();
+				if (true) data[5] = new object ();
+				if (true) data[6] = new object ();
+				if (true) data[7] = new object ();
+				if (true) data[8] = new object ();
+				if (true) data[9] = new object ();
+				if (true) data[10] = new object ();
+				if (true) data[11] = new object ();
+				if (true) data[12] = new object ();
+				if (true) data[13] = new object ();
+				if (true) data[14] = new object ();
+				if (true) data[15] = new object ();
+				if (true) data[16] = new object ();
+				if (true) data[17] = new object ();
+				if (true) data[18] = new object ();
+				if (true) data[19] = new object ();
+			}
+		}
+
+		class ArrayStatesDataFlow
+		{
+			class GenericTypeWithRequires<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] T>
+			{
+			}
+
+			[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer | ProducedBy.NativeAot)]
+			[ExpectedWarning ("IL2090", "'T'")]
+			public static void Test<T> ()
+			{
+				Type[] types = new Type[1] { typeof (int) };
+				if (true) types[0] = typeof (T);
+				typeof (GenericTypeWithRequires<>).MakeGenericType (types);
+			}
+		}
+
+		class ExponentialArrayStatesDataFlow
+		{
+			class GenericTypeWithRequires<
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] T0,
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] T1,
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] T2,
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] T3,
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] T4,
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] T5,
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] T6,
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] T7,
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] T8,
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] T9,
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] T10,
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] T11,
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] T12,
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] T13,
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] T14,
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] T15,
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] T16,
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] T17,
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] T18,
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] T19>
+			{
+			}
+
+			[ExpectedWarning ("IL3050", ProducedBy = ProducedBy.Analyzer | ProducedBy.NativeAot)]
+			// The way we track arrays causes the analyzer to track exponentially many
+			// ArrayValues in the ValueSet for the pattern in this method, hitting the limit.
+			// When this happens, we replace the ValueSet wit a TopValue, which doesn't
+			// produce a warning in this case.
+			[ExpectedWarning ("IL2090", "'T'", ProducedBy = ProducedBy.Trimmer | ProducedBy.NativeAot)]
+			[ExpectedWarning ("IL2090", "'T'", ProducedBy = ProducedBy.Trimmer | ProducedBy.NativeAot)]
+			[ExpectedWarning ("IL2090", "'T'", ProducedBy = ProducedBy.Trimmer | ProducedBy.NativeAot)]
+			[ExpectedWarning ("IL2090", "'T'", ProducedBy = ProducedBy.Trimmer | ProducedBy.NativeAot)]
+			[ExpectedWarning ("IL2090", "'T'", ProducedBy = ProducedBy.Trimmer | ProducedBy.NativeAot)]
+			[ExpectedWarning ("IL2090", "'T'", ProducedBy = ProducedBy.Trimmer | ProducedBy.NativeAot)]
+			[ExpectedWarning ("IL2090", "'T'", ProducedBy = ProducedBy.Trimmer | ProducedBy.NativeAot)]
+			[ExpectedWarning ("IL2090", "'T'", ProducedBy = ProducedBy.Trimmer | ProducedBy.NativeAot)]
+			[ExpectedWarning ("IL2090", "'T'", ProducedBy = ProducedBy.Trimmer | ProducedBy.NativeAot)]
+			[ExpectedWarning ("IL2090", "'T'", ProducedBy = ProducedBy.Trimmer | ProducedBy.NativeAot)]
+			[ExpectedWarning ("IL2090", "'T'", ProducedBy = ProducedBy.Trimmer | ProducedBy.NativeAot)]
+			[ExpectedWarning ("IL2090", "'T'", ProducedBy = ProducedBy.Trimmer | ProducedBy.NativeAot)]
+			[ExpectedWarning ("IL2090", "'T'", ProducedBy = ProducedBy.Trimmer | ProducedBy.NativeAot)]
+			[ExpectedWarning ("IL2090", "'T'", ProducedBy = ProducedBy.Trimmer | ProducedBy.NativeAot)]
+			[ExpectedWarning ("IL2090", "'T'", ProducedBy = ProducedBy.Trimmer | ProducedBy.NativeAot)]
+			[ExpectedWarning ("IL2090", "'T'", ProducedBy = ProducedBy.Trimmer | ProducedBy.NativeAot)]
+			[ExpectedWarning ("IL2090", "'T'", ProducedBy = ProducedBy.Trimmer | ProducedBy.NativeAot)]
+			[ExpectedWarning ("IL2090", "'T'", ProducedBy = ProducedBy.Trimmer | ProducedBy.NativeAot)]
+			[ExpectedWarning ("IL2090", "'T'", ProducedBy = ProducedBy.Trimmer | ProducedBy.NativeAot)]
+			[ExpectedWarning ("IL2090", "'T'", ProducedBy = ProducedBy.Trimmer | ProducedBy.NativeAot)]
+			public static void Test<T> ()
+			{
+				Type[] types = new Type[20] {
+					typeof (int),
+					typeof (int),
+					typeof (int),
+					typeof (int),
+					typeof (int),
+					typeof (int),
+					typeof (int),
+					typeof (int),
+					typeof (int),
+					typeof (int),
+					typeof (int),
+					typeof (int),
+					typeof (int),
+					typeof (int),
+					typeof (int),
+					typeof (int),
+					typeof (int),
+					typeof (int),
+					typeof (int),
+					typeof (int)
+				};
+				if (Condition) types[0] = typeof (T);
+				if (Condition) types[1] = typeof (T);
+				if (Condition) types[2] = typeof (T);
+				if (Condition) types[3] = typeof (T);
+				if (Condition) types[4] = typeof (T);
+				if (Condition) types[5] = typeof (T);
+				if (Condition) types[6] = typeof (T);
+				if (Condition) types[7] = typeof (T);
+				if (Condition) types[8] = typeof (T);
+				if (Condition) types[9] = typeof (T);
+				if (Condition) types[10] = typeof (T);
+				if (Condition) types[11] = typeof (T);
+				if (Condition) types[12] = typeof (T);
+				if (Condition) types[13] = typeof (T);
+				if (Condition) types[14] = typeof (T);
+				if (Condition) types[15] = typeof (T);
+				if (Condition) types[16] = typeof (T);
+				if (Condition) types[17] = typeof (T);
+				if (Condition) types[18] = typeof (T);
+				if (Condition) types[19] = typeof (T);
+
+				typeof (GenericTypeWithRequires<,,,,,,,,,,,,,,,,,,,>).MakeGenericType (types);
+			}
+
+			static bool Condition => Random.Shared.Next (2) == 0;
+		}
+		
 		class ExponentialArrayInStateMachine
 		{
 			// Force state machine
-			static async Task RecursiveReassignment ()
+			static async Task RecursiveReassignment()
 			{
-				typeof (TestType).RequiresAll (); // Force data flow analysis
+				typeof(TestType).RequiresAll(); // Force data flow analysis
 
 				object[] args = null;
 				args = new[] { args };
 			}
 
-			public static void Test ()
+			public static void Test()
 			{
-				RecursiveReassignment ().Wait ();
+				RecursiveReassignment().Wait();
 			}
 		}
 

--- a/test/Mono.Linker.Tests.Cases/DataFlow/ExponentialDataFlow.cs
+++ b/test/Mono.Linker.Tests.Cases/DataFlow/ExponentialDataFlow.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading.Tasks;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
+
+namespace Mono.Linker.Tests.Cases.DataFlow
+{
+	[ExpectedNoWarnings]
+	[SkipKeptItemsValidation]
+	public class ExponentialDataFlow
+	{
+		public static void Main ()
+		{
+			ExponentialArrayInStateMachine.Test ();
+		}
+
+		class ExponentialArrayInStateMachine
+		{
+			// Force state machine
+			static async Task RecursiveReassignment ()
+			{
+				typeof (TestType).RequiresAll (); // Force data flow analysis
+
+				object[] args = null;
+				args = new[] { args };
+			}
+
+			public static void Test ()
+			{
+				RecursiveReassignment ().Wait ();
+			}
+		}
+
+		class TestType { }
+	}
+}

--- a/test/Mono.Linker.Tests/TestCasesRunner/TestCaseCompilationMetadataProvider.cs
+++ b/test/Mono.Linker.Tests/TestCasesRunner/TestCaseCompilationMetadataProvider.cs
@@ -144,6 +144,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				yield return Path.Combine (referenceDir, "System.Collections.dll");
 				yield return Path.Combine (referenceDir, "System.ComponentModel.TypeConverter.dll");
 				yield return Path.Combine (referenceDir, "System.Console.dll");
+				yield return Path.Combine (referenceDir, "System.Linq.dll");
 				yield return Path.Combine (referenceDir, "System.Linq.Expressions.dll");
 				yield return Path.Combine (referenceDir, "System.ObjectModel.dll");
 				yield return Path.Combine (referenceDir, "System.Runtime.dll");


### PR DESCRIPTION
> [!NOTE]
> This says release/7.0 but is actually a backport to 6.0 because the 7.0 linker is used for <= 7.0.

## Customer Impact

These are all crashes/hangs. Each of these has been customer reported in .NET 8, although we have only received a customer issue for the first one in .NET 7. The theory here is that these were somewhat hard to track down and led to a bad customer experience (build hangs), and if we would backport one, it's probably worth it to backport all. We can separate each of them if necessary. The analyzer crash (third in the list) will almost certainly occur if someone tries to use a new language version while sticking on an old framework. This hasn't been common yet, but we guess that it will become more so over time.

 
This ports these PR (at least the parts relevant to trimmer and analyzer) from 8.0:
* https://github.com/dotnet/runtime/pull/82818 - disallow nested array values, this prevents crashes and hangs caused by deep recursion
* https://github.com/dotnet/runtime/pull/87634 - limit the size of the value state to track during analysis. If the state would get too big, we give up on the analysis and simply ignore that value (treat it as unknown). This prevents all kinds of hangs caused by typically exponential growth of the value state.
* https://github.com/dotnet/runtime/pull/88836 - avoid throwing exceptions in the analyzer when an unrecognized code pattern is found. This avoids crashes of the analyzer (and causing build breaks) if a pattern of code we've never encountered is used (applies to new patterns introduced in new language versions as well).

See the specific commits for a bit more detail on the ports.

## Testing


The change adds tests for the first two changes. Adding tests for the 3rd is difficult (how to introduce unknown code patterns - if don't know what they are).

## Risk

Pretty low. Only to trim scenarios. All of these changes simply detect pathological cases and turn them into much simpler state which is not going to harm the analysis.
